### PR TITLE
feat: add diamond-ready access control module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -420,3 +420,6 @@ FodyWeavers.xsd
 # Foundry
 cache/
 broadcast/
+
+# Local portfolio tracking
+PORTFOLIO_PROJECTS.md

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Amir Shirif
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,66 +1,30 @@
-## Foundry
+# smart-contracts
 
-**Foundry is a blazing fast, portable and modular toolkit for Ethereum application development written in Rust.**
+![Solidity](https://img.shields.io/badge/Solidity-0.8.30-363636?logo=solidity)
+![License](https://img.shields.io/github/license/amshirif/smart-contracts)
 
-Foundry consists of:
+Portfolio-focused Solidity modules built with Foundry. The codebase is kept
+dependency-light and "diamond-ready" so core modules can later be wrapped as
+facets without a full rewrite.
 
-- **Forge**: Ethereum testing framework (like Truffle, Hardhat and DappTools).
-- **Cast**: Swiss army knife for interacting with EVM smart contracts, sending transactions and getting chain data.
-- **Anvil**: Local Ethereum node, akin to Ganache, Hardhat Network.
-- **Chisel**: Fast, utilitarian, and verbose solidity REPL.
+## Goals
+- Security-first primitives with clear admin and upgrade boundaries.
+- Clean, testable modules with minimal external dependencies.
+- Diamond-ready storage patterns for future EIP-2535 integration.
 
-## Documentation
+## Structure
+- `src/access`: access control and upgrade-safety primitives.
+- `src/interfaces`: local interfaces (ERC-165, RBAC, etc.).
+- `test`: Foundry tests and coverage.
+- `docs`: usage notes and design decisions.
 
-https://book.getfoundry.sh/
-
-## Usage
-
-### Build
-
+## Commands
 ```shell
-$ forge build
+forge build
+forge test
+forge coverage
+forge fmt
 ```
 
-### Test
-
-```shell
-$ forge test
-```
-
-### Format
-
-```shell
-$ forge fmt
-```
-
-### Gas Snapshots
-
-```shell
-$ forge snapshot
-```
-
-### Anvil
-
-```shell
-$ anvil
-```
-
-### Deploy
-
-```shell
-$ forge script script/Counter.s.sol:CounterScript --rpc-url <your_rpc_url> --private-key <your_private_key>
-```
-
-### Cast
-
-```shell
-$ cast <subcommand>
-```
-
-### Help
-
-```shell
-$ forge --help
-$ anvil --help
-$ cast --help
-```
+## Tooling
+- Foundry docs: [book.getfoundry.sh](https://book.getfoundry.sh/)

--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -1,0 +1,40 @@
+# Access Control
+
+This module provides a minimal role-based access control (RBAC) system with
+an admin hierarchy. Roles default to being administered by `DEFAULT_ADMIN_ROLE`.
+It also supports ERC-165 interface detection and role member enumeration.
+The storage layout is diamond-ready via a fixed storage slot library.
+
+## Usage
+
+1. Inherit from `AccessControl` (implements `IAccessControl`).
+2. Pass the initial admin to the constructor.
+3. Define roles as `bytes32` constants.
+4. Protect functions with `onlyRole(ROLE)`.
+5. Optionally change role admins with `_setRoleAdmin`.
+6. Use `getRoleMemberCount` and `getRoleMember` to enumerate role members.
+
+## Diamond-Ready Usage
+
+When used behind a diamond proxy, call the internal initializer from a facet or init
+contract instead of relying on the constructor.
+
+```solidity
+function init(address admin) external {
+    _initializeAccessControl(admin);
+}
+```
+
+## Example
+
+```solidity
+contract MyContract is AccessControl {
+    bytes32 public constant WRITER_ROLE = keccak256("WRITER_ROLE");
+
+    constructor(address admin) AccessControl(admin) {}
+
+    function write() external onlyRole(WRITER_ROLE) {
+        // ...
+    }
+}
+```

--- a/src/access/AccessControl.sol
+++ b/src/access/AccessControl.sol
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "../interfaces/IAccessControl.sol";
+import {IERC165} from "../interfaces/IERC165.sol";
+import {LibAccessControlStorage} from "./LibAccessControlStorage.sol";
+
+/// @title AccessControl
+/// @notice Minimal role-based access control with admin hierarchy.
+/// @dev Roles default to being administered by DEFAULT_ADMIN_ROLE.
+abstract contract AccessControl is IAccessControl {
+    /// @notice Default admin for all roles unless overridden.
+    /// @dev Equal to bytes32(0).
+    bytes32 public constant DEFAULT_ADMIN_ROLE = 0x00;
+
+    /// @param initialAdmin The account to receive DEFAULT_ADMIN_ROLE.
+    constructor(address initialAdmin) {
+        _initializeAccessControl(initialAdmin);
+    }
+
+    /// @dev Reverts if the caller is missing `role`.
+    modifier onlyRole(bytes32 role) {
+        _checkRole(role, msg.sender);
+        _;
+    }
+
+    /// @notice Returns true if `account` has been granted `role`.
+    /// @param role The role to query.
+    /// @param account The account to query.
+    /// @return True if the account has the role.
+    function hasRole(bytes32 role, address account) public view returns (bool) {
+        return LibAccessControlStorage.layout().roles[role].members[account];
+    }
+
+    /// @notice Returns the admin role that controls `role`.
+    /// @param role The role to query.
+    /// @return The admin role for `role`.
+    function getRoleAdmin(bytes32 role) public view returns (bytes32) {
+        return LibAccessControlStorage.layout().roles[role].adminRole;
+    }
+
+    /// @notice Returns true if this contract implements `interfaceId`.
+    /// @param interfaceId The interface identifier.
+    /// @return True if the interface is supported.
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return interfaceId == type(IAccessControl).interfaceId || interfaceId == type(IERC165).interfaceId;
+    }
+
+    /// @notice Grants `role` to `account`.
+    /// @dev Caller must have ``getRoleAdmin(role)``.
+    /// @param role The role to grant.
+    /// @param account The account to grant the role to.
+    function grantRole(bytes32 role, address account) public virtual onlyRole(getRoleAdmin(role)) {
+        _grantRole(role, account);
+    }
+
+    /// @notice Revokes `role` from `account`.
+    /// @dev Caller must have ``getRoleAdmin(role)``.
+    /// @param role The role to revoke.
+    /// @param account The account to revoke the role from.
+    function revokeRole(bytes32 role, address account) public virtual onlyRole(getRoleAdmin(role)) {
+        _revokeRole(role, account);
+    }
+
+    /// @notice Renounces `role` for `account`.
+    /// @dev Reverts unless `account == msg.sender`.
+    /// @param role The role to renounce.
+    /// @param account The account renouncing the role.
+    function renounceRole(bytes32 role, address account) public virtual {
+        if (account != msg.sender) {
+            revert AccessControlRenounceSelfOnly();
+        }
+        _revokeRole(role, account);
+    }
+
+    /// @notice Returns the role member at `index`.
+    /// @param role The role to enumerate.
+    /// @param index The index in the role member array.
+    /// @return The account at the given index.
+    function getRoleMember(bytes32 role, uint256 index) public view returns (address) {
+        return LibAccessControlStorage.layout().roles[role].memberList[index];
+    }
+
+    /// @notice Returns the number of members for `role`.
+    /// @param role The role to enumerate.
+    /// @return The number of accounts in the role.
+    function getRoleMemberCount(bytes32 role) public view returns (uint256) {
+        return LibAccessControlStorage.layout().roles[role].memberList.length;
+    }
+
+    /// @dev Initializes access control storage (diamond-ready).
+    /// @param initialAdmin The account to receive DEFAULT_ADMIN_ROLE.
+    function _initializeAccessControl(address initialAdmin) internal {
+        LibAccessControlStorage.Layout storage layout = LibAccessControlStorage.layout();
+        if (layout.initialized) {
+            revert AccessControlAlreadyInitialized();
+        }
+        if (initialAdmin == address(0)) {
+            revert AccessControlZeroAdmin();
+        }
+        layout.initialized = true;
+        layout.roles[DEFAULT_ADMIN_ROLE].adminRole = DEFAULT_ADMIN_ROLE;
+        _grantRole(DEFAULT_ADMIN_ROLE, initialAdmin);
+    }
+
+    /// @dev Reverts with {AccessControlUnauthorized} if `account` lacks `role`.
+    /// @param role The required role.
+    /// @param account The account being checked.
+    function _checkRole(bytes32 role, address account) internal view {
+        if (!hasRole(role, account)) {
+            revert AccessControlUnauthorized(account, role);
+        }
+    }
+
+    /// @dev Updates the admin role for `role`.
+    /// @param role The role to update.
+    /// @param adminRole The new admin role.
+    function _setRoleAdmin(bytes32 role, bytes32 adminRole) internal virtual {
+        LibAccessControlStorage.Layout storage layout = LibAccessControlStorage.layout();
+        bytes32 previousAdminRole = layout.roles[role].adminRole;
+        layout.roles[role].adminRole = adminRole;
+        emit RoleAdminChanged(role, previousAdminRole, adminRole);
+    }
+
+    /// @dev Grants `role` to `account` if not already granted.
+    /// @param role The role to grant.
+    /// @param account The account receiving the role.
+    function _grantRole(bytes32 role, address account) internal virtual {
+        LibAccessControlStorage.RoleData storage roleData = LibAccessControlStorage.layout().roles[role];
+        if (!roleData.members[account]) {
+            roleData.members[account] = true;
+            if (roleData.memberIndex[account] == 0) {
+                roleData.memberList.push(account);
+                roleData.memberIndex[account] = roleData.memberList.length;
+            }
+            emit RoleGranted(role, account, msg.sender);
+        }
+    }
+
+    /// @dev Revokes `role` from `account` if currently granted.
+    /// @param role The role to revoke.
+    /// @param account The account losing the role.
+    function _revokeRole(bytes32 role, address account) internal virtual {
+        LibAccessControlStorage.RoleData storage roleData = LibAccessControlStorage.layout().roles[role];
+        if (roleData.members[account]) {
+            roleData.members[account] = false;
+            uint256 index = roleData.memberIndex[account];
+            if (index != 0) {
+                uint256 lastIndex = roleData.memberList.length;
+                if (index != lastIndex) {
+                    address lastMember = roleData.memberList[lastIndex - 1];
+                    roleData.memberList[index - 1] = lastMember;
+                    roleData.memberIndex[lastMember] = index;
+                }
+                roleData.memberList.pop();
+                roleData.memberIndex[account] = 0;
+            }
+            emit RoleRevoked(role, account, msg.sender);
+        }
+    }
+}

--- a/src/access/LibAccessControlStorage.sol
+++ b/src/access/LibAccessControlStorage.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title LibAccessControlStorage
+/// @notice Storage layout for AccessControl modules (diamond-ready).
+library LibAccessControlStorage {
+    /// @dev Storage slot for the layout.
+    bytes32 internal constant STORAGE_SLOT = keccak256("smart-contracts.access-control.storage");
+
+    /// @notice Role membership and admin role data.
+    struct RoleData {
+        mapping(address => bool) members;
+        bytes32 adminRole;
+        address[] memberList;
+        mapping(address => uint256) memberIndex;
+    }
+
+    /// @notice Access control storage layout.
+    struct Layout {
+        bool initialized;
+        mapping(bytes32 => RoleData) roles;
+    }
+
+    /// @notice Returns the storage layout for access control.
+    /// @return l The storage layout pointer.
+    function layout() internal pure returns (Layout storage l) {
+        bytes32 slot = STORAGE_SLOT;
+        assembly {
+            l.slot := slot
+        }
+    }
+}

--- a/src/interfaces/IAccessControl.sol
+++ b/src/interfaces/IAccessControl.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC165} from "./IERC165.sol";
+
+/// @title IAccessControl
+/// @notice Interface for minimal role-based access control with admin hierarchy.
+interface IAccessControl is IERC165 {
+    /// @notice Emitted when a role's admin is changed.
+    event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole);
+    /// @notice Emitted when a role is granted.
+    event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender);
+    /// @notice Emitted when a role is revoked.
+    event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender);
+
+    /// @notice Thrown when an account is missing a required role.
+    error AccessControlUnauthorized(address account, bytes32 role);
+    /// @notice Thrown when renouncing a role for another account.
+    error AccessControlRenounceSelfOnly();
+    /// @notice Thrown when initializing with the zero admin address.
+    error AccessControlZeroAdmin();
+    /// @notice Thrown when initializing more than once.
+    error AccessControlAlreadyInitialized();
+
+    /// @notice Default admin for all roles unless overridden.
+    /// @return The default admin role identifier.
+    function DEFAULT_ADMIN_ROLE() external view returns (bytes32);
+
+    /// @notice Returns true if `account` has been granted `role`.
+    /// @param role The role to query.
+    /// @param account The account to query.
+    /// @return True if the account has the role.
+    function hasRole(bytes32 role, address account) external view returns (bool);
+
+    /// @notice Returns the admin role that controls `role`.
+    /// @param role The role to query.
+    /// @return The admin role for `role`.
+    function getRoleAdmin(bytes32 role) external view returns (bytes32);
+
+    /// @notice Grants `role` to `account`.
+    /// @param role The role to grant.
+    /// @param account The account to grant the role to.
+    function grantRole(bytes32 role, address account) external;
+
+    /// @notice Revokes `role` from `account`.
+    /// @param role The role to revoke.
+    /// @param account The account to revoke the role from.
+    function revokeRole(bytes32 role, address account) external;
+
+    /// @notice Renounces `role` for `account`.
+    /// @param role The role to renounce.
+    /// @param account The account renouncing the role.
+    function renounceRole(bytes32 role, address account) external;
+
+    /// @notice Returns the role member at `index`.
+    /// @param role The role to enumerate.
+    /// @param index The index in the role member array.
+    /// @return The account at the given index.
+    function getRoleMember(bytes32 role, uint256 index) external view returns (address);
+
+    /// @notice Returns the number of members for `role`.
+    /// @param role The role to enumerate.
+    /// @return The number of accounts in the role.
+    function getRoleMemberCount(bytes32 role) external view returns (uint256);
+}

--- a/src/interfaces/IERC165.sol
+++ b/src/interfaces/IERC165.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title IERC165
+/// @notice Interface detection standard.
+interface IERC165 {
+    /// @notice Query if a contract implements an interface.
+    /// @param interfaceId The interface identifier, as specified in ERC-165.
+    /// @return True if the contract implements `interfaceId`.
+    function supportsInterface(bytes4 interfaceId) external view returns (bool);
+}

--- a/test/AccessControl.t.sol
+++ b/test/AccessControl.t.sol
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {AccessControl} from "../src/access/AccessControl.sol";
+import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
+import {IERC165} from "../src/interfaces/IERC165.sol";
+
+// Minimal cheatcode interface to avoid pulling forge-std.
+interface Vm {
+    function prank(address) external;
+    function startPrank(address) external;
+    function stopPrank() external;
+    function expectRevert(bytes calldata) external;
+}
+
+// Lightweight assertions and cheatcode access.
+contract TestBase {
+    Vm internal constant VM = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    function assertTrue(bool condition, string memory message) internal pure {
+        require(condition, message);
+    }
+}
+
+// Harness exposes internal admin setter for testing.
+contract AccessControlHarness is AccessControl {
+    constructor(address initialAdmin) AccessControl(initialAdmin) {}
+
+    function setRoleAdmin(bytes32 role, bytes32 adminRole) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        _setRoleAdmin(role, adminRole);
+    }
+
+    function initialize(address initialAdmin) external {
+        _initializeAccessControl(initialAdmin);
+    }
+}
+
+contract AccessControlTest is TestBase {
+    // Sample roles for testing.
+    bytes32 private constant WRITER_ROLE = keccak256("WRITER_ROLE");
+    bytes32 private constant SPECIAL_ADMIN_ROLE = keccak256("SPECIAL_ADMIN_ROLE");
+
+    // Test actors.
+    address private admin = address(0xA11CE);
+    address private bob = address(0xB0B);
+
+    AccessControlHarness private ac;
+
+    // Deploy fresh instance per test run.
+    function setUp() public {
+        ac = new AccessControlHarness(admin);
+    }
+
+    function testDefaultAdminRoleAssigned() public view {
+        assertTrue(ac.hasRole(ac.DEFAULT_ADMIN_ROLE(), admin), "admin missing default role");
+    }
+
+    function testDefaultAdminIsSelfAdmin() public view {
+        assertTrue(
+            ac.getRoleAdmin(ac.DEFAULT_ADMIN_ROLE()) == ac.DEFAULT_ADMIN_ROLE(), "default admin should self-admin"
+        );
+    }
+
+    function testZeroAdminReverts() public {
+        VM.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlZeroAdmin.selector));
+        new AccessControlHarness(address(0));
+    }
+
+    function testInitializeRevertsWhenAlreadyInitialized() public {
+        VM.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlAlreadyInitialized.selector));
+        ac.initialize(admin);
+    }
+
+    function testSupportsInterface() public view {
+        assertTrue(ac.supportsInterface(type(IERC165).interfaceId), "erc165 not supported");
+        assertTrue(ac.supportsInterface(type(IAccessControl).interfaceId), "access control not supported");
+        assertTrue(!ac.supportsInterface(0xffffffff), "unexpected interface supported");
+    }
+
+    function testNonAdminCannotGrant() public {
+        VM.startPrank(bob);
+        VM.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, ac.getRoleAdmin(WRITER_ROLE))
+        );
+        ac.grantRole(WRITER_ROLE, bob);
+        VM.stopPrank();
+    }
+
+    function testAdminCanGrantAndRevoke() public {
+        VM.prank(admin);
+        ac.grantRole(WRITER_ROLE, bob);
+        assertTrue(ac.hasRole(WRITER_ROLE, bob), "grant failed");
+
+        VM.prank(admin);
+        ac.revokeRole(WRITER_ROLE, bob);
+        assertTrue(!ac.hasRole(WRITER_ROLE, bob), "revoke failed");
+    }
+
+    function testRenounceRoleSelfOnly() public {
+        VM.prank(admin);
+        ac.grantRole(WRITER_ROLE, bob);
+
+        VM.startPrank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlRenounceSelfOnly.selector));
+        ac.renounceRole(WRITER_ROLE, bob);
+        VM.stopPrank();
+
+        VM.prank(bob);
+        ac.renounceRole(WRITER_ROLE, bob);
+        assertTrue(!ac.hasRole(WRITER_ROLE, bob), "renounce failed");
+    }
+
+    function testRoleAdminChange() public {
+        VM.prank(admin);
+        ac.setRoleAdmin(WRITER_ROLE, SPECIAL_ADMIN_ROLE);
+
+        VM.startPrank(admin);
+        VM.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, admin, SPECIAL_ADMIN_ROLE)
+        );
+        ac.grantRole(WRITER_ROLE, bob);
+        VM.stopPrank();
+
+        VM.prank(admin);
+        ac.grantRole(SPECIAL_ADMIN_ROLE, admin);
+
+        VM.prank(admin);
+        ac.grantRole(WRITER_ROLE, bob);
+        assertTrue(ac.hasRole(WRITER_ROLE, bob), "grant after admin change failed");
+    }
+
+    function testRoleEnumeration() public {
+        VM.prank(admin);
+        ac.grantRole(WRITER_ROLE, admin);
+        VM.prank(admin);
+        ac.grantRole(WRITER_ROLE, bob);
+
+        uint256 count = ac.getRoleMemberCount(WRITER_ROLE);
+        assertTrue(count == 2, "count should be 2");
+        assertTrue(_roleHasMember(WRITER_ROLE, admin), "admin missing from enumeration");
+        assertTrue(_roleHasMember(WRITER_ROLE, bob), "bob missing from enumeration");
+
+        VM.prank(admin);
+        ac.revokeRole(WRITER_ROLE, bob);
+        count = ac.getRoleMemberCount(WRITER_ROLE);
+        assertTrue(count == 1, "count should be 1 after revoke");
+        assertTrue(!_roleHasMember(WRITER_ROLE, bob), "bob should be removed");
+    }
+
+    function testRoleEnumerationEmpty() public view {
+        bytes32 emptyRole = keccak256("EMPTY_ROLE");
+        assertTrue(ac.getRoleMemberCount(emptyRole) == 0, "empty role should have zero members");
+        assertTrue(!_roleHasMember(emptyRole, admin), "empty role should not contain admin");
+    }
+
+    function testRoleEnumerationSwapOnRevoke() public {
+        VM.prank(admin);
+        ac.grantRole(WRITER_ROLE, admin);
+        VM.prank(admin);
+        ac.grantRole(WRITER_ROLE, bob);
+
+        VM.prank(admin);
+        ac.revokeRole(WRITER_ROLE, admin);
+
+        uint256 count = ac.getRoleMemberCount(WRITER_ROLE);
+        assertTrue(count == 1, "count should be 1 after revoke");
+        assertTrue(ac.getRoleMember(WRITER_ROLE, 0) == bob, "bob should be swapped into index 0");
+    }
+
+    function testGrantAndRevokeIdempotent() public {
+        VM.prank(admin);
+        ac.grantRole(WRITER_ROLE, bob);
+        VM.prank(admin);
+        ac.grantRole(WRITER_ROLE, bob);
+
+        uint256 count = ac.getRoleMemberCount(WRITER_ROLE);
+        assertTrue(count == 1, "duplicate grant should not add member");
+
+        VM.prank(admin);
+        ac.revokeRole(WRITER_ROLE, bob);
+        VM.prank(admin);
+        ac.revokeRole(WRITER_ROLE, bob);
+
+        count = ac.getRoleMemberCount(WRITER_ROLE);
+        assertTrue(count == 0, "duplicate revoke should not add member");
+        assertTrue(!ac.hasRole(WRITER_ROLE, bob), "role should be revoked");
+    }
+
+    function _roleHasMember(bytes32 role, address member) internal view returns (bool) {
+        uint256 count = ac.getRoleMemberCount(role);
+        for (uint256 i = 0; i < count; i++) {
+            if (ac.getRoleMember(role, i) == member) {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- Add minimal RBAC module with admin hierarchy, events, and role enumeration.
- Make access control diamond-ready via fixed storage slot + initializer guard.
- Add ERC-165 interface support and local interfaces.
- Add comprehensive tests and usage docs.
- Update README and add MIT license.

## Testing
- `forge clean && forge fmt && forge coverage`