### PR TITLE
feat(oracle): add diamond-ready oracle adapter interfaces, storage, and core module

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ facets without a full rewrite.
 - `src/access/storage`: module-local storage libraries (diamond-ready slots).
 - `src/security`: security primitives such as reentrancy protection.
 - `src/security/storage`: module-local storage libraries (diamond-ready slots).
+- `src/oracle`: oracle adapter and feed safety primitives.
+- `src/oracle/storage`: module-local storage libraries (diamond-ready slots).
 - `src/upgrade`: upgrade authorization and execution guardrails.
 - `src/upgrade/storage`: module-local storage libraries (diamond-ready slots).
-- `src/interfaces`: local interfaces (ERC-165, `IAccessControl`, `IAccessControlTime`, `IPausable`, `IReentrancyGuard`, `IUpgradeGuardrails`, etc.).
+- `src/interfaces`: local interfaces (ERC-165, `IAccessControl`, `IAccessControlTime`, `IOracleAdapter`, `IOracleFeed`, `IPausable`, `IReentrancyGuard`, `IUpgradeGuardrails`, etc.).
 - `src/libraries`: shared cross-module libraries.
 - `test`: split by concern (`*Core.t.sol`, `*Time.t.sol`, `*Integration.t.sol`).
 - `test/helpers`: shared test fixtures and harnesses.
@@ -39,6 +41,7 @@ forge fmt
 
 ## Module Docs
 - Access control: `docs/access-control.md`
+- Oracle adapter: `docs/oracle-adapter.md`
 - Pausability: `docs/pausable.md`
 - Reentrancy guard: `docs/reentrancy-guard.md`
 - Upgrade guardrails: `docs/upgrade-guardrails.md`

--- a/docs/oracle-adapter.md
+++ b/docs/oracle-adapter.md
@@ -1,0 +1,39 @@
+# Oracle Adapter
+
+This module defines the oracle adapter foundation for the oracle milestone:
+- provider-facing feed interface
+- normalized quote read interface
+- upgrade-safe storage layout and initializer guard
+
+## Interfaces
+
+- `IOracleFeed`: provider-facing feed reader (Chainlink-style round data).
+- `IOracleAdapter`: normalized adapter API and base configuration surface.
+
+`IOracleAdapter.OracleQuote` returns:
+- `value`: signed raw feed value
+- `updatedAt`: feed update timestamp (normalized to `uint64`)
+- `decimals`: feed decimals
+
+## Base Module Behavior
+
+`OracleAdapter` currently provides:
+- source address management
+- max staleness config storage
+- normalized quote read passthrough from source
+- initializer guard for upgrade-safe deployments
+
+Validation policy (staleness, bounds, and validity checks) is implemented in
+the next issue (`#15`).
+
+## Diamond-Ready Usage
+
+When used behind a diamond proxy, call the internal initializer from a facet or
+init contract:
+
+```solidity
+function initOracleAdapter(address source, uint64 maxStaleness) external {
+    _initializeOracleAdapter(source, maxStaleness);
+}
+```
+

--- a/docs/testing-conventions.md
+++ b/docs/testing-conventions.md
@@ -41,6 +41,7 @@ Use a split test layout so modules stay readable as complexity grows.
 - Core example: `test/AccessControlCore.t.sol`
 - Core example: `test/PausableCore.t.sol`
 - Core example: `test/ReentrancyGuardCore.t.sol`
+- Core example: `test/OracleAdapterCore.t.sol`
 - Core example: `test/UpgradeGuardrailsCore.t.sol`
 - Fuzz example: `test/AccessControlFuzz.t.sol`
 - Fuzz example: `test/PausableFuzz.t.sol`
@@ -49,5 +50,6 @@ Use a split test layout so modules stay readable as complexity grows.
 - Time example: `test/UpgradeGuardrailsTime.t.sol`
 - Helper example: `test/helpers/AccessControlTestHarness.sol`
 - Helper example: `test/helpers/PausableTestHarness.sol`
+- Helper example: `test/helpers/OracleAdapterTestHarness.sol`
 - Helper example: `test/helpers/ReentrancyGuardTestHarness.sol`
 - Helper example: `test/helpers/UpgradeGuardrailsTestHarness.sol`

--- a/src/interfaces/IOracleAdapter.sol
+++ b/src/interfaces/IOracleAdapter.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC165} from "./IERC165.sol";
+
+/// @title IOracleAdapter
+/// @notice Interface for normalized oracle adapter reads and base configuration.
+interface IOracleAdapter is IERC165 {
+    /// @notice Normalized oracle quote returned by the adapter.
+    struct OracleQuote {
+        int256 value;
+        uint64 updatedAt;
+        uint8 decimals;
+    }
+
+    /// @notice Emitted when oracle source is updated.
+    event OracleSourceUpdated(address indexed previousSource, address indexed newSource, address indexed sender);
+    /// @notice Emitted when max staleness is updated.
+    event OracleMaxStalenessUpdated(uint64 previousMaxStaleness, uint64 newMaxStaleness, address indexed sender);
+
+    /// @notice Thrown when the oracle source address is zero.
+    error OracleAdapterZeroSource();
+    /// @notice Thrown when adapter initializer runs more than once.
+    error OracleAdapterAlreadyInitialized();
+    /// @notice Thrown when feed timestamp does not fit in uint64.
+    error OracleAdapterInvalidUpdatedAt(uint256 updatedAt);
+
+    /// @notice Returns the configured oracle source address.
+    /// @return The oracle source contract.
+    function oracleSource() external view returns (address);
+
+    /// @notice Returns the configured max accepted staleness in seconds.
+    /// @return The max staleness window.
+    function maxStaleness() external view returns (uint64);
+
+    /// @notice Returns the latest normalized quote from the configured source.
+    /// @return quote The latest normalized quote payload.
+    function quote() external view returns (OracleQuote memory quote);
+
+    /// @notice Updates the oracle source.
+    /// @param newSource The new oracle source contract.
+    function setOracleSource(address newSource) external;
+
+    /// @notice Updates the max staleness window.
+    /// @param newMaxStaleness New staleness threshold in seconds.
+    function setMaxStaleness(uint64 newMaxStaleness) external;
+}
+

--- a/src/interfaces/IOracleFeed.sol
+++ b/src/interfaces/IOracleFeed.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title IOracleFeed
+/// @notice Provider-facing oracle feed interface (Chainlink-style round data).
+interface IOracleFeed {
+    /// @notice Returns feed decimals for answer normalization.
+    /// @return The number of decimals used by the feed answer.
+    function decimals() external view returns (uint8);
+
+    /// @notice Returns the latest round data.
+    /// @return roundId The round identifier.
+    /// @return answer The raw signed answer.
+    /// @return startedAt Timestamp when the round started.
+    /// @return updatedAt Timestamp when the round was updated.
+    /// @return answeredInRound The round in which the answer was computed.
+    function latestRoundData()
+        external
+        view
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound);
+}
+

--- a/src/oracle/OracleAdapter.sol
+++ b/src/oracle/OracleAdapter.sol
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {AccessControl} from "../access/AccessControl.sol";
+import {IOracleAdapter} from "../interfaces/IOracleAdapter.sol";
+import {IOracleFeed} from "../interfaces/IOracleFeed.sol";
+import {IERC165} from "../interfaces/IERC165.sol";
+import {LibOracleAdapterStorage} from "./storage/LibOracleAdapterStorage.sol";
+
+/// @title OracleAdapter
+/// @notice Base oracle adapter with normalized quote reads and upgrade-safe storage.
+/// @dev Uses DEFAULT_ADMIN_ROLE for baseline configuration controls.
+abstract contract OracleAdapter is AccessControl, IOracleAdapter {
+    /// @param initialAdmin The account to receive DEFAULT_ADMIN_ROLE.
+    /// @param initialSource The initial oracle feed source.
+    /// @param initialMaxStaleness The initial max staleness threshold.
+    constructor(address initialAdmin, address initialSource, uint64 initialMaxStaleness) AccessControl(initialAdmin) {
+        _initializeOracleAdapter(initialSource, initialMaxStaleness);
+    }
+
+    /// @notice Returns the configured oracle source address.
+    /// @return The oracle source contract.
+    function oracleSource() public view returns (address) {
+        return LibOracleAdapterStorage.layout().source;
+    }
+
+    /// @notice Returns the configured max accepted staleness in seconds.
+    /// @return The max staleness window.
+    function maxStaleness() public view returns (uint64) {
+        return LibOracleAdapterStorage.layout().maxStaleness;
+    }
+
+    /// @notice Returns the latest normalized quote from the configured source.
+    /// @return quotePayload The latest normalized quote payload.
+    function quote() public view returns (OracleQuote memory quotePayload) {
+        (, int256 answer,, uint256 updatedAt,) = IOracleFeed(oracleSource()).latestRoundData();
+        if (updatedAt > type(uint64).max) {
+            revert OracleAdapterInvalidUpdatedAt(updatedAt);
+        }
+
+        quotePayload = OracleQuote({
+            value: answer, updatedAt: uint64(updatedAt), decimals: IOracleFeed(oracleSource()).decimals()
+        });
+    }
+
+    /// @notice Updates the oracle source.
+    /// @dev Caller must have DEFAULT_ADMIN_ROLE.
+    /// @param newSource The new oracle source contract.
+    function setOracleSource(address newSource) public onlyRole(DEFAULT_ADMIN_ROLE) {
+        _setOracleSource(newSource);
+    }
+
+    /// @notice Updates the max staleness window.
+    /// @dev Caller must have DEFAULT_ADMIN_ROLE.
+    /// @param newMaxStaleness New staleness threshold in seconds.
+    function setMaxStaleness(uint64 newMaxStaleness) public onlyRole(DEFAULT_ADMIN_ROLE) {
+        _setMaxStaleness(newMaxStaleness);
+    }
+
+    /// @notice Returns true if this contract implements `interfaceId`.
+    /// @param interfaceId The interface identifier.
+    /// @return True if the interface is supported.
+    function supportsInterface(bytes4 interfaceId) public view virtual override(AccessControl, IERC165) returns (bool) {
+        return interfaceId == type(IOracleAdapter).interfaceId || interfaceId == type(IERC165).interfaceId
+            || super.supportsInterface(interfaceId);
+    }
+
+    /// @dev Initializes oracle adapter storage (diamond-ready).
+    /// @param initialSource The initial oracle feed source.
+    /// @param initialMaxStaleness The initial max staleness threshold.
+    function _initializeOracleAdapter(address initialSource, uint64 initialMaxStaleness) internal {
+        LibOracleAdapterStorage.Layout storage layout = LibOracleAdapterStorage.layout();
+        if (layout.initialized) {
+            revert OracleAdapterAlreadyInitialized();
+        }
+        layout.initialized = true;
+        _setOracleSource(initialSource);
+        _setMaxStaleness(initialMaxStaleness);
+    }
+
+    /// @dev Sets oracle source after validation.
+    /// @param newSource The new oracle source contract.
+    function _setOracleSource(address newSource) internal {
+        if (newSource == address(0)) {
+            revert OracleAdapterZeroSource();
+        }
+
+        LibOracleAdapterStorage.Layout storage layout = LibOracleAdapterStorage.layout();
+        address previousSource = layout.source;
+        layout.source = newSource;
+        emit OracleSourceUpdated(previousSource, newSource, msg.sender);
+    }
+
+    /// @dev Sets max staleness threshold.
+    /// @param newMaxStaleness New staleness threshold in seconds.
+    function _setMaxStaleness(uint64 newMaxStaleness) internal {
+        LibOracleAdapterStorage.Layout storage layout = LibOracleAdapterStorage.layout();
+        uint64 previousMaxStaleness = layout.maxStaleness;
+        layout.maxStaleness = newMaxStaleness;
+        emit OracleMaxStalenessUpdated(previousMaxStaleness, newMaxStaleness, msg.sender);
+    }
+}
+

--- a/src/oracle/storage/LibOracleAdapterStorage.sol
+++ b/src/oracle/storage/LibOracleAdapterStorage.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title LibOracleAdapterStorage
+/// @notice Storage layout for oracle adapter modules (diamond-ready).
+library LibOracleAdapterStorage {
+    /// @dev Storage slot for oracle adapter layout.
+    bytes32 internal constant STORAGE_SLOT = keccak256("smart-contracts.oracle-adapter.storage");
+
+    /// @notice Oracle adapter storage layout.
+    struct Layout {
+        bool initialized;
+        address source;
+        uint64 maxStaleness;
+    }
+
+    /// @notice Returns the storage layout for oracle adapter state.
+    /// @return l The storage layout pointer.
+    function layout() internal pure returns (Layout storage l) {
+        bytes32 slot = STORAGE_SLOT;
+        assembly {
+            l.slot := slot
+        }
+    }
+}
+

--- a/test/OracleAdapterCore.t.sol
+++ b/test/OracleAdapterCore.t.sol
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {OracleAdapterFixture, OracleAdapterHarness, MockOracleFeed} from "./helpers/OracleAdapterTestHarness.sol";
+import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
+import {IAccessControlTime} from "../src/interfaces/IAccessControlTime.sol";
+import {IERC165} from "../src/interfaces/IERC165.sol";
+import {IOracleAdapter} from "../src/interfaces/IOracleAdapter.sol";
+
+contract OracleAdapterCoreTest is OracleAdapterFixture {
+    event OracleSourceUpdated(address indexed previousSource, address indexed newSource, address indexed sender);
+    event OracleMaxStalenessUpdated(uint64 previousMaxStaleness, uint64 newMaxStaleness, address indexed sender);
+
+    function testInitialConfig() public view {
+        assertTrue(adapter.oracleSource() == address(feedA), "initial source should match constructor");
+        assertTrue(adapter.maxStaleness() == maxStaleness, "initial max staleness should match constructor");
+    }
+
+    function testSupportsInterface() public view {
+        assertTrue(adapter.supportsInterface(type(IERC165).interfaceId), "erc165 not supported");
+        assertTrue(adapter.supportsInterface(type(IOracleAdapter).interfaceId), "oracle adapter not supported");
+        assertTrue(adapter.supportsInterface(type(IAccessControl).interfaceId), "access control not supported");
+        assertTrue(adapter.supportsInterface(type(IAccessControlTime).interfaceId), "access control time not supported");
+    }
+
+    function testInitializeRevertsWhenAlreadyInitialized() public {
+        VM.expectRevert(abi.encodeWithSelector(IOracleAdapter.OracleAdapterAlreadyInitialized.selector));
+        adapter.initializeOracleAdapterExternal(address(feedA), maxStaleness);
+    }
+
+    function testZeroSourceRevertsOnConstruction() public {
+        VM.expectRevert(abi.encodeWithSelector(IOracleAdapter.OracleAdapterZeroSource.selector));
+        new OracleAdapterHarness(admin, address(0), maxStaleness);
+    }
+
+    function testAdminCanSetOracleSource() public {
+        VM.prank(admin);
+        adapter.setOracleSource(address(feedB));
+        assertTrue(adapter.oracleSource() == address(feedB), "source should update");
+    }
+
+    function testSetOracleSourceEmitsEvent() public {
+        VM.expectEmit(true, true, true, false, address(adapter));
+        emit OracleSourceUpdated(address(feedA), address(feedB), admin);
+
+        VM.prank(admin);
+        adapter.setOracleSource(address(feedB));
+    }
+
+    function testNonAdminCannotSetOracleSource() public {
+        VM.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, adapter.DEFAULT_ADMIN_ROLE())
+        );
+        VM.prank(bob);
+        adapter.setOracleSource(address(feedB));
+    }
+
+    function testSetOracleSourceRejectsZeroAddress() public {
+        VM.expectRevert(abi.encodeWithSelector(IOracleAdapter.OracleAdapterZeroSource.selector));
+        VM.prank(admin);
+        adapter.setOracleSource(address(0));
+    }
+
+    function testAdminCanSetMaxStaleness() public {
+        VM.prank(admin);
+        adapter.setMaxStaleness(2 hours);
+        assertTrue(adapter.maxStaleness() == 2 hours, "max staleness should update");
+    }
+
+    function testSetMaxStalenessEmitsEvent() public {
+        VM.expectEmit(true, true, true, true, address(adapter));
+        emit OracleMaxStalenessUpdated(maxStaleness, 2 hours, admin);
+
+        VM.prank(admin);
+        adapter.setMaxStaleness(2 hours);
+    }
+
+    function testNonAdminCannotSetMaxStaleness() public {
+        VM.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, adapter.DEFAULT_ADMIN_ROLE())
+        );
+        VM.prank(bob);
+        adapter.setMaxStaleness(2 hours);
+    }
+
+    function testQuoteReturnsNormalizedPayload() public view {
+        IOracleAdapter.OracleQuote memory readQuote = adapter.quote();
+        assertTrue(readQuote.value == 100_000_000, "value should match source answer");
+        assertTrue(readQuote.updatedAt == 100, "updatedAt should match source");
+        assertTrue(readQuote.decimals == 8, "decimals should match source");
+    }
+
+    function testQuoteReflectsSourceChange() public {
+        VM.prank(admin);
+        adapter.setOracleSource(address(feedB));
+
+        IOracleAdapter.OracleQuote memory readQuote = adapter.quote();
+        assertTrue(readQuote.value == 2_000_000_000_000_000_000, "value should match new source");
+        assertTrue(readQuote.updatedAt == 200, "updatedAt should match new source");
+        assertTrue(readQuote.decimals == 18, "decimals should match new source");
+    }
+
+    function testQuoteRevertsOnUpdatedAtOverflow() public {
+        feedA.setLatestRoundData(1, 100_000_000, 100, uint256(type(uint64).max) + 1, 1);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(IOracleAdapter.OracleAdapterInvalidUpdatedAt.selector, uint256(type(uint64).max) + 1)
+        );
+        adapter.quote();
+    }
+}

--- a/test/helpers/OracleAdapterTestHarness.sol
+++ b/test/helpers/OracleAdapterTestHarness.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {OracleAdapter} from "../../src/oracle/OracleAdapter.sol";
+import {IOracleFeed} from "../../src/interfaces/IOracleFeed.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+
+contract MockOracleFeed is IOracleFeed {
+    uint8 internal _decimals;
+    uint80 internal _roundId;
+    int256 internal _answer;
+    uint256 internal _startedAt;
+    uint256 internal _updatedAt;
+    uint80 internal _answeredInRound;
+
+    constructor(uint8 decimals_) {
+        _decimals = decimals_;
+    }
+
+    function setDecimals(uint8 decimals_) external {
+        _decimals = decimals_;
+    }
+
+    function setLatestRoundData(
+        uint80 roundId,
+        int256 answer,
+        uint256 startedAt,
+        uint256 updatedAt,
+        uint80 answeredInRound
+    ) external {
+        _roundId = roundId;
+        _answer = answer;
+        _startedAt = startedAt;
+        _updatedAt = updatedAt;
+        _answeredInRound = answeredInRound;
+    }
+
+    function decimals() external view returns (uint8) {
+        return _decimals;
+    }
+
+    function latestRoundData()
+        external
+        view
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+    {
+        return (_roundId, _answer, _startedAt, _updatedAt, _answeredInRound);
+    }
+}
+
+contract OracleAdapterHarness is OracleAdapter {
+    constructor(address initialAdmin, address initialSource, uint64 initialMaxStaleness)
+        OracleAdapter(initialAdmin, initialSource, initialMaxStaleness)
+    {}
+
+    function initializeOracleAdapterExternal(address initialSource, uint64 initialMaxStaleness) external {
+        _initializeOracleAdapter(initialSource, initialMaxStaleness);
+    }
+}
+
+abstract contract OracleAdapterFixture is TestBase {
+    address internal admin = address(0xA11CE);
+    address internal bob = address(0xB0B);
+
+    uint64 internal maxStaleness = 1 hours;
+
+    MockOracleFeed internal feedA;
+    MockOracleFeed internal feedB;
+    OracleAdapterHarness internal adapter;
+
+    function setUp() public virtual {
+        feedA = new MockOracleFeed(8);
+        feedB = new MockOracleFeed(18);
+        feedA.setLatestRoundData(1, 100_000_000, 100, 100, 1);
+        feedB.setLatestRoundData(2, 2_000_000_000_000_000_000, 200, 200, 2);
+
+        adapter = new OracleAdapterHarness(admin, address(feedA), maxStaleness);
+    }
+}
+


### PR DESCRIPTION
## Summary
This PR introduces the oracle adapter foundation for the Oracle Adapter + Circuit Breaker milestone.

## What’s Included
- Add provider-facing oracle interface:
  - `/Users/amirshirif/Documents/personal/smart-contracts/src/interfaces/IOracleFeed.sol`
- Add protocol-facing oracle adapter interface:
  - `/Users/amirshirif/Documents/personal/smart-contracts/src/interfaces/IOracleAdapter.sol`
- Add diamond-ready oracle storage library:
  - `/Users/amirshirif/Documents/personal/smart-contracts/src/oracle/storage/LibOracleAdapterStorage.sol`
- Add base oracle adapter module:
  - `/Users/amirshirif/Documents/personal/smart-contracts/src/oracle/OracleAdapter.sol`
- Add oracle test harness/mocks:
  - `/Users/amirshirif/Documents/personal/smart-contracts/test/helpers/OracleAdapterTestHarness.sol`
- Add core oracle adapter tests:
  - `/Users/amirshirif/Documents/personal/smart-contracts/test/OracleAdapterCore.t.sol`
- Add oracle docs and update references:
  - `/Users/amirshirif/Documents/personal/smart-contracts/docs/oracle-adapter.md`
  - `/Users/amirshirif/Documents/personal/smart-contracts/README.md`
  - `/Users/amirshirif/Documents/personal/smart-contracts/docs/testing-conventions.md`

## Behavior
- Stores oracle config (`source`, `maxStaleness`) in fixed-slot storage for diamond compatibility.
- Exposes normalized quote output: `value`, `updatedAt`, `decimals`.
- Admin-gated updates for source and staleness config.
- Includes initializer guard and zero-source protection.
- Supports ERC-165 interface detection.

## Testing
- `forge test --offline --match-path test/OracleAdapterCore.t.sol`
- Result: `14 passed, 0 failed`

## Scope Note
This PR is the **foundation layer**. Full validation policy (staleness enforcement, bounds checks, circuit breaker/fallback behavior) is intentionally handled in the next issue/PR.