### PR TITLE
ci(security): add Slither and dependency-review gates

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,39 @@
+name: Dependency Review
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: dependency-review-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    if: ${{ github.event.repository.private == false || vars.ENABLE_PRIVATE_DEPENDENCY_REVIEW == 'true' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+
+  dependency-review-skip-notice:
+    name: Dependency Review Availability
+    runs-on: ubuntu-latest
+    if: ${{ github.event.repository.private == true && vars.ENABLE_PRIVATE_DEPENDENCY_REVIEW != 'true' }}
+
+    steps:
+      - name: Explain skip policy
+        run: |
+          echo "Dependency Review is skipped for private repositories unless the repository variable ENABLE_PRIVATE_DEPENDENCY_REVIEW is set to true."
+          echo "Enable that variable after GHAS/dependency review support is available for this repository."

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -1,0 +1,37 @@
+name: Slither Analysis
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - "milestone/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: slither-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  slither:
+    name: Slither
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      - name: Run Slither (fail on high)
+        uses: crytic/slither-action@v0.4.1
+        with:
+          target: "."
+          fail-on: high
+          slither-args: --exclude-dependencies

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ forge fmt
 ## Testing
 - Convention guide: `docs/testing-conventions.md`
 - Oracle hardening suite: `test/OracleAdapterCore.t.sol`, `test/OracleAdapterValidation.t.sol`, `test/OracleAdapterCircuitBreaker.t.sol`, `test/OracleAdapterFuzz.t.sol`
+- Security CI/local checks: `docs/security-checks.md`
 
 ## Module Docs
 - Access control: `docs/access-control.md`

--- a/docs/security-checks.md
+++ b/docs/security-checks.md
@@ -1,0 +1,43 @@
+# Security Checks
+
+This repository runs security-focused CI checks in addition to baseline Foundry checks.
+
+## CI Policy
+
+### Slither (`.github/workflows/slither.yml`)
+
+- Trigger: pull requests, pushes to `main` and `milestone/**`, manual dispatch.
+- Tooling: `crytic/slither-action`.
+- Policy: fail when Slither reports **high-severity** findings (`fail-on: high`).
+- Scope: contract/static analysis findings are printed in CI logs.
+
+### Dependency Review (`.github/workflows/dependency-review.yml`)
+
+- Trigger: pull requests, manual dispatch.
+- Tooling: `actions/dependency-review-action`.
+- Policy: fail on dependencies with **high** (or higher) known vulnerabilities.
+- Private repository note:
+  - Dependency review for private repositories may require additional GitHub security entitlement.
+  - The workflow runs automatically on private repositories only when repository variable
+    `ENABLE_PRIVATE_DEPENDENCY_REVIEW=true` is set.
+
+## Local Reproduction
+
+### Slither
+
+Install and run the same high-severity gate locally:
+
+```bash
+python3 -m pip install --upgrade pip slither-analyzer
+slither . --exclude-dependencies --fail-on high
+```
+
+### Dependency Review
+
+Equivalent local execution can be done via the workflow using [`act`](https://github.com/nektos/act):
+
+```bash
+act pull_request -W .github/workflows/dependency-review.yml
+```
+
+If `act` is unavailable, run the dependency review check in a draft PR before requesting final review.


### PR DESCRIPTION
## Summary
Establish baseline security analysis checks in CI so contract and dependency risks are detected before merge.

## What Changed
- Added .github/workflows/slither.yml.
- Added .github/workflows/dependency-review.yml.
- Added docs/security-checks.md with CI policy and local reproduction commands.
- Updated README.md to reference security checks documentation.

## CI Policy Added
- Slither runs on pull requests, pushes to main and milestone branches, and manual dispatch.
- Slither fails on high severity findings.
- Dependency Review runs on pull requests and manual dispatch.
- Dependency Review fails on high severity vulnerabilities.
- Private-repo dependency review is gated by ENABLE_PRIVATE_DEPENDENCY_REVIEW=true.

## Validation
- forge fmt --check
- forge test --offline (167 passed, 0 failed)

Closes #33