### PR TITLE
feat(upgrade): implement role-gated upgrade guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ facets without a full rewrite.
 - `src/access/storage`: module-local storage libraries (diamond-ready slots).
 - `src/security`: security primitives such as reentrancy protection.
 - `src/security/storage`: module-local storage libraries (diamond-ready slots).
-- `src/interfaces`: local interfaces (ERC-165, `IAccessControl`, `IAccessControlTime`, `IPausable`, `IReentrancyGuard`, etc.).
+- `src/upgrade`: upgrade authorization and execution guardrails.
+- `src/upgrade/storage`: module-local storage libraries (diamond-ready slots).
+- `src/interfaces`: local interfaces (ERC-165, `IAccessControl`, `IAccessControlTime`, `IPausable`, `IReentrancyGuard`, `IUpgradeGuardrails`, etc.).
 - `src/libraries`: shared cross-module libraries.
 - `test`: split by concern (`*Core.t.sol`, `*Time.t.sol`, `*Integration.t.sol`).
 - `test/helpers`: shared test fixtures and harnesses.
@@ -39,6 +41,7 @@ forge fmt
 - Access control: `docs/access-control.md`
 - Pausability: `docs/pausable.md`
 - Reentrancy guard: `docs/reentrancy-guard.md`
+- Upgrade guardrails: `docs/upgrade-guardrails.md`
 
 ## Tooling
 - Foundry docs: [book.getfoundry.sh](https://book.getfoundry.sh/)

--- a/docs/testing-conventions.md
+++ b/docs/testing-conventions.md
@@ -38,7 +38,10 @@ Use a split test layout so modules stay readable as complexity grows.
 - Core example: `test/AccessControlCore.t.sol`
 - Core example: `test/PausableCore.t.sol`
 - Core example: `test/ReentrancyGuardCore.t.sol`
+- Core example: `test/UpgradeGuardrailsCore.t.sol`
 - Time example: `test/AccessControlTime.t.sol`
+- Time example: `test/UpgradeGuardrailsTime.t.sol`
 - Helper example: `test/helpers/AccessControlTestHarness.sol`
 - Helper example: `test/helpers/PausableTestHarness.sol`
 - Helper example: `test/helpers/ReentrancyGuardTestHarness.sol`
+- Helper example: `test/helpers/UpgradeGuardrailsTestHarness.sol`

--- a/docs/upgrade-guardrails.md
+++ b/docs/upgrade-guardrails.md
@@ -1,0 +1,46 @@
+# Upgrade Guardrails
+
+This module adds role-gated controls for upgrade operations with queue/execute
+guardrails and an optional timelock.
+
+## Usage
+
+1. Inherit from `UpgradeGuardrails`.
+2. Configure `minDelaySeconds` in constructor/init.
+3. Queue upgrades with `queueUpgradeIntent(implementation)`.
+4. Execute upgrades with `executeUpgrade(implementation)` after delay checks.
+5. Optionally cancel queued intents with `cancelUpgradeIntent()`.
+6. Implement `_applyUpgrade` with protocol-specific upgrade logic.
+
+## Behavior
+
+- `UPGRADER_ROLE` gates queue/cancel/execute operations.
+- Queued implementation must be nonzero.
+- Execution requires a queued intent and exact implementation match.
+- Execution before `executeAfter` reverts.
+- When `minUpgradeDelay == 0`, queue and execute can happen immediately.
+- Intent is cleared on cancel and after successful execution.
+
+## Diamond-Ready Usage
+
+When used behind a diamond proxy, call the internal initializer from a facet or
+init contract:
+
+```solidity
+function initUpgradeGuardrails(address initialUpgrader, uint64 minDelaySeconds) external {
+    _initializeUpgradeGuardrails(initialUpgrader, minDelaySeconds);
+}
+```
+
+## Example
+
+```solidity
+contract MyUpgradeController is UpgradeGuardrails {
+    constructor(address admin, uint64 delay) UpgradeGuardrails(admin, delay) {}
+
+    function _applyUpgrade(address implementation) internal override {
+        // call proxy/diamond upgrade primitive here
+    }
+}
+```
+

--- a/src/interfaces/IUpgradeGuardrails.sol
+++ b/src/interfaces/IUpgradeGuardrails.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC165} from "./IERC165.sol";
+
+/// @title IUpgradeGuardrails
+/// @notice Interface for role-gated upgrade guard rails.
+interface IUpgradeGuardrails is IERC165 {
+    /// @notice Emitted when an upgrade intent is queued.
+    event UpgradeIntentQueued(address indexed implementation, uint64 executeAfter, address indexed sender);
+    /// @notice Emitted when an upgrade intent is cancelled.
+    event UpgradeIntentCancelled(address indexed implementation, address indexed sender);
+    /// @notice Emitted when an upgrade is executed.
+    event UpgradeExecuted(address indexed implementation, address indexed sender);
+
+    /// @notice Thrown when implementation is zero address.
+    error UpgradeGuardrailsZeroImplementation();
+    /// @notice Thrown when attempting to execute/cancel without a queued intent.
+    error UpgradeGuardrailsNoUpgradeIntent();
+    /// @notice Thrown when requested implementation does not match queued implementation.
+    error UpgradeGuardrailsImplementationNotQueued(address queuedImplementation, address requestedImplementation);
+    /// @notice Thrown when upgrade timelock is still active.
+    error UpgradeGuardrailsUpgradeNotReady(uint64 executeAfter, uint64 currentTime);
+    /// @notice Thrown when upgrade guardrails module is initialized more than once.
+    error UpgradeGuardrailsAlreadyInitialized();
+
+    /// @notice Role required to queue, cancel, and execute upgrades.
+    /// @return The upgrader role identifier.
+    function UPGRADER_ROLE() external view returns (bytes32);
+
+    /// @notice Returns the minimum required delay between queue and execute.
+    /// @return Delay in seconds.
+    function minUpgradeDelay() external view returns (uint64);
+
+    /// @notice Returns the currently queued upgrade intent.
+    /// @return implementation The queued implementation address.
+    /// @return executeAfter Earliest execution timestamp.
+    /// @return exists True when an intent is queued.
+    function getUpgradeIntent() external view returns (address implementation, uint64 executeAfter, bool exists);
+
+    /// @notice Queues an upgrade intent.
+    /// @param implementation The new implementation address.
+    function queueUpgradeIntent(address implementation) external;
+
+    /// @notice Cancels the currently queued upgrade intent.
+    function cancelUpgradeIntent() external;
+
+    /// @notice Executes a queued upgrade after guardrail checks.
+    /// @param implementation The queued implementation address.
+    function executeUpgrade(address implementation) external;
+}
+

--- a/src/upgrade/UpgradeGuardrails.sol
+++ b/src/upgrade/UpgradeGuardrails.sol
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {AccessControl} from "../access/AccessControl.sol";
+import {IERC165} from "../interfaces/IERC165.sol";
+import {IUpgradeGuardrails} from "../interfaces/IUpgradeGuardrails.sol";
+import {LibUpgradeGuardrailsStorage} from "./storage/LibUpgradeGuardrailsStorage.sol";
+
+/// @title UpgradeGuardrails
+/// @notice Role-gated queue/execute upgrade guard rails with optional timelock.
+/// @dev Uses `UPGRADER_ROLE` and diamond-ready storage.
+abstract contract UpgradeGuardrails is AccessControl, IUpgradeGuardrails {
+    /// @notice Role required to queue, cancel, and execute upgrades.
+    bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
+
+    /// @param initialAdmin The account to receive DEFAULT_ADMIN_ROLE.
+    /// @param minDelaySeconds The minimum delay between queue and execute.
+    constructor(address initialAdmin, uint64 minDelaySeconds) AccessControl(initialAdmin) {
+        _initializeUpgradeGuardrails(initialAdmin, minDelaySeconds);
+    }
+
+    /// @notice Returns the minimum required delay between queue and execute.
+    /// @return Delay in seconds.
+    function minUpgradeDelay() public view returns (uint64) {
+        return LibUpgradeGuardrailsStorage.layout().minUpgradeDelay;
+    }
+
+    /// @notice Returns the currently queued upgrade intent.
+    /// @return implementation The queued implementation address.
+    /// @return executeAfter Earliest execution timestamp.
+    /// @return exists True when an intent is queued.
+    function getUpgradeIntent() public view returns (address implementation, uint64 executeAfter, bool exists) {
+        LibUpgradeGuardrailsStorage.UpgradeIntent storage intent = LibUpgradeGuardrailsStorage.layout().intent;
+        return (intent.implementation, intent.executeAfter, intent.exists);
+    }
+
+    /// @notice Queues an upgrade intent.
+    /// @dev Caller must have `UPGRADER_ROLE`.
+    /// @param implementation The new implementation address.
+    function queueUpgradeIntent(address implementation) public onlyRole(UPGRADER_ROLE) {
+        _requireNonZeroImplementation(implementation);
+        uint64 executeAfter = uint64(block.timestamp) + minUpgradeDelay();
+
+        LibUpgradeGuardrailsStorage.UpgradeIntent storage intent = LibUpgradeGuardrailsStorage.layout().intent;
+        intent.implementation = implementation;
+        intent.executeAfter = executeAfter;
+        intent.exists = true;
+
+        emit UpgradeIntentQueued(implementation, executeAfter, msg.sender);
+    }
+
+    /// @notice Cancels the currently queued upgrade intent.
+    /// @dev Caller must have `UPGRADER_ROLE`.
+    function cancelUpgradeIntent() public onlyRole(UPGRADER_ROLE) {
+        LibUpgradeGuardrailsStorage.UpgradeIntent storage intent = LibUpgradeGuardrailsStorage.layout().intent;
+        if (!intent.exists) {
+            revert UpgradeGuardrailsNoUpgradeIntent();
+        }
+
+        address implementation = intent.implementation;
+        delete LibUpgradeGuardrailsStorage.layout().intent;
+        emit UpgradeIntentCancelled(implementation, msg.sender);
+    }
+
+    /// @notice Executes a queued upgrade after guardrail checks.
+    /// @dev Caller must have `UPGRADER_ROLE`.
+    /// @param implementation The queued implementation address.
+    function executeUpgrade(address implementation) public onlyRole(UPGRADER_ROLE) {
+        _requireNonZeroImplementation(implementation);
+        LibUpgradeGuardrailsStorage.UpgradeIntent storage intent = LibUpgradeGuardrailsStorage.layout().intent;
+        if (!intent.exists) {
+            revert UpgradeGuardrailsNoUpgradeIntent();
+        }
+        if (intent.implementation != implementation) {
+            revert UpgradeGuardrailsImplementationNotQueued(intent.implementation, implementation);
+        }
+
+        uint64 currentTime = uint64(block.timestamp);
+        if (currentTime < intent.executeAfter) {
+            revert UpgradeGuardrailsUpgradeNotReady(intent.executeAfter, currentTime);
+        }
+
+        delete LibUpgradeGuardrailsStorage.layout().intent;
+        _applyUpgrade(implementation);
+        emit UpgradeExecuted(implementation, msg.sender);
+    }
+
+    /// @notice Returns true if this contract implements `interfaceId`.
+    /// @param interfaceId The interface identifier.
+    /// @return True if the interface is supported.
+    function supportsInterface(bytes4 interfaceId) public view virtual override(AccessControl, IERC165) returns (bool) {
+        return interfaceId == type(IUpgradeGuardrails).interfaceId || interfaceId == type(IERC165).interfaceId
+            || super.supportsInterface(interfaceId);
+    }
+
+    /// @dev Initializes upgrade guardrails storage (diamond-ready).
+    /// @param initialUpgrader The account to receive `UPGRADER_ROLE`.
+    /// @param minDelaySeconds The minimum delay between queue and execute.
+    function _initializeUpgradeGuardrails(address initialUpgrader, uint64 minDelaySeconds) internal {
+        LibUpgradeGuardrailsStorage.Layout storage layout = LibUpgradeGuardrailsStorage.layout();
+        if (layout.initialized) {
+            revert UpgradeGuardrailsAlreadyInitialized();
+        }
+        _requireNonZeroAccount(initialUpgrader);
+
+        layout.initialized = true;
+        layout.minUpgradeDelay = minDelaySeconds;
+        _grantRole(UPGRADER_ROLE, initialUpgrader);
+    }
+
+    /// @dev Reverts when `implementation` is the zero address.
+    /// @param implementation The implementation to validate.
+    function _requireNonZeroImplementation(address implementation) internal pure {
+        if (implementation == address(0)) {
+            revert UpgradeGuardrailsZeroImplementation();
+        }
+    }
+
+    /// @dev Applies the upgrade operation after guardrail checks pass.
+    /// @param implementation The implementation to apply.
+    function _applyUpgrade(address implementation) internal virtual;
+}

--- a/src/upgrade/storage/LibUpgradeGuardrailsStorage.sol
+++ b/src/upgrade/storage/LibUpgradeGuardrailsStorage.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title LibUpgradeGuardrailsStorage
+/// @notice Storage layout for upgrade guardrails modules (diamond-ready).
+library LibUpgradeGuardrailsStorage {
+    /// @dev Storage slot for upgrade guardrails layout.
+    bytes32 internal constant STORAGE_SLOT = keccak256("smart-contracts.upgrade-guardrails.storage");
+
+    /// @notice Queued upgrade metadata.
+    struct UpgradeIntent {
+        address implementation;
+        uint64 executeAfter;
+        bool exists;
+    }
+
+    /// @notice Upgrade guardrails storage layout.
+    struct Layout {
+        bool initialized;
+        uint64 minUpgradeDelay;
+        UpgradeIntent intent;
+    }
+
+    /// @notice Returns the storage layout for upgrade guardrails state.
+    /// @return l The storage layout pointer.
+    function layout() internal pure returns (Layout storage l) {
+        bytes32 slot = STORAGE_SLOT;
+        assembly {
+            l.slot := slot
+        }
+    }
+}
+

--- a/test/UpgradeGuardrailsCore.t.sol
+++ b/test/UpgradeGuardrailsCore.t.sol
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {UpgradeGuardrailsFixture} from "./helpers/UpgradeGuardrailsTestHarness.sol";
+import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
+import {IAccessControlTime} from "../src/interfaces/IAccessControlTime.sol";
+import {IERC165} from "../src/interfaces/IERC165.sol";
+import {IUpgradeGuardrails} from "../src/interfaces/IUpgradeGuardrails.sol";
+
+contract UpgradeGuardrailsCoreTest is UpgradeGuardrailsFixture {
+    event UpgradeIntentQueued(address indexed implementation, uint64 executeAfter, address indexed sender);
+    event UpgradeIntentCancelled(address indexed implementation, address indexed sender);
+    event UpgradeExecuted(address indexed implementation, address indexed sender);
+
+    function testInitialAdminHasUpgraderRole() public view {
+        assertTrue(guardNoDelay.hasRole(guardNoDelay.UPGRADER_ROLE(), admin), "admin should have upgrader role");
+    }
+
+    function testSupportsInterface() public view {
+        assertTrue(guardNoDelay.supportsInterface(type(IERC165).interfaceId), "erc165 not supported");
+        assertTrue(
+            guardNoDelay.supportsInterface(type(IUpgradeGuardrails).interfaceId), "upgrade interface not supported"
+        );
+        assertTrue(guardNoDelay.supportsInterface(type(IAccessControl).interfaceId), "access control not supported");
+        assertTrue(
+            guardNoDelay.supportsInterface(type(IAccessControlTime).interfaceId), "access control time not supported"
+        );
+    }
+
+    function testMinUpgradeDelaySetAtInitialization() public view {
+        assertTrue(guardNoDelay.minUpgradeDelay() == 0, "no-delay guard should have zero delay");
+        assertTrue(guardDelayed.minUpgradeDelay() == DELAY_SECONDS, "delayed guard should keep configured delay");
+    }
+
+    function testInitializeRevertsWhenAlreadyInitialized() public {
+        VM.expectRevert(abi.encodeWithSelector(IUpgradeGuardrails.UpgradeGuardrailsAlreadyInitialized.selector));
+        guardNoDelay.initializeUpgradeGuardrailsExternal(admin, 0);
+    }
+
+    function testUnauthorizedCannotQueueUpgradeIntent() public {
+        VM.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, guardNoDelay.UPGRADER_ROLE())
+        );
+        VM.prank(bob);
+        guardNoDelay.queueUpgradeIntent(implementationA);
+    }
+
+    function testUnauthorizedCannotCancelUpgradeIntent() public {
+        VM.prank(admin);
+        guardNoDelay.queueUpgradeIntent(implementationA);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, guardNoDelay.UPGRADER_ROLE())
+        );
+        VM.prank(bob);
+        guardNoDelay.cancelUpgradeIntent();
+    }
+
+    function testUnauthorizedCannotExecuteUpgrade() public {
+        VM.prank(admin);
+        guardNoDelay.queueUpgradeIntent(implementationA);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, guardNoDelay.UPGRADER_ROLE())
+        );
+        VM.prank(bob);
+        guardNoDelay.executeUpgrade(implementationA);
+    }
+
+    function testQueueUpgradeIntentRejectsZeroImplementation() public {
+        VM.expectRevert(abi.encodeWithSelector(IUpgradeGuardrails.UpgradeGuardrailsZeroImplementation.selector));
+        VM.prank(admin);
+        guardNoDelay.queueUpgradeIntent(address(0));
+    }
+
+    function testQueueUpgradeIntentEmitsEvent() public {
+        uint64 expectedExecuteAfter = uint64(block.timestamp) + guardNoDelay.minUpgradeDelay();
+        VM.expectEmit(true, true, false, true, address(guardNoDelay));
+        emit UpgradeIntentQueued(implementationA, expectedExecuteAfter, admin);
+
+        VM.prank(admin);
+        guardNoDelay.queueUpgradeIntent(implementationA);
+    }
+
+    function testCancelUpgradeIntentWithoutQueueReverts() public {
+        VM.expectRevert(abi.encodeWithSelector(IUpgradeGuardrails.UpgradeGuardrailsNoUpgradeIntent.selector));
+        VM.prank(admin);
+        guardNoDelay.cancelUpgradeIntent();
+    }
+
+    function testCancelUpgradeIntentEmitsEvent() public {
+        VM.prank(admin);
+        guardNoDelay.queueUpgradeIntent(implementationA);
+
+        VM.expectEmit(true, true, false, false, address(guardNoDelay));
+        emit UpgradeIntentCancelled(implementationA, admin);
+
+        VM.prank(admin);
+        guardNoDelay.cancelUpgradeIntent();
+    }
+
+    function testExecuteUpgradeWithoutQueueReverts() public {
+        VM.expectRevert(abi.encodeWithSelector(IUpgradeGuardrails.UpgradeGuardrailsNoUpgradeIntent.selector));
+        VM.prank(admin);
+        guardNoDelay.executeUpgrade(implementationA);
+    }
+
+    function testExecuteUpgradeMismatchedImplementationReverts() public {
+        VM.prank(admin);
+        guardNoDelay.queueUpgradeIntent(implementationA);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IUpgradeGuardrails.UpgradeGuardrailsImplementationNotQueued.selector, implementationA, implementationB
+            )
+        );
+        VM.prank(admin);
+        guardNoDelay.executeUpgrade(implementationB);
+    }
+
+    function testExecuteUpgradeRejectsZeroImplementation() public {
+        VM.expectRevert(abi.encodeWithSelector(IUpgradeGuardrails.UpgradeGuardrailsZeroImplementation.selector));
+        VM.prank(admin);
+        guardNoDelay.executeUpgrade(address(0));
+    }
+
+    function testExecuteUpgradeWithZeroDelaySucceeds() public {
+        VM.prank(admin);
+        guardNoDelay.queueUpgradeIntent(implementationA);
+
+        VM.prank(admin);
+        guardNoDelay.executeUpgrade(implementationA);
+
+        assertTrue(guardNoDelay.implementation() == implementationA, "implementation should be updated");
+        assertTrue(guardNoDelay.executionCount() == 1, "execution count should increment");
+
+        (address implementation, uint64 executeAfter, bool exists) = guardNoDelay.getUpgradeIntent();
+        assertTrue(implementation == address(0) && executeAfter == 0, "intent values should reset");
+        assertFalse(exists, "intent should be cleared");
+    }
+
+    function testExecuteUpgradeEmitsEvent() public {
+        VM.prank(admin);
+        guardNoDelay.queueUpgradeIntent(implementationA);
+
+        VM.expectEmit(true, true, false, false, address(guardNoDelay));
+        emit UpgradeExecuted(implementationA, admin);
+
+        VM.prank(admin);
+        guardNoDelay.executeUpgrade(implementationA);
+    }
+
+    function testQueueIntentCanBeReplaced() public {
+        VM.prank(admin);
+        guardNoDelay.queueUpgradeIntent(implementationA);
+
+        VM.prank(admin);
+        guardNoDelay.queueUpgradeIntent(implementationB);
+
+        (address implementation, uint64 executeAfter, bool exists) = guardNoDelay.getUpgradeIntent();
+        assertTrue(exists, "intent should exist");
+        assertTrue(implementation == implementationB, "latest intent should replace prior one");
+        assertTrue(executeAfter == uint64(block.timestamp), "executeAfter should be current timestamp for zero delay");
+    }
+}
+

--- a/test/UpgradeGuardrailsTime.t.sol
+++ b/test/UpgradeGuardrailsTime.t.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {UpgradeGuardrailsFixture} from "./helpers/UpgradeGuardrailsTestHarness.sol";
+import {IUpgradeGuardrails} from "../src/interfaces/IUpgradeGuardrails.sol";
+
+contract UpgradeGuardrailsTimeTest is UpgradeGuardrailsFixture {
+    function testQueueUpgradeIntentSetsDelayedExecuteAfter() public {
+        uint64 expectedExecuteAfter = uint64(block.timestamp) + DELAY_SECONDS;
+
+        VM.prank(admin);
+        guardDelayed.queueUpgradeIntent(implementationA);
+
+        (address implementation, uint64 executeAfter, bool exists) = guardDelayed.getUpgradeIntent();
+        assertTrue(exists, "intent should exist");
+        assertTrue(implementation == implementationA, "implementation should match queued value");
+        assertTrue(executeAfter == expectedExecuteAfter, "executeAfter should include delay");
+    }
+
+    function testExecuteUpgradeBeforeDelayReverts() public {
+        VM.prank(admin);
+        guardDelayed.queueUpgradeIntent(implementationA);
+        (, uint64 executeAfter,) = guardDelayed.getUpgradeIntent();
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IUpgradeGuardrails.UpgradeGuardrailsUpgradeNotReady.selector, executeAfter, uint64(block.timestamp)
+            )
+        );
+        VM.prank(admin);
+        guardDelayed.executeUpgrade(implementationA);
+    }
+
+    function testExecuteUpgradeSucceedsAtDelayBoundary() public {
+        VM.prank(admin);
+        guardDelayed.queueUpgradeIntent(implementationA);
+        (, uint64 executeAfter,) = guardDelayed.getUpgradeIntent();
+
+        VM.warp(executeAfter);
+        VM.prank(admin);
+        guardDelayed.executeUpgrade(implementationA);
+
+        assertTrue(guardDelayed.implementation() == implementationA, "implementation should be updated");
+        assertTrue(guardDelayed.executionCount() == 1, "execution count should increment");
+    }
+
+    function testExecuteUpgradeSucceedsAfterDelayBoundary() public {
+        VM.prank(admin);
+        guardDelayed.queueUpgradeIntent(implementationA);
+        (, uint64 executeAfter,) = guardDelayed.getUpgradeIntent();
+
+        VM.warp(executeAfter + 5);
+        VM.prank(admin);
+        guardDelayed.executeUpgrade(implementationA);
+
+        assertTrue(guardDelayed.implementation() == implementationA, "implementation should be updated");
+        assertTrue(guardDelayed.executionCount() == 1, "execution count should increment");
+    }
+
+    function testCancelIntentThenRequeueResetsDelay() public {
+        VM.prank(admin);
+        guardDelayed.queueUpgradeIntent(implementationA);
+
+        VM.prank(admin);
+        guardDelayed.cancelUpgradeIntent();
+
+        VM.warp(block.timestamp + 10);
+        uint64 expectedExecuteAfter = uint64(block.timestamp) + DELAY_SECONDS;
+
+        VM.prank(admin);
+        guardDelayed.queueUpgradeIntent(implementationB);
+        (address implementation, uint64 executeAfter, bool exists) = guardDelayed.getUpgradeIntent();
+        assertTrue(exists, "intent should exist");
+        assertTrue(implementation == implementationB, "implementation should match latest queue");
+        assertTrue(executeAfter == expectedExecuteAfter, "delay should be recalculated from new queue time");
+    }
+}
+

--- a/test/helpers/UpgradeGuardrailsTestHarness.sol
+++ b/test/helpers/UpgradeGuardrailsTestHarness.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {UpgradeGuardrails} from "../../src/upgrade/UpgradeGuardrails.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+
+contract UpgradeGuardrailsHarness is UpgradeGuardrails {
+    address public implementation;
+    uint256 public executionCount;
+
+    constructor(address initialAdmin, uint64 minDelaySeconds) UpgradeGuardrails(initialAdmin, minDelaySeconds) {}
+
+    function initializeUpgradeGuardrailsExternal(address initialUpgrader, uint64 minDelaySeconds) external {
+        _initializeUpgradeGuardrails(initialUpgrader, minDelaySeconds);
+    }
+
+    function _applyUpgrade(address newImplementation) internal override {
+        implementation = newImplementation;
+        executionCount += 1;
+    }
+}
+
+abstract contract UpgradeGuardrailsFixture is TestBase {
+    uint64 internal constant DELAY_SECONDS = 1 days;
+
+    address internal admin = address(0xA11CE);
+    address internal bob = address(0xB0B);
+
+    address internal implementationA = address(0x1000A);
+    address internal implementationB = address(0x1000B);
+
+    UpgradeGuardrailsHarness internal guardNoDelay;
+    UpgradeGuardrailsHarness internal guardDelayed;
+
+    function setUp() public virtual {
+        guardNoDelay = new UpgradeGuardrailsHarness(admin, 0);
+        guardDelayed = new UpgradeGuardrailsHarness(admin, DELAY_SECONDS);
+    }
+}
+


### PR DESCRIPTION
## Summary
Implements upgrade guardrails to reduce operational risk during upgrade operations.

## What Changed
- Added `IUpgradeGuardrails`:
  - role constant + upgrade intent getters
  - queue/cancel/execute functions
  - custom errors and events
- Added `LibUpgradeGuardrailsStorage` (diamond-ready fixed slot).
- Added `UpgradeGuardrails` module:
  - `UPGRADER_ROLE` authorization
  - `queueUpgradeIntent`, `cancelUpgradeIntent`, `executeUpgrade`
  - pre-upgrade checks:
    - nonzero implementation
    - queued intent required
    - implementation must match queued intent
    - optional timelock (`minUpgradeDelay`)
  - `_applyUpgrade` hook for protocol-specific execution
- Added tests:
  - `test/UpgradeGuardrailsCore.t.sol`
  - `test/UpgradeGuardrailsTime.t.sol`
  - `test/helpers/UpgradeGuardrailsTestHarness.sol`
- Added docs:
  - `docs/upgrade-guardrails.md`
  - README/testing-conventions updates

## Validation
- `forge fmt`
- `forge test --offline`

Result: all tests passing.

## Issue
Closes #4 