### PR TITLE
feat(security): add scoped pausability and ACL event coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ facets without a full rewrite.
 - Security-first primitives with clear admin and upgrade boundaries.
 - Clean, testable modules with minimal external dependencies.
 - Diamond-ready storage patterns for future EIP-2535 integration.
+- Global and scope-level emergency controls for safer operations.
 
 ## Structure
 - `src/access`: access control and upgrade-safety primitives.
 - `src/access/storage`: module-local storage libraries (diamond-ready slots).
-- `src/interfaces`: local interfaces (ERC-165, `IAccessControl`, `IAccessControlTime`, etc.).
+- `src/interfaces`: local interfaces (ERC-165, `IAccessControl`, `IAccessControlTime`, `IPausable`, etc.).
 - `src/libraries`: shared cross-module libraries.
 - `test`: split by concern (`*Core.t.sol`, `*Time.t.sol`, `*Integration.t.sol`).
 - `test/helpers`: shared test fixtures and harnesses.
@@ -31,6 +32,10 @@ forge fmt
 
 ## Testing
 - Convention guide: `docs/testing-conventions.md`
+
+## Module Docs
+- Access control: `docs/access-control.md`
+- Pausability: `docs/pausable.md`
 
 ## Tooling
 - Foundry docs: [book.getfoundry.sh](https://book.getfoundry.sh/)

--- a/docs/pausable.md
+++ b/docs/pausable.md
@@ -1,0 +1,61 @@
+# Pausable
+
+This module adds role-gated pause controls for both:
+- a global protocol-wide emergency stop
+- independent scoped pauses for specific flows
+
+## Usage
+
+1. Inherit from `Pausable`.
+2. `PAUSER_ROLE` is granted to the initial admin at construction.
+3. Protect globally critical paths with `whenNotPaused`.
+4. Protect scope-specific paths with `whenScopeNotPaused(SCOPE)`.
+5. Protect emergency-only handlers with `whenPaused` or `whenScopePaused(SCOPE)`.
+6. Use `pause`/`unpause` for global controls, and `pauseScope`/`unpauseScope` for independent flows.
+
+## Behavior
+
+- `pause` and `unpause` require `PAUSER_ROLE`.
+- `pauseScope` and `unpauseScope` require `PAUSER_ROLE`.
+- Calling `pause` while paused reverts with `PausableEnforcedPause`.
+- Calling `unpause` while unpaused reverts with `PausableExpectedPause`.
+- Calling `pauseScope` while that scope is paused reverts with `PausableScopeEnforcedPause`.
+- Calling `unpauseScope` while that scope is unpaused reverts with `PausableScopeExpectedPause`.
+- Scope `bytes32(0)` is rejected with `PausableZeroScope`.
+- `paused()` returns global pause state.
+- `scopePaused(scope)` returns local scope pause state.
+- `paused(scope)` returns effective scope state (global OR local scope pause).
+- Global pause overrides all scope checks.
+
+## Diamond-Ready Usage
+
+When used behind a diamond proxy, call the internal initializer from a facet or
+init contract:
+
+```solidity
+function initPausable(address initialPauser) external {
+    _initializePausable(initialPauser);
+}
+```
+
+## Example
+
+```solidity
+contract MyModule is Pausable {
+    bytes32 internal constant WITHDRAWALS_SCOPE = keccak256("WITHDRAWALS_SCOPE");
+
+    constructor(address admin) Pausable(admin) {}
+
+    function criticalOperation() external whenNotPaused {
+        // ...
+    }
+
+    function withdrawals() external whenScopeNotPaused(WITHDRAWALS_SCOPE) {
+        // ...
+    }
+
+    function emergencyOperation() external whenScopePaused(WITHDRAWALS_SCOPE) {
+        // ...
+    }
+}
+```

--- a/docs/testing-conventions.md
+++ b/docs/testing-conventions.md
@@ -30,10 +30,13 @@ Use a split test layout so modules stay readable as complexity grows.
 - Move shared setup to `test/helpers` to avoid duplication.
 - Add explicit boundary tests for any timestamp logic.
 - Keep revert expectation tests close to the feature they validate.
+- Add explicit event assertion tests for every emitted event.
 - Prefer deterministic timestamps (`vm.warp`) for time-based tests.
 
 ## Current Reference
 
 - Core example: `test/AccessControlCore.t.sol`
+- Core example: `test/PausableCore.t.sol`
 - Time example: `test/AccessControlTime.t.sol`
 - Helper example: `test/helpers/AccessControlTestHarness.sol`
+- Helper example: `test/helpers/PausableTestHarness.sol`

--- a/src/access/Pausable.sol
+++ b/src/access/Pausable.sol
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {AccessControl} from "./AccessControl.sol";
+import {IPausable} from "../interfaces/IPausable.sol";
+import {IERC165} from "../interfaces/IERC165.sol";
+import {LibPausableStorage} from "./storage/LibPausableStorage.sol";
+
+/// @title Pausable
+/// @notice Role-gated pause and emergency stop module.
+/// @dev Uses `PAUSER_ROLE` and diamond-ready storage.
+abstract contract Pausable is AccessControl, IPausable {
+    /// @notice Role required to call `pause` and `unpause`.
+    bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
+
+    /// @param initialAdmin The account to receive DEFAULT_ADMIN_ROLE.
+    constructor(address initialAdmin) AccessControl(initialAdmin) {
+        _initializePausable(initialAdmin);
+    }
+
+    /// @dev Reverts when contract is paused.
+    modifier whenNotPaused() {
+        _requireNotPaused();
+        _;
+    }
+
+    /// @dev Reverts when contract is not paused.
+    modifier whenPaused() {
+        _requirePaused();
+        _;
+    }
+
+    /// @dev Reverts when the given pause `scope` is effectively paused.
+    modifier whenScopeNotPaused(bytes32 scope) {
+        _requireScopeNotPaused(scope);
+        _;
+    }
+
+    /// @dev Reverts when the given pause `scope` is not effectively paused.
+    modifier whenScopePaused(bytes32 scope) {
+        _requireScopePaused(scope);
+        _;
+    }
+
+    /// @notice Returns true when the contract is paused.
+    /// @return True if paused.
+    function paused() public view returns (bool) {
+        return LibPausableStorage.layout().paused;
+    }
+
+    /// @notice Returns true when `scope` is effectively paused.
+    /// @dev Effective pause includes global pause override.
+    /// @param scope The scope identifier.
+    /// @return True if globally paused or scope paused.
+    function paused(bytes32 scope) public view returns (bool) {
+        return paused() || scopePaused(scope);
+    }
+
+    /// @notice Returns true when `scope` is locally paused.
+    /// @param scope The scope identifier.
+    /// @return True if the scope itself is paused.
+    function scopePaused(bytes32 scope) public view returns (bool) {
+        return LibPausableStorage.layout().pausedScopes[scope];
+    }
+
+    /// @notice Pauses the contract.
+    /// @dev Caller must have `PAUSER_ROLE`.
+    function pause() public onlyRole(PAUSER_ROLE) whenNotPaused {
+        LibPausableStorage.layout().paused = true;
+        emit Paused(msg.sender);
+    }
+
+    /// @notice Unpauses the contract.
+    /// @dev Caller must have `PAUSER_ROLE`.
+    function unpause() public onlyRole(PAUSER_ROLE) whenPaused {
+        LibPausableStorage.layout().paused = false;
+        emit Unpaused(msg.sender);
+    }
+
+    /// @notice Pauses a specific scope.
+    /// @dev Caller must have `PAUSER_ROLE`.
+    /// @param scope The scope identifier.
+    function pauseScope(bytes32 scope) public onlyRole(PAUSER_ROLE) {
+        _requireValidScope(scope);
+        if (scopePaused(scope)) {
+            revert PausableScopeEnforcedPause(scope);
+        }
+
+        LibPausableStorage.layout().pausedScopes[scope] = true;
+        emit ScopePaused(scope, msg.sender);
+    }
+
+    /// @notice Unpauses a specific scope.
+    /// @dev Caller must have `PAUSER_ROLE`.
+    /// @param scope The scope identifier.
+    function unpauseScope(bytes32 scope) public onlyRole(PAUSER_ROLE) {
+        _requireValidScope(scope);
+        if (!scopePaused(scope)) {
+            revert PausableScopeExpectedPause(scope);
+        }
+
+        LibPausableStorage.layout().pausedScopes[scope] = false;
+        emit ScopeUnpaused(scope, msg.sender);
+    }
+
+    /// @notice Returns true if this contract implements `interfaceId`.
+    /// @param interfaceId The interface identifier.
+    /// @return True if the interface is supported.
+    function supportsInterface(bytes4 interfaceId) public view virtual override(AccessControl, IERC165) returns (bool) {
+        return interfaceId == type(IPausable).interfaceId || interfaceId == type(IERC165).interfaceId
+            || super.supportsInterface(interfaceId);
+    }
+
+    /// @dev Initializes pausable storage (diamond-ready).
+    /// @param initialPauser The account to receive `PAUSER_ROLE`.
+    function _initializePausable(address initialPauser) internal {
+        LibPausableStorage.Layout storage layout = LibPausableStorage.layout();
+        if (layout.initialized) {
+            revert PausableAlreadyInitialized();
+        }
+        _requireNonZeroAccount(initialPauser);
+        layout.initialized = true;
+        _grantRole(PAUSER_ROLE, initialPauser);
+    }
+
+    /// @dev Reverts with {PausableEnforcedPause} when paused.
+    function _requireNotPaused() internal view {
+        if (paused()) {
+            revert PausableEnforcedPause();
+        }
+    }
+
+    /// @dev Reverts with {PausableExpectedPause} when unpaused.
+    function _requirePaused() internal view {
+        if (!paused()) {
+            revert PausableExpectedPause();
+        }
+    }
+
+    /// @dev Reverts with {PausableScopeEnforcedPause} when scope is effectively paused.
+    /// @param scope The scope identifier.
+    function _requireScopeNotPaused(bytes32 scope) internal view {
+        _requireValidScope(scope);
+        if (paused(scope)) {
+            revert PausableScopeEnforcedPause(scope);
+        }
+    }
+
+    /// @dev Reverts with {PausableScopeExpectedPause} when scope is not effectively paused.
+    /// @param scope The scope identifier.
+    function _requireScopePaused(bytes32 scope) internal view {
+        _requireValidScope(scope);
+        if (!paused(scope)) {
+            revert PausableScopeExpectedPause(scope);
+        }
+    }
+
+    /// @dev Reverts with {PausableZeroScope} when `scope` is zero.
+    /// @param scope The scope identifier.
+    function _requireValidScope(bytes32 scope) internal pure {
+        if (scope == bytes32(0)) {
+            revert PausableZeroScope();
+        }
+    }
+}

--- a/src/access/storage/LibPausableStorage.sol
+++ b/src/access/storage/LibPausableStorage.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title LibPausableStorage
+/// @notice Storage layout for pausability modules (diamond-ready).
+library LibPausableStorage {
+    /// @dev Storage slot for pausable layout.
+    bytes32 internal constant STORAGE_SLOT = keccak256("smart-contracts.pausable.storage");
+
+    /// @notice Pausable storage layout.
+    struct Layout {
+        bool initialized;
+        bool paused;
+        mapping(bytes32 => bool) pausedScopes;
+    }
+
+    /// @notice Returns the storage layout for pausable state.
+    /// @return l The storage layout pointer.
+    function layout() internal pure returns (Layout storage l) {
+        bytes32 slot = STORAGE_SLOT;
+        assembly {
+            l.slot := slot
+        }
+    }
+}

--- a/src/interfaces/IPausable.sol
+++ b/src/interfaces/IPausable.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC165} from "./IERC165.sol";
+
+/// @title IPausable
+/// @notice Interface for role-gated pause and unpause controls.
+interface IPausable is IERC165 {
+    /// @notice Emitted when the contract is paused.
+    event Paused(address indexed account);
+    /// @notice Emitted when the contract is unpaused.
+    event Unpaused(address indexed account);
+    /// @notice Emitted when a pause scope is paused.
+    event ScopePaused(bytes32 indexed scope, address indexed account);
+    /// @notice Emitted when a pause scope is unpaused.
+    event ScopeUnpaused(bytes32 indexed scope, address indexed account);
+
+    /// @notice Thrown when pause is required but contract is not paused.
+    error PausableExpectedPause();
+    /// @notice Thrown when unpaused state is required but contract is paused.
+    error PausableEnforcedPause();
+    /// @notice Thrown when a scope-specific pause is required but scope is not paused.
+    error PausableScopeExpectedPause(bytes32 scope);
+    /// @notice Thrown when unpaused scope state is required but scope is paused.
+    error PausableScopeEnforcedPause(bytes32 scope);
+    /// @notice Thrown when a zero-value scope is used.
+    error PausableZeroScope();
+    /// @notice Thrown when pausable module is initialized more than once.
+    error PausableAlreadyInitialized();
+
+    /// @notice Role required to call `pause` and `unpause`.
+    /// @return The pauser role identifier.
+    function PAUSER_ROLE() external view returns (bytes32);
+
+    /// @notice Returns true when the contract is paused.
+    /// @return True if paused.
+    function paused() external view returns (bool);
+
+    /// @notice Returns true when `scope` is effectively paused.
+    /// @dev Effective pause includes global pause override.
+    /// @param scope The scope identifier.
+    /// @return True if globally paused or scope paused.
+    function paused(bytes32 scope) external view returns (bool);
+
+    /// @notice Returns true when `scope` is locally paused.
+    /// @param scope The scope identifier.
+    /// @return True if the scope itself is paused.
+    function scopePaused(bytes32 scope) external view returns (bool);
+
+    /// @notice Pauses the contract.
+    function pause() external;
+
+    /// @notice Unpauses the contract.
+    function unpause() external;
+
+    /// @notice Pauses a specific scope.
+    /// @param scope The scope identifier.
+    function pauseScope(bytes32 scope) external;
+
+    /// @notice Unpauses a specific scope.
+    /// @param scope The scope identifier.
+    function unpauseScope(bytes32 scope) external;
+}

--- a/test/AccessControlCore.t.sol
+++ b/test/AccessControlCore.t.sol
@@ -7,6 +7,10 @@ import {IAccessControlTime} from "../src/interfaces/IAccessControlTime.sol";
 import {IERC165} from "../src/interfaces/IERC165.sol";
 
 contract AccessControlCoreTest is AccessControlFixture {
+    event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole);
+    event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender);
+    event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender);
+
     function testDefaultAdminRoleAssigned() public view {
         assertTrue(ac.hasRole(ac.DEFAULT_ADMIN_ROLE(), admin), "admin missing default role");
     }
@@ -53,6 +57,36 @@ contract AccessControlCoreTest is AccessControlFixture {
         assertTrue(!ac.hasRole(WRITER_ROLE, bob), "revoke failed");
     }
 
+    function testGrantRoleEmitsEvent() public {
+        VM.expectEmit(true, true, true, false, address(ac));
+        emit RoleGranted(WRITER_ROLE, bob, admin);
+
+        VM.prank(admin);
+        ac.grantRole(WRITER_ROLE, bob);
+    }
+
+    function testRevokeRoleEmitsEvent() public {
+        VM.prank(admin);
+        ac.grantRole(WRITER_ROLE, bob);
+
+        VM.expectEmit(true, true, true, false, address(ac));
+        emit RoleRevoked(WRITER_ROLE, bob, admin);
+
+        VM.prank(admin);
+        ac.revokeRole(WRITER_ROLE, bob);
+    }
+
+    function testRenounceRoleEmitsEvent() public {
+        VM.prank(admin);
+        ac.grantRole(WRITER_ROLE, bob);
+
+        VM.expectEmit(true, true, true, false, address(ac));
+        emit RoleRevoked(WRITER_ROLE, bob, bob);
+
+        VM.prank(bob);
+        ac.renounceRole(WRITER_ROLE, bob);
+    }
+
     function testRenounceRoleSelfOnly() public {
         VM.prank(admin);
         ac.grantRole(WRITER_ROLE, bob);
@@ -84,6 +118,16 @@ contract AccessControlCoreTest is AccessControlFixture {
         VM.prank(admin);
         ac.grantRole(WRITER_ROLE, bob);
         assertTrue(ac.hasRole(WRITER_ROLE, bob), "grant after admin change failed");
+    }
+
+    function testRoleAdminChangeEmitsEvent() public {
+        bytes32 previousAdminRole = ac.getRoleAdmin(WRITER_ROLE);
+
+        VM.expectEmit(true, true, true, false, address(ac));
+        emit RoleAdminChanged(WRITER_ROLE, previousAdminRole, SPECIAL_ADMIN_ROLE);
+
+        VM.prank(admin);
+        ac.setRoleAdmin(WRITER_ROLE, SPECIAL_ADMIN_ROLE);
     }
 
     function testRoleEnumeration() public {

--- a/test/AccessControlTime.t.sol
+++ b/test/AccessControlTime.t.sol
@@ -6,6 +6,11 @@ import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
 import {IAccessControlTime} from "../src/interfaces/IAccessControlTime.sol";
 
 contract AccessControlTimeTest is AccessControlFixture {
+    event RoleWindowSet(
+        bytes32 indexed role, address indexed account, uint64 start, uint64 end, address indexed sender
+    );
+    event RoleWindowCleared(bytes32 indexed role, address indexed account, address indexed sender);
+
     function testNonAdminCannotSetRoleWindow() public {
         VM.startPrank(bob);
         VM.expectRevert(
@@ -66,6 +71,38 @@ contract AccessControlTimeTest is AccessControlFixture {
         VM.prank(admin);
         VM.expectRevert(abi.encodeWithSelector(IAccessControlTime.AccessControlInvalidRoleWindow.selector, 100, 100));
         ac.setRoleWindow(WRITER_ROLE, bob, 100, 100);
+    }
+
+    function testSetRoleWindowEmitsEvent() public {
+        VM.expectEmit(true, true, true, true, address(ac));
+        emit RoleWindowSet(WRITER_ROLE, bob, 100, 200, admin);
+
+        VM.prank(admin);
+        ac.setRoleWindow(WRITER_ROLE, bob, 100, 200);
+    }
+
+    function testClearRoleWindowEmitsEvent() public {
+        VM.prank(admin);
+        ac.setRoleWindow(WRITER_ROLE, bob, 100, 200);
+
+        VM.expectEmit(true, true, true, false, address(ac));
+        emit RoleWindowCleared(WRITER_ROLE, bob, admin);
+
+        VM.prank(admin);
+        ac.clearRoleWindow(WRITER_ROLE, bob);
+    }
+
+    function testRevokeRoleEmitsRoleWindowClearedEvent() public {
+        VM.prank(admin);
+        ac.grantRole(WRITER_ROLE, bob);
+        VM.prank(admin);
+        ac.setRoleWindow(WRITER_ROLE, bob, 100, 200);
+
+        VM.expectEmit(true, true, true, false, address(ac));
+        emit RoleWindowCleared(WRITER_ROLE, bob, admin);
+
+        VM.prank(admin);
+        ac.revokeRole(WRITER_ROLE, bob);
     }
 
     function testZeroAddressWindowGuards() public {

--- a/test/PausableCore.t.sol
+++ b/test/PausableCore.t.sol
@@ -1,0 +1,281 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {PausableFixture} from "./helpers/PausableTestHarness.sol";
+import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
+import {IAccessControlTime} from "../src/interfaces/IAccessControlTime.sol";
+import {IPausable} from "../src/interfaces/IPausable.sol";
+import {IERC165} from "../src/interfaces/IERC165.sol";
+
+contract PausableCoreTest is PausableFixture {
+    event Paused(address indexed account);
+    event Unpaused(address indexed account);
+    event ScopePaused(bytes32 indexed scope, address indexed account);
+    event ScopeUnpaused(bytes32 indexed scope, address indexed account);
+
+    function testInitialStateUnpaused() public view {
+        assertFalse(pausable.paused(), "should start unpaused");
+    }
+
+    function testScopesStartUnpaused() public view {
+        assertFalse(pausable.scopePaused(pausable.betsScope()), "bets scope should start unpaused");
+        assertFalse(pausable.paused(pausable.betsScope()), "effective bets pause should start false");
+    }
+
+    function testInitialAdminHasPauserRole() public view {
+        assertTrue(pausable.hasRole(pausable.PAUSER_ROLE(), admin), "admin should have pauser role");
+    }
+
+    function testSupportsInterface() public view {
+        assertTrue(pausable.supportsInterface(type(IERC165).interfaceId), "erc165 not supported");
+        assertTrue(pausable.supportsInterface(type(IPausable).interfaceId), "pausable not supported");
+        assertTrue(pausable.supportsInterface(type(IAccessControl).interfaceId), "access control not supported");
+        assertTrue(
+            pausable.supportsInterface(type(IAccessControlTime).interfaceId), "access control time not supported"
+        );
+    }
+
+    function testNonPauserCannotPause() public {
+        VM.startPrank(bob);
+        VM.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, pausable.PAUSER_ROLE())
+        );
+        pausable.pause();
+        VM.stopPrank();
+    }
+
+    function testNonPauserCannotUnpause() public {
+        VM.prank(admin);
+        pausable.pause();
+
+        VM.startPrank(bob);
+        VM.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, pausable.PAUSER_ROLE())
+        );
+        pausable.unpause();
+        VM.stopPrank();
+    }
+
+    function testPauseAndUnpause() public {
+        VM.prank(admin);
+        pausable.pause();
+        assertTrue(pausable.paused(), "pause should set paused state");
+
+        VM.prank(admin);
+        pausable.unpause();
+        assertFalse(pausable.paused(), "unpause should clear paused state");
+    }
+
+    function testPauseScopeAndUnpauseScope() public {
+        bytes32 betsScope = pausable.betsScope();
+
+        VM.prank(admin);
+        pausable.pauseScope(betsScope);
+        assertTrue(pausable.scopePaused(betsScope), "scope pause should set local scope state");
+        assertTrue(pausable.paused(betsScope), "scope pause should set effective paused state");
+
+        VM.prank(admin);
+        pausable.unpauseScope(betsScope);
+        assertFalse(pausable.scopePaused(betsScope), "scope unpause should clear local scope state");
+        assertFalse(pausable.paused(betsScope), "scope unpause should clear effective paused state");
+    }
+
+    function testPauseEmitsEvent() public {
+        VM.expectEmit(true, false, false, false, address(pausable));
+        emit Paused(admin);
+
+        VM.prank(admin);
+        pausable.pause();
+    }
+
+    function testUnpauseEmitsEvent() public {
+        VM.prank(admin);
+        pausable.pause();
+
+        VM.expectEmit(true, false, false, false, address(pausable));
+        emit Unpaused(admin);
+
+        VM.prank(admin);
+        pausable.unpause();
+    }
+
+    function testPauseScopeEmitsEvent() public {
+        bytes32 betsScope = pausable.betsScope();
+        VM.expectEmit(true, true, false, false, address(pausable));
+        emit ScopePaused(betsScope, admin);
+
+        VM.prank(admin);
+        pausable.pauseScope(betsScope);
+    }
+
+    function testUnpauseScopeEmitsEvent() public {
+        bytes32 betsScope = pausable.betsScope();
+
+        VM.prank(admin);
+        pausable.pauseScope(betsScope);
+
+        VM.expectEmit(true, true, false, false, address(pausable));
+        emit ScopeUnpaused(betsScope, admin);
+
+        VM.prank(admin);
+        pausable.unpauseScope(betsScope);
+    }
+
+    function testCannotPauseWhenPaused() public {
+        VM.prank(admin);
+        pausable.pause();
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+        pausable.pause();
+    }
+
+    function testCannotUnpauseWhenUnpaused() public {
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableExpectedPause.selector));
+        pausable.unpause();
+    }
+
+    function testCannotPauseScopeWhenScopePaused() public {
+        bytes32 betsScope = pausable.betsScope();
+        VM.prank(admin);
+        pausable.pauseScope(betsScope);
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, betsScope));
+        pausable.pauseScope(betsScope);
+    }
+
+    function testCannotUnpauseScopeWhenScopeUnpaused() public {
+        bytes32 betsScope = pausable.betsScope();
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeExpectedPause.selector, betsScope));
+        pausable.unpauseScope(betsScope);
+    }
+
+    function testZeroScopeGuards() public {
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableZeroScope.selector));
+        pausable.pauseScope(bytes32(0));
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableZeroScope.selector));
+        pausable.unpauseScope(bytes32(0));
+
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableZeroScope.selector));
+        pausable.scopedEmergencyAction(bytes32(0));
+    }
+
+    function testCriticalActionBlockedWhenPaused() public {
+        VM.prank(admin);
+        pausable.pause();
+
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+        pausable.criticalAction();
+    }
+
+    function testScopedActionBlockedWhenScopePaused() public {
+        bytes32 betsScope = pausable.betsScope();
+        VM.prank(admin);
+        pausable.pauseScope(betsScope);
+
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, betsScope));
+        pausable.betsAction();
+    }
+
+    function testPauseScopeDoesNotPauseOtherScope() public {
+        bytes32 betsScope = pausable.betsScope();
+        bytes32 settlementScope = pausable.settlementScope();
+
+        VM.prank(admin);
+        pausable.pauseScope(betsScope);
+
+        assertTrue(pausable.scopePaused(betsScope), "bets scope should be paused");
+        assertFalse(pausable.scopePaused(settlementScope), "settlement scope should remain unpaused");
+        assertTrue(pausable.settlementAction(), "settlement action should remain callable");
+    }
+
+    function testGlobalPauseOverridesScopeChecks() public {
+        bytes32 settlementScope = pausable.settlementScope();
+        assertFalse(pausable.scopePaused(settlementScope), "scope should start unpaused");
+
+        VM.prank(admin);
+        pausable.pause();
+
+        assertTrue(pausable.paused(settlementScope), "effective scope pause should follow global pause");
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, settlementScope));
+        pausable.settlementAction();
+    }
+
+    function testCriticalActionAllowedWhenUnpaused() public view {
+        assertTrue(pausable.criticalAction(), "critical action should work when unpaused");
+    }
+
+    function testEmergencyActionRequiresPause() public {
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableExpectedPause.selector));
+        pausable.emergencyAction();
+
+        VM.prank(admin);
+        pausable.pause();
+        assertTrue(pausable.emergencyAction(), "emergency action should work when paused");
+    }
+
+    function testScopedEmergencyActionRequiresEffectivePause() public {
+        bytes32 betsScope = pausable.betsScope();
+
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeExpectedPause.selector, betsScope));
+        pausable.scopedEmergencyAction(betsScope);
+
+        VM.prank(admin);
+        pausable.pauseScope(betsScope);
+        assertTrue(pausable.scopedEmergencyAction(betsScope), "scope emergency should work when scope paused");
+    }
+
+    function testScopedEmergencyActionWorksDuringGlobalPause() public {
+        bytes32 settlementScope = pausable.settlementScope();
+
+        VM.prank(admin);
+        pausable.pause();
+        assertTrue(pausable.scopedEmergencyAction(settlementScope), "scope emergency should work when globally paused");
+    }
+
+    function testAdminCanGrantPauserRole() public {
+        VM.startPrank(admin);
+        pausable.grantRole(pausable.PAUSER_ROLE(), bob);
+        VM.stopPrank();
+
+        VM.prank(bob);
+        pausable.pause();
+        assertTrue(pausable.paused(), "granted pauser should pause");
+    }
+
+    function testNonPauserCannotPauseScope() public {
+        bytes32 betsScope = pausable.betsScope();
+
+        VM.startPrank(bob);
+        VM.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, pausable.PAUSER_ROLE())
+        );
+        pausable.pauseScope(betsScope);
+        VM.stopPrank();
+    }
+
+    function testNonPauserCannotUnpauseScope() public {
+        bytes32 betsScope = pausable.betsScope();
+        VM.prank(admin);
+        pausable.pauseScope(betsScope);
+
+        VM.startPrank(bob);
+        VM.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, pausable.PAUSER_ROLE())
+        );
+        pausable.unpauseScope(betsScope);
+        VM.stopPrank();
+    }
+
+    function testInitializePausableRevertsWhenAlreadyInitialized() public {
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableAlreadyInitialized.selector));
+        pausable.initializePausable(admin);
+    }
+}

--- a/test/helpers/AccessControlTestHarness.sol
+++ b/test/helpers/AccessControlTestHarness.sol
@@ -8,6 +8,8 @@ interface Vm {
     function startPrank(address) external;
     function stopPrank() external;
     function expectRevert(bytes calldata) external;
+    function expectEmit(bool, bool, bool, bool) external;
+    function expectEmit(bool, bool, bool, bool, address) external;
     function warp(uint256) external;
 }
 

--- a/test/helpers/PausableTestHarness.sol
+++ b/test/helpers/PausableTestHarness.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Pausable} from "../../src/access/Pausable.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+
+contract PausableHarness is Pausable {
+    bytes32 internal constant BETS_SCOPE = keccak256("BETS_SCOPE");
+    bytes32 internal constant SETTLEMENT_SCOPE = keccak256("SETTLEMENT_SCOPE");
+
+    constructor(address initialAdmin) Pausable(initialAdmin) {}
+
+    function initializePausable(address initialPauser) external {
+        _initializePausable(initialPauser);
+    }
+
+    function criticalAction() external view whenNotPaused returns (bool) {
+        return true;
+    }
+
+    function emergencyAction() external view whenPaused returns (bool) {
+        return true;
+    }
+
+    function betsAction() external view whenScopeNotPaused(BETS_SCOPE) returns (bool) {
+        return true;
+    }
+
+    function settlementAction() external view whenScopeNotPaused(SETTLEMENT_SCOPE) returns (bool) {
+        return true;
+    }
+
+    function scopedEmergencyAction(bytes32 scope) external view whenScopePaused(scope) returns (bool) {
+        return true;
+    }
+
+    function betsScope() external pure returns (bytes32) {
+        return BETS_SCOPE;
+    }
+
+    function settlementScope() external pure returns (bytes32) {
+        return SETTLEMENT_SCOPE;
+    }
+}
+
+abstract contract PausableFixture is TestBase {
+    address internal admin = address(0xA11CE);
+    address internal bob = address(0xB0B);
+
+    PausableHarness internal pausable;
+
+    function setUp() public virtual {
+        pausable = new PausableHarness(admin);
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds protocol pause guard rails with both global and per-scope controls, and tightens security test coverage by adding explicit ACL event assertions.

## What Changed
- Added `IPausable` interface and `Pausable` module with:
  - global pause/unpause
  - scoped pause/unpause (`pauseScope` / `unpauseScope`)
  - effective scoped pause checks (`paused(scope)`)
  - scope-level guard modifiers
- Added pause storage library for diamond-ready scoped state.
- Expanded pausable harness + test coverage for:
  - authorization
  - state transitions
  - global override behavior
  - zero-scope guards
  - event emission
- Added explicit event tests for access control:
  - `RoleGranted`
  - `RoleRevoked`
  - `RoleAdminChanged`
  - `RoleWindowSet`
  - `RoleWindowCleared`
- Updated docs/readme/testing conventions for pause + event-test expectations.

## Validation
- `forge fmt`
- `forge test --offline`