### PR TITLE
docs(ops): add release standards and operations runbooks

### DIFF
--- a/.github/workflows/main-pr-branch-guard.yml
+++ b/.github/workflows/main-pr-branch-guard.yml
@@ -1,0 +1,33 @@
+name: Main PR Branch Guard
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: main-pr-branch-guard-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  enforce-milestone-head:
+    name: Enforce milestone/* head for main
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Validate pull request head branch
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          echo "Base branch: ${{ github.base_ref }}"
+          echo "Head branch: ${{ github.head_ref }}"
+
+          if [[ "${{ github.head_ref }}" != milestone/* ]]; then
+            echo "Only branches named milestone/* may open PRs into main."
+            exit 1
+          fi
+
+          echo "Branch naming rule satisfied."

--- a/README.md
+++ b/README.md
@@ -50,5 +50,14 @@ forge fmt
 - Upgrade guardrails: `docs/upgrade-guardrails.md`
 - Threat model: `docs/threat-model.md`
 
+## Operations
+- Ops docs index: `docs/ops/README.md`
+- Release checklist: `docs/ops/release-checklist.md`
+- Release notes template: `docs/ops/release-notes-template.md`
+- Oracle incident runbook: `docs/ops/runbook-oracle-incident.md`
+- Pause/unpause runbook: `docs/ops/runbook-pause-unpause.md`
+- Upgrade execution runbook: `docs/ops/runbook-upgrade-execution.md`
+- Milestone close checklist: `docs/ops/milestone-close-checklist.md`
+
 ## Tooling
 - Foundry docs: [book.getfoundry.sh](https://book.getfoundry.sh/)

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -1,0 +1,10 @@
+# Operations Docs
+
+This folder contains release and incident-response operational guides.
+
+- Release checklist: `docs/ops/release-checklist.md`
+- Release notes template: `docs/ops/release-notes-template.md`
+- Oracle incident runbook: `docs/ops/runbook-oracle-incident.md`
+- Pause/unpause runbook: `docs/ops/runbook-pause-unpause.md`
+- Upgrade execution runbook: `docs/ops/runbook-upgrade-execution.md`
+- Milestone close checklist: `docs/ops/milestone-close-checklist.md`

--- a/docs/ops/milestone-close-checklist.md
+++ b/docs/ops/milestone-close-checklist.md
@@ -1,0 +1,44 @@
+# Milestone Close Checklist
+
+Use this checklist before merging a milestone branch into `main`.
+
+## 1. Issue Hygiene
+
+- All milestone issues are closed or explicitly deferred.
+- Parent milestone issue includes final scope summary.
+- Blocking relationships are updated and resolved.
+
+## 2. Branch and PR Hygiene
+
+- Milestone branch is up to date with child PR merges.
+- Final milestone PR to `main` has:
+  - clear summary
+  - test/security evidence
+  - linked issues
+
+## 3. Validation Evidence
+
+- CI checks are green on milestone PR.
+- Required local checks were run and documented:
+  - `forge fmt --check`
+  - `forge build --sizes`
+  - `forge test --offline`
+  - `forge coverage --offline`
+
+## 4. Security and Operations
+
+- Slither and dependency review status reviewed (as enabled).
+- Relevant runbooks are updated for new controls.
+- Residual risks are documented in threat model or milestone PR notes.
+
+## 5. Release Readiness
+
+- Version bump decision made (patch/minor/major).
+- Release notes draft prepared from template.
+- Tag and release plan confirmed.
+
+## 6. Post-Merge Tasks
+
+- Merge milestone branch into `main`.
+- Publish release/tag if in scope.
+- Start next milestone branch and seed initial issues.

--- a/docs/ops/release-checklist.md
+++ b/docs/ops/release-checklist.md
@@ -1,0 +1,59 @@
+# Release Checklist
+
+Use this checklist before tagging and publishing a new release.
+
+## 1. Scope and Versioning
+
+- Confirm merged PR scope for the release.
+- Choose semantic version bump:
+  - patch: fixes/docs/test-only
+  - minor: backwards-compatible features
+  - major: breaking interface or behavior changes
+- Confirm target tag format (for example `v0.2.0`).
+
+## 2. Changelog and Notes
+
+- Draft release notes using `docs/ops/release-notes-template.md`.
+- Include:
+  - highlights
+  - security-impacting changes
+  - migration notes
+  - linked PRs/issues
+- Confirm closed issues and milestone status match release notes.
+
+## 3. Validation Gates
+
+Run and record:
+
+```bash
+forge fmt --check
+forge build --sizes
+forge test --offline
+forge coverage --offline
+```
+
+Required outcomes:
+- no formatting violations
+- no build failures
+- no failing tests
+- coverage report generated and reviewed for regressions in touched modules
+
+## 4. Security/Quality Gates
+
+- Confirm CI status is green for:
+  - Foundry CI
+  - Slither
+  - Dependency Review (when enabled)
+- Confirm no unresolved high-severity findings introduced by this release.
+
+## 5. Publish
+
+- Create and push tag.
+- Publish GitHub release with finalized notes.
+- Attach milestone and key issue links.
+
+## 6. Post-Release
+
+- Verify release artifact and commit hash correctness.
+- Announce release summary (internal/public channel as appropriate).
+- Track follow-up items in a post-release issue if needed.

--- a/docs/ops/release-notes-template.md
+++ b/docs/ops/release-notes-template.md
@@ -1,0 +1,47 @@
+# Release `vX.Y.Z`
+
+Release date: `YYYY-MM-DD`
+
+## Summary
+
+- 
+
+## Highlights
+
+- 
+
+## Security and Risk Notes
+
+- 
+
+## Validation
+
+- `forge fmt --check`
+- `forge build --sizes`
+- `forge test --offline`
+- `forge coverage --offline`
+
+Result summary:
+- 
+
+## Breaking Changes / Migration Notes
+
+- None.
+
+or
+
+- 
+
+## Included PRs
+
+- #NN - 
+- #NN - 
+
+## Included Issues
+
+- #NN
+- #NN
+
+## Known Limitations
+
+- 

--- a/docs/ops/runbook-oracle-incident.md
+++ b/docs/ops/runbook-oracle-incident.md
@@ -1,0 +1,50 @@
+# Runbook: Oracle Incident
+
+Use this runbook when live oracle reads are unhealthy or untrusted.
+
+## Relevant Controls
+
+- `tripCircuitBreaker()` requires `ORACLE_GUARDIAN_ROLE`.
+- `resetCircuitBreaker()` requires `ORACLE_ADMIN_ROLE`.
+- `setFallbackMode(...)` requires `ORACLE_ADMIN_ROLE`.
+- `setFallbackQuote(...)` requires `ORACLE_ADMIN_ROLE`.
+- `clearFallbackQuote()` requires `ORACLE_ADMIN_ROLE`.
+
+## Incident Triggers
+
+- feed call reverts or returns malformed payload
+- stale or future timestamps
+- invalid round consistency (`answeredInRound < roundId`)
+- out-of-bounds answers when bounds are enabled
+
+## Immediate Response
+
+1. Confirm signal quality from monitoring and logs.
+2. Trip breaker:
+  - call `tripCircuitBreaker()`
+3. Choose fallback policy:
+  - strict safety: keep `FallbackMode.StrictRevert`
+  - degraded operation: set `FallbackMode.UseConfiguredQuote`
+4. If degraded operation is needed, set a vetted fallback:
+  - call `setFallbackQuote(value, updatedAt, decimals)`
+
+## Ongoing Management
+
+- Reassess fallback quote freshness on a fixed cadence.
+- Keep incident notes with:
+  - trigger timestamp
+  - account used for control actions
+  - fallback quote source and rationale
+
+## Recovery
+
+1. Validate live feed health (round updates, timestamp freshness, value sanity).
+2. If degraded mode was enabled, decide whether to keep or clear fallback quote.
+3. Reset breaker:
+  - call `resetCircuitBreaker()`
+4. Confirm `quote()` returns expected live data.
+
+## Post-Incident
+
+- Document root cause and timeline.
+- Record whether bounds, staleness window, or responder roles should be adjusted.

--- a/docs/ops/runbook-pause-unpause.md
+++ b/docs/ops/runbook-pause-unpause.md
@@ -1,0 +1,42 @@
+# Runbook: Pause and Unpause
+
+Use this runbook for operational containment using global or scoped pauses.
+
+## Relevant Controls
+
+- `pause()` / `unpause()` require `PAUSER_ROLE`.
+- `pauseScope(bytes32)` / `unpauseScope(bytes32)` require `PAUSER_ROLE`.
+- Global pause overrides all scoped pause checks.
+
+## Decision Guide
+
+- Use global pause when blast radius is unclear or cross-module.
+- Use scoped pause when impact is isolated to a known scope.
+
+## Emergency Pause Procedure
+
+1. Confirm incident and affected module/scope.
+2. Choose containment mode:
+  - global: call `pause()`
+  - scoped: call `pauseScope(scope)`
+3. Verify enforcement by exercising a protected path expected to revert.
+4. Record:
+  - actor
+  - timestamp
+  - scope/global decision
+  - reason
+
+## Unpause Procedure
+
+1. Confirm mitigation is complete.
+2. Validate that unsafe condition is no longer present.
+3. Unpause in reverse order:
+  - scoped: call `unpauseScope(scope)`
+  - global: call `unpause()`
+4. Verify normal behavior on previously paused paths.
+
+## Safety Notes
+
+- Do not unpause on partial diagnosis.
+- Prefer phased scope unpausing before global unpausing in uncertain recoveries.
+- Keep a short post-incident report with timeline and remediation details.

--- a/docs/ops/runbook-upgrade-execution.md
+++ b/docs/ops/runbook-upgrade-execution.md
@@ -1,0 +1,53 @@
+# Runbook: Upgrade Execution
+
+Use this runbook for guarded upgrade operations.
+
+## Relevant Controls
+
+- `queueUpgradeIntent(address)` requires `UPGRADER_ROLE`.
+- `cancelUpgradeIntent()` requires `UPGRADER_ROLE`.
+- `executeUpgrade(address)` requires `UPGRADER_ROLE`.
+- Guardrails enforce:
+  - nonzero implementation
+  - queued intent existence
+  - implementation match
+  - minimum delay (`minUpgradeDelay`)
+
+## Pre-Queue Checklist
+
+- Confirm implementation address is final and deployed.
+- Confirm compatibility and migration assumptions.
+- Confirm rollback or cancel path is clear.
+
+## Execution Flow
+
+1. Queue:
+  - call `queueUpgradeIntent(implementation)`
+2. Verify queued intent:
+  - call `getUpgradeIntent()`
+3. Wait until `executeAfter` is reached.
+4. Execute:
+  - call `executeUpgrade(implementation)`
+5. Verify post-upgrade behavior and key invariants.
+
+## Cancel Flow
+
+- If any concern appears before execution:
+  - call `cancelUpgradeIntent()`
+- Re-queue only after updated review.
+
+## Post-Execution Validation
+
+- Confirm expected implementation is active (module-specific check).
+- Run smoke checks on critical paths.
+- Record:
+  - queued by / executed by
+  - queue and execution timestamps
+  - validation results
+
+## Failure Handling
+
+- If `executeUpgrade` reverts:
+  - inspect revert reason (not ready / mismatch / zero implementation / no intent)
+  - do not force retries without diagnosing queue state
+  - cancel and re-queue when needed


### PR DESCRIPTION
## Summary
- add a dedicated operations docs index at `docs/ops/README.md`
- add release checklist and release-notes template for repeatable release hygiene
- add runbooks for oracle incident response, pause/unpause flow, and guarded upgrade execution
- add milestone close checklist for consistent milestone-to-main merge readiness
- link operations docs from README

## Deliverables
- `docs/ops/release-checklist.md`
- `docs/ops/release-notes-template.md`
- `docs/ops/runbook-oracle-incident.md`
- `docs/ops/runbook-pause-unpause.md`
- `docs/ops/runbook-upgrade-execution.md`
- `docs/ops/milestone-close-checklist.md`
- `docs/ops/README.md`

## Validation
- `forge test --offline` (167 passed, 0 failed)

Closes #35