### PR TITLE
feat: add ERC-4626 interfaces and storage foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ facets without a full rewrite.
 - `src/oracle/storage`: module-local storage libraries (diamond-ready slots).
 - `src/upgrade`: upgrade authorization and execution guardrails.
 - `src/upgrade/storage`: module-local storage libraries (diamond-ready slots).
-- `src/interfaces`: local interfaces (ERC-165, `IAccessControl`, `IAccessControlTime`, `IOracleAdapter`, `IOracleFeed`, `IPausable`, `IReentrancyGuard`, `IUpgradeGuardrails`, etc.).
+- `src/vault`: ERC-4626 vault foundation utilities.
+- `src/vault/storage`: module-local storage libraries (diamond-ready slots).
+- `src/interfaces`: local interfaces (ERC-165, `IAccessControl`, `IAccessControlTime`, `IERC20`, `IERC20Metadata`, `IERC4626`, `IERC4626VaultBase`, `IOracleAdapter`, `IOracleFeed`, `IPausable`, `IReentrancyGuard`, `IUpgradeGuardrails`, etc.).
 - `src/libraries`: shared cross-module libraries.
 - `test`: split by concern (`*Core.t.sol`, `*Time.t.sol`, `*Integration.t.sol`).
 - `test/helpers`: shared test fixtures and harnesses.
@@ -39,6 +41,7 @@ forge fmt
 
 ## Testing
 - Convention guide: `docs/testing-conventions.md`
+- Vault foundation suite: `test/ERC4626VaultFoundationCore.t.sol`
 - Oracle hardening suite: `test/OracleAdapterCore.t.sol`, `test/OracleAdapterValidation.t.sol`, `test/OracleAdapterCircuitBreaker.t.sol`, `test/OracleAdapterFuzz.t.sol`
 - Security CI/local checks: `docs/security-checks.md`
 

--- a/docs/testing-conventions.md
+++ b/docs/testing-conventions.md
@@ -45,6 +45,7 @@ Use a split test layout so modules stay readable as complexity grows.
 - Core example: `test/OracleAdapterValidation.t.sol`
 - Core example: `test/OracleAdapterCircuitBreaker.t.sol`
 - Core example: `test/UpgradeGuardrailsCore.t.sol`
+- Core example: `test/ERC4626VaultFoundationCore.t.sol`
 - Fuzz example: `test/AccessControlFuzz.t.sol`
 - Fuzz example: `test/OracleAdapterFuzz.t.sol`
 - Fuzz example: `test/PausableFuzz.t.sol`
@@ -56,3 +57,4 @@ Use a split test layout so modules stay readable as complexity grows.
 - Helper example: `test/helpers/OracleAdapterTestHarness.sol`
 - Helper example: `test/helpers/ReentrancyGuardTestHarness.sol`
 - Helper example: `test/helpers/UpgradeGuardrailsTestHarness.sol`
+- Helper example: `test/helpers/ERC4626VaultTestHarness.sol`

--- a/src/interfaces/IERC20.sol
+++ b/src/interfaces/IERC20.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title IERC20
+/// @notice Minimal ERC-20 token interface.
+interface IERC20 {
+    /// @notice Emitted when `value` tokens move from `from` to `to`.
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /// @notice Emitted when `owner` sets `value` allowance for `spender`.
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    /// @notice Returns the total token supply.
+    /// @return The current total supply.
+    function totalSupply() external view returns (uint256);
+
+    /// @notice Returns the token balance for `account`.
+    /// @param account The account to query.
+    /// @return The token balance.
+    function balanceOf(address account) external view returns (uint256);
+
+    /// @notice Transfers `value` tokens to `to`.
+    /// @param to Recipient account.
+    /// @param value Amount of tokens to transfer.
+    /// @return True if the transfer succeeded.
+    function transfer(address to, uint256 value) external returns (bool);
+
+    /// @notice Returns allowance from `owner` to `spender`.
+    /// @param owner Token owner.
+    /// @param spender Approved spender.
+    /// @return Remaining allowance amount.
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /// @notice Sets allowance from caller to `spender`.
+    /// @param spender Approved spender.
+    /// @param value New allowance amount.
+    /// @return True if the approval succeeded.
+    function approve(address spender, uint256 value) external returns (bool);
+
+    /// @notice Transfers `value` tokens from `from` to `to` using allowance.
+    /// @param from Source account.
+    /// @param to Recipient account.
+    /// @param value Amount of tokens to transfer.
+    /// @return True if the transfer succeeded.
+    function transferFrom(address from, address to, uint256 value) external returns (bool);
+}

--- a/src/interfaces/IERC20Metadata.sol
+++ b/src/interfaces/IERC20Metadata.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC20} from "./IERC20.sol";
+
+/// @title IERC20Metadata
+/// @notice ERC-20 metadata extension interface.
+interface IERC20Metadata is IERC20 {
+    /// @notice Returns token display name.
+    /// @return Token name.
+    function name() external view returns (string memory);
+
+    /// @notice Returns token ticker symbol.
+    /// @return Token symbol.
+    function symbol() external view returns (string memory);
+
+    /// @notice Returns token decimals used for display.
+    /// @return Token decimals.
+    function decimals() external view returns (uint8);
+}

--- a/src/interfaces/IERC4626.sol
+++ b/src/interfaces/IERC4626.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC20Metadata} from "./IERC20Metadata.sol";
+
+/// @title IERC4626
+/// @notice ERC-4626 tokenized vault interface.
+interface IERC4626 is IERC20Metadata {
+    /// @notice Emitted after a successful deposit or mint.
+    event Deposit(address indexed caller, address indexed owner, uint256 assets, uint256 shares);
+
+    /// @notice Emitted after a successful withdraw or redeem.
+    event Withdraw(
+        address indexed caller, address indexed receiver, address indexed owner, uint256 assets, uint256 shares
+    );
+
+    /// @notice Returns the vault underlying asset token.
+    /// @return The underlying asset token address.
+    function asset() external view returns (address);
+
+    /// @notice Returns total assets managed by the vault.
+    /// @return The total managed assets amount.
+    function totalAssets() external view returns (uint256);
+
+    /// @notice Converts `assets` to vault shares, rounding down.
+    /// @param assets Asset amount.
+    /// @return Estimated shares.
+    function convertToShares(uint256 assets) external view returns (uint256);
+
+    /// @notice Converts `shares` to vault assets, rounding down.
+    /// @param shares Share amount.
+    /// @return Estimated assets.
+    function convertToAssets(uint256 shares) external view returns (uint256);
+
+    /// @notice Returns max assets that `receiver` can deposit.
+    /// @param receiver Target receiver.
+    /// @return Max deposit amount.
+    function maxDeposit(address receiver) external view returns (uint256);
+
+    /// @notice Returns shares minted by depositing `assets`.
+    /// @param assets Asset amount.
+    /// @return Estimated shares.
+    function previewDeposit(uint256 assets) external view returns (uint256);
+
+    /// @notice Deposits `assets` and mints shares to `receiver`.
+    /// @param assets Asset amount.
+    /// @param receiver Share receiver.
+    /// @return Shares minted.
+    function deposit(uint256 assets, address receiver) external returns (uint256);
+
+    /// @notice Returns max shares that `receiver` can mint.
+    /// @param receiver Target receiver.
+    /// @return Max mint amount.
+    function maxMint(address receiver) external view returns (uint256);
+
+    /// @notice Returns assets required to mint `shares`.
+    /// @param shares Share amount.
+    /// @return Estimated asset amount.
+    function previewMint(uint256 shares) external view returns (uint256);
+
+    /// @notice Mints `shares` to `receiver`.
+    /// @param shares Share amount.
+    /// @param receiver Share receiver.
+    /// @return Assets deposited.
+    function mint(uint256 shares, address receiver) external returns (uint256);
+
+    /// @notice Returns max assets that `owner` can withdraw.
+    /// @param owner Token owner.
+    /// @return Max withdraw amount.
+    function maxWithdraw(address owner) external view returns (uint256);
+
+    /// @notice Returns shares burned by withdrawing `assets`.
+    /// @param assets Asset amount.
+    /// @return Estimated shares burned.
+    function previewWithdraw(uint256 assets) external view returns (uint256);
+
+    /// @notice Withdraws `assets` to `receiver` from `owner`.
+    /// @param assets Asset amount.
+    /// @param receiver Asset receiver.
+    /// @param owner Share owner.
+    /// @return Shares burned.
+    function withdraw(uint256 assets, address receiver, address owner) external returns (uint256);
+
+    /// @notice Returns max shares that `owner` can redeem.
+    /// @param owner Token owner.
+    /// @return Max redeemable shares.
+    function maxRedeem(address owner) external view returns (uint256);
+
+    /// @notice Returns assets received by redeeming `shares`.
+    /// @param shares Share amount.
+    /// @return Estimated assets returned.
+    function previewRedeem(uint256 shares) external view returns (uint256);
+
+    /// @notice Redeems `shares` from `owner` to `receiver`.
+    /// @param shares Share amount.
+    /// @param receiver Asset receiver.
+    /// @param owner Share owner.
+    /// @return Assets returned.
+    function redeem(uint256 shares, address receiver, address owner) external returns (uint256);
+}

--- a/src/interfaces/IERC4626VaultBase.sol
+++ b/src/interfaces/IERC4626VaultBase.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC20Metadata} from "./IERC20Metadata.sol";
+
+/// @title IERC4626VaultBase
+/// @notice Interface for ERC-4626 vault foundation storage and accounting helpers.
+interface IERC4626VaultBase is IERC20Metadata {
+    /// @notice Thrown when vault initializer runs more than once.
+    error ERC4626VaultAlreadyInitialized();
+    /// @notice Thrown when mutating helpers run before initialization.
+    error ERC4626VaultNotInitialized();
+    /// @notice Thrown when vault asset is zero address.
+    error ERC4626VaultZeroAsset();
+    /// @notice Thrown when a required account is zero address.
+    error ERC4626VaultZeroAddress();
+    /// @notice Thrown when an account balance is insufficient for requested operation.
+    error ERC4626VaultInsufficientBalance(address account, uint256 available, uint256 required);
+    /// @notice Thrown when allowance is insufficient for requested operation.
+    error ERC4626VaultInsufficientAllowance(address owner, address spender, uint256 available, uint256 required);
+    /// @notice Thrown when managed asset accounting would underflow.
+    error ERC4626VaultManagedAssetsUnderflow(uint256 available, uint256 required);
+
+    /// @notice Returns true when vault storage is initialized.
+    /// @return True if initialized.
+    function isVaultInitialized() external view returns (bool);
+
+    /// @notice Returns vault asset token.
+    /// @return The underlying asset token address.
+    function asset() external view returns (address);
+
+    /// @notice Returns currently managed asset accounting amount.
+    /// @return The tracked managed asset amount.
+    function totalManagedAssets() external view returns (uint256);
+}

--- a/src/vault/ERC4626VaultBase.sol
+++ b/src/vault/ERC4626VaultBase.sol
@@ -1,0 +1,314 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC20Metadata} from "../interfaces/IERC20Metadata.sol";
+import {IERC4626VaultBase} from "../interfaces/IERC4626VaultBase.sol";
+import {LibERC4626VaultStorage} from "./storage/LibERC4626VaultStorage.sol";
+
+/// @title ERC4626VaultBase
+/// @notice Diamond-ready ERC-4626 foundation with initializer and shared accounting helpers.
+abstract contract ERC4626VaultBase is IERC4626VaultBase {
+    /// @notice Rounding direction used for conversion helpers.
+    enum Rounding {
+        Down,
+        Up
+    }
+
+    /// @notice Returns true when vault storage is initialized.
+    /// @return True if initialized.
+    function isVaultInitialized() public view returns (bool) {
+        return LibERC4626VaultStorage.layout().initialized;
+    }
+
+    /// @notice Returns vault asset token.
+    /// @return The underlying asset token address.
+    function asset() public view returns (address) {
+        return LibERC4626VaultStorage.layout().asset;
+    }
+
+    /// @notice Returns currently managed asset accounting amount.
+    /// @return The tracked managed asset amount.
+    function totalManagedAssets() public view returns (uint256) {
+        return LibERC4626VaultStorage.layout().totalManagedAssets;
+    }
+
+    /// @notice Returns ERC-20 share token name.
+    /// @return The share token name.
+    function name() public view virtual returns (string memory) {
+        return LibERC4626VaultStorage.layout().name;
+    }
+
+    /// @notice Returns ERC-20 share token symbol.
+    /// @return The share token symbol.
+    function symbol() public view virtual returns (string memory) {
+        return LibERC4626VaultStorage.layout().symbol;
+    }
+
+    /// @notice Returns ERC-20 share token decimals.
+    /// @return The share token decimals.
+    function decimals() public view virtual returns (uint8) {
+        return LibERC4626VaultStorage.layout().decimals;
+    }
+
+    /// @notice Returns total ERC-20 share supply.
+    /// @return The share supply.
+    function totalSupply() public view virtual returns (uint256) {
+        return LibERC4626VaultStorage.layout().totalSupply;
+    }
+
+    /// @notice Returns share balance for `account`.
+    /// @param account The account to query.
+    /// @return The share balance.
+    function balanceOf(address account) public view virtual returns (uint256) {
+        return LibERC4626VaultStorage.layout().balances[account];
+    }
+
+    /// @notice Returns allowance from `owner` to `spender`.
+    /// @param owner Token owner.
+    /// @param spender Approved spender.
+    /// @return Remaining allowance.
+    function allowance(address owner, address spender) public view virtual returns (uint256) {
+        return LibERC4626VaultStorage.layout().allowances[owner][spender];
+    }
+
+    /// @dev Initializes vault storage (diamond-ready).
+    /// @dev If `asset` does not expose standard metadata decimals, defaults to 18.
+    /// @param vaultAsset The underlying asset token.
+    /// @param vaultName The share token name.
+    /// @param vaultSymbol The share token symbol.
+    function _initializeErc4626Vault(address vaultAsset, string memory vaultName, string memory vaultSymbol) internal {
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        if (layout.initialized) {
+            revert ERC4626VaultAlreadyInitialized();
+        }
+        if (vaultAsset == address(0)) {
+            revert ERC4626VaultZeroAsset();
+        }
+
+        layout.initialized = true;
+        layout.asset = vaultAsset;
+        layout.name = vaultName;
+        layout.symbol = vaultSymbol;
+        layout.decimals = _readAssetDecimals(vaultAsset);
+    }
+
+    /// @dev Mints `shares` to `account`.
+    /// @param account Share recipient.
+    /// @param shares Shares to mint.
+    function _mintShares(address account, uint256 shares) internal {
+        _requireInitialized();
+        _requireNonZeroAddress(account);
+
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        layout.totalSupply += shares;
+        layout.balances[account] += shares;
+        emit Transfer(address(0), account, shares);
+    }
+
+    /// @dev Burns `shares` from `account`.
+    /// @param account Share holder.
+    /// @param shares Shares to burn.
+    function _burnShares(address account, uint256 shares) internal {
+        _requireInitialized();
+        _requireNonZeroAddress(account);
+
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        uint256 currentBalance = layout.balances[account];
+        if (currentBalance < shares) {
+            revert ERC4626VaultInsufficientBalance(account, currentBalance, shares);
+        }
+
+        unchecked {
+            layout.balances[account] = currentBalance - shares;
+            layout.totalSupply -= shares;
+        }
+
+        emit Transfer(account, address(0), shares);
+    }
+
+    /// @dev Transfers `shares` from `from` to `to`.
+    /// @param from Source account.
+    /// @param to Recipient account.
+    /// @param shares Shares to transfer.
+    function _transferShares(address from, address to, uint256 shares) internal {
+        _requireInitialized();
+        _requireNonZeroAddress(from);
+        _requireNonZeroAddress(to);
+
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        uint256 fromBalance = layout.balances[from];
+        if (fromBalance < shares) {
+            revert ERC4626VaultInsufficientBalance(from, fromBalance, shares);
+        }
+
+        unchecked {
+            layout.balances[from] = fromBalance - shares;
+        }
+        layout.balances[to] += shares;
+
+        emit Transfer(from, to, shares);
+    }
+
+    /// @dev Sets allowance from `owner` to `spender`.
+    /// @param owner Token owner.
+    /// @param spender Approved spender.
+    /// @param value New allowance amount.
+    function _setAllowance(address owner, address spender, uint256 value) internal {
+        _requireInitialized();
+        _requireNonZeroAddress(owner);
+        _requireNonZeroAddress(spender);
+
+        LibERC4626VaultStorage.layout().allowances[owner][spender] = value;
+        emit Approval(owner, spender, value);
+    }
+
+    /// @dev Consumes allowance from `owner` to `spender`.
+    /// @dev Infinite allowance (`type(uint256).max`) is not decremented.
+    /// @param owner Token owner.
+    /// @param spender Approved spender.
+    /// @param value Allowance amount to consume.
+    function _spendAllowance(address owner, address spender, uint256 value) internal {
+        _requireInitialized();
+
+        uint256 currentAllowance = allowance(owner, spender);
+        if (currentAllowance == type(uint256).max) {
+            return;
+        }
+        if (currentAllowance < value) {
+            revert ERC4626VaultInsufficientAllowance(owner, spender, currentAllowance, value);
+        }
+
+        unchecked {
+            _setAllowance(owner, spender, currentAllowance - value);
+        }
+    }
+
+    /// @dev Increases managed asset accounting.
+    /// @param assets Asset amount to add.
+    function _increaseManagedAssets(uint256 assets) internal {
+        _requireInitialized();
+        LibERC4626VaultStorage.layout().totalManagedAssets += assets;
+    }
+
+    /// @dev Decreases managed asset accounting.
+    /// @param assets Asset amount to remove.
+    function _decreaseManagedAssets(uint256 assets) internal {
+        _requireInitialized();
+
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        uint256 managedAssets = layout.totalManagedAssets;
+        if (managedAssets < assets) {
+            revert ERC4626VaultManagedAssetsUnderflow(managedAssets, assets);
+        }
+
+        unchecked {
+            layout.totalManagedAssets = managedAssets - assets;
+        }
+    }
+
+    /// @dev Converts `assets` to shares using current vault totals.
+    /// @param assets Asset amount.
+    /// @param rounding Rounding direction.
+    /// @return Share amount.
+    function _convertToShares(uint256 assets, Rounding rounding) internal view returns (uint256) {
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        return _convertToShares(assets, layout.totalSupply, layout.totalManagedAssets, rounding);
+    }
+
+    /// @dev Converts `shares` to assets using current vault totals.
+    /// @param shares Share amount.
+    /// @param rounding Rounding direction.
+    /// @return Asset amount.
+    function _convertToAssets(uint256 shares, Rounding rounding) internal view returns (uint256) {
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        return _convertToAssets(shares, layout.totalSupply, layout.totalManagedAssets, rounding);
+    }
+
+    /// @dev Converts `assets` to shares using explicit totals.
+    /// @param assets Asset amount.
+    /// @param supply Share supply.
+    /// @param managedAssets Managed assets.
+    /// @param rounding Rounding direction.
+    /// @return Share amount.
+    function _convertToShares(uint256 assets, uint256 supply, uint256 managedAssets, Rounding rounding)
+        internal
+        pure
+        returns (uint256)
+    {
+        if (assets == 0) {
+            return 0;
+        }
+        if (supply == 0 || managedAssets == 0) {
+            return assets;
+        }
+
+        return _mulDiv(assets, supply, managedAssets, rounding);
+    }
+
+    /// @dev Converts `shares` to assets using explicit totals.
+    /// @param shares Share amount.
+    /// @param supply Share supply.
+    /// @param managedAssets Managed assets.
+    /// @param rounding Rounding direction.
+    /// @return Asset amount.
+    function _convertToAssets(uint256 shares, uint256 supply, uint256 managedAssets, Rounding rounding)
+        internal
+        pure
+        returns (uint256)
+    {
+        if (shares == 0) {
+            return 0;
+        }
+        if (supply == 0 || managedAssets == 0) {
+            return shares;
+        }
+
+        return _mulDiv(shares, managedAssets, supply, rounding);
+    }
+
+    /// @dev Returns floor/ceil of `(x * y) / denominator`.
+    /// @param x Multiplicand.
+    /// @param y Multiplier.
+    /// @param denominator Divisor.
+    /// @param rounding Rounding direction.
+    /// @return result Computed quotient.
+    function _mulDiv(uint256 x, uint256 y, uint256 denominator, Rounding rounding)
+        internal
+        pure
+        returns (uint256 result)
+    {
+        uint256 product = x * y;
+        result = product / denominator;
+
+        if (rounding == Rounding.Up && product % denominator != 0) {
+            result += 1;
+        }
+    }
+
+    /// @dev Reverts when vault is not initialized.
+    function _requireInitialized() internal view {
+        if (!isVaultInitialized()) {
+            revert ERC4626VaultNotInitialized();
+        }
+    }
+
+    /// @dev Reverts when `account` is zero address.
+    /// @param account Address to validate.
+    function _requireNonZeroAddress(address account) internal pure {
+        if (account == address(0)) {
+            revert ERC4626VaultZeroAddress();
+        }
+    }
+
+    /// @dev Reads decimals from `vaultAsset`; falls back to `18` when unavailable.
+    /// @param vaultAsset Asset token address.
+    /// @return Token decimals value.
+    function _readAssetDecimals(address vaultAsset) internal view returns (uint8) {
+        (bool success, bytes memory data) = vaultAsset.staticcall(abi.encodeCall(IERC20Metadata.decimals, ()));
+        if (!success || data.length != 32) {
+            return 18;
+        }
+
+        return abi.decode(data, (uint8));
+    }
+}

--- a/src/vault/storage/LibERC4626VaultStorage.sol
+++ b/src/vault/storage/LibERC4626VaultStorage.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title LibERC4626VaultStorage
+/// @notice Storage layout for ERC-4626 vault modules (diamond-ready).
+library LibERC4626VaultStorage {
+    /// @dev Storage slot for vault layout.
+    bytes32 internal constant STORAGE_SLOT = keccak256("smart-contracts.erc4626-vault.storage");
+
+    /// @notice Configurable fee settings for vault flows.
+    struct FeeConfig {
+        uint16 depositFeeBps;
+        uint16 withdrawFeeBps;
+        address feeRecipient;
+    }
+
+    /// @notice Configurable limits for vault flows.
+    struct LimitConfig {
+        uint128 maxTotalAssets;
+        uint128 maxDeposit;
+        uint128 maxMint;
+        uint128 maxWithdraw;
+        uint128 maxRedeem;
+    }
+
+    /// @notice Vault storage layout.
+    struct Layout {
+        bool initialized;
+        address asset;
+        uint8 decimals;
+        string name;
+        string symbol;
+        uint256 totalSupply;
+        mapping(address => uint256) balances;
+        mapping(address => mapping(address => uint256)) allowances;
+        uint256 totalManagedAssets;
+        FeeConfig fees;
+        LimitConfig limits;
+    }
+
+    /// @notice Returns the storage layout for vault state.
+    /// @return l The storage layout pointer.
+    function layout() internal pure returns (Layout storage l) {
+        bytes32 slot = STORAGE_SLOT;
+        assembly {
+            l.slot := slot
+        }
+    }
+}

--- a/test/ERC4626VaultFoundationCore.t.sol
+++ b/test/ERC4626VaultFoundationCore.t.sol
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {ERC4626VaultFixture, MockAssetWithDecimals, NoMetadataAsset} from "./helpers/ERC4626VaultTestHarness.sol";
+import {ERC4626VaultHarness} from "./helpers/ERC4626VaultTestHarness.sol";
+import {IERC4626VaultBase} from "../src/interfaces/IERC4626VaultBase.sol";
+
+contract ERC4626VaultFoundationCoreTest is ERC4626VaultFixture {
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    function testInitializeSetsVaultStorage() public {
+        _initializeVault();
+
+        assertTrue(vault.isVaultInitialized(), "vault not initialized");
+        assertTrue(vault.asset() == address(asset), "asset mismatch");
+        assertTrue(keccak256(bytes(vault.name())) == keccak256(bytes("Vault Share")), "name mismatch");
+        assertTrue(keccak256(bytes(vault.symbol())) == keccak256(bytes("vSHARE")), "symbol mismatch");
+        assertTrue(vault.decimals() == 6, "decimals mismatch");
+    }
+
+    function testInitializeDefaultsDecimalsWhenMetadataMissing() public {
+        NoMetadataAsset noMetadataAsset = new NoMetadataAsset();
+
+        vault.initialize(address(noMetadataAsset), "Vault Share", "vSHARE");
+
+        assertTrue(vault.decimals() == 18, "missing metadata should default to 18 decimals");
+    }
+
+    function testInitializeRevertsOnZeroAsset() public {
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultZeroAsset.selector));
+        vault.initialize(address(0), "Vault Share", "vSHARE");
+    }
+
+    function testInitializeRevertsWhenAlreadyInitialized() public {
+        _initializeVault();
+
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultAlreadyInitialized.selector));
+        vault.initialize(address(asset), "Vault Share", "vSHARE");
+    }
+
+    function testHelpersRevertBeforeInitialize() public {
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultNotInitialized.selector));
+        vault.mintShares(bob, 1);
+
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultNotInitialized.selector));
+        vault.addManagedAssets(1);
+    }
+
+    function testMintSharesUpdatesSupplyAndBalances() public {
+        _initializeVault();
+
+        vault.mintShares(bob, 10);
+
+        assertTrue(vault.totalSupply() == 10, "total supply mismatch");
+        assertTrue(vault.balanceOf(bob) == 10, "balance mismatch");
+    }
+
+    function testMintSharesEmitsTransfer() public {
+        _initializeVault();
+
+        VM.expectEmit(true, true, false, true, address(vault));
+        emit Transfer(address(0), bob, 10);
+        vault.mintShares(bob, 10);
+    }
+
+    function testBurnSharesUpdatesSupplyAndBalances() public {
+        _initializeVault();
+        vault.mintShares(bob, 10);
+
+        vault.burnShares(bob, 4);
+
+        assertTrue(vault.totalSupply() == 6, "total supply mismatch after burn");
+        assertTrue(vault.balanceOf(bob) == 6, "balance mismatch after burn");
+    }
+
+    function testBurnSharesEmitsTransfer() public {
+        _initializeVault();
+        vault.mintShares(bob, 10);
+
+        VM.expectEmit(true, true, false, true, address(vault));
+        emit Transfer(bob, address(0), 4);
+        vault.burnShares(bob, 4);
+    }
+
+    function testBurnSharesRevertsOnInsufficientBalance() public {
+        _initializeVault();
+
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultInsufficientBalance.selector, bob, 0, 1));
+        vault.burnShares(bob, 1);
+    }
+
+    function testTransferFromUsesAllowanceAndUpdatesBalances() public {
+        _initializeVault();
+        vault.mintShares(bob, 10);
+
+        VM.prank(bob);
+        vault.approve(eve, 7);
+
+        VM.prank(eve);
+        bool success = vault.transferFrom(bob, admin, 6);
+        assertTrue(success, "transferFrom should succeed");
+
+        assertTrue(vault.allowance(bob, eve) == 1, "allowance mismatch");
+        assertTrue(vault.balanceOf(bob) == 4, "sender balance mismatch");
+        assertTrue(vault.balanceOf(admin) == 6, "receiver balance mismatch");
+    }
+
+    function testApproveEmitsEvent() public {
+        _initializeVault();
+
+        VM.expectEmit(true, true, false, true, address(vault));
+        emit Approval(bob, eve, 7);
+
+        VM.prank(bob);
+        vault.approve(eve, 7);
+    }
+
+    function testTransferFromRevertsOnInsufficientAllowance() public {
+        _initializeVault();
+        vault.mintShares(bob, 10);
+
+        VM.prank(bob);
+        vault.approve(eve, 2);
+
+        VM.prank(eve);
+        VM.expectRevert(
+            abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultInsufficientAllowance.selector, bob, eve, 2, 3)
+        );
+        vault.transferFromNoReturn(bob, admin, 3);
+    }
+
+    function testManagedAssetAccountingHelpers() public {
+        _initializeVault();
+
+        vault.addManagedAssets(100);
+        vault.removeManagedAssets(45);
+
+        assertTrue(vault.totalManagedAssets() == 55, "managed assets mismatch");
+    }
+
+    function testManagedAssetAccountingRevertsOnUnderflow() public {
+        _initializeVault();
+
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultManagedAssetsUnderflow.selector, 0, 1));
+        vault.removeManagedAssets(1);
+    }
+
+    function testConversionHelpersBootstrapOneToOne() public {
+        _initializeVault();
+
+        assertTrue(vault.convertToSharesDown(5) == 5, "bootstrap shares conversion mismatch");
+        assertTrue(vault.convertToAssetsDown(5) == 5, "bootstrap assets conversion mismatch");
+    }
+
+    function testConversionHelpersApplyRounding() public {
+        _initializeVault();
+        vault.mintShares(bob, 3);
+        vault.addManagedAssets(2);
+
+        assertTrue(vault.convertToAssetsDown(1) == 0, "round down assets mismatch");
+        assertTrue(vault.convertToAssetsUp(1) == 1, "round up assets mismatch");
+
+        assertTrue(vault.convertToSharesDown(1) == 1, "round down shares mismatch");
+        assertTrue(vault.convertToSharesUp(1) == 2, "round up shares mismatch");
+    }
+
+    function testInfiniteAllowanceIsNotDecremented() public {
+        _initializeVault();
+        vault.mintShares(bob, 10);
+
+        VM.prank(bob);
+        vault.approve(eve, type(uint256).max);
+
+        VM.prank(eve);
+        bool success = vault.transferFrom(bob, admin, 3);
+        assertTrue(success, "transferFrom should succeed");
+
+        assertTrue(vault.allowance(bob, eve) == type(uint256).max, "infinite allowance should remain unchanged");
+    }
+
+    function testZeroAddressGuardsForMintAndApprove() public {
+        _initializeVault();
+
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultZeroAddress.selector));
+        vault.mintShares(address(0), 1);
+
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultZeroAddress.selector));
+        vault.approve(address(0), 1);
+    }
+
+    function testAssetDecimalsCanBeUpdatedAtSourceWithoutChangingVaultMetadata() public {
+        _initializeVault();
+
+        MockAssetWithDecimals newAsset = new MockAssetWithDecimals(12);
+        ERC4626VaultHarness secondVault = new ERC4626VaultHarness();
+        secondVault.initialize(address(newAsset), "Second Vault", "sVAULT");
+
+        assertTrue(secondVault.decimals() == 12, "second vault decimals mismatch");
+        assertTrue(vault.decimals() == 6, "original vault decimals should remain unchanged");
+    }
+}

--- a/test/helpers/ERC4626VaultTestHarness.sol
+++ b/test/helpers/ERC4626VaultTestHarness.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {ERC4626VaultBase} from "../../src/vault/ERC4626VaultBase.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+
+contract MockAssetWithDecimals {
+    uint8 internal _decimals;
+
+    constructor(uint8 decimals_) {
+        _decimals = decimals_;
+    }
+
+    function decimals() external view returns (uint8) {
+        return _decimals;
+    }
+}
+
+contract NoMetadataAsset {}
+
+contract ERC4626VaultHarness is ERC4626VaultBase {
+    function initialize(address vaultAsset, string calldata vaultName, string calldata vaultSymbol) external {
+        _initializeErc4626Vault(vaultAsset, vaultName, vaultSymbol);
+    }
+
+    function mintShares(address account, uint256 shares) external {
+        _mintShares(account, shares);
+    }
+
+    function burnShares(address account, uint256 shares) external {
+        _burnShares(account, shares);
+    }
+
+    function addManagedAssets(uint256 assets) external {
+        _increaseManagedAssets(assets);
+    }
+
+    function removeManagedAssets(uint256 assets) external {
+        _decreaseManagedAssets(assets);
+    }
+
+    function convertToSharesDown(uint256 assets) external view returns (uint256) {
+        return _convertToShares(assets, Rounding.Down);
+    }
+
+    function convertToSharesUp(uint256 assets) external view returns (uint256) {
+        return _convertToShares(assets, Rounding.Up);
+    }
+
+    function convertToAssetsDown(uint256 shares) external view returns (uint256) {
+        return _convertToAssets(shares, Rounding.Down);
+    }
+
+    function convertToAssetsUp(uint256 shares) external view returns (uint256) {
+        return _convertToAssets(shares, Rounding.Up);
+    }
+
+    function transfer(address to, uint256 value) external returns (bool) {
+        _transferShares(msg.sender, to, value);
+        return true;
+    }
+
+    function approve(address spender, uint256 value) external returns (bool) {
+        _setAllowance(msg.sender, spender, value);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 value) external returns (bool) {
+        _spendAllowance(from, msg.sender, value);
+        _transferShares(from, to, value);
+        return true;
+    }
+
+    function transferFromNoReturn(address from, address to, uint256 value) external {
+        _spendAllowance(from, msg.sender, value);
+        _transferShares(from, to, value);
+    }
+}
+
+abstract contract ERC4626VaultFixture is TestBase {
+    address internal admin = address(0xA11CE);
+    address internal bob = address(0xB0B);
+    address internal eve = address(0xE11E);
+
+    MockAssetWithDecimals internal asset;
+    ERC4626VaultHarness internal vault;
+
+    function setUp() public virtual {
+        asset = new MockAssetWithDecimals(6);
+        vault = new ERC4626VaultHarness();
+    }
+
+    function _initializeVault() internal {
+        vault.initialize(address(asset), "Vault Share", "vSHARE");
+    }
+}


### PR DESCRIPTION
## Summary
- Add ERC-20 and ERC-4626 interface set for upcoming vault work.
- Add diamond-ready ERC-4626 storage library and vault foundation base contract.
- Add initializer/accounting helper test harness and dedicated foundation test suite.
- Update README and testing conventions to include the new vault foundation module.

## Changes
- Added interfaces:
  - `src/interfaces/IERC20.sol`
  - `src/interfaces/IERC20Metadata.sol`
  - `src/interfaces/IERC4626.sol`
  - `src/interfaces/IERC4626VaultBase.sol`
- Added vault foundation:
  - `src/vault/storage/LibERC4626VaultStorage.sol`
  - `src/vault/ERC4626VaultBase.sol`
- Added tests:
  - `test/helpers/ERC4626VaultTestHarness.sol`
  - `test/ERC4626VaultFoundationCore.t.sol`
- Updated docs:
  - `README.md`
  - `docs/testing-conventions.md`

## Validation
- `forge fmt`
- `forge test --offline`
