### PR TITLE
test(docs): add fuzz coverage and threat model for access safety kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ forge fmt
 - Pausability: `docs/pausable.md`
 - Reentrancy guard: `docs/reentrancy-guard.md`
 - Upgrade guardrails: `docs/upgrade-guardrails.md`
+- Threat model: `docs/threat-model.md`
 
 ## Tooling
 - Foundry docs: [book.getfoundry.sh](https://book.getfoundry.sh/)

--- a/docs/testing-conventions.md
+++ b/docs/testing-conventions.md
@@ -6,6 +6,7 @@ Use a split test layout so modules stay readable as complexity grows.
 
 - `test/<Module>Core.t.sol`
 - `test/<Module>Time.t.sol` (only when time-window behavior exists)
+- `test/<Module>Fuzz.t.sol` (for property/fuzz coverage)
 - `test/<Module>Integration.t.sol` (optional, cross-module workflows)
 - `test/helpers/<Module>TestHarness.sol`
 
@@ -14,6 +15,7 @@ Use a split test layout so modules stay readable as complexity grows.
 - `Core`: role checks, permissions, initialization, enumeration, idempotency.
 - `Time`: schedule/window logic, boundary timestamps, active/inactive checks.
 - `Integration`: interactions between modules and end-to-end flows.
+- `Fuzz`: property-style checks across random inputs and edge value ranges.
 - `helpers`: shared fixture setup, actors, harness wrappers, and utility assertions.
 
 ## Naming
@@ -32,6 +34,7 @@ Use a split test layout so modules stay readable as complexity grows.
 - Keep revert expectation tests close to the feature they validate.
 - Add explicit event assertion tests for every emitted event.
 - Prefer deterministic timestamps (`vm.warp`) for time-based tests.
+- Keep fuzz assertions invariant-oriented (state/permission properties, not exact gas values).
 
 ## Current Reference
 
@@ -39,6 +42,9 @@ Use a split test layout so modules stay readable as complexity grows.
 - Core example: `test/PausableCore.t.sol`
 - Core example: `test/ReentrancyGuardCore.t.sol`
 - Core example: `test/UpgradeGuardrailsCore.t.sol`
+- Fuzz example: `test/AccessControlFuzz.t.sol`
+- Fuzz example: `test/PausableFuzz.t.sol`
+- Fuzz example: `test/UpgradeGuardrailsFuzz.t.sol`
 - Time example: `test/AccessControlTime.t.sol`
 - Time example: `test/UpgradeGuardrailsTime.t.sol`
 - Helper example: `test/helpers/AccessControlTestHarness.sol`

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,0 +1,57 @@
+# Threat Model
+
+This summary covers the security assumptions and guard rails for the
+Access Control + Upgrade Safety Kit modules.
+
+## In-Scope Modules
+
+- `AccessControl`
+- `Pausable`
+- `ReentrancyGuard`
+- `UpgradeGuardrails`
+
+## Security Goals
+
+- Unauthorized accounts cannot perform privileged actions.
+- Role administration and permission state changes are explicit and auditable.
+- Emergency pause controls can contain incidents.
+- Reentrant state-changing entrypoints are blocked.
+- Upgrade execution follows explicit authorization and guardrail checks.
+
+## Trust Assumptions
+
+- Initial admin/upgrader/pauser assignments are correct at initialization.
+- Governance/operator keys are managed securely off-chain.
+- Deployed contracts integrate `_applyUpgrade` correctly for their proxy/diamond mechanism.
+- Time-based checks rely on `block.timestamp` and accept normal timestamp variance.
+
+## Key Threats and Mitigations
+
+1. Privilege escalation
+- Mitigation: role-based checks (`onlyRole`), role admin hierarchy, explicit grant/revoke/renounce flows.
+
+2. Misuse of temporary permissions
+- Mitigation: role windows with start/end bounds and active-role checks.
+
+3. Incident blast radius
+- Mitigation: global and scoped pausing, plus role-gated pause/unpause controls.
+
+4. Reentrant write-path execution
+- Mitigation: `nonReentrant` guard for state-changing entrypoints.
+
+5. Unsafe or rushed upgrades
+- Mitigation: upgrader role, queued intent model, optional timelock delay, strict implementation matching, cancel flow.
+
+## Residual Risks / Out of Scope
+
+- Compromised privileged keys can still perform privileged actions.
+- Economic attacks and protocol-specific business logic exploits are out of scope for this base kit.
+- Diamond-specific `diamondCut` payload validation and multi-step governance workflows are deferred to the diamond milestone.
+- The current upgrade guardrails check nonzero implementation; deeper bytecode/interface validation is protocol-specific and should be added where needed.
+
+## Operational Guidance
+
+- Use multisig-controlled privileged roles in production.
+- Set nonzero upgrade delays in production.
+- Restrict and monitor role admin changes.
+- Keep pause and upgrade procedures documented and rehearsed.

--- a/test/AccessControlFuzz.t.sol
+++ b/test/AccessControlFuzz.t.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {AccessControlFixture} from "./helpers/AccessControlTestHarness.sol";
+
+contract AccessControlFuzzTest is AccessControlFixture {
+    function testFuzzGrantRevokeRoundTrip(bytes32 role, address account) public {
+        VM.assume(account != address(0));
+
+        VM.prank(admin);
+        ac.grantRole(role, account);
+        assertTrue(ac.hasRole(role, account), "role should be granted");
+
+        VM.prank(admin);
+        ac.revokeRole(role, account);
+        assertFalse(ac.hasRole(role, account), "role should be revoked");
+    }
+
+    function testFuzzGrantRoleIdempotent(bytes32 role, address account) public {
+        VM.assume(account != address(0));
+        VM.assume(role != ac.DEFAULT_ADMIN_ROLE());
+
+        VM.prank(admin);
+        ac.grantRole(role, account);
+        VM.prank(admin);
+        ac.grantRole(role, account);
+
+        assertTrue(ac.hasRole(role, account), "role should remain granted");
+        assertTrue(ac.getRoleMemberCount(role) == 1, "duplicate grant should not duplicate member");
+    }
+
+    function testFuzzSetRoleWindowRoundTrip(bytes32 role, address account, uint64 start, uint32 rawDuration) public {
+        VM.assume(account != address(0));
+
+        uint64 duration = uint64((rawDuration % 30 days) + 1);
+        if (start > type(uint64).max - duration) {
+            start = type(uint64).max - duration;
+        }
+        uint64 end = start + duration;
+
+        VM.prank(admin);
+        ac.setRoleWindow(role, account, start, end);
+
+        (uint64 readStart, uint64 readEnd, bool exists) = ac.getRoleWindow(role, account);
+        assertTrue(exists, "window should exist");
+        assertTrue(readStart == start, "window start should match");
+        assertTrue(readEnd == end, "window end should match");
+    }
+}
+

--- a/test/PausableFuzz.t.sol
+++ b/test/PausableFuzz.t.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {PausableFixture} from "./helpers/PausableTestHarness.sol";
+import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
+import {IPausable} from "../src/interfaces/IPausable.sol";
+
+contract PausableFuzzTest is PausableFixture {
+    function testFuzzPauseScopeRoundTrip(bytes32 scope) public {
+        VM.assume(scope != bytes32(0));
+
+        VM.prank(admin);
+        pausable.pauseScope(scope);
+        assertTrue(pausable.scopePaused(scope), "scope should be paused");
+        assertTrue(pausable.paused(scope), "effective scope pause should be true");
+
+        VM.prank(admin);
+        pausable.unpauseScope(scope);
+        assertFalse(pausable.scopePaused(scope), "scope should be unpaused");
+        assertFalse(pausable.paused(scope), "effective scope pause should be false");
+    }
+
+    function testFuzzGlobalPauseOverridesAnyScope(bytes32 scope) public {
+        VM.assume(scope != bytes32(0));
+
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeExpectedPause.selector, scope));
+        pausable.scopedEmergencyAction(scope);
+
+        VM.prank(admin);
+        pausable.pause();
+
+        assertTrue(pausable.paused(scope), "global pause should force effective scope pause");
+        assertTrue(pausable.scopedEmergencyAction(scope), "scoped emergency action should pass during global pause");
+    }
+
+    function testFuzzDistinctScopeIsolation(bytes32 scopeA, bytes32 scopeB) public {
+        VM.assume(scopeA != bytes32(0));
+        VM.assume(scopeB != bytes32(0));
+        VM.assume(scopeA != scopeB);
+
+        VM.prank(admin);
+        pausable.pauseScope(scopeA);
+
+        assertTrue(pausable.scopePaused(scopeA), "scopeA should be paused");
+        assertFalse(pausable.scopePaused(scopeB), "scopeB should remain unpaused");
+        assertFalse(pausable.paused(scopeB), "effective scopeB pause should remain false");
+
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeExpectedPause.selector, scopeB));
+        pausable.scopedEmergencyAction(scopeB);
+        assertTrue(pausable.scopedEmergencyAction(scopeA), "scopeA emergency action should pass");
+    }
+
+    function testFuzzUnauthorizedScopePauseReverts(address actor, bytes32 scope) public {
+        VM.assume(actor != address(0));
+        VM.assume(actor != admin);
+        VM.assume(scope != bytes32(0));
+
+        VM.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, actor, pausable.PAUSER_ROLE())
+        );
+        VM.prank(actor);
+        pausable.pauseScope(scope);
+    }
+}
+

--- a/test/UpgradeGuardrailsFuzz.t.sol
+++ b/test/UpgradeGuardrailsFuzz.t.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {UpgradeGuardrailsFixture, UpgradeGuardrailsHarness} from "./helpers/UpgradeGuardrailsTestHarness.sol";
+import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
+import {IUpgradeGuardrails} from "../src/interfaces/IUpgradeGuardrails.sol";
+
+contract UpgradeGuardrailsFuzzTest is UpgradeGuardrailsFixture {
+    function testFuzzQueueSetsExecuteAfter(uint32 rawDelay, address implementation) public {
+        VM.assume(implementation != address(0));
+        uint64 delay = uint64(rawDelay);
+        UpgradeGuardrailsHarness guard = new UpgradeGuardrailsHarness(admin, delay);
+        uint64 expectedExecuteAfter = uint64(block.timestamp) + delay;
+
+        VM.prank(admin);
+        guard.queueUpgradeIntent(implementation);
+
+        (address queuedImplementation, uint64 executeAfter, bool exists) = guard.getUpgradeIntent();
+        assertTrue(exists, "intent should exist");
+        assertTrue(queuedImplementation == implementation, "implementation should match queue input");
+        assertTrue(executeAfter == expectedExecuteAfter, "executeAfter should equal queue time + delay");
+    }
+
+    function testFuzzExecuteAfterDelaySucceeds(uint32 rawDelay, address implementation, uint16 extraSeconds) public {
+        VM.assume(implementation != address(0));
+        uint64 delay = uint64((rawDelay % 7 days) + 1);
+        UpgradeGuardrailsHarness guard = new UpgradeGuardrailsHarness(admin, delay);
+
+        VM.prank(admin);
+        guard.queueUpgradeIntent(implementation);
+        (, uint64 executeAfter,) = guard.getUpgradeIntent();
+
+        VM.warp(uint256(executeAfter) + uint256(extraSeconds));
+        VM.prank(admin);
+        guard.executeUpgrade(implementation);
+
+        assertTrue(guard.implementation() == implementation, "implementation should update after ready time");
+    }
+
+    function testFuzzExecuteBeforeDelayReverts(uint32 rawDelay, address implementation) public {
+        VM.assume(implementation != address(0));
+        uint64 delay = uint64((rawDelay % 7 days) + 1);
+        UpgradeGuardrailsHarness guard = new UpgradeGuardrailsHarness(admin, delay);
+
+        VM.prank(admin);
+        guard.queueUpgradeIntent(implementation);
+        (, uint64 executeAfter,) = guard.getUpgradeIntent();
+
+        uint64 earlyTime = executeAfter - 1;
+        VM.warp(earlyTime);
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IUpgradeGuardrails.UpgradeGuardrailsUpgradeNotReady.selector, executeAfter, earlyTime
+            )
+        );
+        VM.prank(admin);
+        guard.executeUpgrade(implementation);
+    }
+
+    function testFuzzQueueIntentReplacement(address implA, address implB) public {
+        VM.assume(implA != address(0));
+        VM.assume(implB != address(0));
+        VM.assume(implA != implB);
+
+        VM.prank(admin);
+        guardNoDelay.queueUpgradeIntent(implA);
+        VM.prank(admin);
+        guardNoDelay.queueUpgradeIntent(implB);
+
+        (address queuedImplementation,, bool exists) = guardNoDelay.getUpgradeIntent();
+        assertTrue(exists, "intent should exist");
+        assertTrue(queuedImplementation == implB, "latest intent should replace previous implementation");
+    }
+
+    function testFuzzUnauthorizedQueueReverts(address actor, address implementation) public {
+        VM.assume(actor != address(0));
+        VM.assume(actor != admin);
+        VM.assume(implementation != address(0));
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorized.selector, actor, guardNoDelay.UPGRADER_ROLE()
+            )
+        );
+        VM.prank(actor);
+        guardNoDelay.queueUpgradeIntent(implementation);
+    }
+}
+

--- a/test/helpers/AccessControlTestHarness.sol
+++ b/test/helpers/AccessControlTestHarness.sol
@@ -7,6 +7,7 @@ interface Vm {
     function prank(address) external;
     function startPrank(address) external;
     function stopPrank() external;
+    function assume(bool) external;
     function expectRevert(bytes calldata) external;
     function expectEmit(bool, bool, bool, bool) external;
     function expectEmit(bool, bool, bool, bool, address) external;


### PR DESCRIPTION
## Summary
Completes the Access Control + Upgrade Safety Kit hardening pass by adding property/fuzz tests and a concise threat model/security assumptions document.

## What Changed
- Added fuzz/property tests:
  - `test/AccessControlFuzz.t.sol`
  - `test/PausableFuzz.t.sol`
  - `test/UpgradeGuardrailsFuzz.t.sol`
- Extended test helper cheatcodes for fuzz assumptions:
  - `test/helpers/AccessControlTestHarness.sol`
- Added security assumptions/threat model:
  - `docs/threat-model.md`
- Updated docs index and testing conventions:
  - `README.md`
  - `docs/testing-conventions.md`

## Validation
- `forge fmt`
- `forge test --offline`

Result: all tests passing (`103 passed, 0 failed`).

## Issue
Closes #5