### PR TITLE
feat(oracle): add circuit breaker fallback policy and degraded-read tests

### DIFF
--- a/docs/oracle-adapter.md
+++ b/docs/oracle-adapter.md
@@ -1,12 +1,17 @@
 # Oracle Adapter
 
-This module provides a normalized oracle read surface with configurable
-validation guardrails.
+This module defines the oracle adapter and breaker controls for the oracle
+milestone:
+- provider-facing feed interface
+- normalized quote read interface
+- validation guardrails for live reads
+- circuit breaker + fallback policy
+- upgrade-safe storage layout and initializer guard
 
 ## Interfaces
 
 - `IOracleFeed`: provider-facing feed reader (Chainlink-style round data).
-- `IOracleAdapter`: normalized adapter API and base configuration surface.
+- `IOracleAdapter`: normalized adapter API and configuration surface.
 
 `IOracleAdapter.OracleQuote` returns:
 - `value`: signed raw feed value
@@ -19,22 +24,35 @@ validation guardrails.
 - source address management
 - max staleness policy (seconds)
 - optional answer bounds policy (`minAnswer` / `maxAnswer`)
-- normalized quote reads from source
+- breaker state transitions (`trip` / `reset`)
+- fallback policy:
+  - `StrictRevert`: unhealthy reads revert
+  - `UseConfiguredQuote`: unhealthy reads return configured fallback quote
+- fallback quote management
 - initializer guard for upgrade-safe deployments
 
-Read validation checks enforced in `quote()`:
-- `updatedAt` must fit in `uint64` and be nonzero.
-- `updatedAt` cannot be in the future.
-- quote must be within configured staleness threshold when `maxStaleness != 0`.
-- round consistency requires `answeredInRound >= roundId`.
-- answer must be within configured bounds when bounds are enabled.
+Read validation checks enforced in strict mode:
+- `updatedAt` must fit in `uint64` and be nonzero
+- `updatedAt` cannot be in the future
+- quote must be within configured staleness threshold when `maxStaleness != 0`
+- round consistency requires `answeredInRound >= roundId`
+- answer must be within configured bounds when bounds are enabled
+
+Unhealthy read conditions include:
+- source call failure
+- malformed oracle responses
+- zero/future/out-of-range timestamps
+- stale quotes (when `maxStaleness != 0`)
+- `answeredInRound < roundId`
+- out-of-bounds answers (when bounds are enabled)
 
 Configuration notes:
-- `setMaxStaleness(0)` disables staleness checks.
-- bounds are disabled by default.
-- bounds can be updated via `setValidationBounds(min, max, enabled)`.
-
-All configuration changes emit events for auditability.
+- `setMaxStaleness(0)` disables staleness checks
+- bounds are disabled by default
+- bounds can be updated via `setValidationBounds(min, max, enabled)`
+- fallback mode defaults to `StrictRevert`
+- fallback quote must be configured before using `UseConfiguredQuote`
+- fallback usage during `quote()` is not emitted as an event because reads are `view`
 
 ## Diamond-Ready Usage
 
@@ -47,7 +65,11 @@ function initOracleAdapter(address source, uint64 maxStaleness) external {
 }
 ```
 
-## Next Step
+## Operational Policy
 
-The circuit breaker / fallback policy is implemented separately so validation and
-failover decisions remain explicit and testable.
+- Use `tripCircuitBreaker()` during oracle incidents.
+- Choose fallback behavior with `setFallbackMode(...)`.
+- If using configured fallback mode, set a fallback quote first with
+  `setFallbackQuote(...)`.
+- Return to normal mode by fixing feed health and calling
+  `resetCircuitBreaker()`.

--- a/docs/testing-conventions.md
+++ b/docs/testing-conventions.md
@@ -43,6 +43,7 @@ Use a split test layout so modules stay readable as complexity grows.
 - Core example: `test/ReentrancyGuardCore.t.sol`
 - Core example: `test/OracleAdapterCore.t.sol`
 - Core example: `test/OracleAdapterValidation.t.sol`
+- Core example: `test/OracleAdapterCircuitBreaker.t.sol`
 - Core example: `test/UpgradeGuardrailsCore.t.sol`
 - Fuzz example: `test/AccessControlFuzz.t.sol`
 - Fuzz example: `test/PausableFuzz.t.sol`

--- a/src/interfaces/IOracleAdapter.sol
+++ b/src/interfaces/IOracleAdapter.sol
@@ -6,6 +6,12 @@ import {IERC165} from "./IERC165.sol";
 /// @title IOracleAdapter
 /// @notice Interface for normalized oracle adapter reads and base configuration.
 interface IOracleAdapter is IERC165 {
+    /// @notice Defines how reads behave when live oracle data is unavailable.
+    enum FallbackMode {
+        StrictRevert,
+        UseConfiguredQuote
+    }
+
     /// @notice Normalized oracle quote returned by the adapter.
     struct OracleQuote {
         int256 value;
@@ -27,6 +33,16 @@ interface IOracleAdapter is IERC165 {
         bool newBoundsEnabled,
         address indexed sender
     );
+    /// @notice Emitted when circuit breaker is tripped.
+    event OracleCircuitBreakerTripped(address indexed sender);
+    /// @notice Emitted when circuit breaker is reset.
+    event OracleCircuitBreakerReset(address indexed sender);
+    /// @notice Emitted when fallback mode is updated.
+    event OracleFallbackModeUpdated(FallbackMode previousMode, FallbackMode newMode, address indexed sender);
+    /// @notice Emitted when fallback quote is configured.
+    event OracleFallbackQuoteUpdated(int256 value, uint64 updatedAt, uint8 decimals, address indexed sender);
+    /// @notice Emitted when fallback quote is cleared.
+    event OracleFallbackQuoteCleared(address indexed sender);
 
     /// @notice Thrown when the oracle source address is zero.
     error OracleAdapterZeroSource();
@@ -46,6 +62,18 @@ interface IOracleAdapter is IERC165 {
     error OracleAdapterInvalidValidationBounds(int256 minAnswer, int256 maxAnswer);
     /// @notice Thrown when quote value falls outside configured bounds.
     error OracleAdapterAnswerOutOfBounds(int256 answer, int256 minAnswer, int256 maxAnswer);
+    /// @notice Thrown when breaker is already active.
+    error OracleAdapterBreakerAlreadyActive();
+    /// @notice Thrown when breaker is already inactive.
+    error OracleAdapterBreakerAlreadyInactive();
+    /// @notice Thrown when strict mode is active and breaker blocks reads.
+    error OracleAdapterCircuitBreakerActive();
+    /// @notice Thrown when strict mode is active and live reads fail.
+    error OracleAdapterLiveReadFailed();
+    /// @notice Thrown when fallback mode is selected but no fallback quote is configured.
+    error OracleAdapterFallbackUnavailable();
+    /// @notice Thrown when configured fallback quote is invalid.
+    error OracleAdapterInvalidFallbackQuote(uint64 updatedAt);
 
     /// @notice Returns the configured oracle source address.
     /// @return The oracle source contract.
@@ -55,15 +83,28 @@ interface IOracleAdapter is IERC165 {
     /// @return The max staleness window.
     function maxStaleness() external view returns (uint64);
 
-    /// @notice Returns the latest normalized quote from the configured source.
-    /// @return quote The latest normalized quote payload.
-    function quote() external view returns (OracleQuote memory quote);
-
     /// @notice Returns configured answer bounds and whether bounds checks are enabled.
     /// @return minAnswer The inclusive minimum answer.
     /// @return maxAnswer The inclusive maximum answer.
     /// @return boundsEnabled True when bounds checks are enforced.
     function validationBounds() external view returns (int256 minAnswer, int256 maxAnswer, bool boundsEnabled);
+
+    /// @notice Returns true when circuit breaker is active.
+    /// @return True if breaker is active.
+    function circuitBreakerActive() external view returns (bool);
+
+    /// @notice Returns fallback mode used for unhealthy oracle reads.
+    /// @return The configured fallback mode.
+    function fallbackMode() external view returns (FallbackMode);
+
+    /// @notice Returns configured fallback quote and whether it exists.
+    /// @return fallbackQuotePayload The configured fallback quote.
+    /// @return configured True if a fallback quote is configured.
+    function fallbackQuote() external view returns (OracleQuote memory fallbackQuotePayload, bool configured);
+
+    /// @notice Returns the latest normalized quote from the configured source.
+    /// @return quote The latest normalized quote payload.
+    function quote() external view returns (OracleQuote memory quote);
 
     /// @notice Updates the oracle source.
     /// @param newSource The new oracle source contract.
@@ -78,4 +119,23 @@ interface IOracleAdapter is IERC165 {
     /// @param newMaxAnswer The inclusive maximum answer.
     /// @param newBoundsEnabled True to enforce bounds during reads.
     function setValidationBounds(int256 newMinAnswer, int256 newMaxAnswer, bool newBoundsEnabled) external;
+
+    /// @notice Trips the oracle circuit breaker.
+    function tripCircuitBreaker() external;
+
+    /// @notice Resets the oracle circuit breaker.
+    function resetCircuitBreaker() external;
+
+    /// @notice Updates fallback behavior used under unhealthy oracle conditions.
+    /// @param newMode The new fallback mode.
+    function setFallbackMode(FallbackMode newMode) external;
+
+    /// @notice Sets fallback quote returned in `UseConfiguredQuote` mode.
+    /// @param value Fallback quote value.
+    /// @param updatedAt Fallback quote timestamp.
+    /// @param decimals Fallback quote decimals.
+    function setFallbackQuote(int256 value, uint64 updatedAt, uint8 decimals) external;
+
+    /// @notice Clears configured fallback quote.
+    function clearFallbackQuote() external;
 }

--- a/src/oracle/OracleAdapter.sol
+++ b/src/oracle/OracleAdapter.sol
@@ -39,16 +39,46 @@ abstract contract OracleAdapter is AccessControl, IOracleAdapter {
         return (layout.minAnswer, layout.maxAnswer, layout.boundsEnabled);
     }
 
+    /// @notice Returns true when circuit breaker is active.
+    /// @return True if breaker is active.
+    function circuitBreakerActive() public view returns (bool) {
+        return LibOracleAdapterStorage.layout().breakerActive;
+    }
+
+    /// @notice Returns fallback mode used for unhealthy oracle reads.
+    /// @return The configured fallback mode.
+    function fallbackMode() public view returns (FallbackMode) {
+        return FallbackMode(LibOracleAdapterStorage.layout().fallbackMode);
+    }
+
+    /// @notice Returns configured fallback quote and whether it exists.
+    /// @return fallbackQuotePayload The configured fallback quote.
+    /// @return configured True if a fallback quote is configured.
+    function fallbackQuote() public view returns (OracleQuote memory fallbackQuotePayload, bool configured) {
+        LibOracleAdapterStorage.Layout storage layout = LibOracleAdapterStorage.layout();
+        fallbackQuotePayload = OracleQuote({
+            value: layout.fallbackValue, updatedAt: layout.fallbackUpdatedAt, decimals: layout.fallbackDecimals
+        });
+        configured = layout.hasFallbackQuote;
+    }
+
     /// @notice Returns the latest normalized quote from the configured source.
+    /// @dev Applies breaker and fallback policy for unhealthy conditions.
     /// @return quotePayload The latest normalized quote payload.
     function quote() public view returns (OracleQuote memory quotePayload) {
-        address source = oracleSource();
-        (uint80 roundId, int256 answer,, uint256 updatedAt, uint80 answeredInRound) =
-            IOracleFeed(source).latestRoundData();
-        uint64 normalizedUpdatedAt = _validateRoundData(roundId, answer, updatedAt, answeredInRound);
+        if (circuitBreakerActive()) {
+            return _resolveFallbackOrRevert(true);
+        }
 
-        quotePayload =
-            OracleQuote({value: answer, updatedAt: normalizedUpdatedAt, decimals: IOracleFeed(source).decimals()});
+        if (fallbackMode() == FallbackMode.StrictRevert) {
+            return _readLiveQuoteStrict();
+        }
+
+        (bool liveReadSuccess, OracleQuote memory liveQuote) = _tryReadLiveQuote();
+        if (liveReadSuccess) {
+            return liveQuote;
+        }
+        return _resolveFallbackOrRevert(false);
     }
 
     /// @notice Updates the oracle source.
@@ -77,6 +107,58 @@ abstract contract OracleAdapter is AccessControl, IOracleAdapter {
         _setValidationBounds(newMinAnswer, newMaxAnswer, newBoundsEnabled);
     }
 
+    /// @notice Trips the oracle circuit breaker.
+    /// @dev Caller must have DEFAULT_ADMIN_ROLE.
+    function tripCircuitBreaker() public onlyRole(DEFAULT_ADMIN_ROLE) {
+        LibOracleAdapterStorage.Layout storage layout = LibOracleAdapterStorage.layout();
+        if (layout.breakerActive) {
+            revert OracleAdapterBreakerAlreadyActive();
+        }
+        layout.breakerActive = true;
+        emit OracleCircuitBreakerTripped(msg.sender);
+    }
+
+    /// @notice Resets the oracle circuit breaker.
+    /// @dev Caller must have DEFAULT_ADMIN_ROLE.
+    function resetCircuitBreaker() public onlyRole(DEFAULT_ADMIN_ROLE) {
+        LibOracleAdapterStorage.Layout storage layout = LibOracleAdapterStorage.layout();
+        if (!layout.breakerActive) {
+            revert OracleAdapterBreakerAlreadyInactive();
+        }
+        layout.breakerActive = false;
+        emit OracleCircuitBreakerReset(msg.sender);
+    }
+
+    /// @notice Updates fallback behavior used under unhealthy oracle conditions.
+    /// @dev Caller must have DEFAULT_ADMIN_ROLE.
+    /// @param newMode The new fallback mode.
+    function setFallbackMode(FallbackMode newMode) public onlyRole(DEFAULT_ADMIN_ROLE) {
+        LibOracleAdapterStorage.Layout storage layout = LibOracleAdapterStorage.layout();
+        FallbackMode previousMode = FallbackMode(layout.fallbackMode);
+        layout.fallbackMode = uint8(newMode);
+        emit OracleFallbackModeUpdated(previousMode, newMode, msg.sender);
+    }
+
+    /// @notice Sets fallback quote returned in `UseConfiguredQuote` mode.
+    /// @dev Caller must have DEFAULT_ADMIN_ROLE.
+    /// @param value Fallback quote value.
+    /// @param updatedAt Fallback quote timestamp.
+    /// @param decimals Fallback quote decimals.
+    function setFallbackQuote(int256 value, uint64 updatedAt, uint8 decimals) public onlyRole(DEFAULT_ADMIN_ROLE) {
+        _setFallbackQuote(value, updatedAt, decimals);
+    }
+
+    /// @notice Clears configured fallback quote.
+    /// @dev Caller must have DEFAULT_ADMIN_ROLE.
+    function clearFallbackQuote() public onlyRole(DEFAULT_ADMIN_ROLE) {
+        LibOracleAdapterStorage.Layout storage layout = LibOracleAdapterStorage.layout();
+        layout.hasFallbackQuote = false;
+        layout.fallbackValue = 0;
+        layout.fallbackUpdatedAt = 0;
+        layout.fallbackDecimals = 0;
+        emit OracleFallbackQuoteCleared(msg.sender);
+    }
+
     /// @notice Returns true if this contract implements `interfaceId`.
     /// @param interfaceId The interface identifier.
     /// @return True if the interface is supported.
@@ -97,6 +179,7 @@ abstract contract OracleAdapter is AccessControl, IOracleAdapter {
         layout.minAnswer = type(int256).min;
         layout.maxAnswer = type(int256).max;
         layout.boundsEnabled = false;
+        layout.fallbackMode = uint8(FallbackMode.StrictRevert);
         _setOracleSource(initialSource);
         _setMaxStaleness(initialMaxStaleness);
     }
@@ -152,6 +235,125 @@ abstract contract OracleAdapter is AccessControl, IOracleAdapter {
         );
     }
 
+    /// @dev Sets fallback quote configuration.
+    /// @param value Fallback quote value.
+    /// @param updatedAt Fallback quote timestamp.
+    /// @param decimals Fallback quote decimals.
+    function _setFallbackQuote(int256 value, uint64 updatedAt, uint8 decimals) internal {
+        if (updatedAt == 0) {
+            revert OracleAdapterInvalidFallbackQuote(updatedAt);
+        }
+
+        LibOracleAdapterStorage.Layout storage layout = LibOracleAdapterStorage.layout();
+        layout.hasFallbackQuote = true;
+        layout.fallbackValue = value;
+        layout.fallbackUpdatedAt = updatedAt;
+        layout.fallbackDecimals = decimals;
+        emit OracleFallbackQuoteUpdated(value, updatedAt, decimals, msg.sender);
+    }
+
+    /// @dev Reads live oracle data using strict validation semantics.
+    /// @dev Reverts with validation errors or {OracleAdapterLiveReadFailed} on source call failures.
+    /// @return quotePayload The validated live quote payload.
+    function _readLiveQuoteStrict() internal view returns (OracleQuote memory quotePayload) {
+        address source = oracleSource();
+        uint80 roundId;
+        int256 answer;
+        uint256 updatedAt;
+        uint80 answeredInRound;
+
+        try IOracleFeed(source).latestRoundData() returns (
+            uint80 returnedRoundId,
+            int256 returnedAnswer,
+            uint256,
+            uint256 returnedUpdatedAt,
+            uint80 returnedAnsweredInRound
+        ) {
+            roundId = returnedRoundId;
+            answer = returnedAnswer;
+            updatedAt = returnedUpdatedAt;
+            answeredInRound = returnedAnsweredInRound;
+        } catch {
+            revert OracleAdapterLiveReadFailed();
+        }
+
+        uint64 normalizedUpdatedAt = _validateRoundData(roundId, answer, updatedAt, answeredInRound);
+        uint8 decimals;
+        try IOracleFeed(source).decimals() returns (uint8 returnedDecimals) {
+            decimals = returnedDecimals;
+        } catch {
+            revert OracleAdapterLiveReadFailed();
+        }
+
+        quotePayload = OracleQuote({value: answer, updatedAt: normalizedUpdatedAt, decimals: decimals});
+    }
+
+    /// @dev Attempts to read and validate live oracle data without reverting.
+    /// @return success True when read/validation succeeds.
+    /// @return quotePayload Normalized quote payload.
+    function _tryReadLiveQuote() internal view returns (bool success, OracleQuote memory quotePayload) {
+        address source = oracleSource();
+        (bool roundDataCallSuccess, bytes memory roundDataRaw) =
+            source.staticcall(abi.encodeWithSelector(IOracleFeed.latestRoundData.selector));
+        if (!roundDataCallSuccess || roundDataRaw.length != 160) {
+            return (false, quotePayload);
+        }
+
+        (uint80 roundId, int256 answer,, uint256 updatedAt, uint80 answeredInRound) =
+            abi.decode(roundDataRaw, (uint80, int256, uint256, uint256, uint80));
+        if (!_isRoundDataValid(roundId, answer, updatedAt, answeredInRound)) {
+            return (false, quotePayload);
+        }
+
+        (bool decimalsCallSuccess, bytes memory decimalsRaw) =
+            source.staticcall(abi.encodeWithSelector(IOracleFeed.decimals.selector));
+        if (!decimalsCallSuccess || decimalsRaw.length != 32) {
+            return (false, quotePayload);
+        }
+        uint8 decimals = abi.decode(decimalsRaw, (uint8));
+
+        // casting to `uint64` is safe because `_isRoundDataValid` enforces bounds.
+        // forge-lint: disable-next-line(unsafe-typecast)
+        quotePayload = OracleQuote({value: answer, updatedAt: uint64(updatedAt), decimals: decimals});
+        return (true, quotePayload);
+    }
+
+    /// @dev Checks whether returned round data passes baseline validity rules.
+    /// @param roundId The source round ID.
+    /// @param answer The source answer.
+    /// @param updatedAt The round update timestamp.
+    /// @param answeredInRound The round in which the answer was computed.
+    /// @return True when data is valid for fallback mode reads.
+    function _isRoundDataValid(uint80 roundId, int256 answer, uint256 updatedAt, uint80 answeredInRound)
+        internal
+        view
+        returns (bool)
+    {
+        if (updatedAt == 0 || updatedAt > type(uint64).max) {
+            return false;
+        }
+
+        uint256 currentTimestamp = block.timestamp;
+        if (updatedAt > currentTimestamp) {
+            return false;
+        }
+
+        uint256 allowedStaleness = maxStaleness();
+        if (allowedStaleness != 0 && currentTimestamp - updatedAt > allowedStaleness) {
+            return false;
+        }
+
+        if (answeredInRound < roundId) {
+            return false;
+        }
+
+        if (!_isAnswerWithinBounds(answer)) {
+            return false;
+        }
+
+        return true;
+    }
+
     /// @dev Validates round data freshness, consistency, and optional bounds.
     /// @param roundId The returned round identifier.
     /// @param answer The returned answer value.
@@ -190,12 +392,38 @@ abstract contract OracleAdapter is AccessControl, IOracleAdapter {
         _validateAnswerBounds(answer);
     }
 
+    /// @dev Returns true when `answer` is inside configured bounds.
+    /// @param answer The oracle answer to validate.
+    /// @return True when answer is in range or bounds are disabled.
+    function _isAnswerWithinBounds(int256 answer) internal view returns (bool) {
+        (int256 minAnswer, int256 maxAnswer, bool boundsEnabled) = validationBounds();
+        return !boundsEnabled || (answer >= minAnswer && answer <= maxAnswer);
+    }
+
     /// @dev Reverts when `answer` is outside configured bounds while bounds are enabled.
     /// @param answer The oracle answer to validate.
     function _validateAnswerBounds(int256 answer) internal view {
-        (int256 minAnswer, int256 maxAnswer, bool boundsEnabled) = validationBounds();
-        if (boundsEnabled && (answer < minAnswer || answer > maxAnswer)) {
+        if (!_isAnswerWithinBounds(answer)) {
+            (int256 minAnswer, int256 maxAnswer,) = validationBounds();
             revert OracleAdapterAnswerOutOfBounds(answer, minAnswer, maxAnswer);
         }
+    }
+
+    /// @dev Resolves fallback policy, reverting in strict mode.
+    /// @param breakerTriggered True when fallback resolution is due to active breaker.
+    /// @return quotePayload The fallback quote payload.
+    function _resolveFallbackOrRevert(bool breakerTriggered) internal view returns (OracleQuote memory quotePayload) {
+        if (fallbackMode() == FallbackMode.StrictRevert) {
+            if (breakerTriggered) {
+                revert OracleAdapterCircuitBreakerActive();
+            }
+            revert OracleAdapterLiveReadFailed();
+        }
+
+        (OracleQuote memory configuredFallback, bool configured) = fallbackQuote();
+        if (!configured) {
+            revert OracleAdapterFallbackUnavailable();
+        }
+        return configuredFallback;
     }
 }

--- a/src/oracle/storage/LibOracleAdapterStorage.sol
+++ b/src/oracle/storage/LibOracleAdapterStorage.sol
@@ -15,6 +15,12 @@ library LibOracleAdapterStorage {
         int256 minAnswer;
         int256 maxAnswer;
         bool boundsEnabled;
+        bool breakerActive;
+        uint8 fallbackMode;
+        bool hasFallbackQuote;
+        int256 fallbackValue;
+        uint64 fallbackUpdatedAt;
+        uint8 fallbackDecimals;
     }
 
     /// @notice Returns the storage layout for oracle adapter state.

--- a/test/OracleAdapterCircuitBreaker.t.sol
+++ b/test/OracleAdapterCircuitBreaker.t.sol
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {
+    MalformedDecimalsFeed,
+    MalformedRoundDataFeed,
+    OracleAdapterFixture
+} from "./helpers/OracleAdapterTestHarness.sol";
+import {IOracleAdapter} from "../src/interfaces/IOracleAdapter.sol";
+
+contract OracleAdapterCircuitBreakerTest is OracleAdapterFixture {
+    function testQuoteRevertsWhenBreakerActiveInStrictMode() public {
+        VM.prank(admin);
+        adapter.tripCircuitBreaker();
+
+        VM.expectRevert(abi.encodeWithSelector(IOracleAdapter.OracleAdapterCircuitBreakerActive.selector));
+        adapter.quote();
+    }
+
+    function testQuoteUsesFallbackWhenBreakerActiveAndFallbackModeEnabled() public {
+        VM.prank(admin);
+        adapter.setFallbackQuote(123, 888_000, 8);
+        VM.prank(admin);
+        adapter.setFallbackMode(IOracleAdapter.FallbackMode.UseConfiguredQuote);
+        VM.prank(admin);
+        adapter.tripCircuitBreaker();
+
+        IOracleAdapter.OracleQuote memory readQuote = adapter.quote();
+        assertTrue(readQuote.value == 123, "breaker should return fallback value");
+        assertTrue(readQuote.updatedAt == 888_000, "breaker should return fallback timestamp");
+        assertTrue(readQuote.decimals == 8, "breaker should return fallback decimals");
+    }
+
+    function testQuoteRevertsWhenLiveReadFailsInStrictMode() public {
+        feedA.setRevertLatestRoundData(true);
+
+        VM.expectRevert(abi.encodeWithSelector(IOracleAdapter.OracleAdapterLiveReadFailed.selector));
+        adapter.quote();
+    }
+
+    function testQuoteUsesFallbackWhenLiveReadFails() public {
+        VM.prank(admin);
+        adapter.setFallbackQuote(55, 777_000, 8);
+        VM.prank(admin);
+        adapter.setFallbackMode(IOracleAdapter.FallbackMode.UseConfiguredQuote);
+        feedA.setRevertLatestRoundData(true);
+
+        IOracleAdapter.OracleQuote memory readQuote = adapter.quote();
+        assertTrue(readQuote.value == 55, "fallback value should be used");
+        assertTrue(readQuote.updatedAt == 777_000, "fallback updatedAt should be used");
+        assertTrue(readQuote.decimals == 8, "fallback decimals should be used");
+    }
+
+    function testQuoteUsesFallbackWhenDecimalsCallReverts() public {
+        VM.prank(admin);
+        adapter.setFallbackQuote(44, 770_000, 8);
+        VM.prank(admin);
+        adapter.setFallbackMode(IOracleAdapter.FallbackMode.UseConfiguredQuote);
+        feedA.setRevertDecimals(true);
+
+        IOracleAdapter.OracleQuote memory readQuote = adapter.quote();
+        assertTrue(readQuote.value == 44, "fallback value should be used");
+        assertTrue(readQuote.updatedAt == 770_000, "fallback updatedAt should be used");
+        assertTrue(readQuote.decimals == 8, "fallback decimals should be used");
+    }
+
+    function testQuoteUsesFallbackWhenRoundDataPayloadMalformed() public {
+        MalformedRoundDataFeed malformedFeed = new MalformedRoundDataFeed();
+
+        VM.prank(admin);
+        adapter.setOracleSource(address(malformedFeed));
+        VM.prank(admin);
+        adapter.setFallbackQuote(45, 771_000, 8);
+        VM.prank(admin);
+        adapter.setFallbackMode(IOracleAdapter.FallbackMode.UseConfiguredQuote);
+
+        IOracleAdapter.OracleQuote memory readQuote = adapter.quote();
+        assertTrue(readQuote.value == 45, "fallback value should be used");
+        assertTrue(readQuote.updatedAt == 771_000, "fallback updatedAt should be used");
+        assertTrue(readQuote.decimals == 8, "fallback decimals should be used");
+    }
+
+    function testQuoteUsesFallbackWhenDecimalsPayloadMalformed() public {
+        MalformedDecimalsFeed malformedFeed = new MalformedDecimalsFeed();
+
+        VM.prank(admin);
+        adapter.setOracleSource(address(malformedFeed));
+        VM.prank(admin);
+        adapter.setFallbackQuote(46, 772_000, 8);
+        VM.prank(admin);
+        adapter.setFallbackMode(IOracleAdapter.FallbackMode.UseConfiguredQuote);
+
+        IOracleAdapter.OracleQuote memory readQuote = adapter.quote();
+        assertTrue(readQuote.value == 46, "fallback value should be used");
+        assertTrue(readQuote.updatedAt == 772_000, "fallback updatedAt should be used");
+        assertTrue(readQuote.decimals == 8, "fallback decimals should be used");
+    }
+
+    function testQuoteRevertsWhenFallbackModeEnabledWithoutConfiguredFallback() public {
+        VM.prank(admin);
+        adapter.setFallbackMode(IOracleAdapter.FallbackMode.UseConfiguredQuote);
+        feedA.setRevertLatestRoundData(true);
+
+        VM.expectRevert(abi.encodeWithSelector(IOracleAdapter.OracleAdapterFallbackUnavailable.selector));
+        adapter.quote();
+    }
+
+    function testQuoteTreatsStaleDataAsUnhealthy() public {
+        VM.prank(admin);
+        adapter.setFallbackMode(IOracleAdapter.FallbackMode.UseConfiguredQuote);
+        VM.prank(admin);
+        adapter.setFallbackQuote(66, 700_000, 8);
+
+        uint64 staleUpdatedAt = currentTime - maxStaleness - 1;
+        feedA.setLatestRoundData(1, 100_000_000, staleUpdatedAt, staleUpdatedAt, 1);
+
+        IOracleAdapter.OracleQuote memory readQuote = adapter.quote();
+        assertTrue(readQuote.value == 66, "stale live quote should fall back");
+    }
+
+    function testQuoteTreatsFutureDataAsUnhealthy() public {
+        VM.prank(admin);
+        adapter.setFallbackMode(IOracleAdapter.FallbackMode.UseConfiguredQuote);
+        VM.prank(admin);
+        adapter.setFallbackQuote(77, 700_000, 8);
+
+        uint64 futureUpdatedAt = currentTime + 1;
+        feedA.setLatestRoundData(1, 100_000_000, futureUpdatedAt, futureUpdatedAt, 1);
+
+        IOracleAdapter.OracleQuote memory readQuote = adapter.quote();
+        assertTrue(readQuote.value == 77, "future live quote should fall back");
+    }
+
+    function testQuoteTreatsInvalidRoundAsUnhealthy() public {
+        VM.prank(admin);
+        adapter.setFallbackMode(IOracleAdapter.FallbackMode.UseConfiguredQuote);
+        VM.prank(admin);
+        adapter.setFallbackQuote(88, 700_000, 8);
+        feedA.setLatestRoundData(2, 100_000_000, feedAUpdatedAt, feedAUpdatedAt, 1);
+
+        IOracleAdapter.OracleQuote memory readQuote = adapter.quote();
+        assertTrue(readQuote.value == 88, "invalid round should fall back");
+    }
+
+    function testRecoveredStateUsesLiveQuoteAfterBreakerReset() public {
+        VM.prank(admin);
+        adapter.setFallbackQuote(99, 700_000, 8);
+        VM.prank(admin);
+        adapter.setFallbackMode(IOracleAdapter.FallbackMode.UseConfiguredQuote);
+        VM.prank(admin);
+        adapter.tripCircuitBreaker();
+
+        IOracleAdapter.OracleQuote memory degradedQuote = adapter.quote();
+        assertTrue(degradedQuote.value == 99, "degraded quote should use fallback");
+
+        VM.prank(admin);
+        adapter.resetCircuitBreaker();
+        feedA.setRevertLatestRoundData(false);
+        feedA.setLatestRoundData(1, 111_000_000, feedAUpdatedAt, feedAUpdatedAt, 1);
+
+        IOracleAdapter.OracleQuote memory recoveredQuote = adapter.quote();
+        assertTrue(recoveredQuote.value == 111_000_000, "recovered quote should use live source");
+    }
+}

--- a/test/OracleAdapterCore.t.sol
+++ b/test/OracleAdapterCore.t.sol
@@ -19,6 +19,13 @@ contract OracleAdapterCoreTest is OracleAdapterFixture {
         bool newBoundsEnabled,
         address indexed sender
     );
+    event OracleCircuitBreakerTripped(address indexed sender);
+    event OracleCircuitBreakerReset(address indexed sender);
+    event OracleFallbackModeUpdated(
+        IOracleAdapter.FallbackMode previousMode, IOracleAdapter.FallbackMode newMode, address indexed sender
+    );
+    event OracleFallbackQuoteUpdated(int256 value, uint64 updatedAt, uint8 decimals, address indexed sender);
+    event OracleFallbackQuoteCleared(address indexed sender);
 
     function testInitialConfig() public view {
         assertTrue(adapter.oracleSource() == address(feedA), "initial source should match constructor");
@@ -27,6 +34,12 @@ contract OracleAdapterCoreTest is OracleAdapterFixture {
         assertTrue(minAnswer == type(int256).min, "initial min should be int256 min");
         assertTrue(maxAnswer == type(int256).max, "initial max should be int256 max");
         assertFalse(boundsEnabled, "bounds should start disabled");
+        assertFalse(adapter.circuitBreakerActive(), "breaker should start inactive");
+        assertTrue(
+            adapter.fallbackMode() == IOracleAdapter.FallbackMode.StrictRevert, "fallback mode should start strict"
+        );
+        (, bool configured) = adapter.fallbackQuote();
+        assertFalse(configured, "fallback quote should start unset");
     }
 
     function testSupportsInterface() public view {
@@ -126,6 +139,147 @@ contract OracleAdapterCoreTest is OracleAdapterFixture {
         VM.expectRevert(abi.encodeWithSelector(IOracleAdapter.OracleAdapterInvalidValidationBounds.selector, 2, 1));
         VM.prank(admin);
         adapter.setValidationBounds(2, 1, true);
+    }
+
+    function testAdminCanTripAndResetCircuitBreaker() public {
+        VM.prank(admin);
+        adapter.tripCircuitBreaker();
+        assertTrue(adapter.circuitBreakerActive(), "breaker should be active");
+
+        VM.prank(admin);
+        adapter.resetCircuitBreaker();
+        assertFalse(adapter.circuitBreakerActive(), "breaker should be inactive");
+    }
+
+    function testTripAndResetCircuitBreakerEmitEvents() public {
+        VM.expectEmit(true, true, true, true, address(adapter));
+        emit OracleCircuitBreakerTripped(admin);
+
+        VM.prank(admin);
+        adapter.tripCircuitBreaker();
+
+        VM.expectEmit(true, true, true, true, address(adapter));
+        emit OracleCircuitBreakerReset(admin);
+
+        VM.prank(admin);
+        adapter.resetCircuitBreaker();
+    }
+
+    function testTripCircuitBreakerRevertsWhenAlreadyActive() public {
+        VM.prank(admin);
+        adapter.tripCircuitBreaker();
+
+        VM.expectRevert(abi.encodeWithSelector(IOracleAdapter.OracleAdapterBreakerAlreadyActive.selector));
+        VM.prank(admin);
+        adapter.tripCircuitBreaker();
+    }
+
+    function testResetCircuitBreakerRevertsWhenAlreadyInactive() public {
+        VM.expectRevert(abi.encodeWithSelector(IOracleAdapter.OracleAdapterBreakerAlreadyInactive.selector));
+        VM.prank(admin);
+        adapter.resetCircuitBreaker();
+    }
+
+    function testNonAdminCannotManageCircuitBreaker() public {
+        VM.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, adapter.DEFAULT_ADMIN_ROLE())
+        );
+        VM.prank(bob);
+        adapter.tripCircuitBreaker();
+
+        VM.prank(admin);
+        adapter.tripCircuitBreaker();
+
+        VM.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, adapter.DEFAULT_ADMIN_ROLE())
+        );
+        VM.prank(bob);
+        adapter.resetCircuitBreaker();
+    }
+
+    function testAdminCanSetFallbackMode() public {
+        VM.prank(admin);
+        adapter.setFallbackMode(IOracleAdapter.FallbackMode.UseConfiguredQuote);
+        assertTrue(
+            adapter.fallbackMode() == IOracleAdapter.FallbackMode.UseConfiguredQuote, "fallback mode should update"
+        );
+    }
+
+    function testSetFallbackModeEmitsEvent() public {
+        VM.expectEmit(true, true, true, true, address(adapter));
+        emit OracleFallbackModeUpdated(
+            IOracleAdapter.FallbackMode.StrictRevert, IOracleAdapter.FallbackMode.UseConfiguredQuote, admin
+        );
+
+        VM.prank(admin);
+        adapter.setFallbackMode(IOracleAdapter.FallbackMode.UseConfiguredQuote);
+    }
+
+    function testNonAdminCannotSetFallbackMode() public {
+        VM.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, adapter.DEFAULT_ADMIN_ROLE())
+        );
+        VM.prank(bob);
+        adapter.setFallbackMode(IOracleAdapter.FallbackMode.UseConfiguredQuote);
+    }
+
+    function testAdminCanSetAndClearFallbackQuote() public {
+        VM.prank(admin);
+        adapter.setFallbackQuote(42, 999_000, 8);
+
+        (IOracleAdapter.OracleQuote memory configuredQuote, bool configured) = adapter.fallbackQuote();
+        assertTrue(configured, "fallback should be configured");
+        assertTrue(configuredQuote.value == 42, "fallback value should match");
+        assertTrue(configuredQuote.updatedAt == 999_000, "fallback updatedAt should match");
+        assertTrue(configuredQuote.decimals == 8, "fallback decimals should match");
+
+        VM.prank(admin);
+        adapter.clearFallbackQuote();
+
+        (, configured) = adapter.fallbackQuote();
+        assertFalse(configured, "fallback should be cleared");
+    }
+
+    function testSetFallbackQuoteEmitsEvent() public {
+        VM.expectEmit(true, true, true, true, address(adapter));
+        emit OracleFallbackQuoteUpdated(42, 999_000, 8, admin);
+
+        VM.prank(admin);
+        adapter.setFallbackQuote(42, 999_000, 8);
+    }
+
+    function testClearFallbackQuoteEmitsEvent() public {
+        VM.prank(admin);
+        adapter.setFallbackQuote(42, 999_000, 8);
+
+        VM.expectEmit(true, true, true, true, address(adapter));
+        emit OracleFallbackQuoteCleared(admin);
+
+        VM.prank(admin);
+        adapter.clearFallbackQuote();
+    }
+
+    function testSetFallbackQuoteRejectsZeroUpdatedAt() public {
+        VM.expectRevert(abi.encodeWithSelector(IOracleAdapter.OracleAdapterInvalidFallbackQuote.selector, 0));
+        VM.prank(admin);
+        adapter.setFallbackQuote(1, 0, 8);
+    }
+
+    function testNonAdminCannotSetOrClearFallbackQuote() public {
+        VM.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, adapter.DEFAULT_ADMIN_ROLE())
+        );
+        VM.prank(bob);
+        adapter.setFallbackQuote(42, 999_000, 8);
+
+        VM.prank(admin);
+        adapter.setFallbackQuote(42, 999_000, 8);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, adapter.DEFAULT_ADMIN_ROLE())
+        );
+        VM.prank(bob);
+        adapter.clearFallbackQuote();
     }
 
     function testQuoteReturnsNormalizedPayload() public view {

--- a/test/helpers/OracleAdapterTestHarness.sol
+++ b/test/helpers/OracleAdapterTestHarness.sol
@@ -12,6 +12,8 @@ contract MockOracleFeed is IOracleFeed {
     uint256 internal _startedAt;
     uint256 internal _updatedAt;
     uint80 internal _answeredInRound;
+    bool internal _revertLatestRoundData;
+    bool internal _revertDecimals;
 
     constructor(uint8 decimals_) {
         _decimals = decimals_;
@@ -35,7 +37,18 @@ contract MockOracleFeed is IOracleFeed {
         _answeredInRound = answeredInRound;
     }
 
+    function setRevertLatestRoundData(bool shouldRevert) external {
+        _revertLatestRoundData = shouldRevert;
+    }
+
+    function setRevertDecimals(bool shouldRevert) external {
+        _revertDecimals = shouldRevert;
+    }
+
     function decimals() external view returns (uint8) {
+        if (_revertDecimals) {
+            revert("MOCK_DECIMALS_REVERT");
+        }
         return _decimals;
     }
 
@@ -44,7 +57,42 @@ contract MockOracleFeed is IOracleFeed {
         view
         returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
     {
+        if (_revertLatestRoundData) {
+            revert("MOCK_ROUND_DATA_REVERT");
+        }
         return (_roundId, _answer, _startedAt, _updatedAt, _answeredInRound);
+    }
+}
+
+contract MalformedRoundDataFeed is IOracleFeed {
+    function decimals() external pure returns (uint8) {
+        return 8;
+    }
+
+    function latestRoundData() external pure returns (uint80, int256, uint256, uint256, uint80) {
+        // Intentionally return malformed payload to simulate bad provider ABI behavior.
+        assembly {
+            mstore(0x00, 0x01)
+            return(0x00, 0x20)
+        }
+    }
+}
+
+contract MalformedDecimalsFeed is IOracleFeed {
+    function decimals() external pure returns (uint8) {
+        // Intentionally return malformed payload to simulate bad provider ABI behavior.
+        assembly {
+            mstore8(0x00, 0x08)
+            return(0x00, 0x01)
+        }
+    }
+
+    function latestRoundData()
+        external
+        pure
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+    {
+        return (1, 100_000_000, 999_900, 999_900, 1);
     }
 }
 


### PR DESCRIPTION
## Summary
This PR implements the circuit breaker and fallback policy for the oracle adapter module.

## What’s Included
- Added circuit breaker state and role-gated transitions:
  - `tripCircuitBreaker()`
  - `resetCircuitBreaker()`
- Added configurable fallback behavior for unhealthy oracle conditions:
  - `FallbackMode.StrictRevert`
  - `FallbackMode.UseConfiguredQuote`
- Added role-gated fallback configuration:
  - `setFallbackMode(...)`
  - `setFallbackQuote(...)`
  - `clearFallbackQuote()`
- Extended interface/events/errors for breaker and fallback controls.
- Extended oracle storage layout for breaker/fallback state.
- Integrated breaker/fallback policy directly into `quote()` read path.
- Preserved strict validation semantics (staleness, future/zero timestamp, round consistency, bounds) in strict mode.
- Added degraded/recovery tests and malformed payload tests.
- Updated oracle docs and testing references.

## Enforcement Behavior
- **Healthy**: `quote()` returns validated live oracle data.
- **Degraded + StrictRevert**: `quote()` reverts deterministically.
- **Degraded + UseConfiguredQuote**: `quote()` returns configured fallback quote.
- **Breaker Active + StrictRevert**: `quote()` reverts with breaker-specific error.
- **Breaker Active + UseConfiguredQuote**: `quote()` returns fallback quote.
- **Recovered**: after breaker reset and healthy feed, `quote()` returns live data again.

## Security Notes
- Breaker and fallback controls are admin-gated.
- Unhealthy read paths are deterministic.
- Malformed provider responses are treated as unhealthy and routed through policy.
- Fallback usage during `quote()` is not emitted as an event because `quote()` is `view`.

## Testing
- Added/updated:
  - `test/OracleAdapterCore.t.sol`
  - `test/OracleAdapterCircuitBreaker.t.sol`
  - `test/OracleAdapterValidation.t.sol`
  - `test/helpers/OracleAdapterTestHarness.sol`
- Validation command:
  - `forge test --offline`
- Result:
  - `155 passed, 0 failed`