### PR TITLE
docs: add ERC-4626 usage, math, and edge-case guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ forge fmt
 
 ## Module Docs
 - Access control: `docs/access-control.md`
+- ERC-4626 vault: `docs/erc4626-vault.md`
 - Oracle adapter: `docs/oracle-adapter.md`
 - Pausability: `docs/pausable.md`
 - Reentrancy guard: `docs/reentrancy-guard.md`

--- a/docs/erc4626-vault.md
+++ b/docs/erc4626-vault.md
@@ -1,0 +1,138 @@
+# ERC-4626 Vault
+
+This document describes how to integrate and review the vault modules in this
+repository:
+- `ERC4626VaultBase`
+- `ERC4626Vault`
+- `ERC4626VaultControls`
+
+## Contract Roles
+
+- `ERC4626VaultBase`: initializer + share/asset accounting primitives.
+- `ERC4626Vault`: ERC-4626 core user flows.
+- `ERC4626VaultControls`: optional controls layer (fees, limits, pause,
+  reentrancy guard, manager role).
+
+## Usage Flows
+
+### Deposit
+
+- Caller transfers `assets` into vault and receives minted shares.
+- `receiver` receives shares.
+- Reverts on zero assets, zero receiver, or when computed shares are zero.
+
+### Mint
+
+- Caller requests exact `shares` and vault computes required assets.
+- `receiver` receives shares.
+- Reverts on zero shares, zero receiver, or when computed assets are zero.
+
+### Withdraw
+
+- Caller requests exact `assets` to send to `receiver`.
+- Shares are burned from `owner`.
+- If `msg.sender != owner`, caller must have enough share allowance.
+
+### Redeem
+
+- Caller burns exact `shares` from `owner`.
+- Vault returns assets to `receiver`.
+- If `msg.sender != owner`, caller must have enough share allowance.
+
+## Permission Expectations
+
+Core flows (`deposit`, `mint`, `withdraw`, `redeem`) are public user flows.
+Access is constrained by balance and allowance rules, not an admin role.
+
+Control-plane functions are role-gated in `ERC4626VaultControls`:
+- `setFeeConfig(...)` requires `VAULT_MANAGER_ROLE`.
+- `setLimitConfig(...)` requires `VAULT_MANAGER_ROLE`.
+- `pause()` / `unpause()` require `PAUSER_ROLE` (from `Pausable`).
+
+When paused, `deposit`, `mint`, `withdraw`, and `redeem` revert.
+
+## Conversion Math and Rounding
+
+Vault conversions use tracked managed assets (`totalManagedAssets`) and share
+supply (`totalSupply`).
+
+If `supply == 0` or `managedAssets == 0`, conversions bootstrap 1:1.
+
+Formulas:
+
+```text
+shares = assets * supply / managedAssets
+assets = shares * managedAssets / supply
+```
+
+Rounding direction by function:
+- `convertToShares`: down
+- `convertToAssets`: down
+- `previewDeposit`: down
+- `previewMint`: up
+- `previewWithdraw`: up
+- `previewRedeem`: down
+
+## Fee Application Order (`ERC4626VaultControls`)
+
+Deposit and mint use deposit fee:
+- `deposit(assets)`: fee is computed from gross assets, then net assets are
+  converted to shares.
+- `mint(shares)`: required net assets are computed first, then gross assets are
+  computed with fee gross-up.
+
+Withdraw and redeem use withdraw fee:
+- `withdraw(assetsOut)`: requested net assets are grossed-up before share burn.
+- `redeem(shares)`: gross assets from shares are computed first, then net
+  receiver assets are derived by subtracting fee.
+
+Fee rounding:
+- Deposit fee on raw assets rounds down.
+- Withdraw fee on requested net assets rounds up.
+- Withdraw fee on gross redeem amount rounds down.
+
+## Limits and Cap Behavior (`ERC4626VaultControls`)
+
+- `maxDeposit` and `maxMint` are reduced by per-call limits and by remaining
+  `maxTotalAssets` capacity.
+- `maxWithdraw` and `maxRedeem` are reduced by per-call limits.
+- Limit value `0` means unlimited for that specific limit.
+- Exceeding limits reverts with typed custom errors.
+
+## Threat-Model Notes
+
+### Donation / direct-transfer behavior
+
+`totalAssets()` uses `totalManagedAssets`, not raw token balance. Direct token
+donations do not inflate share price through conversion math.
+
+Implication:
+- Donation-style PPS manipulation is reduced.
+- Extra donated tokens are not automatically accounted into managed assets.
+
+### Rounding exploitation surface
+
+Rounding is deterministic and favors conservative previews (`mint`/`withdraw`
+round up, `deposit`/`redeem` round down). Very low-liquidity states can create
+small edge losses due to integer math. Tests cover these boundary cases.
+
+### Emergency controls
+
+When `ERC4626VaultControls` is used, pause state blocks all four mutating
+vault entrypoints. This is the primary emergency stop for vault write paths.
+
+## Known Limitations and Assumptions
+
+- `_mulDiv` uses direct `x * y` math, so unrealistic extreme values can overflow.
+- `totalManagedAssets` assumes integrators use canonical vault flows for
+  accounting updates.
+- No native slippage parameters are present on ERC-4626 functions; integrators
+  should pre-check previews and enforce client-side constraints.
+- The controls layer applies global limits, not per-user risk limits.
+
+## Test References
+
+- Core: `test/ERC4626Core.t.sol`
+- Controls: `test/ERC4626VaultControlsCore.t.sol`
+- Fuzz: `test/ERC4626VaultAccountingFuzz.t.sol`
+- Invariant: `test/ERC4626VaultAccountingInvariant.t.sol`

--- a/docs/testing-conventions.md
+++ b/docs/testing-conventions.md
@@ -41,6 +41,7 @@ Use a split test layout so modules stay readable as complexity grows.
 
 ## Current Reference
 
+- Vault usage/math reference: `docs/erc4626-vault.md`
 - Core example: `test/AccessControlCore.t.sol`
 - Core example: `test/PausableCore.t.sol`
 - Core example: `test/ReentrancyGuardCore.t.sol`

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,11 +1,13 @@
 # Threat Model
 
-This summary covers the security assumptions and guard rails for the
-Access, Oracle, and Upgrade Safety Kit modules.
+This summary covers security assumptions and guard rails for access, oracle,
+upgrade, and vault modules.
 
 ## In-Scope Modules
 
 - `AccessControl`
+- `ERC4626Vault`
+- `ERC4626VaultControls`
 - `OracleAdapter`
 - `Pausable`
 - `ReentrancyGuard`
@@ -19,6 +21,7 @@ Access, Oracle, and Upgrade Safety Kit modules.
 - Emergency pause controls can contain incidents.
 - Reentrant state-changing entrypoints are blocked.
 - Upgrade execution follows explicit authorization and guardrail checks.
+- Vault share/accounting behavior remains explicit under rounding and low-liquidity edge conditions.
 
 ## Trust Assumptions
 
@@ -51,6 +54,15 @@ Access, Oracle, and Upgrade Safety Kit modules.
 7. Unsafe or rushed upgrades
 - Mitigation: upgrader role, queued intent model, optional timelock delay, strict implementation matching, cancel flow.
 
+8. Donation-style vault share-price manipulation
+- Mitigation: vault conversions use managed accounting (`totalManagedAssets`) instead of raw token balance.
+
+9. Rounding edge exploitation in low-liquidity vault states
+- Mitigation: deterministic rounding direction plus fuzz/invariant tests for roundtrip and accounting properties.
+
+10. Emergency response lag on vault write paths
+- Mitigation: pausable controls block `deposit`, `mint`, `withdraw`, and `redeem` when paused.
+
 ## Residual Risks / Out of Scope
 
 - Compromised privileged keys can still perform privileged actions.
@@ -58,6 +70,7 @@ Access, Oracle, and Upgrade Safety Kit modules.
 - Oracle market manipulation resistance is feed/provider-specific and must be handled at integration and policy layers.
 - Diamond-specific `diamondCut` payload validation and multi-step governance workflows are deferred to the diamond milestone.
 - The current upgrade guardrails check nonzero implementation; deeper bytecode/interface validation is protocol-specific and should be added where needed.
+- Direct token donations to vault addresses can create untracked surplus unless explicitly reconciled by integration policy.
 
 ## Operational Guidance
 


### PR DESCRIPTION
## Summary
- add a dedicated ERC-4626 vault guide covering user flows, permission expectations, conversion math, fee ordering, and limit behavior
- expand the threat model with vault-specific notes for donation handling, rounding edges, and emergency controls
- link the new vault documentation from the README and testing conventions

## Validation
- `forge test --offline --match-path test/ERC4626Core.t.sol`

Closes #46