### PR TITLE
feat: implement ERC-4626 core vault flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ forge fmt
 ## Testing
 - Convention guide: `docs/testing-conventions.md`
 - Vault foundation suite: `test/ERC4626VaultFoundationCore.t.sol`
+- Vault core suite: `test/ERC4626Core.t.sol`
 - Oracle hardening suite: `test/OracleAdapterCore.t.sol`, `test/OracleAdapterValidation.t.sol`, `test/OracleAdapterCircuitBreaker.t.sol`, `test/OracleAdapterFuzz.t.sol`
 - Security CI/local checks: `docs/security-checks.md`
 

--- a/docs/testing-conventions.md
+++ b/docs/testing-conventions.md
@@ -46,6 +46,7 @@ Use a split test layout so modules stay readable as complexity grows.
 - Core example: `test/OracleAdapterCircuitBreaker.t.sol`
 - Core example: `test/UpgradeGuardrailsCore.t.sol`
 - Core example: `test/ERC4626VaultFoundationCore.t.sol`
+- Core example: `test/ERC4626Core.t.sol`
 - Fuzz example: `test/AccessControlFuzz.t.sol`
 - Fuzz example: `test/OracleAdapterFuzz.t.sol`
 - Fuzz example: `test/PausableFuzz.t.sol`
@@ -58,3 +59,4 @@ Use a split test layout so modules stay readable as complexity grows.
 - Helper example: `test/helpers/ReentrancyGuardTestHarness.sol`
 - Helper example: `test/helpers/UpgradeGuardrailsTestHarness.sol`
 - Helper example: `test/helpers/ERC4626VaultTestHarness.sol`
+- Helper example: `test/helpers/ERC4626CoreTestHarness.sol`

--- a/src/vault/ERC4626Vault.sol
+++ b/src/vault/ERC4626Vault.sol
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC20} from "../interfaces/IERC20.sol";
+import {IERC4626} from "../interfaces/IERC4626.sol";
+import {ERC4626VaultBase} from "./ERC4626VaultBase.sol";
+
+/// @title ERC4626Vault
+/// @notice ERC-4626 core vault flows built on top of diamond-ready vault storage.
+abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
+    /// @notice Thrown when assets input is zero.
+    error ERC4626VaultZeroAssets();
+    /// @notice Thrown when shares input is zero.
+    error ERC4626VaultZeroShares();
+    /// @notice Thrown when asset transfer fails.
+    error ERC4626VaultAssetTransferFailed();
+    /// @notice Thrown when asset transferFrom fails.
+    error ERC4626VaultAssetTransferFromFailed();
+
+    /// @notice Returns vault underlying asset token address.
+    /// @return The underlying asset token.
+    function asset() public view virtual override(ERC4626VaultBase, IERC4626) returns (address) {
+        return super.asset();
+    }
+
+    /// @notice Returns total assets managed by the vault.
+    /// @return The total managed asset amount.
+    function totalAssets() public view virtual returns (uint256) {
+        return totalManagedAssets();
+    }
+
+    /// @notice Converts `assets` to shares, rounding down.
+    /// @param assets Asset amount to convert.
+    /// @return Estimated shares.
+    function convertToShares(uint256 assets) public view virtual returns (uint256) {
+        return _convertToShares(assets, Rounding.Down);
+    }
+
+    /// @notice Converts `shares` to assets, rounding down.
+    /// @param shares Share amount to convert.
+    /// @return Estimated assets.
+    function convertToAssets(uint256 shares) public view virtual returns (uint256) {
+        return _convertToAssets(shares, Rounding.Down);
+    }
+
+    /// @notice Returns max assets `receiver` can deposit.
+    /// @param receiver Target receiver.
+    /// @return Max asset amount accepted.
+    function maxDeposit(address receiver) public view virtual returns (uint256) {
+        return receiver == address(0) ? 0 : type(uint256).max;
+    }
+
+    /// @notice Returns shares minted by depositing `assets`.
+    /// @param assets Asset amount.
+    /// @return Estimated shares.
+    function previewDeposit(uint256 assets) public view virtual returns (uint256) {
+        return _convertToShares(assets, Rounding.Down);
+    }
+
+    /// @notice Deposits `assets` and mints shares to `receiver`.
+    /// @param assets Asset amount.
+    /// @param receiver Receiver of minted shares.
+    /// @return shares Minted shares.
+    function deposit(uint256 assets, address receiver) public virtual returns (uint256 shares) {
+        _requireInitialized();
+        _requireNonZeroAddress(receiver);
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        shares = previewDeposit(assets);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        _safeTransferFromAsset(msg.sender, address(this), assets);
+        _increaseManagedAssets(assets);
+        _mintShares(receiver, shares);
+
+        emit Deposit(msg.sender, receiver, assets, shares);
+    }
+
+    /// @notice Returns max shares `receiver` can mint.
+    /// @param receiver Target receiver.
+    /// @return Max shares accepted.
+    function maxMint(address receiver) public view virtual returns (uint256) {
+        return receiver == address(0) ? 0 : type(uint256).max;
+    }
+
+    /// @notice Returns assets required to mint `shares`.
+    /// @param shares Share amount.
+    /// @return Required assets.
+    function previewMint(uint256 shares) public view virtual returns (uint256) {
+        return _convertToAssets(shares, Rounding.Up);
+    }
+
+    /// @notice Mints `shares` to `receiver`.
+    /// @param shares Share amount.
+    /// @param receiver Receiver of minted shares.
+    /// @return assets Deposited assets.
+    function mint(uint256 shares, address receiver) public virtual returns (uint256 assets) {
+        _requireInitialized();
+        _requireNonZeroAddress(receiver);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        assets = previewMint(shares);
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        _safeTransferFromAsset(msg.sender, address(this), assets);
+        _increaseManagedAssets(assets);
+        _mintShares(receiver, shares);
+
+        emit Deposit(msg.sender, receiver, assets, shares);
+    }
+
+    /// @notice Returns max assets `owner` can withdraw.
+    /// @param owner Share owner.
+    /// @return Max withdrawable assets.
+    function maxWithdraw(address owner) public view virtual returns (uint256) {
+        if (owner == address(0)) {
+            return 0;
+        }
+        return _convertToAssets(balanceOf(owner), Rounding.Down);
+    }
+
+    /// @notice Returns shares burned by withdrawing `assets`.
+    /// @param assets Asset amount.
+    /// @return Estimated shares burned.
+    function previewWithdraw(uint256 assets) public view virtual returns (uint256) {
+        return _convertToShares(assets, Rounding.Up);
+    }
+
+    /// @notice Withdraws `assets` to `receiver` from `owner`.
+    /// @param assets Asset amount.
+    /// @param receiver Asset receiver.
+    /// @param owner Share owner.
+    /// @return shares Burned shares.
+    function withdraw(uint256 assets, address receiver, address owner) public virtual returns (uint256 shares) {
+        _requireInitialized();
+        _requireNonZeroAddress(receiver);
+        _requireNonZeroAddress(owner);
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        shares = previewWithdraw(assets);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        if (msg.sender != owner) {
+            _spendAllowance(owner, msg.sender, shares);
+        }
+
+        _burnShares(owner, shares);
+        _decreaseManagedAssets(assets);
+        _safeTransferAsset(receiver, assets);
+
+        emit Withdraw(msg.sender, receiver, owner, assets, shares);
+    }
+
+    /// @notice Returns max shares `owner` can redeem.
+    /// @param owner Share owner.
+    /// @return Max redeemable shares.
+    function maxRedeem(address owner) public view virtual returns (uint256) {
+        if (owner == address(0)) {
+            return 0;
+        }
+        return balanceOf(owner);
+    }
+
+    /// @notice Returns assets received by redeeming `shares`.
+    /// @param shares Share amount.
+    /// @return Estimated assets returned.
+    function previewRedeem(uint256 shares) public view virtual returns (uint256) {
+        return _convertToAssets(shares, Rounding.Down);
+    }
+
+    /// @notice Redeems `shares` from `owner` to `receiver`.
+    /// @param shares Share amount.
+    /// @param receiver Asset receiver.
+    /// @param owner Share owner.
+    /// @return assets Returned assets.
+    function redeem(uint256 shares, address receiver, address owner) public virtual returns (uint256 assets) {
+        _requireInitialized();
+        _requireNonZeroAddress(receiver);
+        _requireNonZeroAddress(owner);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        assets = previewRedeem(shares);
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        if (msg.sender != owner) {
+            _spendAllowance(owner, msg.sender, shares);
+        }
+
+        _burnShares(owner, shares);
+        _decreaseManagedAssets(assets);
+        _safeTransferAsset(receiver, assets);
+
+        emit Withdraw(msg.sender, receiver, owner, assets, shares);
+    }
+
+    /// @notice Transfers shares from caller to `to`.
+    /// @param to Recipient account.
+    /// @param value Share amount.
+    /// @return True when transfer succeeds.
+    function transfer(address to, uint256 value) public virtual returns (bool) {
+        _transferShares(msg.sender, to, value);
+        return true;
+    }
+
+    /// @notice Sets allowance from caller to `spender`.
+    /// @param spender Approved spender.
+    /// @param value New allowance.
+    /// @return True when approval succeeds.
+    function approve(address spender, uint256 value) public virtual returns (bool) {
+        _setAllowance(msg.sender, spender, value);
+        return true;
+    }
+
+    /// @notice Transfers shares from `from` to `to` using allowance.
+    /// @param from Share owner.
+    /// @param to Recipient account.
+    /// @param value Share amount.
+    /// @return True when transfer succeeds.
+    function transferFrom(address from, address to, uint256 value) public virtual returns (bool) {
+        _spendAllowance(from, msg.sender, value);
+        _transferShares(from, to, value);
+        return true;
+    }
+
+    /// @dev Performs ERC-20 transfer and handles optional return values.
+    /// @param to Asset receiver.
+    /// @param value Asset amount.
+    function _safeTransferAsset(address to, uint256 value) internal {
+        (bool success, bytes memory data) = asset().call(abi.encodeCall(IERC20.transfer, (to, value)));
+        if (!success || (data.length != 0 && !abi.decode(data, (bool)))) {
+            revert ERC4626VaultAssetTransferFailed();
+        }
+    }
+
+    /// @dev Performs ERC-20 transferFrom and handles optional return values.
+    /// @param from Asset sender.
+    /// @param to Asset receiver.
+    /// @param value Asset amount.
+    function _safeTransferFromAsset(address from, address to, uint256 value) internal {
+        (bool success, bytes memory data) = asset().call(abi.encodeCall(IERC20.transferFrom, (from, to, value)));
+        if (!success || (data.length != 0 && !abi.decode(data, (bool)))) {
+            revert ERC4626VaultAssetTransferFromFailed();
+        }
+    }
+}

--- a/src/vault/ERC4626VaultBase.sol
+++ b/src/vault/ERC4626VaultBase.sol
@@ -22,7 +22,7 @@ abstract contract ERC4626VaultBase is IERC4626VaultBase {
 
     /// @notice Returns vault asset token.
     /// @return The underlying asset token address.
-    function asset() public view returns (address) {
+    function asset() public view virtual returns (address) {
         return LibERC4626VaultStorage.layout().asset;
     }
 

--- a/test/ERC4626Core.t.sol
+++ b/test/ERC4626Core.t.sol
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC4626VaultBase} from "../src/interfaces/IERC4626VaultBase.sol";
+import {ERC4626Vault} from "../src/vault/ERC4626Vault.sol";
+import {ERC4626CoreFixture} from "./helpers/ERC4626CoreTestHarness.sol";
+
+contract ERC4626CoreTest is ERC4626CoreFixture {
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+    event Deposit(address indexed caller, address indexed owner, uint256 assets, uint256 shares);
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Withdraw(
+        address indexed caller, address indexed receiver, address indexed owner, uint256 assets, uint256 shares
+    );
+
+    function testPreviewAndConvertBootstrapOneToOne() public view {
+        assertTrue(vault.convertToShares(8) == 8, "convertToShares bootstrap mismatch");
+        assertTrue(vault.convertToAssets(8) == 8, "convertToAssets bootstrap mismatch");
+        assertTrue(vault.previewDeposit(8) == 8, "previewDeposit bootstrap mismatch");
+        assertTrue(vault.previewMint(8) == 8, "previewMint bootstrap mismatch");
+        assertTrue(vault.previewWithdraw(8) == 8, "previewWithdraw bootstrap mismatch");
+        assertTrue(vault.previewRedeem(8) == 8, "previewRedeem bootstrap mismatch");
+    }
+
+    function testPreviewAndConvertRespectRoundingDirection() public {
+        _seedPosition(admin, 3, 2);
+
+        assertTrue(vault.convertToShares(1) == 1, "convertToShares down mismatch");
+        assertTrue(vault.convertToAssets(1) == 0, "convertToAssets down mismatch");
+        assertTrue(vault.previewDeposit(1) == 1, "previewDeposit down mismatch");
+        assertTrue(vault.previewMint(1) == 1, "previewMint up mismatch");
+        assertTrue(vault.previewWithdraw(1) == 2, "previewWithdraw up mismatch");
+        assertTrue(vault.previewRedeem(1) == 0, "previewRedeem down mismatch");
+    }
+
+    function testMaxFunctions() public {
+        _seedPosition(bob, 3, 2);
+
+        assertTrue(vault.maxDeposit(bob) == type(uint256).max, "maxDeposit mismatch");
+        assertTrue(vault.maxMint(bob) == type(uint256).max, "maxMint mismatch");
+        assertTrue(vault.maxDeposit(address(0)) == 0, "maxDeposit zero receiver mismatch");
+        assertTrue(vault.maxMint(address(0)) == 0, "maxMint zero receiver mismatch");
+
+        assertTrue(vault.maxWithdraw(bob) == 2, "maxWithdraw mismatch");
+        assertTrue(vault.maxRedeem(bob) == 3, "maxRedeem mismatch");
+        assertTrue(vault.maxWithdraw(address(0)) == 0, "maxWithdraw zero owner mismatch");
+        assertTrue(vault.maxRedeem(address(0)) == 0, "maxRedeem zero owner mismatch");
+    }
+
+    function testDepositMintsSharesForReceiver() public {
+        _approveAsset(bob, 20);
+
+        VM.prank(bob);
+        uint256 shares = vault.deposit(10, eve);
+
+        assertTrue(shares == 10, "shares mismatch");
+        assertTrue(vault.balanceOf(eve) == 10, "receiver share balance mismatch");
+        assertTrue(vault.totalSupply() == 10, "total supply mismatch");
+        assertTrue(vault.totalAssets() == 10, "total assets mismatch");
+        assertTrue(asset.balanceOf(address(vault)) == 10, "vault asset balance mismatch");
+        assertTrue(asset.balanceOf(bob) == INITIAL_ASSETS - 10, "caller asset balance mismatch");
+    }
+
+    function testDepositEmitsErc20AndErc4626Events() public {
+        _approveAsset(bob, 10);
+
+        VM.expectEmit(true, true, false, true, address(vault));
+        emit Transfer(address(0), eve, 10);
+        VM.expectEmit(true, true, false, true, address(vault));
+        emit Deposit(bob, eve, 10, 10);
+
+        VM.prank(bob);
+        vault.deposit(10, eve);
+    }
+
+    function testMintPullsRoundedUpAssets() public {
+        _seedPosition(admin, 3, 2);
+        _approveAsset(bob, 10);
+
+        VM.prank(bob);
+        uint256 assetsUsed = vault.mint(2, eve);
+
+        assertTrue(assetsUsed == 2, "assets used mismatch");
+        assertTrue(vault.balanceOf(eve) == 2, "receiver share balance mismatch");
+        assertTrue(vault.totalSupply() == 5, "total supply mismatch");
+        assertTrue(vault.totalAssets() == 4, "total assets mismatch");
+        assertTrue(asset.balanceOf(address(vault)) == 4, "vault asset balance mismatch");
+    }
+
+    function testWithdrawBurnsOwnerSharesAndTransfersAssets() public {
+        _seedPosition(bob, 10, 10);
+
+        VM.prank(bob);
+        uint256 burnedShares = vault.withdraw(4, eve, bob);
+
+        assertTrue(burnedShares == 4, "burned shares mismatch");
+        assertTrue(vault.balanceOf(bob) == 6, "owner share balance mismatch");
+        assertTrue(vault.totalSupply() == 6, "total supply mismatch");
+        assertTrue(vault.totalAssets() == 6, "total assets mismatch");
+        assertTrue(asset.balanceOf(eve) == INITIAL_ASSETS + 4, "receiver asset balance mismatch");
+    }
+
+    function testWithdrawEmitsErc20AndErc4626Events() public {
+        _seedPosition(bob, 10, 10);
+
+        VM.expectEmit(true, true, false, true, address(vault));
+        emit Transfer(bob, address(0), 4);
+        VM.expectEmit(true, true, true, true, address(vault));
+        emit Withdraw(bob, eve, bob, 4, 4);
+
+        VM.prank(bob);
+        vault.withdraw(4, eve, bob);
+    }
+
+    function testWithdrawByApprovedSpenderUsesOwnerAllowance() public {
+        _seedPosition(bob, 10, 10);
+
+        VM.prank(bob);
+        vault.approve(eve, 5);
+
+        VM.prank(eve);
+        uint256 burnedShares = vault.withdraw(4, admin, bob);
+
+        assertTrue(burnedShares == 4, "burned shares mismatch");
+        assertTrue(vault.allowance(bob, eve) == 1, "allowance mismatch");
+        assertTrue(vault.balanceOf(bob) == 6, "owner share balance mismatch");
+        assertTrue(asset.balanceOf(admin) == 4, "receiver asset balance mismatch");
+    }
+
+    function testWithdrawWithoutAllowanceReverts() public {
+        _seedPosition(bob, 10, 10);
+
+        VM.prank(eve);
+        VM.expectRevert(
+            abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultInsufficientAllowance.selector, bob, eve, 0, 1)
+        );
+        vault.withdraw(1, eve, bob);
+    }
+
+    function testRedeemBurnsSharesAndReturnsAssets() public {
+        _seedPosition(bob, 10, 10);
+
+        VM.prank(bob);
+        uint256 assetsOut = vault.redeem(3, eve, bob);
+
+        assertTrue(assetsOut == 3, "assets out mismatch");
+        assertTrue(vault.balanceOf(bob) == 7, "owner share balance mismatch");
+        assertTrue(vault.totalSupply() == 7, "total supply mismatch");
+        assertTrue(vault.totalAssets() == 7, "total assets mismatch");
+        assertTrue(asset.balanceOf(eve) == INITIAL_ASSETS + 3, "receiver asset balance mismatch");
+    }
+
+    function testRedeemByApprovedSpenderUsesOwnerAllowance() public {
+        _seedPosition(bob, 10, 10);
+
+        VM.prank(bob);
+        vault.approve(eve, 4);
+
+        VM.prank(eve);
+        uint256 assetsOut = vault.redeem(4, admin, bob);
+
+        assertTrue(assetsOut == 4, "assets out mismatch");
+        assertTrue(vault.allowance(bob, eve) == 0, "allowance mismatch");
+        assertTrue(vault.balanceOf(bob) == 6, "owner share balance mismatch");
+        assertTrue(asset.balanceOf(admin) == 4, "receiver asset balance mismatch");
+    }
+
+    function testRedeemWithoutAllowanceReverts() public {
+        _seedPosition(bob, 10, 10);
+
+        VM.prank(eve);
+        VM.expectRevert(
+            abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultInsufficientAllowance.selector, bob, eve, 0, 1)
+        );
+        vault.redeem(1, eve, bob);
+    }
+
+    function testShareApproveAndTransferFromFlow() public {
+        _seedPosition(bob, 8, 8);
+
+        VM.expectEmit(true, true, false, true, address(vault));
+        emit Approval(bob, eve, 3);
+        VM.prank(bob);
+        vault.approve(eve, 3);
+
+        VM.prank(eve);
+        bool transferSuccess = vault.transferFrom(bob, admin, 2);
+
+        assertTrue(transferSuccess, "transferFrom should succeed");
+        assertTrue(vault.balanceOf(bob) == 6, "owner share balance mismatch");
+        assertTrue(vault.balanceOf(admin) == 2, "recipient share balance mismatch");
+        assertTrue(vault.allowance(bob, eve) == 1, "allowance mismatch");
+    }
+
+    function testZeroAddressGuards() public {
+        _approveAsset(bob, 10);
+        _seedPosition(bob, 1, 1);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultZeroAddress.selector));
+        vault.deposit(1, address(0));
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultZeroAddress.selector));
+        vault.mint(1, address(0));
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultZeroAddress.selector));
+        vault.withdraw(1, address(0), bob);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultZeroAddress.selector));
+        vault.withdraw(1, eve, address(0));
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultZeroAddress.selector));
+        vault.redeem(1, address(0), bob);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultZeroAddress.selector));
+        vault.redeem(1, eve, address(0));
+    }
+
+    function testZeroValueGuards() public {
+        _approveAsset(bob, 10);
+        _seedPosition(bob, 1, 1);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(ERC4626Vault.ERC4626VaultZeroAssets.selector));
+        vault.deposit(0, bob);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(ERC4626Vault.ERC4626VaultZeroShares.selector));
+        vault.mint(0, bob);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(ERC4626Vault.ERC4626VaultZeroAssets.selector));
+        vault.withdraw(0, bob, bob);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(ERC4626Vault.ERC4626VaultZeroShares.selector));
+        vault.redeem(0, bob, bob);
+    }
+
+    function testDepositRevertsWhenTransferFromFails() public {
+        _approveAsset(bob, 10);
+        asset.setFailTransferFrom(true);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(ERC4626Vault.ERC4626VaultAssetTransferFromFailed.selector));
+        vault.deposit(1, bob);
+    }
+
+    function testWithdrawRevertsWhenTransferFails() public {
+        _seedPosition(bob, 5, 5);
+        asset.setFailTransfer(true);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(ERC4626Vault.ERC4626VaultAssetTransferFailed.selector));
+        vault.withdraw(1, bob, bob);
+    }
+
+    function testRedeemRevertsWhenRoundedAssetsIsZero() public {
+        _seedPosition(bob, 3, 2);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(ERC4626Vault.ERC4626VaultZeroAssets.selector));
+        vault.redeem(1, bob, bob);
+    }
+}

--- a/test/helpers/ERC4626CoreTestHarness.sol
+++ b/test/helpers/ERC4626CoreTestHarness.sol
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC20Metadata} from "../../src/interfaces/IERC20Metadata.sol";
+import {ERC4626Vault} from "../../src/vault/ERC4626Vault.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+
+contract MockVaultAsset is IERC20Metadata {
+    string internal _name;
+    string internal _symbol;
+    uint8 internal _decimals;
+    uint256 internal _totalSupply;
+
+    bool internal _failTransfer;
+    bool internal _failTransferFrom;
+
+    mapping(address => uint256) internal _balances;
+    mapping(address => mapping(address => uint256)) internal _allowances;
+
+    constructor(string memory name_, string memory symbol_, uint8 decimals_) {
+        _name = name_;
+        _symbol = symbol_;
+        _decimals = decimals_;
+    }
+
+    function name() external view returns (string memory) {
+        return _name;
+    }
+
+    function symbol() external view returns (string memory) {
+        return _symbol;
+    }
+
+    function decimals() external view returns (uint8) {
+        return _decimals;
+    }
+
+    function totalSupply() external view returns (uint256) {
+        return _totalSupply;
+    }
+
+    function balanceOf(address account) external view returns (uint256) {
+        return _balances[account];
+    }
+
+    function allowance(address owner, address spender) external view returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    function mint(address to, uint256 amount) external {
+        _balances[to] += amount;
+        _totalSupply += amount;
+        emit Transfer(address(0), to, amount);
+    }
+
+    function setFailTransfer(bool shouldFail) external {
+        _failTransfer = shouldFail;
+    }
+
+    function setFailTransferFrom(bool shouldFail) external {
+        _failTransferFrom = shouldFail;
+    }
+
+    function approve(address spender, uint256 value) external returns (bool) {
+        _allowances[msg.sender][spender] = value;
+        emit Approval(msg.sender, spender, value);
+        return true;
+    }
+
+    function transfer(address to, uint256 value) external returns (bool) {
+        if (_failTransfer) {
+            return false;
+        }
+
+        _transfer(msg.sender, to, value);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 value) external returns (bool) {
+        if (_failTransferFrom) {
+            return false;
+        }
+
+        uint256 currentAllowance = _allowances[from][msg.sender];
+        require(currentAllowance >= value, "INSUFFICIENT_ALLOWANCE");
+        if (currentAllowance != type(uint256).max) {
+            unchecked {
+                _allowances[from][msg.sender] = currentAllowance - value;
+            }
+            emit Approval(from, msg.sender, _allowances[from][msg.sender]);
+        }
+
+        _transfer(from, to, value);
+        return true;
+    }
+
+    function _transfer(address from, address to, uint256 value) internal {
+        require(to != address(0), "ZERO_TO");
+
+        uint256 fromBalance = _balances[from];
+        require(fromBalance >= value, "INSUFFICIENT_BALANCE");
+
+        unchecked {
+            _balances[from] = fromBalance - value;
+        }
+        _balances[to] += value;
+
+        emit Transfer(from, to, value);
+    }
+}
+
+contract ERC4626VaultCoreHarness is ERC4626Vault {
+    function initialize(address vaultAsset, string calldata vaultName, string calldata vaultSymbol) external {
+        _initializeErc4626Vault(vaultAsset, vaultName, vaultSymbol);
+    }
+
+    function seedPosition(address owner, uint256 shares, uint256 assets) external {
+        _mintShares(owner, shares);
+        _increaseManagedAssets(assets);
+    }
+}
+
+abstract contract ERC4626CoreFixture is TestBase {
+    uint256 internal constant INITIAL_ASSETS = 1_000_000;
+
+    address internal admin = address(0xA11CE);
+    address internal bob = address(0xB0B);
+    address internal eve = address(0xE11E);
+
+    MockVaultAsset internal asset;
+    ERC4626VaultCoreHarness internal vault;
+
+    function setUp() public virtual {
+        asset = new MockVaultAsset("Mock USD", "mUSD", 6);
+        vault = new ERC4626VaultCoreHarness();
+        vault.initialize(address(asset), "Vault Share", "vSHARE");
+
+        asset.mint(bob, INITIAL_ASSETS);
+        asset.mint(eve, INITIAL_ASSETS);
+    }
+
+    function _approveAsset(address owner, uint256 amount) internal {
+        VM.prank(owner);
+        asset.approve(address(vault), amount);
+    }
+
+    function _seedPosition(address owner, uint256 shares, uint256 assetsAmount) internal {
+        vault.seedPosition(owner, shares, assetsAmount);
+        asset.mint(address(vault), assetsAmount);
+    }
+}


### PR DESCRIPTION
## Summary
- Implement ERC-4626 core flow contract on top of the vault foundation.
- Add spec-style behavior for `totalAssets`, conversion/preview helpers, and max-limit helpers.
- Implement `deposit`, `mint`, `withdraw`, and `redeem` with owner/receiver/allowance semantics.
- Add unit tests for happy paths, event emission, rounding behavior, and revert paths.

## Changes
- Added `src/vault/ERC4626Vault.sol` with:
  - `totalAssets`, `convertToShares`, `convertToAssets`
  - `maxDeposit`, `maxMint`, `maxWithdraw`, `maxRedeem`
  - `previewDeposit`, `previewMint`, `previewWithdraw`, `previewRedeem`
  - `deposit`, `mint`, `withdraw`, `redeem`
  - ERC-20 share flows: `transfer`, `approve`, `transferFrom`
- Added `test/helpers/ERC4626CoreTestHarness.sol`
- Added `test/ERC4626Core.t.sol`
- Updated references in `README.md` and `docs/testing-conventions.md`
- Updated `src/vault/ERC4626VaultBase.sol` to make `asset()` virtual for interface override compatibility

## Validation
- `forge test --offline --match-path test/ERC4626Core.t.sol`
- `forge test --offline`

Closes #43
