### PR TITLE
test: add vault accounting fuzz and invariant suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ forge fmt
 - Vault foundation suite: `test/ERC4626VaultFoundationCore.t.sol`
 - Vault core suite: `test/ERC4626Core.t.sol`
 - Vault controls suite: `test/ERC4626VaultControlsCore.t.sol`
+- Vault accounting fuzz suite: `test/ERC4626VaultAccountingFuzz.t.sol`
+- Vault accounting invariant suite: `test/ERC4626VaultAccountingInvariant.t.sol`
 - Oracle hardening suite: `test/OracleAdapterCore.t.sol`, `test/OracleAdapterValidation.t.sol`, `test/OracleAdapterCircuitBreaker.t.sol`, `test/OracleAdapterFuzz.t.sol`
 - Security CI/local checks: `docs/security-checks.md`
 

--- a/docs/testing-conventions.md
+++ b/docs/testing-conventions.md
@@ -7,6 +7,7 @@ Use a split test layout so modules stay readable as complexity grows.
 - `test/<Module>Core.t.sol`
 - `test/<Module>Time.t.sol` (only when time-window behavior exists)
 - `test/<Module>Fuzz.t.sol` (for property/fuzz coverage)
+- `test/<Module>Invariant.t.sol` (for stateful invariant coverage)
 - `test/<Module>Integration.t.sol` (optional, cross-module workflows)
 - `test/helpers/<Module>TestHarness.sol`
 
@@ -16,11 +17,13 @@ Use a split test layout so modules stay readable as complexity grows.
 - `Time`: schedule/window logic, boundary timestamps, active/inactive checks.
 - `Integration`: interactions between modules and end-to-end flows.
 - `Fuzz`: property-style checks across random inputs and edge value ranges.
+- `Invariant`: stateful safety properties across randomized action sequences.
 - `helpers`: shared fixture setup, actors, harness wrappers, and utility assertions.
 
 ## Naming
 
 - Test contract names: `<Module>CoreTest`, `<Module>TimeTest`, `<Module>IntegrationTest`.
+- Test contract names: `<Module>FuzzTest`, `<Module>InvariantTest`.
 - Test function names should describe one behavior each, for example:
   - `testNonAdminCannotSetRoleWindow`
   - `testRoleWindowBoundariesAndOnlyActiveRole`
@@ -52,6 +55,8 @@ Use a split test layout so modules stay readable as complexity grows.
 - Fuzz example: `test/OracleAdapterFuzz.t.sol`
 - Fuzz example: `test/PausableFuzz.t.sol`
 - Fuzz example: `test/UpgradeGuardrailsFuzz.t.sol`
+- Fuzz example: `test/ERC4626VaultAccountingFuzz.t.sol`
+- Invariant example: `test/ERC4626VaultAccountingInvariant.t.sol`
 - Time example: `test/AccessControlTime.t.sol`
 - Time example: `test/UpgradeGuardrailsTime.t.sol`
 - Helper example: `test/helpers/AccessControlTestHarness.sol`
@@ -62,3 +67,4 @@ Use a split test layout so modules stay readable as complexity grows.
 - Helper example: `test/helpers/ERC4626VaultTestHarness.sol`
 - Helper example: `test/helpers/ERC4626VaultControlsTestHarness.sol`
 - Helper example: `test/helpers/ERC4626CoreTestHarness.sol`
+- Helper example: `test/helpers/ERC4626VaultAccountingTestHarness.sol`

--- a/test/ERC4626VaultAccountingFuzz.t.sol
+++ b/test/ERC4626VaultAccountingFuzz.t.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {ERC4626VaultAccountingFixture} from "./helpers/ERC4626VaultAccountingTestHarness.sol";
+
+contract ERC4626VaultAccountingFuzzTest is ERC4626VaultAccountingFixture {
+    function testFuzzPreviewDepositMatchesExecutedDeposit(uint8 actorSeed, uint96 assetsRaw) public {
+        address actor = _actor(actorSeed);
+        uint256 maxAssets = _min(vault.maxDeposit(actor), asset.balanceOf(actor));
+        uint256 assets = _boundAmount(assetsRaw, maxAssets);
+        if (assets == 0) {
+            return;
+        }
+
+        uint256 previewShares = vault.previewDeposit(assets);
+        if (previewShares == 0) {
+            return;
+        }
+
+        VM.prank(actor);
+        uint256 mintedShares = vault.deposit(assets, actor);
+        assertTrue(mintedShares == previewShares, "deposit shares should match preview");
+    }
+
+    function testFuzzPreviewMintMatchesExecutedMint(uint8 actorSeed, uint96 sharesRaw) public {
+        address actor = _actor(actorSeed);
+        uint256 availableAssets = asset.balanceOf(actor);
+        if (availableAssets == 0) {
+            return;
+        }
+
+        uint256 maxSharesByAssets = vault.convertToShares(availableAssets);
+        uint256 maxShares = _min(vault.maxMint(actor), maxSharesByAssets);
+        uint256 shares = _boundAmount(sharesRaw, maxShares);
+        if (shares == 0) {
+            return;
+        }
+
+        uint256 previewAssets = vault.previewMint(shares);
+        if (previewAssets > availableAssets) {
+            return;
+        }
+
+        VM.prank(actor);
+        uint256 usedAssets = vault.mint(shares, actor);
+        assertTrue(usedAssets == previewAssets, "mint assets should match preview");
+    }
+
+    function testFuzzPreviewFunctionsRespectRoundingConventions(
+        uint96 seedSharesRaw,
+        uint96 seedAssetsRaw,
+        uint96 probeRaw
+    ) public {
+        uint256 seedShares = uint256(seedSharesRaw % 1e18) + 1;
+        uint256 seedAssets = uint256(seedAssetsRaw % 1e18) + 1;
+        uint256 probe = uint256(probeRaw % 1e18) + 1;
+
+        vault.seedPosition(admin, seedShares, seedAssets);
+        asset.mint(address(vault), seedAssets);
+
+        assertTrue(vault.previewDeposit(probe) == vault.convertToShares(probe), "deposit preview should round down");
+        assertTrue(vault.previewMint(probe) >= vault.convertToAssets(probe), "mint preview should round up");
+        assertTrue(vault.previewWithdraw(probe) >= vault.convertToShares(probe), "withdraw preview should round up");
+        assertTrue(vault.previewRedeem(probe) <= vault.convertToAssets(probe), "redeem preview should round down");
+    }
+
+    function testFuzzLowLiquidityDepositRedeemRoundTripLossBounded(uint96 assetsRaw) public {
+        _seedLowLiquidityState();
+
+        uint256 assetsIn = uint256(assetsRaw % 1_000_000) + 1;
+        VM.prank(bob);
+        uint256 mintedShares = vault.deposit(assetsIn, bob);
+
+        if (vault.previewRedeem(mintedShares) == 0) {
+            return;
+        }
+
+        VM.prank(bob);
+        uint256 assetsOut = vault.redeem(mintedShares, bob, bob);
+
+        assertTrue(assetsOut <= assetsIn, "roundtrip cannot output more than input");
+        assertTrue(assetsIn - assetsOut <= 1, "roundtrip loss should be <= 1 asset");
+    }
+
+    function testLowLiquidityPreviewBoundaries() public {
+        _seedLowLiquidityState();
+
+        assertTrue(vault.previewWithdraw(1) == 2, "previewWithdraw should round up to 2 shares");
+        assertTrue(vault.previewRedeem(1) == 0, "previewRedeem should round down to 0 assets");
+    }
+}

--- a/test/ERC4626VaultAccountingInvariant.t.sol
+++ b/test/ERC4626VaultAccountingInvariant.t.sol
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {ERC4626VaultAccountingFixture} from "./helpers/ERC4626VaultAccountingTestHarness.sol";
+
+contract ERC4626VaultAccountingInvariantTest is ERC4626VaultAccountingFixture {
+    uint256 internal constant INITIAL_ASSET_SUPPLY = INITIAL_ASSETS * ACTOR_COUNT;
+
+    function targetContracts() external view returns (address[] memory contracts) {
+        contracts = new address[](1);
+        contracts[0] = address(this);
+    }
+
+    function actionDeposit(uint8 actorSeed, uint96 assetsRaw) external {
+        address actor = _actor(actorSeed);
+        uint256 maxAssets = _min(vault.maxDeposit(actor), asset.balanceOf(actor));
+        uint256 assets = _boundAmount(assetsRaw, maxAssets);
+        if (assets == 0) {
+            return;
+        }
+
+        uint256 previewShares = vault.previewDeposit(assets);
+        if (previewShares == 0) {
+            return;
+        }
+
+        VM.prank(actor);
+        vault.deposit(assets, actor);
+    }
+
+    function actionMint(uint8 actorSeed, uint96 sharesRaw) external {
+        address actor = _actor(actorSeed);
+        uint256 availableAssets = asset.balanceOf(actor);
+        if (availableAssets == 0) {
+            return;
+        }
+
+        uint256 maxSharesByAssets = vault.convertToShares(availableAssets);
+        uint256 maxShares = _min(vault.maxMint(actor), maxSharesByAssets);
+        uint256 shares = _boundAmount(sharesRaw, maxShares);
+        if (shares == 0) {
+            return;
+        }
+
+        uint256 requiredAssets = vault.previewMint(shares);
+        if (requiredAssets > availableAssets) {
+            return;
+        }
+
+        VM.prank(actor);
+        vault.mint(shares, actor);
+    }
+
+    function actionWithdraw(uint8 actorSeed, uint96 assetsRaw) external {
+        address actor = _actor(actorSeed);
+        uint256 maxAssets = vault.maxWithdraw(actor);
+        uint256 assets = _boundAmount(assetsRaw, maxAssets);
+        if (assets == 0) {
+            return;
+        }
+
+        VM.prank(actor);
+        vault.withdraw(assets, actor, actor);
+    }
+
+    function actionRedeem(uint8 actorSeed, uint96 sharesRaw) external {
+        address actor = _actor(actorSeed);
+        uint256 maxShares = vault.maxRedeem(actor);
+        uint256 shares = _boundAmount(sharesRaw, maxShares);
+        if (shares == 0) {
+            return;
+        }
+
+        if (vault.previewRedeem(shares) == 0) {
+            return;
+        }
+
+        VM.prank(actor);
+        vault.redeem(shares, actor, actor);
+    }
+
+    function actionTransferShares(uint8 fromSeed, uint8 toSeed, uint96 sharesRaw) external {
+        address from = _actor(fromSeed);
+        address to = _actor(toSeed);
+        if (from == to) {
+            return;
+        }
+
+        uint256 maxShares = vault.balanceOf(from);
+        uint256 shares = _boundAmount(sharesRaw, maxShares);
+        if (shares == 0) {
+            return;
+        }
+
+        VM.prank(from);
+        vault.transfer(to, shares);
+    }
+
+    function invariantManagedAssetsMatchUnderlyingBalance() public view {
+        assertTrue(
+            vault.totalAssets() == asset.balanceOf(address(vault)), "managed assets and underlying balance must match"
+        );
+    }
+
+    function invariantShareSupplyConservedAcrossTrackedActors() public view {
+        assertTrue(
+            vault.totalSupply() == _sumActorShareBalances(), "total supply must equal tracked actor share balances"
+        );
+    }
+
+    function invariantUnderlyingAssetConservedAcrossTrackedActorsAndVault() public view {
+        assertTrue(
+            _sumActorAssetBalances() + asset.balanceOf(address(vault)) == INITIAL_ASSET_SUPPLY,
+            "underlying assets should be conserved"
+        );
+    }
+}

--- a/test/helpers/ERC4626VaultAccountingTestHarness.sol
+++ b/test/helpers/ERC4626VaultAccountingTestHarness.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {MockVaultAsset, ERC4626VaultCoreHarness} from "./ERC4626CoreTestHarness.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+
+abstract contract ERC4626VaultAccountingFixture is TestBase {
+    uint256 internal constant INITIAL_ASSETS = 1_000_000;
+    uint256 internal constant ACTOR_COUNT = 4;
+
+    address internal admin = address(0xA11CE);
+    address internal bob = address(0xB0B);
+    address internal carol = address(0xCA11);
+    address internal dave = address(0xD0D);
+
+    MockVaultAsset internal asset;
+    ERC4626VaultCoreHarness internal vault;
+    address[ACTOR_COUNT] internal actors;
+
+    function setUp() public virtual {
+        asset = new MockVaultAsset("Mock USD", "mUSD", 6);
+        vault = new ERC4626VaultCoreHarness();
+        vault.initialize(address(asset), "Vault Share", "vSHARE");
+
+        actors[0] = admin;
+        actors[1] = bob;
+        actors[2] = carol;
+        actors[3] = dave;
+
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            address actor = actors[i];
+            asset.mint(actor, INITIAL_ASSETS);
+            VM.prank(actor);
+            asset.approve(address(vault), type(uint256).max);
+        }
+    }
+
+    function _actor(uint8 seed) internal view returns (address) {
+        return actors[uint256(seed) % ACTOR_COUNT];
+    }
+
+    function _boundAmount(uint256 raw, uint256 max) internal pure returns (uint256) {
+        if (max == 0) {
+            return 0;
+        }
+        return (raw % max) + 1;
+    }
+
+    function _min(uint256 x, uint256 y) internal pure returns (uint256) {
+        return x < y ? x : y;
+    }
+
+    function _sumActorShareBalances() internal view returns (uint256 sum) {
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            sum += vault.balanceOf(actors[i]);
+        }
+    }
+
+    function _sumActorAssetBalances() internal view returns (uint256 sum) {
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            sum += asset.balanceOf(actors[i]);
+        }
+    }
+
+    function _seedLowLiquidityState() internal {
+        vault.seedPosition(admin, 3, 2);
+        asset.mint(address(vault), 2);
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated vault accounting test fixture for multi-actor fuzz and invariant scenarios
- add fuzz coverage for preview/convert alignment, rounding conventions, and low-liquidity roundtrip behavior
- add stateful invariants for managed-assets/balance consistency, share supply conservation, and underlying asset conservation
- update testing docs and README with the new fuzz/invariant suites

## Validation
- `forge fmt`
- `forge test --offline --match-path test/ERC4626VaultAccountingFuzz.t.sol`
- `forge test --offline --match-path test/ERC4626VaultAccountingInvariant.t.sol`
- `forge test --offline`

Closes #45