### PR TITLE
ci(foundry): establish baseline PR quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: Foundry CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - "milestone/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: foundry-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  foundry-checks:
+    name: Foundry Checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      - name: Cache Foundry Artifacts
+        uses: actions/cache@v4
+        with:
+          path: ~/.foundry/cache
+          key: ${{ runner.os }}-foundry-cache-${{ hashFiles('foundry.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-foundry-cache-
+
+      - name: Show Foundry Version
+        run: forge --version
+
+      - name: Check Formatting
+        run: forge fmt --check
+
+      - name: Build With Sizes
+        run: forge build --sizes
+
+      - name: Run Offline Tests
+        run: forge test --offline

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # smart-contracts
 
 ![Solidity](https://img.shields.io/badge/Solidity-0.8.30-363636?logo=solidity)
+[![Foundry CI](https://github.com/amshirif/smart-contracts/actions/workflows/ci.yml/badge.svg)](https://github.com/amshirif/smart-contracts/actions/workflows/ci.yml)
 ![License](https://img.shields.io/github/license/amshirif/smart-contracts)
 
 Portfolio-focused Solidity modules built with Foundry. The codebase is kept


### PR DESCRIPTION
## Why
This issue introduces a minimal, enforceable CI baseline so formatting, build health, and test regressions are caught automatically before merge.

## What Changed
- Added `.github/workflows/ci.yml` with a `Foundry CI` workflow.
- Workflow runs on `pull_request`, `push` to `main` and `milestone/**`, and manual dispatch.
- Added checks:
  - `forge fmt --check`
  - `forge build --sizes`
  - `forge test --offline`
- Added Foundry toolchain install and cache step in workflow.
- Added CI status badge to `README.md`.

## Validation
Executed locally on this branch:
- `forge fmt --check`
- `forge build --sizes`
- `forge test --offline`

Result: all checks passed (`167 passed, 0 failed`).

## Notes
- This PR intentionally sets baseline checks only.
- Required-check enforcement and ruleset wiring are handled in issue #34.

Closes #32