### PR TITLE
feat(security): add diamond-ready reentrancy guard module

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ facets without a full rewrite.
 ## Structure
 - `src/access`: access control and upgrade-safety primitives.
 - `src/access/storage`: module-local storage libraries (diamond-ready slots).
-- `src/interfaces`: local interfaces (ERC-165, `IAccessControl`, `IAccessControlTime`, `IPausable`, etc.).
+- `src/security`: security primitives such as reentrancy protection.
+- `src/security/storage`: module-local storage libraries (diamond-ready slots).
+- `src/interfaces`: local interfaces (ERC-165, `IAccessControl`, `IAccessControlTime`, `IPausable`, `IReentrancyGuard`, etc.).
 - `src/libraries`: shared cross-module libraries.
 - `test`: split by concern (`*Core.t.sol`, `*Time.t.sol`, `*Integration.t.sol`).
 - `test/helpers`: shared test fixtures and harnesses.
@@ -36,6 +38,7 @@ forge fmt
 ## Module Docs
 - Access control: `docs/access-control.md`
 - Pausability: `docs/pausable.md`
+- Reentrancy guard: `docs/reentrancy-guard.md`
 
 ## Tooling
 - Foundry docs: [book.getfoundry.sh](https://book.getfoundry.sh/)

--- a/docs/reentrancy-guard.md
+++ b/docs/reentrancy-guard.md
@@ -1,0 +1,35 @@
+# Reentrancy Guard
+
+This module provides a dependency-light `nonReentrant` guard using
+diamond-ready storage.
+
+## Usage
+
+1. Inherit from `ReentrancyGuard`.
+2. Add `nonReentrant` to state-changing external entrypoints.
+3. Avoid calling one `nonReentrant` function from another `nonReentrant` function.
+
+## Behavior
+
+- Reentrant calls revert with `ReentrancyGuardReentrantCall`.
+- Nested `nonReentrant` calls in the same call stack revert.
+- Successful calls reset guard state at the end of execution.
+
+## Diamond-Ready Usage
+
+When used behind a diamond proxy, call the internal initializer from a facet or
+init contract:
+
+```solidity
+function initReentrancyGuard() external {
+    _initializeReentrancyGuard();
+}
+```
+
+## Composition Notes
+
+- Composes with `AccessControl` and `Pausable`.
+- In composed modules, protect critical external entrypoints with both:
+  - role/pause checks (`onlyRole`, `whenNotPaused`, etc.)
+  - `nonReentrant`
+

--- a/docs/testing-conventions.md
+++ b/docs/testing-conventions.md
@@ -37,6 +37,8 @@ Use a split test layout so modules stay readable as complexity grows.
 
 - Core example: `test/AccessControlCore.t.sol`
 - Core example: `test/PausableCore.t.sol`
+- Core example: `test/ReentrancyGuardCore.t.sol`
 - Time example: `test/AccessControlTime.t.sol`
 - Helper example: `test/helpers/AccessControlTestHarness.sol`
 - Helper example: `test/helpers/PausableTestHarness.sol`
+- Helper example: `test/helpers/ReentrancyGuardTestHarness.sol`

--- a/src/interfaces/IReentrancyGuard.sol
+++ b/src/interfaces/IReentrancyGuard.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC165} from "./IERC165.sol";
+
+/// @title IReentrancyGuard
+/// @notice Interface for reentrancy protection module.
+interface IReentrancyGuard is IERC165 {
+    /// @notice Thrown when a non-reentrant function is called reentrantly.
+    error ReentrancyGuardReentrantCall();
+    /// @notice Thrown when reentrancy guard is initialized more than once.
+    error ReentrancyGuardAlreadyInitialized();
+
+    /// @notice Returns true if the reentrancy guard is currently entered.
+    /// @return True when entered.
+    function reentrancyGuardEntered() external view returns (bool);
+}
+

--- a/src/security/ReentrancyGuard.sol
+++ b/src/security/ReentrancyGuard.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IReentrancyGuard} from "../interfaces/IReentrancyGuard.sol";
+import {IERC165} from "../interfaces/IERC165.sol";
+import {LibReentrancyGuardStorage} from "./storage/LibReentrancyGuardStorage.sol";
+
+/// @title ReentrancyGuard
+/// @notice Reentrancy protection module with diamond-ready storage.
+/// @dev Uses a status flag to block nested entry to `nonReentrant` functions.
+abstract contract ReentrancyGuard is IReentrancyGuard {
+    /// @dev Reentrancy status for a function call not currently entered.
+    uint256 internal constant NOT_ENTERED = 1;
+    /// @dev Reentrancy status for a function call currently entered.
+    uint256 internal constant ENTERED = 2;
+
+    constructor() {
+        _initializeReentrancyGuard();
+    }
+
+    /// @dev Prevents a function from being called reentrantly.
+    modifier nonReentrant() {
+        _nonReentrantBefore();
+        _;
+        _nonReentrantAfter();
+    }
+
+    /// @notice Returns true if the reentrancy guard is currently entered.
+    /// @return True when entered.
+    function reentrancyGuardEntered() public view returns (bool) {
+        return LibReentrancyGuardStorage.layout().status == ENTERED;
+    }
+
+    /// @notice Returns true if this contract implements `interfaceId`.
+    /// @param interfaceId The interface identifier.
+    /// @return True if the interface is supported.
+    function supportsInterface(bytes4 interfaceId) public view virtual returns (bool) {
+        return interfaceId == type(IReentrancyGuard).interfaceId || interfaceId == type(IERC165).interfaceId;
+    }
+
+    /// @dev Initializes reentrancy guard storage (diamond-ready).
+    function _initializeReentrancyGuard() internal {
+        LibReentrancyGuardStorage.Layout storage layout = LibReentrancyGuardStorage.layout();
+        if (layout.initialized) {
+            revert ReentrancyGuardAlreadyInitialized();
+        }
+        layout.initialized = true;
+        layout.status = NOT_ENTERED;
+    }
+
+    /// @dev Reverts when the guard is already entered.
+    function _nonReentrantBefore() internal {
+        LibReentrancyGuardStorage.Layout storage layout = LibReentrancyGuardStorage.layout();
+        if (layout.status == ENTERED) {
+            revert ReentrancyGuardReentrantCall();
+        }
+        layout.status = ENTERED;
+    }
+
+    /// @dev Resets the guard status after execution.
+    function _nonReentrantAfter() internal {
+        LibReentrancyGuardStorage.layout().status = NOT_ENTERED;
+    }
+}
+

--- a/src/security/storage/LibReentrancyGuardStorage.sol
+++ b/src/security/storage/LibReentrancyGuardStorage.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title LibReentrancyGuardStorage
+/// @notice Storage layout for reentrancy guard modules (diamond-ready).
+library LibReentrancyGuardStorage {
+    /// @dev Storage slot for reentrancy guard layout.
+    bytes32 internal constant STORAGE_SLOT = keccak256("smart-contracts.reentrancy-guard.storage");
+
+    /// @notice Reentrancy guard storage layout.
+    struct Layout {
+        bool initialized;
+        uint256 status;
+    }
+
+    /// @notice Returns the storage layout for reentrancy guard state.
+    /// @return l The storage layout pointer.
+    function layout() internal pure returns (Layout storage l) {
+        bytes32 slot = STORAGE_SLOT;
+        assembly {
+            l.slot := slot
+        }
+    }
+}
+

--- a/test/ReentrancyGuardCore.t.sol
+++ b/test/ReentrancyGuardCore.t.sol
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {ReentrancyGuardFixture} from "./helpers/ReentrancyGuardTestHarness.sol";
+import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
+import {IReentrancyGuard} from "../src/interfaces/IReentrancyGuard.sol";
+import {IPausable} from "../src/interfaces/IPausable.sol";
+import {IERC165} from "../src/interfaces/IERC165.sol";
+
+contract ReentrancyGuardCoreTest is ReentrancyGuardFixture {
+    address internal bob = address(0xB0B);
+
+    function testSupportsInterface() public view {
+        assertTrue(guard.supportsInterface(type(IERC165).interfaceId), "erc165 not supported");
+        assertTrue(guard.supportsInterface(type(IReentrancyGuard).interfaceId), "reentrancy interface not supported");
+
+        assertTrue(guardedPausable.supportsInterface(type(IERC165).interfaceId), "erc165 not supported");
+        assertTrue(
+            guardedPausable.supportsInterface(type(IReentrancyGuard).interfaceId),
+            "composed contract should support reentrancy interface"
+        );
+        assertTrue(guardedPausable.supportsInterface(type(IPausable).interfaceId), "composed contract missing pausable");
+        assertTrue(
+            guardedPausable.supportsInterface(type(IAccessControl).interfaceId),
+            "composed contract missing access control"
+        );
+    }
+
+    function testNonReentrantValidCallSucceeds() public {
+        guard.guardedIncrement();
+        assertTrue(guard.counter() == 1, "first guarded call should succeed");
+
+        guard.guardedIncrement();
+        assertTrue(guard.counter() == 2, "second guarded call should succeed");
+        assertFalse(guard.reentrancyGuardEntered(), "guard should reset after call");
+    }
+
+    function testDirectReentrantCallReverts() public {
+        VM.expectRevert(abi.encodeWithSelector(IReentrancyGuard.ReentrancyGuardReentrantCall.selector));
+        attacker.attack();
+    }
+
+    function testNestedGuardedCallReverts() public {
+        VM.expectRevert(abi.encodeWithSelector(IReentrancyGuard.ReentrancyGuardReentrantCall.selector));
+        guard.guardedOuter();
+    }
+
+    function testUnguardedPathsRemainUnaffected() public {
+        guard.unguardedIncrement();
+        assertTrue(guard.unguardedRead() == 1, "unguarded writes should remain unaffected");
+
+        guard.guardedIncrement();
+        assertTrue(guard.unguardedRead() == 2, "guarded and unguarded paths should compose");
+    }
+
+    function testInitializeRevertsWhenAlreadyInitialized() public {
+        VM.expectRevert(abi.encodeWithSelector(IReentrancyGuard.ReentrancyGuardAlreadyInitialized.selector));
+        guard.initializeReentrancyGuardExternal();
+    }
+
+    function testComposedGuardAndPauseBehavior() public {
+        assertTrue(guardedPausable.guardedCriticalAction(), "unguarded paused state should allow action");
+
+        VM.prank(admin);
+        guardedPausable.pause();
+
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+        guardedPausable.guardedCriticalAction();
+    }
+
+    function testComposedGuardAndAccessControlBehavior() public {
+        VM.prank(admin);
+        assertTrue(guardedPausable.guardedRoleAction(), "authorized role should call action");
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorized.selector, bob, guardedPausable.PAUSER_ROLE()
+            )
+        );
+        VM.prank(bob);
+        guardedPausable.guardedRoleAction();
+    }
+}

--- a/test/helpers/ReentrancyGuardTestHarness.sol
+++ b/test/helpers/ReentrancyGuardTestHarness.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {ReentrancyGuard} from "../../src/security/ReentrancyGuard.sol";
+import {Pausable} from "../../src/access/Pausable.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+
+interface IReentrantCallback {
+    function onReentrantCallback() external;
+}
+
+contract ReentrancyGuardHarness is ReentrancyGuard {
+    uint256 public counter;
+
+    constructor() ReentrancyGuard() {}
+
+    function initializeReentrancyGuardExternal() external {
+        _initializeReentrancyGuard();
+    }
+
+    function guardedIncrement() external nonReentrant {
+        counter += 1;
+    }
+
+    function guardedCall(address callback) external nonReentrant {
+        counter += 1;
+        if (callback != address(0)) {
+            IReentrantCallback(callback).onReentrantCallback();
+        }
+    }
+
+    function guardedOuter() external nonReentrant {
+        guardedInner();
+    }
+
+    function guardedInner() public nonReentrant {
+        counter += 1;
+    }
+
+    function unguardedIncrement() external {
+        counter += 1;
+    }
+
+    function unguardedRead() external view returns (uint256) {
+        return counter;
+    }
+}
+
+contract ReentrantAttacker is IReentrantCallback {
+    ReentrancyGuardHarness internal immutable target;
+
+    constructor(ReentrancyGuardHarness target_) {
+        target = target_;
+    }
+
+    function attack() external {
+        target.guardedCall(address(this));
+    }
+
+    function onReentrantCallback() external {
+        target.guardedIncrement();
+    }
+}
+
+contract GuardedPausableHarness is Pausable, ReentrancyGuard {
+    uint256 public writes;
+
+    constructor(address initialAdmin) Pausable(initialAdmin) ReentrancyGuard() {}
+
+    function guardedCriticalAction() external nonReentrant whenNotPaused returns (bool) {
+        writes += 1;
+        return true;
+    }
+
+    function guardedRoleAction() external nonReentrant onlyRole(PAUSER_ROLE) returns (bool) {
+        writes += 1;
+        return true;
+    }
+
+    function supportsInterface(bytes4 interfaceId) public view override(Pausable, ReentrancyGuard) returns (bool) {
+        return Pausable.supportsInterface(interfaceId) || ReentrancyGuard.supportsInterface(interfaceId);
+    }
+}
+
+abstract contract ReentrancyGuardFixture is TestBase {
+    address internal admin = address(0xA11CE);
+
+    ReentrancyGuardHarness internal guard;
+    ReentrantAttacker internal attacker;
+    GuardedPausableHarness internal guardedPausable;
+
+    function setUp() public virtual {
+        guard = new ReentrancyGuardHarness();
+        attacker = new ReentrantAttacker(guard);
+        guardedPausable = new GuardedPausableHarness(admin);
+    }
+}


### PR DESCRIPTION
## Summary
This PR introduces a dependency-light, diamond-ready reentrancy guard module and integrates it into the toolkit with strict tests and docs.

## What Changed
- Added `IReentrancyGuard` interface with custom errors and ERC-165 compatibility.
- Added `ReentrancyGuard` module using module-local storage and `nonReentrant` modifier.
- Added `LibReentrancyGuardStorage` with fixed storage slot for upgrade-safe/diamond-ready usage.
- Added dedicated test harnesses for:
  - valid protected calls
  - direct reentrant callback attempts
  - nested guarded call attempts
  - unguarded/read path behavior
- Added composition tests showing `ReentrancyGuard` works with `Pausable` and `AccessControl`.
- Added docs:
  - `docs/reentrancy-guard.md`
  - README structure/module docs update
  - testing conventions update

## Validation
- `forge fmt`
- `forge test --offline`

Result: all tests passing.

## Issue
Closes #8 