### PR TITLE
feat: add ERC-4626 vault controls (fees, limits, pausability, reentrancy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ facets without a full rewrite.
 - `src/oracle/storage`: module-local storage libraries (diamond-ready slots).
 - `src/upgrade`: upgrade authorization and execution guardrails.
 - `src/upgrade/storage`: module-local storage libraries (diamond-ready slots).
-- `src/vault`: ERC-4626 vault foundation utilities.
+- `src/vault`: ERC-4626 vault core and control-layer utilities.
 - `src/vault/storage`: module-local storage libraries (diamond-ready slots).
-- `src/interfaces`: local interfaces (ERC-165, `IAccessControl`, `IAccessControlTime`, `IERC20`, `IERC20Metadata`, `IERC4626`, `IERC4626VaultBase`, `IOracleAdapter`, `IOracleFeed`, `IPausable`, `IReentrancyGuard`, `IUpgradeGuardrails`, etc.).
+- `src/interfaces`: local interfaces (ERC-165, `IAccessControl`, `IAccessControlTime`, `IERC20`, `IERC20Metadata`, `IERC4626`, `IERC4626VaultBase`, `IERC4626VaultControls`, `IOracleAdapter`, `IOracleFeed`, `IPausable`, `IReentrancyGuard`, `IUpgradeGuardrails`, etc.).
 - `src/libraries`: shared cross-module libraries.
 - `test`: split by concern (`*Core.t.sol`, `*Time.t.sol`, `*Integration.t.sol`).
 - `test/helpers`: shared test fixtures and harnesses.
@@ -43,6 +43,7 @@ forge fmt
 - Convention guide: `docs/testing-conventions.md`
 - Vault foundation suite: `test/ERC4626VaultFoundationCore.t.sol`
 - Vault core suite: `test/ERC4626Core.t.sol`
+- Vault controls suite: `test/ERC4626VaultControlsCore.t.sol`
 - Oracle hardening suite: `test/OracleAdapterCore.t.sol`, `test/OracleAdapterValidation.t.sol`, `test/OracleAdapterCircuitBreaker.t.sol`, `test/OracleAdapterFuzz.t.sol`
 - Security CI/local checks: `docs/security-checks.md`
 

--- a/docs/testing-conventions.md
+++ b/docs/testing-conventions.md
@@ -47,6 +47,7 @@ Use a split test layout so modules stay readable as complexity grows.
 - Core example: `test/UpgradeGuardrailsCore.t.sol`
 - Core example: `test/ERC4626VaultFoundationCore.t.sol`
 - Core example: `test/ERC4626Core.t.sol`
+- Core example: `test/ERC4626VaultControlsCore.t.sol`
 - Fuzz example: `test/AccessControlFuzz.t.sol`
 - Fuzz example: `test/OracleAdapterFuzz.t.sol`
 - Fuzz example: `test/PausableFuzz.t.sol`
@@ -59,4 +60,5 @@ Use a split test layout so modules stay readable as complexity grows.
 - Helper example: `test/helpers/ReentrancyGuardTestHarness.sol`
 - Helper example: `test/helpers/UpgradeGuardrailsTestHarness.sol`
 - Helper example: `test/helpers/ERC4626VaultTestHarness.sol`
+- Helper example: `test/helpers/ERC4626VaultControlsTestHarness.sol`
 - Helper example: `test/helpers/ERC4626CoreTestHarness.sol`

--- a/src/interfaces/IERC4626VaultControls.sol
+++ b/src/interfaces/IERC4626VaultControls.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC165} from "./IERC165.sol";
+
+/// @title IERC4626VaultControls
+/// @notice Interface for ERC-4626 fee, limit, and safety control extensions.
+interface IERC4626VaultControls is IERC165 {
+    /// @notice Emitted when fee configuration is updated.
+    event VaultFeeConfigUpdated(
+        uint16 previousDepositFeeBps,
+        uint16 previousWithdrawFeeBps,
+        address indexed previousFeeRecipient,
+        uint16 newDepositFeeBps,
+        uint16 newWithdrawFeeBps,
+        address indexed newFeeRecipient,
+        address indexed sender
+    );
+
+    /// @notice Emitted when limit configuration is updated.
+    event VaultLimitConfigUpdated(
+        uint128 maxTotalAssets,
+        uint128 maxDeposit,
+        uint128 maxMint,
+        uint128 maxWithdraw,
+        uint128 maxRedeem,
+        address indexed sender
+    );
+
+    /// @notice Thrown when a fee basis point value is invalid.
+    error ERC4626VaultInvalidFeeBps(uint16 feeBps);
+    /// @notice Thrown when fee recipient is invalid for non-zero fee config.
+    error ERC4626VaultInvalidFeeRecipient();
+    /// @notice Thrown when deposit input exceeds configured limits.
+    error ERC4626VaultDepositLimitExceeded(uint256 requestedAssets, uint256 maxAssets);
+    /// @notice Thrown when mint input exceeds configured limits.
+    error ERC4626VaultMintLimitExceeded(uint256 requestedShares, uint256 maxShares);
+    /// @notice Thrown when withdraw input exceeds configured limits.
+    error ERC4626VaultWithdrawLimitExceeded(uint256 requestedAssets, uint256 maxAssets);
+    /// @notice Thrown when redeem input exceeds configured limits.
+    error ERC4626VaultRedeemLimitExceeded(uint256 requestedShares, uint256 maxShares);
+    /// @notice Thrown when operation would exceed total-assets cap.
+    error ERC4626VaultTotalAssetsCapExceeded(uint256 currentAssets, uint256 addedAssets, uint256 maxTotalAssets);
+
+    /// @notice Role that can manage vault fees and limits.
+    /// @return The vault manager role identifier.
+    function VAULT_MANAGER_ROLE() external view returns (bytes32);
+
+    /// @notice Returns current fee configuration.
+    /// @return depositFeeBps Deposit fee in basis points.
+    /// @return withdrawFeeBps Withdraw fee in basis points.
+    /// @return feeRecipient Fee recipient account.
+    function feeConfig() external view returns (uint16 depositFeeBps, uint16 withdrawFeeBps, address feeRecipient);
+
+    /// @notice Returns current limit configuration.
+    /// @return maxTotalAssets Cap for managed assets (`0` means unlimited).
+    /// @return maxDeposit Per-call deposit limit (`0` means unlimited).
+    /// @return maxMint Per-call mint limit (`0` means unlimited).
+    /// @return maxWithdraw Per-call withdraw limit (`0` means unlimited).
+    /// @return maxRedeem Per-call redeem limit (`0` means unlimited).
+    function limitConfig()
+        external
+        view
+        returns (uint128 maxTotalAssets, uint128 maxDeposit, uint128 maxMint, uint128 maxWithdraw, uint128 maxRedeem);
+
+    /// @notice Sets fee configuration.
+    /// @param depositFeeBps Deposit fee in basis points.
+    /// @param withdrawFeeBps Withdraw fee in basis points.
+    /// @param feeRecipient Fee recipient account.
+    function setFeeConfig(uint16 depositFeeBps, uint16 withdrawFeeBps, address feeRecipient) external;
+
+    /// @notice Sets limit configuration.
+    /// @param maxTotalAssets Cap for managed assets (`0` means unlimited).
+    /// @param maxDeposit Per-call deposit limit (`0` means unlimited).
+    /// @param maxMint Per-call mint limit (`0` means unlimited).
+    /// @param maxWithdraw Per-call withdraw limit (`0` means unlimited).
+    /// @param maxRedeem Per-call redeem limit (`0` means unlimited).
+    function setLimitConfig(
+        uint128 maxTotalAssets,
+        uint128 maxDeposit,
+        uint128 maxMint,
+        uint128 maxWithdraw,
+        uint128 maxRedeem
+    ) external;
+}

--- a/src/vault/ERC4626VaultControls.sol
+++ b/src/vault/ERC4626VaultControls.sol
@@ -1,0 +1,537 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Pausable} from "../access/Pausable.sol";
+import {IERC165} from "../interfaces/IERC165.sol";
+import {IERC4626VaultControls} from "../interfaces/IERC4626VaultControls.sol";
+import {ReentrancyGuard} from "../security/ReentrancyGuard.sol";
+import {LibERC4626VaultStorage} from "./storage/LibERC4626VaultStorage.sol";
+import {ERC4626Vault} from "./ERC4626Vault.sol";
+
+/// @title ERC4626VaultControls
+/// @notice ERC-4626 extension with role-gated fee/limit controls and safety hooks.
+abstract contract ERC4626VaultControls is ERC4626Vault, Pausable, ReentrancyGuard, IERC4626VaultControls {
+    /// @notice Role that can manage fee and limit configuration.
+    bytes32 public constant VAULT_MANAGER_ROLE = keccak256("VAULT_MANAGER_ROLE");
+
+    /// @dev Basis points denominator.
+    uint256 internal constant BPS_DENOMINATOR = 10_000;
+
+    /// @param initialAdmin Account receiving admin, pauser, and manager roles.
+    /// @param vaultAsset Underlying vault asset token.
+    /// @param vaultName ERC-20 share token name.
+    /// @param vaultSymbol ERC-20 share token symbol.
+    constructor(address initialAdmin, address vaultAsset, string memory vaultName, string memory vaultSymbol)
+        Pausable(initialAdmin)
+        ReentrancyGuard()
+    {
+        _initializeErc4626Vault(vaultAsset, vaultName, vaultSymbol);
+        _initializeVaultControls(initialAdmin);
+    }
+
+    /// @notice Returns true if this contract implements `interfaceId`.
+    /// @param interfaceId The interface identifier.
+    /// @return True if the interface is supported.
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(Pausable, ReentrancyGuard, IERC165)
+        returns (bool)
+    {
+        return interfaceId == type(IERC4626VaultControls).interfaceId || interfaceId == type(IERC165).interfaceId
+            || Pausable.supportsInterface(interfaceId) || ReentrancyGuard.supportsInterface(interfaceId);
+    }
+
+    /// @notice Returns current fee configuration.
+    /// @return depositFeeBps Deposit fee in basis points.
+    /// @return withdrawFeeBps Withdraw fee in basis points.
+    /// @return feeRecipient Fee recipient account.
+    function feeConfig() public view returns (uint16 depositFeeBps, uint16 withdrawFeeBps, address feeRecipient) {
+        LibERC4626VaultStorage.FeeConfig storage fees = LibERC4626VaultStorage.layout().fees;
+        return (fees.depositFeeBps, fees.withdrawFeeBps, fees.feeRecipient);
+    }
+
+    /// @notice Returns current limit configuration.
+    /// @return limitMaxTotalAssets Cap for managed assets (`0` means unlimited).
+    /// @return limitMaxDeposit Per-call deposit limit (`0` means unlimited).
+    /// @return limitMaxMint Per-call mint limit (`0` means unlimited).
+    /// @return limitMaxWithdraw Per-call withdraw limit (`0` means unlimited).
+    /// @return limitMaxRedeem Per-call redeem limit (`0` means unlimited).
+    function limitConfig()
+        public
+        view
+        returns (
+            uint128 limitMaxTotalAssets,
+            uint128 limitMaxDeposit,
+            uint128 limitMaxMint,
+            uint128 limitMaxWithdraw,
+            uint128 limitMaxRedeem
+        )
+    {
+        LibERC4626VaultStorage.LimitConfig storage limits = LibERC4626VaultStorage.layout().limits;
+        return (limits.maxTotalAssets, limits.maxDeposit, limits.maxMint, limits.maxWithdraw, limits.maxRedeem);
+    }
+
+    /// @notice Sets fee configuration.
+    /// @dev Caller must have `VAULT_MANAGER_ROLE`.
+    /// @param depositFeeBps Deposit fee in basis points.
+    /// @param withdrawFeeBps Withdraw fee in basis points.
+    /// @param feeRecipient Fee recipient account.
+    function setFeeConfig(uint16 depositFeeBps, uint16 withdrawFeeBps, address feeRecipient)
+        public
+        onlyRole(VAULT_MANAGER_ROLE)
+    {
+        _validateFeeBps(depositFeeBps);
+        _validateFeeBps(withdrawFeeBps);
+
+        if ((depositFeeBps != 0 || withdrawFeeBps != 0) && feeRecipient == address(0)) {
+            revert ERC4626VaultInvalidFeeRecipient();
+        }
+
+        LibERC4626VaultStorage.FeeConfig storage fees = LibERC4626VaultStorage.layout().fees;
+        uint16 previousDepositFeeBps = fees.depositFeeBps;
+        uint16 previousWithdrawFeeBps = fees.withdrawFeeBps;
+        address previousFeeRecipient = fees.feeRecipient;
+
+        fees.depositFeeBps = depositFeeBps;
+        fees.withdrawFeeBps = withdrawFeeBps;
+        fees.feeRecipient = feeRecipient;
+
+        emit VaultFeeConfigUpdated(
+            previousDepositFeeBps,
+            previousWithdrawFeeBps,
+            previousFeeRecipient,
+            depositFeeBps,
+            withdrawFeeBps,
+            feeRecipient,
+            msg.sender
+        );
+    }
+
+    /// @notice Sets limit configuration.
+    /// @dev Caller must have `VAULT_MANAGER_ROLE`.
+    /// @param limitMaxTotalAssets Cap for managed assets (`0` means unlimited).
+    /// @param limitMaxDeposit Per-call deposit limit (`0` means unlimited).
+    /// @param limitMaxMint Per-call mint limit (`0` means unlimited).
+    /// @param limitMaxWithdraw Per-call withdraw limit (`0` means unlimited).
+    /// @param limitMaxRedeem Per-call redeem limit (`0` means unlimited).
+    function setLimitConfig(
+        uint128 limitMaxTotalAssets,
+        uint128 limitMaxDeposit,
+        uint128 limitMaxMint,
+        uint128 limitMaxWithdraw,
+        uint128 limitMaxRedeem
+    ) public onlyRole(VAULT_MANAGER_ROLE) {
+        LibERC4626VaultStorage.LimitConfig storage limits = LibERC4626VaultStorage.layout().limits;
+
+        limits.maxTotalAssets = limitMaxTotalAssets;
+        limits.maxDeposit = limitMaxDeposit;
+        limits.maxMint = limitMaxMint;
+        limits.maxWithdraw = limitMaxWithdraw;
+        limits.maxRedeem = limitMaxRedeem;
+
+        emit VaultLimitConfigUpdated(
+            limitMaxTotalAssets, limitMaxDeposit, limitMaxMint, limitMaxWithdraw, limitMaxRedeem, msg.sender
+        );
+    }
+
+    /// @notice Returns max assets `receiver` can deposit.
+    /// @param receiver Target receiver.
+    /// @return Max asset amount accepted.
+    function maxDeposit(address receiver) public view virtual override returns (uint256) {
+        if (receiver == address(0) || paused()) {
+            return 0;
+        }
+
+        uint256 maxAssets = type(uint256).max;
+        LibERC4626VaultStorage.LimitConfig storage limits = LibERC4626VaultStorage.layout().limits;
+
+        if (limits.maxDeposit != 0) {
+            maxAssets = limits.maxDeposit;
+        }
+
+        if (limits.maxTotalAssets != 0) {
+            uint256 currentAssets = totalAssets();
+            if (currentAssets >= limits.maxTotalAssets) {
+                return 0;
+            }
+
+            uint256 remainingAssets = limits.maxTotalAssets - currentAssets;
+            uint256 capBasedMaxAssets = _grossUpForDepositFee(remainingAssets);
+            if (capBasedMaxAssets < maxAssets) {
+                maxAssets = capBasedMaxAssets;
+            }
+        }
+
+        return maxAssets;
+    }
+
+    /// @notice Returns max shares `receiver` can mint.
+    /// @param receiver Target receiver.
+    /// @return Max shares accepted.
+    function maxMint(address receiver) public view virtual override returns (uint256) {
+        if (receiver == address(0) || paused()) {
+            return 0;
+        }
+
+        uint256 maxShares = type(uint256).max;
+        LibERC4626VaultStorage.LimitConfig storage limits = LibERC4626VaultStorage.layout().limits;
+
+        if (limits.maxMint != 0) {
+            maxShares = limits.maxMint;
+        }
+
+        if (limits.maxTotalAssets != 0) {
+            uint256 currentAssets = totalAssets();
+            if (currentAssets >= limits.maxTotalAssets) {
+                return 0;
+            }
+
+            uint256 remainingAssets = limits.maxTotalAssets - currentAssets;
+            uint256 capBasedMaxShares = _convertToShares(remainingAssets, Rounding.Down);
+            if (capBasedMaxShares < maxShares) {
+                maxShares = capBasedMaxShares;
+            }
+        }
+
+        return maxShares;
+    }
+
+    /// @notice Returns max assets `owner` can withdraw.
+    /// @param owner Share owner.
+    /// @return Max withdrawable assets.
+    function maxWithdraw(address owner) public view virtual override returns (uint256) {
+        if (owner == address(0) || paused()) {
+            return 0;
+        }
+
+        uint256 grossAssets = _convertToAssets(balanceOf(owner), Rounding.Down);
+        (uint256 netAssets,) = _withdrawNetFromGross(grossAssets);
+
+        uint128 configuredMaxWithdraw = LibERC4626VaultStorage.layout().limits.maxWithdraw;
+        if (configuredMaxWithdraw != 0 && netAssets > configuredMaxWithdraw) {
+            return configuredMaxWithdraw;
+        }
+
+        return netAssets;
+    }
+
+    /// @notice Returns max shares `owner` can redeem.
+    /// @param owner Share owner.
+    /// @return Max redeemable shares.
+    function maxRedeem(address owner) public view virtual override returns (uint256) {
+        if (owner == address(0) || paused()) {
+            return 0;
+        }
+
+        uint256 redeemableShares = balanceOf(owner);
+        uint128 configuredMaxRedeem = LibERC4626VaultStorage.layout().limits.maxRedeem;
+        if (configuredMaxRedeem != 0 && redeemableShares > configuredMaxRedeem) {
+            return configuredMaxRedeem;
+        }
+
+        return redeemableShares;
+    }
+
+    /// @notice Returns shares minted by depositing `assets`.
+    /// @param assets Asset amount.
+    /// @return Estimated shares.
+    function previewDeposit(uint256 assets) public view virtual override returns (uint256) {
+        (uint256 netAssets,) = _netAfterDepositFee(assets);
+        return _convertToShares(netAssets, Rounding.Down);
+    }
+
+    /// @notice Returns assets required to mint `shares`.
+    /// @param shares Share amount.
+    /// @return Required assets.
+    function previewMint(uint256 shares) public view virtual override returns (uint256) {
+        uint256 netAssets = _convertToAssets(shares, Rounding.Up);
+        return _grossUpForDepositFee(netAssets);
+    }
+
+    /// @notice Returns shares burned by withdrawing `assets`.
+    /// @param assets Asset amount.
+    /// @return Estimated shares burned.
+    function previewWithdraw(uint256 assets) public view virtual override returns (uint256) {
+        (uint256 grossAssets,) = _withdrawGrossFromNet(assets);
+        return _convertToShares(grossAssets, Rounding.Up);
+    }
+
+    /// @notice Returns assets received by redeeming `shares`.
+    /// @param shares Share amount.
+    /// @return Estimated assets returned.
+    function previewRedeem(uint256 shares) public view virtual override returns (uint256) {
+        uint256 grossAssets = _convertToAssets(shares, Rounding.Down);
+        (uint256 netAssets,) = _withdrawNetFromGross(grossAssets);
+        return netAssets;
+    }
+
+    /// @notice Deposits `assets` and mints shares to `receiver`.
+    /// @param assets Asset amount.
+    /// @param receiver Receiver of minted shares.
+    /// @return shares Minted shares.
+    function deposit(uint256 assets, address receiver)
+        public
+        virtual
+        override
+        whenNotPaused
+        nonReentrant
+        returns (uint256 shares)
+    {
+        _requireInitialized();
+        _requireNonZeroAddress(receiver);
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        uint256 maxAssets = maxDeposit(receiver);
+        if (assets > maxAssets) {
+            revert ERC4626VaultDepositLimitExceeded(assets, maxAssets);
+        }
+
+        (uint256 netAssets, uint256 feeAssets) = _netAfterDepositFee(assets);
+        _enforceTotalAssetsCap(netAssets);
+
+        shares = _convertToShares(netAssets, Rounding.Down);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        _safeTransferFromAsset(msg.sender, address(this), assets);
+        _increaseManagedAssets(netAssets);
+        _mintShares(receiver, shares);
+        _payoutFee(feeAssets);
+
+        emit Deposit(msg.sender, receiver, assets, shares);
+    }
+
+    /// @notice Mints `shares` to `receiver`.
+    /// @param shares Share amount.
+    /// @param receiver Receiver of minted shares.
+    /// @return assets Deposited assets.
+    function mint(uint256 shares, address receiver)
+        public
+        virtual
+        override
+        whenNotPaused
+        nonReentrant
+        returns (uint256 assets)
+    {
+        _requireInitialized();
+        _requireNonZeroAddress(receiver);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        uint256 maxShares = maxMint(receiver);
+        if (shares > maxShares) {
+            revert ERC4626VaultMintLimitExceeded(shares, maxShares);
+        }
+
+        uint256 netAssets = _convertToAssets(shares, Rounding.Up);
+        if (netAssets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        assets = _grossUpForDepositFee(netAssets);
+        uint256 feeAssets = assets - netAssets;
+
+        _enforceTotalAssetsCap(netAssets);
+        _safeTransferFromAsset(msg.sender, address(this), assets);
+        _increaseManagedAssets(netAssets);
+        _mintShares(receiver, shares);
+        _payoutFee(feeAssets);
+
+        emit Deposit(msg.sender, receiver, assets, shares);
+    }
+
+    /// @notice Withdraws `assets` to `receiver` from `owner`.
+    /// @param assets Asset amount.
+    /// @param receiver Asset receiver.
+    /// @param owner Share owner.
+    /// @return shares Burned shares.
+    function withdraw(uint256 assets, address receiver, address owner)
+        public
+        virtual
+        override
+        whenNotPaused
+        nonReentrant
+        returns (uint256 shares)
+    {
+        _requireInitialized();
+        _requireNonZeroAddress(receiver);
+        _requireNonZeroAddress(owner);
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        uint256 maxAssets = maxWithdraw(owner);
+        if (assets > maxAssets) {
+            revert ERC4626VaultWithdrawLimitExceeded(assets, maxAssets);
+        }
+
+        (uint256 grossAssets, uint256 feeAssets) = _withdrawGrossFromNet(assets);
+        shares = _convertToShares(grossAssets, Rounding.Up);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        if (msg.sender != owner) {
+            _spendAllowance(owner, msg.sender, shares);
+        }
+
+        _burnShares(owner, shares);
+        _decreaseManagedAssets(grossAssets);
+        _safeTransferAsset(receiver, assets);
+        _payoutFee(feeAssets);
+
+        emit Withdraw(msg.sender, receiver, owner, assets, shares);
+    }
+
+    /// @notice Redeems `shares` from `owner` to `receiver`.
+    /// @param shares Share amount.
+    /// @param receiver Asset receiver.
+    /// @param owner Share owner.
+    /// @return assets Returned assets.
+    function redeem(uint256 shares, address receiver, address owner)
+        public
+        virtual
+        override
+        whenNotPaused
+        nonReentrant
+        returns (uint256 assets)
+    {
+        _requireInitialized();
+        _requireNonZeroAddress(receiver);
+        _requireNonZeroAddress(owner);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        uint256 maxShares = maxRedeem(owner);
+        if (shares > maxShares) {
+            revert ERC4626VaultRedeemLimitExceeded(shares, maxShares);
+        }
+
+        uint256 grossAssets = _convertToAssets(shares, Rounding.Down);
+        uint256 feeAssets;
+        (assets, feeAssets) = _withdrawNetFromGross(grossAssets);
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        if (msg.sender != owner) {
+            _spendAllowance(owner, msg.sender, shares);
+        }
+
+        _burnShares(owner, shares);
+        _decreaseManagedAssets(grossAssets);
+        _safeTransferAsset(receiver, assets);
+        _payoutFee(feeAssets);
+
+        emit Withdraw(msg.sender, receiver, owner, assets, shares);
+    }
+
+    /// @dev Initializes control-plane defaults.
+    /// @param initialManager Account receiving `VAULT_MANAGER_ROLE`.
+    function _initializeVaultControls(address initialManager) internal {
+        LibERC4626VaultStorage.layout().fees.feeRecipient = initialManager;
+        _grantRole(VAULT_MANAGER_ROLE, initialManager);
+    }
+
+    /// @dev Enforces configured total-assets cap.
+    /// @param additionalAssets Assets to be added to managed accounting.
+    function _enforceTotalAssetsCap(uint256 additionalAssets) internal view {
+        uint128 cap = LibERC4626VaultStorage.layout().limits.maxTotalAssets;
+        if (cap == 0) {
+            return;
+        }
+
+        uint256 currentAssets = totalAssets();
+        uint256 nextAssets = currentAssets + additionalAssets;
+        if (nextAssets > cap) {
+            revert ERC4626VaultTotalAssetsCapExceeded(currentAssets, additionalAssets, cap);
+        }
+    }
+
+    /// @dev Returns net deposit assets and fee amount from a gross input.
+    /// @param assets Gross deposit asset amount.
+    /// @return netAssets Net assets credited to vault accounting.
+    /// @return feeAssets Fee assets paid out.
+    function _netAfterDepositFee(uint256 assets) internal view returns (uint256 netAssets, uint256 feeAssets) {
+        uint16 depositFeeBps = LibERC4626VaultStorage.layout().fees.depositFeeBps;
+        feeAssets = _feeOnRaw(assets, depositFeeBps, Rounding.Down);
+        netAssets = assets - feeAssets;
+    }
+
+    /// @dev Returns gross deposit amount needed to credit `netAssets`.
+    /// @param netAssets Desired net assets credited to vault accounting.
+    /// @return grossAssets Gross assets that must be transferred in.
+    function _grossUpForDepositFee(uint256 netAssets) internal view returns (uint256 grossAssets) {
+        uint16 depositFeeBps = LibERC4626VaultStorage.layout().fees.depositFeeBps;
+        if (depositFeeBps == 0 || netAssets == 0) {
+            return netAssets;
+        }
+
+        uint256 denominator = BPS_DENOMINATOR - depositFeeBps;
+        grossAssets = _mulDiv(netAssets, BPS_DENOMINATOR, denominator, Rounding.Up);
+
+        (uint256 creditedAssets,) = _netAfterDepositFee(grossAssets);
+        if (creditedAssets < netAssets) {
+            grossAssets += 1;
+        }
+    }
+
+    /// @dev Returns gross withdraw assets and fee from a requested net output.
+    /// @param assets Requested receiver assets.
+    /// @return grossAssets Gross assets removed from managed accounting.
+    /// @return feeAssets Fee assets paid out.
+    function _withdrawGrossFromNet(uint256 assets) internal view returns (uint256 grossAssets, uint256 feeAssets) {
+        uint16 withdrawFeeBps = LibERC4626VaultStorage.layout().fees.withdrawFeeBps;
+        feeAssets = _feeOnRaw(assets, withdrawFeeBps, Rounding.Up);
+        grossAssets = assets + feeAssets;
+    }
+
+    /// @dev Returns receiver assets and fee from a gross redeemed amount.
+    /// @param grossAssets Gross assets removed from managed accounting.
+    /// @return netAssets Assets sent to receiver.
+    /// @return feeAssets Fee assets paid out.
+    function _withdrawNetFromGross(uint256 grossAssets) internal view returns (uint256 netAssets, uint256 feeAssets) {
+        uint16 withdrawFeeBps = LibERC4626VaultStorage.layout().fees.withdrawFeeBps;
+        feeAssets = _feeOnRaw(grossAssets, withdrawFeeBps, Rounding.Down);
+        netAssets = grossAssets - feeAssets;
+    }
+
+    /// @dev Pays `feeAssets` to configured fee recipient when non-zero.
+    /// @param feeAssets Fee amount to transfer.
+    function _payoutFee(uint256 feeAssets) internal {
+        if (feeAssets == 0) {
+            return;
+        }
+
+        address recipient = LibERC4626VaultStorage.layout().fees.feeRecipient;
+        _safeTransferAsset(recipient, feeAssets);
+    }
+
+    /// @dev Reverts when `feeBps` is invalid.
+    /// @param feeBps Fee basis points.
+    function _validateFeeBps(uint16 feeBps) internal pure {
+        if (feeBps >= BPS_DENOMINATOR) {
+            revert ERC4626VaultInvalidFeeBps(feeBps);
+        }
+    }
+
+    /// @dev Returns fee amount for `assets` and `feeBps` with controlled rounding.
+    /// @param assets Asset amount used for fee computation.
+    /// @param feeBps Fee basis points.
+    /// @param rounding Rounding direction.
+    /// @return Computed fee amount.
+    function _feeOnRaw(uint256 assets, uint16 feeBps, Rounding rounding) internal pure returns (uint256) {
+        if (feeBps == 0 || assets == 0) {
+            return 0;
+        }
+
+        return _mulDiv(assets, feeBps, BPS_DENOMINATOR, rounding);
+    }
+}

--- a/test/ERC4626VaultControlsCore.t.sol
+++ b/test/ERC4626VaultControlsCore.t.sol
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
+import {IPausable} from "../src/interfaces/IPausable.sol";
+import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol";
+import {ERC4626VaultControlsFixture, ERC4626VaultControlsHarness} from "./helpers/ERC4626VaultControlsTestHarness.sol";
+
+contract ERC4626VaultControlsCoreTest is ERC4626VaultControlsFixture {
+    event VaultFeeConfigUpdated(
+        uint16 previousDepositFeeBps,
+        uint16 previousWithdrawFeeBps,
+        address indexed previousFeeRecipient,
+        uint16 newDepositFeeBps,
+        uint16 newWithdrawFeeBps,
+        address indexed newFeeRecipient,
+        address indexed sender
+    );
+
+    event VaultLimitConfigUpdated(
+        uint128 maxTotalAssets,
+        uint128 maxDeposit,
+        uint128 maxMint,
+        uint128 maxWithdraw,
+        uint128 maxRedeem,
+        address indexed sender
+    );
+
+    function testInitialRolesAndDefaults() public view {
+        assertTrue(vault.hasRole(vault.DEFAULT_ADMIN_ROLE(), admin), "missing default admin role");
+        assertTrue(vault.hasRole(vault.PAUSER_ROLE(), admin), "missing pauser role");
+        assertTrue(vault.hasRole(vault.VAULT_MANAGER_ROLE(), admin), "missing vault manager role");
+
+        (uint16 depositFeeBps, uint16 withdrawFeeBps, address feeRecipient) = vault.feeConfig();
+        assertTrue(depositFeeBps == 0, "unexpected default deposit fee");
+        assertTrue(withdrawFeeBps == 0, "unexpected default withdraw fee");
+        assertTrue(feeRecipient == admin, "unexpected default fee recipient");
+
+        (uint128 maxTotalAssets, uint128 maxDeposit, uint128 maxMint, uint128 maxWithdraw, uint128 maxRedeem) =
+            vault.limitConfig();
+        assertTrue(maxTotalAssets == 0, "unexpected default max total assets");
+        assertTrue(maxDeposit == 0, "unexpected default max deposit");
+        assertTrue(maxMint == 0, "unexpected default max mint");
+        assertTrue(maxWithdraw == 0, "unexpected default max withdraw");
+        assertTrue(maxRedeem == 0, "unexpected default max redeem");
+    }
+
+    function testManagerCanSetFeeConfigAndEmitEvent() public {
+        VM.expectEmit(false, false, true, true, address(vault));
+        emit VaultFeeConfigUpdated(0, 0, admin, 500, 250, eve, admin);
+
+        VM.prank(admin);
+        vault.setFeeConfig(500, 250, eve);
+
+        (uint16 depositFeeBps, uint16 withdrawFeeBps, address feeRecipient) = vault.feeConfig();
+        assertTrue(depositFeeBps == 500, "deposit fee not updated");
+        assertTrue(withdrawFeeBps == 250, "withdraw fee not updated");
+        assertTrue(feeRecipient == eve, "fee recipient not updated");
+    }
+
+    function testNonManagerCannotSetFeeConfig() public {
+        VM.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, eve, vault.VAULT_MANAGER_ROLE())
+        );
+        VM.prank(eve);
+        vault.setFeeConfig(200, 100, eve);
+    }
+
+    function testInvalidFeeConfigReverts() public {
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultControls.ERC4626VaultInvalidFeeBps.selector, 10_000));
+        vault.setFeeConfig(10_000, 0, admin);
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultControls.ERC4626VaultInvalidFeeRecipient.selector));
+        vault.setFeeConfig(100, 0, address(0));
+    }
+
+    function testManagerCanSetLimitConfigAndEmitEvent() public {
+        VM.expectEmit(false, false, false, true, address(vault));
+        emit VaultLimitConfigUpdated(1_000, 500, 300, 200, 100, admin);
+
+        VM.prank(admin);
+        vault.setLimitConfig(1_000, 500, 300, 200, 100);
+
+        (uint128 maxTotalAssets, uint128 maxDeposit, uint128 maxMint, uint128 maxWithdraw, uint128 maxRedeem) =
+            vault.limitConfig();
+        assertTrue(maxTotalAssets == 1_000, "maxTotalAssets not updated");
+        assertTrue(maxDeposit == 500, "maxDeposit not updated");
+        assertTrue(maxMint == 300, "maxMint not updated");
+        assertTrue(maxWithdraw == 200, "maxWithdraw not updated");
+        assertTrue(maxRedeem == 100, "maxRedeem not updated");
+    }
+
+    function testNonManagerCannotSetLimitConfig() public {
+        VM.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, eve, vault.VAULT_MANAGER_ROLE())
+        );
+        VM.prank(eve);
+        vault.setLimitConfig(1_000, 500, 300, 200, 100);
+    }
+
+    function testDepositAppliesConfiguredFee() public {
+        VM.prank(admin);
+        vault.setFeeConfig(1_000, 0, eve);
+
+        _approveAsset(bob, 100);
+
+        VM.prank(bob);
+        uint256 shares = vault.deposit(100, bob);
+
+        assertTrue(shares == 90, "deposit shares mismatch");
+        assertTrue(vault.totalAssets() == 90, "total assets mismatch");
+        assertTrue(vault.balanceOf(bob) == 90, "share balance mismatch");
+        assertTrue(asset.balanceOf(eve) == INITIAL_ASSETS + 10, "fee recipient balance mismatch");
+    }
+
+    function testMintAppliesConfiguredFee() public {
+        VM.prank(admin);
+        vault.setFeeConfig(1_000, 0, eve);
+
+        _approveAsset(bob, 1_000);
+
+        VM.prank(bob);
+        uint256 assetsIn = vault.mint(50, bob);
+
+        assertTrue(assetsIn == 56, "mint assets mismatch");
+        assertTrue(vault.totalAssets() == 50, "total assets mismatch");
+        assertTrue(vault.balanceOf(bob) == 50, "share balance mismatch");
+        assertTrue(asset.balanceOf(eve) == INITIAL_ASSETS + 6, "fee recipient balance mismatch");
+    }
+
+    function testWithdrawAppliesConfiguredFee() public {
+        _seedPosition(bob, 100);
+
+        VM.prank(admin);
+        vault.setFeeConfig(0, 1_000, eve);
+
+        VM.prank(bob);
+        uint256 sharesBurned = vault.withdraw(20, bob, bob);
+
+        assertTrue(sharesBurned == 22, "withdraw burned shares mismatch");
+        assertTrue(vault.totalAssets() == 78, "total assets mismatch");
+        assertTrue(vault.balanceOf(bob) == 78, "share balance mismatch");
+        assertTrue(asset.balanceOf(eve) == INITIAL_ASSETS + 2, "fee recipient balance mismatch");
+    }
+
+    function testRedeemAppliesConfiguredFee() public {
+        _seedPosition(bob, 100);
+
+        VM.prank(admin);
+        vault.setFeeConfig(0, 1_000, eve);
+
+        VM.prank(bob);
+        uint256 assetsOut = vault.redeem(20, bob, bob);
+
+        assertTrue(assetsOut == 18, "redeem assets mismatch");
+        assertTrue(vault.totalAssets() == 80, "total assets mismatch");
+        assertTrue(vault.balanceOf(bob) == 80, "share balance mismatch");
+        assertTrue(asset.balanceOf(eve) == INITIAL_ASSETS + 2, "fee recipient balance mismatch");
+    }
+
+    function testDepositLimitEnforced() public {
+        VM.prank(admin);
+        vault.setLimitConfig(0, 50, 0, 0, 0);
+
+        _approveAsset(bob, 100);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultControls.ERC4626VaultDepositLimitExceeded.selector, 51, 50));
+        vault.deposit(51, bob);
+    }
+
+    function testMintLimitEnforced() public {
+        VM.prank(admin);
+        vault.setLimitConfig(0, 0, 30, 0, 0);
+
+        _approveAsset(bob, 100);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultControls.ERC4626VaultMintLimitExceeded.selector, 31, 30));
+        vault.mint(31, bob);
+    }
+
+    function testWithdrawLimitEnforced() public {
+        _seedPosition(bob, 100);
+
+        VM.prank(admin);
+        vault.setLimitConfig(0, 0, 0, 25, 0);
+
+        VM.prank(bob);
+        VM.expectRevert(
+            abi.encodeWithSelector(IERC4626VaultControls.ERC4626VaultWithdrawLimitExceeded.selector, 26, 25)
+        );
+        vault.withdraw(26, bob, bob);
+    }
+
+    function testRedeemLimitEnforced() public {
+        _seedPosition(bob, 100);
+
+        VM.prank(admin);
+        vault.setLimitConfig(0, 0, 0, 0, 20);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultControls.ERC4626VaultRedeemLimitExceeded.selector, 21, 20));
+        vault.redeem(21, bob, bob);
+    }
+
+    function testTotalAssetsCapShapesMaxDepositAndEnforcesDepositFlow() public {
+        VM.prank(admin);
+        vault.setLimitConfig(60, 0, 0, 0, 0);
+
+        _approveAsset(bob, 100);
+
+        VM.prank(bob);
+        vault.deposit(50, bob);
+
+        assertTrue(vault.maxDeposit(bob) == 10, "maxDeposit should honor remaining cap");
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultControls.ERC4626VaultDepositLimitExceeded.selector, 11, 10));
+        vault.deposit(11, bob);
+    }
+
+    function testPauseBlocksMutatingVaultFlows() public {
+        _seedPosition(bob, 100);
+        _approveAsset(bob, 100);
+
+        VM.prank(admin);
+        vault.pause();
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+        vault.deposit(10, bob);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+        vault.mint(10, bob);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+        vault.withdraw(10, bob, bob);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+        vault.redeem(10, bob, bob);
+    }
+
+    function testReentrantAttemptDuringDepositIsBlocked() public {
+        bytes memory payload = abi.encodeCall(ERC4626VaultControlsHarness.probeNonReentrant, ());
+        asset.configureReentry(address(vault), payload, true);
+
+        _approveAsset(bob, 100);
+
+        VM.prank(bob);
+        uint256 shares = vault.deposit(10, bob);
+
+        assertTrue(shares == 10, "deposit should succeed");
+        assertTrue(asset.reentryAttemptBlocked(), "expected reentry attempt to be blocked");
+    }
+}

--- a/test/helpers/ERC4626CoreTestHarness.sol
+++ b/test/helpers/ERC4626CoreTestHarness.sol
@@ -67,7 +67,7 @@ contract MockVaultAsset is IERC20Metadata {
         return true;
     }
 
-    function transfer(address to, uint256 value) external returns (bool) {
+    function transfer(address to, uint256 value) public virtual returns (bool) {
         if (_failTransfer) {
             return false;
         }
@@ -76,7 +76,7 @@ contract MockVaultAsset is IERC20Metadata {
         return true;
     }
 
-    function transferFrom(address from, address to, uint256 value) external returns (bool) {
+    function transferFrom(address from, address to, uint256 value) public virtual returns (bool) {
         if (_failTransferFrom) {
             return false;
         }

--- a/test/helpers/ERC4626VaultControlsTestHarness.sol
+++ b/test/helpers/ERC4626VaultControlsTestHarness.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {ERC4626VaultControls} from "../../src/vault/ERC4626VaultControls.sol";
+import {MockVaultAsset} from "./ERC4626CoreTestHarness.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+
+contract ReentrantMockVaultAsset is MockVaultAsset {
+    bool internal _reenterOnTransferFrom;
+    bool internal _reentryAttemptBlocked;
+    address internal _reentryTarget;
+    bytes internal _reentryPayload;
+
+    constructor() MockVaultAsset("Mock USD", "mUSD", 6) {}
+
+    function configureReentry(address target, bytes calldata payload, bool enabled) external {
+        _reentryTarget = target;
+        _reentryPayload = payload;
+        _reenterOnTransferFrom = enabled;
+        _reentryAttemptBlocked = false;
+    }
+
+    function reentryAttemptBlocked() external view returns (bool) {
+        return _reentryAttemptBlocked;
+    }
+
+    function transferFrom(address from, address to, uint256 value) public override returns (bool) {
+        bool success = super.transferFrom(from, to, value);
+        if (_reenterOnTransferFrom) {
+            (bool callbackSuccess,) = _reentryTarget.call(_reentryPayload);
+            if (!callbackSuccess) {
+                _reentryAttemptBlocked = true;
+            }
+        }
+        return success;
+    }
+}
+
+contract ERC4626VaultControlsHarness is ERC4626VaultControls {
+    constructor(address initialAdmin, address vaultAsset, string memory vaultName, string memory vaultSymbol)
+        ERC4626VaultControls(initialAdmin, vaultAsset, vaultName, vaultSymbol)
+    {}
+
+    function probeNonReentrant() external nonReentrant returns (bool) {
+        return true;
+    }
+}
+
+abstract contract ERC4626VaultControlsFixture is TestBase {
+    uint256 internal constant INITIAL_ASSETS = 1_000_000;
+
+    address internal admin = address(0xA11CE);
+    address internal bob = address(0xB0B);
+    address internal eve = address(0xE11E);
+
+    ReentrantMockVaultAsset internal asset;
+    ERC4626VaultControlsHarness internal vault;
+
+    function setUp() public virtual {
+        asset = new ReentrantMockVaultAsset();
+        vault = new ERC4626VaultControlsHarness(admin, address(asset), "Vault Share", "vSHARE");
+
+        asset.mint(bob, INITIAL_ASSETS);
+        asset.mint(eve, INITIAL_ASSETS);
+    }
+
+    function _approveAsset(address owner, uint256 amount) internal {
+        VM.prank(owner);
+        asset.approve(address(vault), amount);
+    }
+
+    function _seedPosition(address owner, uint256 assetsAmount) internal {
+        asset.mint(owner, assetsAmount);
+        VM.prank(owner);
+        asset.approve(address(vault), assetsAmount);
+        VM.prank(owner);
+        vault.deposit(assetsAmount, owner);
+    }
+}


### PR DESCRIPTION
## Summary
- Add configurable fee and limit controls around ERC-4626 core flows.
- Integrate pausability and reentrancy protections into all mutating vault entrypoints.
- Extend previews and max helpers to reflect configured fee/limit policy.
- Add unit coverage for role-gated config updates, fee math, cap enforcement, pause behavior, and reentrancy blocking.

## Changes
- Added `src/interfaces/IERC4626VaultControls.sol`.
- Added `src/vault/ERC4626VaultControls.sol` with:
  - `VAULT_MANAGER_ROLE`
  - fee config + limit config setters (role-gated)
  - capped `max*` behavior and fee-aware `preview*`
  - `whenNotPaused` + `nonReentrant` on `deposit/mint/withdraw/redeem`
- Added `test/helpers/ERC4626VaultControlsTestHarness.sol`.
- Added `test/ERC4626VaultControlsCore.t.sol`.
- Updated:
  - `test/helpers/ERC4626CoreTestHarness.sol`
  - `README.md`
  - `docs/testing-conventions.md`

## Validation
- `forge fmt`
- `forge test --offline --match-path test/ERC4626VaultControlsCore.t.sol`
- `forge test --offline`

Closes #44
