### PR TITLE
docs(governance): add CODEOWNERS and branch policy guidance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,18 @@
+# Default ownership for repository paths.
+* @amshirif
+
+# Smart contracts and interfaces.
+/src/ @amshirif
+
+# Tests and test fixtures.
+/test/ @amshirif
+
+# Workflow and repository automation configuration.
+/.github/workflows/ @amshirif
+
+# Documentation and runbooks.
+/docs/ @amshirif
+
+# Build and package configuration.
+/foundry.toml @amshirif
+/README.md @amshirif

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ forge fmt
 - Convention guide: `docs/testing-conventions.md`
 - Oracle hardening suite: `test/OracleAdapterCore.t.sol`, `test/OracleAdapterValidation.t.sol`, `test/OracleAdapterCircuitBreaker.t.sol`, `test/OracleAdapterFuzz.t.sol`
 - Security CI/local checks: `docs/security-checks.md`
+- Governance policy: `docs/repository-governance.md`
 
 ## Module Docs
 - Access control: `docs/access-control.md`

--- a/docs/repository-governance.md
+++ b/docs/repository-governance.md
@@ -1,0 +1,54 @@
+# Repository Governance
+
+This document defines ownership and merge controls for this repository.
+
+## CODEOWNERS Policy
+
+Repository ownership is defined in `.github/CODEOWNERS`.
+
+Current owner map:
+- Global default owner: `@amshirif`
+- Contracts and interfaces: `/src/`
+- Tests: `/test/`
+- Workflows: `/.github/workflows/`
+- Documentation: `/docs/`
+
+## Branch Protection Target State
+
+Apply protections to:
+- `main`
+- `milestone/**`
+
+Required settings:
+- Require a pull request before merging.
+- Require approvals.
+- Require review from code owners.
+- Require status checks to pass.
+- Require linear history.
+- Block force pushes.
+- Restrict branch deletion.
+
+## Required Status Checks
+
+Once branch protection is available, configure these checks as required:
+- `Foundry Checks`
+- `Slither`
+
+Conditionally required (only after enabled in private repo):
+- `Dependency Review`
+
+## Platform Constraint
+
+This repository currently receives `403` responses for branch protection/ruleset APIs:
+- `GET /repos/{owner}/{repo}/branches/{branch}/protection`
+- `GET /repos/{owner}/{repo}/rulesets`
+
+GitHub indicates branch protection/ruleset features require a higher plan tier for this private repository.
+
+## Interim Operating Policy (Until Protection Is Available)
+
+- Do not push directly to `main`.
+- Use issue branches and PRs into milestone branches.
+- Merge milestone branches into `main` only via PR.
+- Do not force-push milestone or `main` branches.
+- Treat CI checks (`Foundry CI`, `Slither`) as merge gates.


### PR DESCRIPTION
## Summary
Track governance ownership and branch-protection expectations in the repository, even though enforced branch protection is currently constrained by GitHub plan limits on this private repo.

## What Changed
- Added .github/CODEOWNERS for critical repository paths.
- Added docs/repository-governance.md with target branch-protection settings and interim operating policy.
- Updated README.md to link governance policy docs.

## Validation
- forge test --offline (167 passed, 0 failed)

Closes #34