### PR TITLE
test(oracle): add hardening fuzz coverage and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ forge fmt
 
 ## Testing
 - Convention guide: `docs/testing-conventions.md`
+- Oracle hardening suite: `test/OracleAdapterCore.t.sol`, `test/OracleAdapterValidation.t.sol`, `test/OracleAdapterCircuitBreaker.t.sol`, `test/OracleAdapterFuzz.t.sol`
 
 ## Module Docs
 - Access control: `docs/access-control.md`

--- a/docs/oracle-adapter.md
+++ b/docs/oracle-adapter.md
@@ -96,3 +96,15 @@ function initOracleAdapter(address source, uint64 maxStaleness) external {
 - Assign `ORACLE_ADMIN_ROLE` to a smaller operator multisig that manages oracle policy.
 - Assign `ORACLE_GUARDIAN_ROLE` to incident responders or automation that can only trip breaker.
 - Keep `trip` and `reset` authority separated in production environments unless operational simplicity is preferred.
+
+## Security Assumptions
+
+- Oracle source contract implements the expected `latestRoundData` and `decimals` ABI.
+- Privileged role keys are operationally secured and rotated when needed.
+- Fallback quotes are managed with off-chain operational policy and bounded by governance process.
+
+## Failure Modes
+
+- In `StrictRevert`, unhealthy reads revert and do not return stale/invalid data.
+- In `UseConfiguredQuote`, unhealthy reads return the configured fallback quote.
+- If fallback mode is enabled without a configured quote, reads revert with `OracleAdapterFallbackUnavailable`.

--- a/docs/testing-conventions.md
+++ b/docs/testing-conventions.md
@@ -46,6 +46,7 @@ Use a split test layout so modules stay readable as complexity grows.
 - Core example: `test/OracleAdapterCircuitBreaker.t.sol`
 - Core example: `test/UpgradeGuardrailsCore.t.sol`
 - Fuzz example: `test/AccessControlFuzz.t.sol`
+- Fuzz example: `test/OracleAdapterFuzz.t.sol`
 - Fuzz example: `test/PausableFuzz.t.sol`
 - Fuzz example: `test/UpgradeGuardrailsFuzz.t.sol`
 - Time example: `test/AccessControlTime.t.sol`

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,11 +1,12 @@
 # Threat Model
 
 This summary covers the security assumptions and guard rails for the
-Access Control + Upgrade Safety Kit modules.
+Access, Oracle, and Upgrade Safety Kit modules.
 
 ## In-Scope Modules
 
 - `AccessControl`
+- `OracleAdapter`
 - `Pausable`
 - `ReentrancyGuard`
 - `UpgradeGuardrails`
@@ -14,6 +15,7 @@ Access Control + Upgrade Safety Kit modules.
 
 - Unauthorized accounts cannot perform privileged actions.
 - Role administration and permission state changes are explicit and auditable.
+- Oracle reads fail closed by default and only degrade under explicit fallback policy.
 - Emergency pause controls can contain incidents.
 - Reentrant state-changing entrypoints are blocked.
 - Upgrade execution follows explicit authorization and guardrail checks.
@@ -21,6 +23,7 @@ Access Control + Upgrade Safety Kit modules.
 ## Trust Assumptions
 
 - Initial admin/upgrader/pauser assignments are correct at initialization.
+- Oracle feed sources are configured to trusted contracts with expected ABI behavior.
 - Governance/operator keys are managed securely off-chain.
 - Deployed contracts integrate `_applyUpgrade` correctly for their proxy/diamond mechanism.
 - Time-based checks rely on `block.timestamp` and accept normal timestamp variance.
@@ -39,13 +42,20 @@ Access Control + Upgrade Safety Kit modules.
 4. Reentrant write-path execution
 - Mitigation: `nonReentrant` guard for state-changing entrypoints.
 
-5. Unsafe or rushed upgrades
+5. Oracle data quality failures (stale/invalid/malformed source reads)
+- Mitigation: strict validation of timestamps/round consistency/bounds, strict-revert default mode, breaker trip path, optional configured fallback.
+
+6. Oracle control-plane misuse
+- Mitigation: separate `ORACLE_ADMIN_ROLE` (config/reset) and `ORACLE_GUARDIAN_ROLE` (trip-only) with explicit admin hierarchy.
+
+7. Unsafe or rushed upgrades
 - Mitigation: upgrader role, queued intent model, optional timelock delay, strict implementation matching, cancel flow.
 
 ## Residual Risks / Out of Scope
 
 - Compromised privileged keys can still perform privileged actions.
 - Economic attacks and protocol-specific business logic exploits are out of scope for this base kit.
+- Oracle market manipulation resistance is feed/provider-specific and must be handled at integration and policy layers.
 - Diamond-specific `diamondCut` payload validation and multi-step governance workflows are deferred to the diamond milestone.
 - The current upgrade guardrails check nonzero implementation; deeper bytecode/interface validation is protocol-specific and should be added where needed.
 

--- a/src/oracle/OracleAdapter.sol
+++ b/src/oracle/OracleAdapter.sol
@@ -273,33 +273,21 @@ abstract contract OracleAdapter is AccessControl, IOracleAdapter {
     /// @return quotePayload The validated live quote payload.
     function _readLiveQuoteStrict() internal view returns (OracleQuote memory quotePayload) {
         address source = oracleSource();
-        uint80 roundId;
-        int256 answer;
-        uint256 updatedAt;
-        uint80 answeredInRound;
-
-        try IOracleFeed(source).latestRoundData() returns (
-            uint80 returnedRoundId,
-            int256 returnedAnswer,
-            uint256,
-            uint256 returnedUpdatedAt,
-            uint80 returnedAnsweredInRound
-        ) {
-            roundId = returnedRoundId;
-            answer = returnedAnswer;
-            updatedAt = returnedUpdatedAt;
-            answeredInRound = returnedAnsweredInRound;
-        } catch {
+        (bool roundDataCallSuccess, bytes memory roundDataRaw) =
+            source.staticcall(abi.encodeWithSelector(IOracleFeed.latestRoundData.selector));
+        if (!roundDataCallSuccess || roundDataRaw.length != 160) {
             revert OracleAdapterLiveReadFailed();
         }
+        (uint80 roundId, int256 answer,, uint256 updatedAt, uint80 answeredInRound) =
+            abi.decode(roundDataRaw, (uint80, int256, uint256, uint256, uint80));
 
         uint64 normalizedUpdatedAt = _validateRoundData(roundId, answer, updatedAt, answeredInRound);
-        uint8 decimals;
-        try IOracleFeed(source).decimals() returns (uint8 returnedDecimals) {
-            decimals = returnedDecimals;
-        } catch {
+        (bool decimalsCallSuccess, bytes memory decimalsRaw) =
+            source.staticcall(abi.encodeWithSelector(IOracleFeed.decimals.selector));
+        if (!decimalsCallSuccess || decimalsRaw.length != 32) {
             revert OracleAdapterLiveReadFailed();
         }
+        uint8 decimals = abi.decode(decimalsRaw, (uint8));
 
         quotePayload = OracleQuote({value: answer, updatedAt: normalizedUpdatedAt, decimals: decimals});
     }

--- a/test/OracleAdapterCircuitBreaker.t.sol
+++ b/test/OracleAdapterCircuitBreaker.t.sol
@@ -38,6 +38,26 @@ contract OracleAdapterCircuitBreakerTest is OracleAdapterFixture {
         adapter.quote();
     }
 
+    function testQuoteRevertsWhenRoundDataPayloadMalformedInStrictMode() public {
+        MalformedRoundDataFeed malformedFeed = new MalformedRoundDataFeed();
+
+        VM.prank(admin);
+        adapter.setOracleSource(address(malformedFeed));
+
+        VM.expectRevert(abi.encodeWithSelector(IOracleAdapter.OracleAdapterLiveReadFailed.selector));
+        adapter.quote();
+    }
+
+    function testQuoteRevertsWhenDecimalsPayloadMalformedInStrictMode() public {
+        MalformedDecimalsFeed malformedFeed = new MalformedDecimalsFeed();
+
+        VM.prank(admin);
+        adapter.setOracleSource(address(malformedFeed));
+
+        VM.expectRevert(abi.encodeWithSelector(IOracleAdapter.OracleAdapterLiveReadFailed.selector));
+        adapter.quote();
+    }
+
     function testQuoteUsesFallbackWhenLiveReadFails() public {
         VM.prank(admin);
         adapter.setFallbackQuote(55, 777_000, 8);

--- a/test/OracleAdapterFuzz.t.sol
+++ b/test/OracleAdapterFuzz.t.sol
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {OracleAdapterFixture} from "./helpers/OracleAdapterTestHarness.sol";
+import {IOracleAdapter} from "../src/interfaces/IOracleAdapter.sol";
+
+contract OracleAdapterFuzzTest is OracleAdapterFixture {
+    function testFuzzQuoteReturnsHealthyLivePayload(
+        int192 answerRaw,
+        uint8 decimals,
+        uint16 ageRaw,
+        uint8 answeredOffsetRaw
+    ) public {
+        uint64 age = uint64(ageRaw % (maxStaleness + 1));
+        uint64 updatedAt = currentTime - age;
+        int256 answer = int256(answerRaw);
+        uint80 roundId = 100;
+        uint80 answeredInRound = roundId + uint80(answeredOffsetRaw % 8);
+
+        feedA.setDecimals(decimals);
+        feedA.setLatestRoundData(roundId, answer, updatedAt, updatedAt, answeredInRound);
+
+        IOracleAdapter.OracleQuote memory readQuote = adapter.quote();
+        assertTrue(readQuote.value == answer, "quote value should match live feed");
+        assertTrue(readQuote.updatedAt == updatedAt, "quote timestamp should match live feed");
+        assertTrue(readQuote.decimals == decimals, "quote decimals should match live feed");
+    }
+
+    function testFuzzQuoteRevertsWhenStalenessExceeded(uint16 staleExtraRaw) public {
+        uint64 extraRange = currentTime - maxStaleness - 1;
+        uint64 age = maxStaleness + 1 + uint64(staleExtraRaw % extraRange);
+        uint64 staleUpdatedAt = currentTime - age;
+        feedA.setLatestRoundData(1, 100_000_000, staleUpdatedAt, staleUpdatedAt, 1);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IOracleAdapter.OracleAdapterStaleQuote.selector,
+                staleUpdatedAt,
+                uint64(currentTime),
+                uint64(maxStaleness)
+            )
+        );
+        adapter.quote();
+    }
+
+    function testFuzzBoundsInclusiveEndpoints(int64 minAnswerRaw, uint32 spanRaw, bool useUpperBound) public {
+        int256 minAnswer = int256(minAnswerRaw);
+        int256 maxAnswer = minAnswer + int256(uint256(spanRaw));
+        int256 answer = useUpperBound ? maxAnswer : minAnswer;
+
+        VM.prank(admin);
+        adapter.setValidationBounds(minAnswer, maxAnswer, true);
+        feedA.setLatestRoundData(1, answer, feedAUpdatedAt, feedAUpdatedAt, 1);
+
+        IOracleAdapter.OracleQuote memory readQuote = adapter.quote();
+        assertTrue(readQuote.value == answer, "inclusive bounds should accept endpoint answers");
+    }
+
+    function testFuzzOutOfBoundsFallsBackWhenConfigured(
+        int64 minAnswerRaw,
+        uint32 spanRaw,
+        bool aboveMax,
+        int192 fallbackValueRaw,
+        uint8 fallbackDecimals
+    ) public {
+        int256 minAnswer = int256(minAnswerRaw);
+        int256 maxAnswer = minAnswer + int256(uint256(spanRaw));
+        int256 outOfBoundsAnswer = aboveMax ? maxAnswer + 1 : minAnswer - 1;
+        int256 fallbackValue = int256(fallbackValueRaw);
+        uint64 fallbackUpdatedAt = currentTime;
+
+        VM.prank(admin);
+        adapter.setValidationBounds(minAnswer, maxAnswer, true);
+        VM.prank(admin);
+        adapter.setFallbackQuote(fallbackValue, fallbackUpdatedAt, fallbackDecimals);
+        VM.prank(admin);
+        adapter.setFallbackMode(IOracleAdapter.FallbackMode.UseConfiguredQuote);
+
+        feedA.setLatestRoundData(1, outOfBoundsAnswer, feedAUpdatedAt, feedAUpdatedAt, 1);
+
+        IOracleAdapter.OracleQuote memory readQuote = adapter.quote();
+        assertTrue(readQuote.value == fallbackValue, "out-of-bounds live answer should fall back");
+        assertTrue(readQuote.updatedAt == fallbackUpdatedAt, "fallback timestamp should be returned");
+        assertTrue(readQuote.decimals == fallbackDecimals, "fallback decimals should be returned");
+    }
+
+    function testFuzzCircuitBreakerReturnsConfiguredFallback(
+        int192 fallbackValueRaw,
+        uint64 fallbackUpdatedAtRaw,
+        uint8 fallbackDecimals
+    ) public {
+        uint64 fallbackUpdatedAt = uint64((fallbackUpdatedAtRaw % currentTime) + 1);
+        int256 fallbackValue = int256(fallbackValueRaw);
+
+        VM.prank(admin);
+        adapter.setFallbackQuote(fallbackValue, fallbackUpdatedAt, fallbackDecimals);
+        VM.prank(admin);
+        adapter.setFallbackMode(IOracleAdapter.FallbackMode.UseConfiguredQuote);
+        VM.prank(admin);
+        adapter.tripCircuitBreaker();
+
+        IOracleAdapter.OracleQuote memory readQuote = adapter.quote();
+        assertTrue(readQuote.value == fallbackValue, "breaker path should return configured fallback value");
+        assertTrue(readQuote.updatedAt == fallbackUpdatedAt, "breaker path should return fallback timestamp");
+        assertTrue(readQuote.decimals == fallbackDecimals, "breaker path should return fallback decimals");
+    }
+
+    function testFuzzInvalidRoundStrictRevertsThenFallbackModeUsesConfiguredQuote(
+        uint80 roundIdRaw,
+        int192 fallbackValueRaw,
+        uint8 fallbackDecimals
+    ) public {
+        uint80 roundId = uint80((uint256(roundIdRaw) % 1_000_000) + 1);
+        uint80 answeredInRound = roundId - 1;
+        int256 fallbackValue = int256(fallbackValueRaw);
+        uint64 fallbackUpdatedAt = currentTime;
+
+        feedA.setLatestRoundData(roundId, 100_000_000, feedAUpdatedAt, feedAUpdatedAt, answeredInRound);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(IOracleAdapter.OracleAdapterInvalidRound.selector, roundId, answeredInRound)
+        );
+        adapter.quote();
+
+        VM.prank(admin);
+        adapter.setFallbackQuote(fallbackValue, fallbackUpdatedAt, fallbackDecimals);
+        VM.prank(admin);
+        adapter.setFallbackMode(IOracleAdapter.FallbackMode.UseConfiguredQuote);
+
+        IOracleAdapter.OracleQuote memory readQuote = adapter.quote();
+        assertTrue(readQuote.value == fallbackValue, "invalid round should resolve to configured fallback quote");
+        assertTrue(readQuote.updatedAt == fallbackUpdatedAt, "fallback timestamp should be returned");
+        assertTrue(readQuote.decimals == fallbackDecimals, "fallback decimals should be returned");
+    }
+}


### PR DESCRIPTION
## Summary
- add oracle fuzz/property test suite covering healthy reads, stale bounds, inclusive bounds, breaker fallback, and invalid-round fallback behavior
- add strict-mode malformed payload tests for round data and decimals handling
- harden strict read path so malformed payloads consistently return OracleAdapterLiveReadFailed
- update oracle docs, testing conventions, and threat model with oracle-specific assumptions and failure modes
- update README testing section with oracle hardening suite references

## Validation
- forge test --offline (167 passed, 0 failed)
- forge coverage --offline

Closes #18