### PR TITLE
feat(oracle): integrate ACL roles for oracle operations

### DIFF
--- a/docs/oracle-adapter.md
+++ b/docs/oracle-adapter.md
@@ -31,6 +31,22 @@ milestone:
 - fallback quote management
 - initializer guard for upgrade-safe deployments
 
+Role-gated control surfaces:
+- `ORACLE_ADMIN_ROLE`
+  - `setOracleSource`
+  - `setMaxStaleness`
+  - `setValidationBounds`
+  - `setFallbackMode`
+  - `setFallbackQuote`
+  - `clearFallbackQuote`
+  - `resetCircuitBreaker`
+- `ORACLE_GUARDIAN_ROLE`
+  - `tripCircuitBreaker`
+
+Role hierarchy:
+- `DEFAULT_ADMIN_ROLE` administers `ORACLE_ADMIN_ROLE`
+- `ORACLE_ADMIN_ROLE` administers `ORACLE_GUARDIAN_ROLE`
+
 Read validation checks enforced in strict mode:
 - `updatedAt` must fit in `uint64` and be nonzero
 - `updatedAt` cannot be in the future
@@ -73,3 +89,10 @@ function initOracleAdapter(address source, uint64 maxStaleness) external {
   `setFallbackQuote(...)`.
 - Return to normal mode by fixing feed health and calling
   `resetCircuitBreaker()`.
+
+## Recommended Assignments
+
+- Assign `DEFAULT_ADMIN_ROLE` to governance or root multisig.
+- Assign `ORACLE_ADMIN_ROLE` to a smaller operator multisig that manages oracle policy.
+- Assign `ORACLE_GUARDIAN_ROLE` to incident responders or automation that can only trip breaker.
+- Keep `trip` and `reset` authority separated in production environments unless operational simplicity is preferred.

--- a/src/interfaces/IOracleAdapter.sol
+++ b/src/interfaces/IOracleAdapter.sol
@@ -79,6 +79,14 @@ interface IOracleAdapter is IERC165 {
     /// @return The oracle source contract.
     function oracleSource() external view returns (address);
 
+    /// @notice Role that can manage oracle configuration.
+    /// @return The oracle admin role identifier.
+    function ORACLE_ADMIN_ROLE() external view returns (bytes32);
+
+    /// @notice Role that can trigger emergency breaker operations.
+    /// @return The oracle guardian role identifier.
+    function ORACLE_GUARDIAN_ROLE() external view returns (bytes32);
+
     /// @notice Returns the configured max accepted staleness in seconds.
     /// @return The max staleness window.
     function maxStaleness() external view returns (uint64);

--- a/src/oracle/OracleAdapter.sol
+++ b/src/oracle/OracleAdapter.sol
@@ -9,12 +9,18 @@ import {LibOracleAdapterStorage} from "./storage/LibOracleAdapterStorage.sol";
 
 /// @title OracleAdapter
 /// @notice Base oracle adapter with normalized quote reads and upgrade-safe storage.
-/// @dev Uses DEFAULT_ADMIN_ROLE for baseline configuration controls.
+/// @dev Uses dedicated oracle roles for least-privilege controls.
 abstract contract OracleAdapter is AccessControl, IOracleAdapter {
+    /// @notice Role allowed to manage oracle configuration and fallback policy.
+    bytes32 public constant ORACLE_ADMIN_ROLE = keccak256("ORACLE_ADMIN_ROLE");
+    /// @notice Role allowed to trip the oracle circuit breaker.
+    bytes32 public constant ORACLE_GUARDIAN_ROLE = keccak256("ORACLE_GUARDIAN_ROLE");
+
     /// @param initialAdmin The account to receive DEFAULT_ADMIN_ROLE.
     /// @param initialSource The initial oracle feed source.
     /// @param initialMaxStaleness The initial max staleness threshold.
     constructor(address initialAdmin, address initialSource, uint64 initialMaxStaleness) AccessControl(initialAdmin) {
+        _initializeOracleRoles(initialAdmin, initialAdmin);
         _initializeOracleAdapter(initialSource, initialMaxStaleness);
     }
 
@@ -82,34 +88,34 @@ abstract contract OracleAdapter is AccessControl, IOracleAdapter {
     }
 
     /// @notice Updates the oracle source.
-    /// @dev Caller must have DEFAULT_ADMIN_ROLE.
+    /// @dev Caller must have ORACLE_ADMIN_ROLE.
     /// @param newSource The new oracle source contract.
-    function setOracleSource(address newSource) public onlyRole(DEFAULT_ADMIN_ROLE) {
+    function setOracleSource(address newSource) public onlyRole(ORACLE_ADMIN_ROLE) {
         _setOracleSource(newSource);
     }
 
     /// @notice Updates the max staleness window.
-    /// @dev Caller must have DEFAULT_ADMIN_ROLE.
+    /// @dev Caller must have ORACLE_ADMIN_ROLE.
     /// @param newMaxStaleness New staleness threshold in seconds.
-    function setMaxStaleness(uint64 newMaxStaleness) public onlyRole(DEFAULT_ADMIN_ROLE) {
+    function setMaxStaleness(uint64 newMaxStaleness) public onlyRole(ORACLE_ADMIN_ROLE) {
         _setMaxStaleness(newMaxStaleness);
     }
 
     /// @notice Updates answer bounds validation policy.
-    /// @dev Caller must have DEFAULT_ADMIN_ROLE.
+    /// @dev Caller must have ORACLE_ADMIN_ROLE.
     /// @param newMinAnswer The inclusive minimum answer.
     /// @param newMaxAnswer The inclusive maximum answer.
     /// @param newBoundsEnabled True to enforce bounds during reads.
     function setValidationBounds(int256 newMinAnswer, int256 newMaxAnswer, bool newBoundsEnabled)
         public
-        onlyRole(DEFAULT_ADMIN_ROLE)
+        onlyRole(ORACLE_ADMIN_ROLE)
     {
         _setValidationBounds(newMinAnswer, newMaxAnswer, newBoundsEnabled);
     }
 
     /// @notice Trips the oracle circuit breaker.
-    /// @dev Caller must have DEFAULT_ADMIN_ROLE.
-    function tripCircuitBreaker() public onlyRole(DEFAULT_ADMIN_ROLE) {
+    /// @dev Caller must have ORACLE_GUARDIAN_ROLE.
+    function tripCircuitBreaker() public onlyRole(ORACLE_GUARDIAN_ROLE) {
         LibOracleAdapterStorage.Layout storage layout = LibOracleAdapterStorage.layout();
         if (layout.breakerActive) {
             revert OracleAdapterBreakerAlreadyActive();
@@ -119,8 +125,8 @@ abstract contract OracleAdapter is AccessControl, IOracleAdapter {
     }
 
     /// @notice Resets the oracle circuit breaker.
-    /// @dev Caller must have DEFAULT_ADMIN_ROLE.
-    function resetCircuitBreaker() public onlyRole(DEFAULT_ADMIN_ROLE) {
+    /// @dev Caller must have ORACLE_ADMIN_ROLE.
+    function resetCircuitBreaker() public onlyRole(ORACLE_ADMIN_ROLE) {
         LibOracleAdapterStorage.Layout storage layout = LibOracleAdapterStorage.layout();
         if (!layout.breakerActive) {
             revert OracleAdapterBreakerAlreadyInactive();
@@ -130,9 +136,9 @@ abstract contract OracleAdapter is AccessControl, IOracleAdapter {
     }
 
     /// @notice Updates fallback behavior used under unhealthy oracle conditions.
-    /// @dev Caller must have DEFAULT_ADMIN_ROLE.
+    /// @dev Caller must have ORACLE_ADMIN_ROLE.
     /// @param newMode The new fallback mode.
-    function setFallbackMode(FallbackMode newMode) public onlyRole(DEFAULT_ADMIN_ROLE) {
+    function setFallbackMode(FallbackMode newMode) public onlyRole(ORACLE_ADMIN_ROLE) {
         LibOracleAdapterStorage.Layout storage layout = LibOracleAdapterStorage.layout();
         FallbackMode previousMode = FallbackMode(layout.fallbackMode);
         layout.fallbackMode = uint8(newMode);
@@ -140,17 +146,17 @@ abstract contract OracleAdapter is AccessControl, IOracleAdapter {
     }
 
     /// @notice Sets fallback quote returned in `UseConfiguredQuote` mode.
-    /// @dev Caller must have DEFAULT_ADMIN_ROLE.
+    /// @dev Caller must have ORACLE_ADMIN_ROLE.
     /// @param value Fallback quote value.
     /// @param updatedAt Fallback quote timestamp.
     /// @param decimals Fallback quote decimals.
-    function setFallbackQuote(int256 value, uint64 updatedAt, uint8 decimals) public onlyRole(DEFAULT_ADMIN_ROLE) {
+    function setFallbackQuote(int256 value, uint64 updatedAt, uint8 decimals) public onlyRole(ORACLE_ADMIN_ROLE) {
         _setFallbackQuote(value, updatedAt, decimals);
     }
 
     /// @notice Clears configured fallback quote.
-    /// @dev Caller must have DEFAULT_ADMIN_ROLE.
-    function clearFallbackQuote() public onlyRole(DEFAULT_ADMIN_ROLE) {
+    /// @dev Caller must have ORACLE_ADMIN_ROLE.
+    function clearFallbackQuote() public onlyRole(ORACLE_ADMIN_ROLE) {
         LibOracleAdapterStorage.Layout storage layout = LibOracleAdapterStorage.layout();
         layout.hasFallbackQuote = false;
         layout.fallbackValue = 0;
@@ -182,6 +188,16 @@ abstract contract OracleAdapter is AccessControl, IOracleAdapter {
         layout.fallbackMode = uint8(FallbackMode.StrictRevert);
         _setOracleSource(initialSource);
         _setMaxStaleness(initialMaxStaleness);
+    }
+
+    /// @dev Initializes oracle role hierarchy and initial role assignments.
+    /// @param initialOracleAdmin Account to receive ORACLE_ADMIN_ROLE.
+    /// @param initialOracleGuardian Account to receive ORACLE_GUARDIAN_ROLE.
+    function _initializeOracleRoles(address initialOracleAdmin, address initialOracleGuardian) internal {
+        _setRoleAdmin(ORACLE_ADMIN_ROLE, DEFAULT_ADMIN_ROLE);
+        _setRoleAdmin(ORACLE_GUARDIAN_ROLE, ORACLE_ADMIN_ROLE);
+        _grantRole(ORACLE_ADMIN_ROLE, initialOracleAdmin);
+        _grantRole(ORACLE_GUARDIAN_ROLE, initialOracleGuardian);
     }
 
     /// @dev Sets oracle source after validation.

--- a/test/OracleAdapterCore.t.sol
+++ b/test/OracleAdapterCore.t.sol
@@ -42,6 +42,34 @@ contract OracleAdapterCoreTest is OracleAdapterFixture {
         assertFalse(configured, "fallback quote should start unset");
     }
 
+    function testInitialOracleRoleAssignmentsAndHierarchy() public view {
+        assertTrue(adapter.hasRole(adapter.ORACLE_ADMIN_ROLE(), admin), "initial admin should have oracle admin role");
+        assertTrue(
+            adapter.hasRole(adapter.ORACLE_GUARDIAN_ROLE(), admin), "initial admin should have oracle guardian role"
+        );
+        assertTrue(
+            adapter.getRoleAdmin(adapter.ORACLE_ADMIN_ROLE()) == adapter.DEFAULT_ADMIN_ROLE(),
+            "oracle admin role should be governed by default admin role"
+        );
+        assertTrue(
+            adapter.getRoleAdmin(adapter.ORACLE_GUARDIAN_ROLE()) == adapter.ORACLE_ADMIN_ROLE(),
+            "oracle guardian role should be governed by oracle admin role"
+        );
+    }
+
+    function testOracleAdminCanGrantGuardianRole() public {
+        bytes32 oracleAdminRole = adapter.ORACLE_ADMIN_ROLE();
+        bytes32 oracleGuardianRole = adapter.ORACLE_GUARDIAN_ROLE();
+
+        VM.prank(admin);
+        adapter.grantRole(oracleAdminRole, bob);
+
+        VM.prank(bob);
+        adapter.grantRole(oracleGuardianRole, eve);
+
+        assertTrue(adapter.hasRole(oracleGuardianRole, eve), "oracle admin should grant guardian role");
+    }
+
     function testSupportsInterface() public view {
         assertTrue(adapter.supportsInterface(type(IERC165).interfaceId), "erc165 not supported");
         assertTrue(adapter.supportsInterface(type(IOracleAdapter).interfaceId), "oracle adapter not supported");
@@ -75,7 +103,7 @@ contract OracleAdapterCoreTest is OracleAdapterFixture {
 
     function testNonAdminCannotSetOracleSource() public {
         VM.expectRevert(
-            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, adapter.DEFAULT_ADMIN_ROLE())
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, adapter.ORACLE_ADMIN_ROLE())
         );
         VM.prank(bob);
         adapter.setOracleSource(address(feedB));
@@ -103,7 +131,7 @@ contract OracleAdapterCoreTest is OracleAdapterFixture {
 
     function testNonAdminCannotSetMaxStaleness() public {
         VM.expectRevert(
-            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, adapter.DEFAULT_ADMIN_ROLE())
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, adapter.ORACLE_ADMIN_ROLE())
         );
         VM.prank(bob);
         adapter.setMaxStaleness(2 hours);
@@ -129,7 +157,7 @@ contract OracleAdapterCoreTest is OracleAdapterFixture {
 
     function testNonAdminCannotSetValidationBounds() public {
         VM.expectRevert(
-            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, adapter.DEFAULT_ADMIN_ROLE())
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, adapter.ORACLE_ADMIN_ROLE())
         );
         VM.prank(bob);
         adapter.setValidationBounds(1, 2_000_000_000, true);
@@ -182,19 +210,50 @@ contract OracleAdapterCoreTest is OracleAdapterFixture {
 
     function testNonAdminCannotManageCircuitBreaker() public {
         VM.expectRevert(
-            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, adapter.DEFAULT_ADMIN_ROLE())
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorized.selector, bob, adapter.ORACLE_GUARDIAN_ROLE()
+            )
         );
         VM.prank(bob);
-        adapter.tripCircuitBreaker();
-
-        VM.prank(admin);
         adapter.tripCircuitBreaker();
 
         VM.expectRevert(
-            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, adapter.DEFAULT_ADMIN_ROLE())
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, adapter.ORACLE_ADMIN_ROLE())
         );
         VM.prank(bob);
         adapter.resetCircuitBreaker();
+    }
+
+    function testOracleGuardianCanTripButCannotReset() public {
+        bytes32 oracleAdminRole = adapter.ORACLE_ADMIN_ROLE();
+        bytes32 oracleGuardianRole = adapter.ORACLE_GUARDIAN_ROLE();
+
+        VM.prank(admin);
+        adapter.grantRole(oracleGuardianRole, bob);
+        VM.prank(admin);
+        adapter.revokeRole(oracleAdminRole, bob);
+
+        VM.prank(bob);
+        adapter.tripCircuitBreaker();
+        assertTrue(adapter.circuitBreakerActive(), "guardian should trip breaker");
+
+        VM.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, oracleAdminRole));
+        VM.prank(bob);
+        adapter.resetCircuitBreaker();
+    }
+
+    function testOracleAdminCannotTripWithoutGuardianRole() public {
+        bytes32 oracleAdminRole = adapter.ORACLE_ADMIN_ROLE();
+        bytes32 oracleGuardianRole = adapter.ORACLE_GUARDIAN_ROLE();
+
+        VM.prank(admin);
+        adapter.grantRole(oracleAdminRole, bob);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, oracleGuardianRole)
+        );
+        VM.prank(bob);
+        adapter.tripCircuitBreaker();
     }
 
     function testAdminCanSetFallbackMode() public {
@@ -217,7 +276,7 @@ contract OracleAdapterCoreTest is OracleAdapterFixture {
 
     function testNonAdminCannotSetFallbackMode() public {
         VM.expectRevert(
-            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, adapter.DEFAULT_ADMIN_ROLE())
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, adapter.ORACLE_ADMIN_ROLE())
         );
         VM.prank(bob);
         adapter.setFallbackMode(IOracleAdapter.FallbackMode.UseConfiguredQuote);
@@ -267,7 +326,7 @@ contract OracleAdapterCoreTest is OracleAdapterFixture {
 
     function testNonAdminCannotSetOrClearFallbackQuote() public {
         VM.expectRevert(
-            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, adapter.DEFAULT_ADMIN_ROLE())
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, adapter.ORACLE_ADMIN_ROLE())
         );
         VM.prank(bob);
         adapter.setFallbackQuote(42, 999_000, 8);
@@ -276,7 +335,7 @@ contract OracleAdapterCoreTest is OracleAdapterFixture {
         adapter.setFallbackQuote(42, 999_000, 8);
 
         VM.expectRevert(
-            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, adapter.DEFAULT_ADMIN_ROLE())
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, adapter.ORACLE_ADMIN_ROLE())
         );
         VM.prank(bob);
         adapter.clearFallbackQuote();

--- a/test/helpers/OracleAdapterTestHarness.sol
+++ b/test/helpers/OracleAdapterTestHarness.sol
@@ -109,6 +109,7 @@ contract OracleAdapterHarness is OracleAdapter {
 abstract contract OracleAdapterFixture is TestBase {
     address internal admin = address(0xA11CE);
     address internal bob = address(0xB0B);
+    address internal eve = address(0xE11E);
 
     uint64 internal maxStaleness = 1 hours;
     uint64 internal currentTime = 1_000_000;


### PR DESCRIPTION
## Summary
- add dedicated oracle ACL roles: `ORACLE_ADMIN_ROLE` and `ORACLE_GUARDIAN_ROLE`
- gate oracle control surfaces by least-privilege responsibilities
- define explicit role hierarchy for oracle operations
- expand oracle core tests for role assignment and authorized/unauthorized paths
- document role responsibilities and recommended operational assignments

## Role Model
- `DEFAULT_ADMIN_ROLE` administers `ORACLE_ADMIN_ROLE`
- `ORACLE_ADMIN_ROLE` administers `ORACLE_GUARDIAN_ROLE`
- `ORACLE_ADMIN_ROLE`: source/config/fallback management and breaker reset
- `ORACLE_GUARDIAN_ROLE`: breaker trip only

## Validation
- `forge test --offline` (159 passed, 0 failed)

Closes #17