### PR TITLE
feat: add diamond interfaces and storage foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ facets without a full rewrite.
 ## Structure
 - `src/access`: access control and upgrade-safety primitives.
 - `src/access/storage`: module-local storage libraries (diamond-ready slots).
+- `src/diamond`: diamond core primitives and shared routing helpers.
+- `src/diamond/storage`: diamond routing and ownership storage layout.
 - `src/security`: security primitives such as reentrancy protection.
 - `src/security/storage`: module-local storage libraries (diamond-ready slots).
 - `src/oracle`: oracle adapter and feed safety primitives.

--- a/src/diamond/libraries/LibDiamond.sol
+++ b/src/diamond/libraries/LibDiamond.sol
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IDiamondLoupe} from "../../interfaces/IDiamondLoupe.sol";
+import {LibDiamondStorage} from "../storage/LibDiamondStorage.sol";
+
+/// @title LibDiamond
+/// @notice Shared diamond bookkeeping helpers for ownership, interfaces, and selector routing.
+library LibDiamond {
+    /// @notice Emitted when ownership changes.
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /// @notice Thrown when a zero owner is provided.
+    error DiamondOwnerZeroAddress();
+    /// @notice Thrown when `account` is not the current owner.
+    error DiamondUnauthorized(address account, address owner);
+    /// @notice Thrown when a zero facet address is provided.
+    error DiamondFacetAddressZero();
+    /// @notice Thrown when an invalid ERC-165 interface id is registered.
+    error DiamondInvalidInterfaceId(bytes4 interfaceId);
+    /// @notice Thrown when a selector already exists on another facet.
+    error DiamondSelectorAlreadyExists(bytes4 selector, address existingFacet);
+    /// @notice Thrown when a selector is not currently installed.
+    error DiamondSelectorNotFound(bytes4 selector);
+    /// @notice Thrown when replacing a selector with the same facet.
+    error DiamondReplaceWithSameFacet(bytes4 selector, address facetAddress);
+
+    /// @notice Returns the current contract owner.
+    /// @return owner_ The current contract owner.
+    function contractOwner() internal view returns (address owner_) {
+        return LibDiamondStorage.layout().contractOwner;
+    }
+
+    /// @notice Sets the current contract owner and emits the ERC-173 event.
+    /// @param newOwner The new owner account.
+    function setContractOwner(address newOwner) internal {
+        if (newOwner == address(0)) {
+            revert DiamondOwnerZeroAddress();
+        }
+
+        LibDiamondStorage.Layout storage diamondStorage = LibDiamondStorage.layout();
+        address previousOwner = diamondStorage.contractOwner;
+        diamondStorage.contractOwner = newOwner;
+
+        emit OwnershipTransferred(previousOwner, newOwner);
+    }
+
+    /// @notice Reverts unless `msg.sender` is the current owner.
+    function enforceIsContractOwner() internal view {
+        address owner = contractOwner();
+        if (msg.sender != owner) {
+            revert DiamondUnauthorized(msg.sender, owner);
+        }
+    }
+
+    /// @notice Returns whether the diamond supports `interfaceId`.
+    /// @param interfaceId The interface identifier to inspect.
+    /// @return True if the interface is marked as supported.
+    function supportsInterface(bytes4 interfaceId) internal view returns (bool) {
+        return LibDiamondStorage.layout().supportedInterfaces[interfaceId];
+    }
+
+    /// @notice Sets support for `interfaceId`.
+    /// @param interfaceId The interface identifier to update.
+    /// @param supported Whether the interface is supported.
+    function setSupportedInterface(bytes4 interfaceId, bool supported) internal {
+        if (interfaceId == 0xffffffff) {
+            revert DiamondInvalidInterfaceId(interfaceId);
+        }
+
+        LibDiamondStorage.layout().supportedInterfaces[interfaceId] = supported;
+    }
+
+    /// @notice Returns the facet responsible for `selector`.
+    /// @param selector The selector to inspect.
+    /// @return facetAddress_ The owning facet address, or zero when unset.
+    function facetAddress(bytes4 selector) internal view returns (address facetAddress_) {
+        return LibDiamondStorage.layout().selectorData[selector].facetAddress;
+    }
+
+    /// @notice Returns all active facet addresses.
+    /// @return facetAddresses_ Active facet addresses.
+    function facetAddresses() internal view returns (address[] memory facetAddresses_) {
+        return LibDiamondStorage.layout().facetAddresses;
+    }
+
+    /// @notice Returns all selectors owned by `facetAddress_`.
+    /// @param facetAddress_ The facet address to inspect.
+    /// @return selectors The facet selectors.
+    function facetFunctionSelectors(address facetAddress_) internal view returns (bytes4[] memory selectors) {
+        return LibDiamondStorage.layout().facetData[facetAddress_].selectors;
+    }
+
+    /// @notice Returns all facets and selectors for loupe queries.
+    /// @return diamondFacets Active facets and their selectors.
+    function facets() internal view returns (IDiamondLoupe.Facet[] memory diamondFacets) {
+        LibDiamondStorage.Layout storage diamondStorage = LibDiamondStorage.layout();
+        uint256 facetCount = diamondStorage.facetAddresses.length;
+        diamondFacets = new IDiamondLoupe.Facet[](facetCount);
+
+        for (uint256 i = 0; i < facetCount; i++) {
+            address facetAddress_ = diamondStorage.facetAddresses[i];
+            diamondFacets[i] = IDiamondLoupe.Facet({
+                facetAddress: facetAddress_, functionSelectors: facetFunctionSelectors(facetAddress_)
+            });
+        }
+    }
+
+    /// @notice Returns true when `selector` is installed.
+    /// @param selector The selector to inspect.
+    /// @return True if the selector exists.
+    function selectorExists(bytes4 selector) internal view returns (bool) {
+        return facetAddress(selector) != address(0);
+    }
+
+    /// @notice Adds `selector` to `facetAddress_`.
+    /// @param facetAddress_ The facet that will own the selector.
+    /// @param selector The selector to add.
+    function addSelector(address facetAddress_, bytes4 selector) internal {
+        if (facetAddress_ == address(0)) {
+            revert DiamondFacetAddressZero();
+        }
+
+        address existingFacet = facetAddress(selector);
+        if (existingFacet != address(0)) {
+            revert DiamondSelectorAlreadyExists(selector, existingFacet);
+        }
+
+        LibDiamondStorage.Layout storage diamondStorage = LibDiamondStorage.layout();
+        _addFacetIfMissing(diamondStorage, facetAddress_);
+
+        uint256 selectorPosition = diamondStorage.facetData[facetAddress_].selectors.length;
+        diamondStorage.selectorData[selector] =
+            LibDiamondStorage.SelectorData({facetAddress: facetAddress_, selectorPosition: uint96(selectorPosition)});
+        diamondStorage.facetData[facetAddress_].selectors.push(selector);
+    }
+
+    /// @notice Replaces the current owner of `selector` with `facetAddress_`.
+    /// @param facetAddress_ The new facet address.
+    /// @param selector The selector to replace.
+    function replaceSelector(address facetAddress_, bytes4 selector) internal {
+        if (facetAddress_ == address(0)) {
+            revert DiamondFacetAddressZero();
+        }
+
+        address existingFacet = facetAddress(selector);
+        if (existingFacet == address(0)) {
+            revert DiamondSelectorNotFound(selector);
+        }
+        if (existingFacet == facetAddress_) {
+            revert DiamondReplaceWithSameFacet(selector, facetAddress_);
+        }
+
+        removeSelector(selector);
+        addSelector(facetAddress_, selector);
+    }
+
+    /// @notice Removes `selector` from its current facet.
+    /// @param selector The selector to remove.
+    function removeSelector(bytes4 selector) internal {
+        LibDiamondStorage.Layout storage diamondStorage = LibDiamondStorage.layout();
+        LibDiamondStorage.SelectorData memory selectorData = diamondStorage.selectorData[selector];
+        address facetAddress_ = selectorData.facetAddress;
+        if (facetAddress_ == address(0)) {
+            revert DiamondSelectorNotFound(selector);
+        }
+
+        bytes4[] storage selectors = diamondStorage.facetData[facetAddress_].selectors;
+        uint256 selectorPosition = selectorData.selectorPosition;
+        uint256 lastSelectorPosition = selectors.length - 1;
+
+        if (selectorPosition != lastSelectorPosition) {
+            bytes4 lastSelector = selectors[lastSelectorPosition];
+            selectors[selectorPosition] = lastSelector;
+            diamondStorage.selectorData[lastSelector].selectorPosition = uint96(selectorPosition);
+        }
+
+        selectors.pop();
+        delete diamondStorage.selectorData[selector];
+
+        if (selectors.length == 0) {
+            _removeFacetAddress(diamondStorage, facetAddress_);
+        }
+    }
+
+    /// @dev Adds `facetAddress_` to the active facet list when missing.
+    /// @param diamondStorage The diamond layout.
+    /// @param facetAddress_ The facet address to add.
+    function _addFacetIfMissing(LibDiamondStorage.Layout storage diamondStorage, address facetAddress_) private {
+        if (diamondStorage.facetData[facetAddress_].selectors.length != 0) {
+            return;
+        }
+
+        diamondStorage.facetData[facetAddress_].facetAddressPosition = diamondStorage.facetAddresses.length;
+        diamondStorage.facetAddresses.push(facetAddress_);
+    }
+
+    /// @dev Removes `facetAddress_` from the active facet list.
+    /// @param diamondStorage The diamond layout.
+    /// @param facetAddress_ The facet address to remove.
+    function _removeFacetAddress(LibDiamondStorage.Layout storage diamondStorage, address facetAddress_) private {
+        uint256 facetAddressPosition = diamondStorage.facetData[facetAddress_].facetAddressPosition;
+        uint256 lastFacetAddressPosition = diamondStorage.facetAddresses.length - 1;
+
+        if (facetAddressPosition != lastFacetAddressPosition) {
+            address lastFacetAddress = diamondStorage.facetAddresses[lastFacetAddressPosition];
+            diamondStorage.facetAddresses[facetAddressPosition] = lastFacetAddress;
+            diamondStorage.facetData[lastFacetAddress].facetAddressPosition = facetAddressPosition;
+        }
+
+        diamondStorage.facetAddresses.pop();
+        delete diamondStorage.facetData[facetAddress_].facetAddressPosition;
+    }
+}

--- a/src/diamond/storage/LibDiamondStorage.sol
+++ b/src/diamond/storage/LibDiamondStorage.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title LibDiamondStorage
+/// @notice Diamond storage layout for selector routing, facet metadata, and ownership.
+library LibDiamondStorage {
+    /// @dev Storage slot for the diamond layout.
+    bytes32 internal constant STORAGE_SLOT = keccak256("smart-contracts.diamond.storage");
+
+    /// @notice Selector routing metadata.
+    struct SelectorData {
+        address facetAddress;
+        uint96 selectorPosition;
+    }
+
+    /// @notice Selector collection metadata for one facet.
+    struct FacetData {
+        bytes4[] selectors;
+        uint256 facetAddressPosition;
+    }
+
+    /// @notice Full diamond storage layout.
+    struct Layout {
+        mapping(bytes4 => SelectorData) selectorData;
+        mapping(address => FacetData) facetData;
+        address[] facetAddresses;
+        mapping(bytes4 => bool) supportedInterfaces;
+        address contractOwner;
+    }
+
+    /// @notice Returns the storage layout for the diamond state.
+    /// @return l The storage layout pointer.
+    function layout() internal pure returns (Layout storage l) {
+        bytes32 slot = STORAGE_SLOT;
+        assembly {
+            l.slot := slot
+        }
+    }
+}

--- a/src/interfaces/IDiamondCut.sol
+++ b/src/interfaces/IDiamondCut.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title IDiamondCut
+/// @notice EIP-2535 cut interface for adding, replacing, and removing selectors.
+interface IDiamondCut {
+    /// @notice Selector mutation action.
+    enum FacetCutAction {
+        Add,
+        Replace,
+        Remove
+    }
+
+    /// @notice Facet cut payload.
+    struct FacetCut {
+        address facetAddress;
+        FacetCutAction action;
+        bytes4[] functionSelectors;
+    }
+
+    /// @notice Emitted when selectors are added, replaced, or removed.
+    /// @param diamondCut The selector mutation payload.
+    /// @param init The optional init target for post-cut initialization.
+    /// @param initCalldata The optional init calldata executed after the cut.
+    event DiamondCut(FacetCut[] diamondCut, address init, bytes initCalldata);
+
+    /// @notice Applies selector mutations to the diamond.
+    /// @param diamondCut The selector mutation payload.
+    /// @param init The optional init target for post-cut initialization.
+    /// @param initCalldata The optional init calldata executed after the cut.
+    function diamondCut(FacetCut[] calldata diamondCut, address init, bytes calldata initCalldata) external;
+}

--- a/src/interfaces/IDiamondLoupe.sol
+++ b/src/interfaces/IDiamondLoupe.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title IDiamondLoupe
+/// @notice EIP-2535 loupe interface for facet and selector introspection.
+interface IDiamondLoupe {
+    /// @notice Facet metadata returned by loupe queries.
+    struct Facet {
+        address facetAddress;
+        bytes4[] functionSelectors;
+    }
+
+    /// @notice Returns every facet and its selectors.
+    /// @return diamondFacets All active facets and their selectors.
+    function facets() external view returns (Facet[] memory diamondFacets);
+
+    /// @notice Returns all selectors owned by `facetAddress`.
+    /// @param facetAddress The facet address to inspect.
+    /// @return functionSelectors The selectors owned by the facet.
+    function facetFunctionSelectors(address facetAddress) external view returns (bytes4[] memory functionSelectors);
+
+    /// @notice Returns every active facet address.
+    /// @return facetAddresses All active facet addresses.
+    function facetAddresses() external view returns (address[] memory facetAddresses);
+
+    /// @notice Returns the facet responsible for `functionSelector`.
+    /// @param functionSelector The selector to inspect.
+    /// @return facetAddress The owning facet address, or zero when unset.
+    function facetAddress(bytes4 functionSelector) external view returns (address facetAddress);
+}

--- a/src/interfaces/IERC173.sol
+++ b/src/interfaces/IERC173.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title IERC173
+/// @notice Ownership interface used by diamonds and proxy-like deployments.
+interface IERC173 {
+    /// @notice Emitted when ownership changes.
+    /// @param previousOwner The previous owner.
+    /// @param newOwner The new owner.
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /// @notice Returns the current owner.
+    /// @return contractOwner The current owner.
+    function owner() external view returns (address contractOwner);
+
+    /// @notice Transfers ownership to `newOwner`.
+    /// @param newOwner The new owner account.
+    function transferOwnership(address newOwner) external;
+}

--- a/test/DiamondFoundationCore.t.sol
+++ b/test/DiamondFoundationCore.t.sol
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
+import {LibDiamond} from "../src/diamond/libraries/LibDiamond.sol";
+import {DiamondFixture, DiamondFacetOne, DiamondFacetTwo} from "./helpers/DiamondTestHarness.sol";
+
+contract DiamondFoundationCoreTest is DiamondFixture {
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    function testOwnerCanBeSetAndRead() public {
+        diamond.setOwner(admin);
+        assertTrue(diamond.owner() == admin, "owner should be updated");
+    }
+
+    function testOwnerTransferEmitsEvent() public {
+        VM.expectEmit(true, true, false, true, address(diamond));
+        emit OwnershipTransferred(address(0), admin);
+
+        diamond.setOwner(admin);
+    }
+
+    function testOwnerZeroAddressReverts() public {
+        VM.expectRevert(abi.encodeWithSelector(LibDiamond.DiamondOwnerZeroAddress.selector));
+        diamond.setOwner(address(0));
+    }
+
+    function testOwnerEnforcementRevertsForNonOwner() public {
+        diamond.setOwner(admin);
+
+        VM.prank(eve);
+        VM.expectRevert(abi.encodeWithSelector(LibDiamond.DiamondUnauthorized.selector, eve, admin));
+        diamond.enforceOwner();
+    }
+
+    function testSupportedInterfaceRoundTrip() public {
+        bytes4 interfaceId = 0x1f931c1c;
+        diamond.setSupportedInterface(interfaceId, true);
+        assertTrue(diamond.supportsInterface(interfaceId), "interface support should be enabled");
+
+        diamond.setSupportedInterface(interfaceId, false);
+        assertFalse(diamond.supportsInterface(interfaceId), "interface support should be disabled");
+    }
+
+    function testInvalidInterfaceIdReverts() public {
+        VM.expectRevert(abi.encodeWithSelector(LibDiamond.DiamondInvalidInterfaceId.selector, bytes4(0xffffffff)));
+        diamond.setSupportedInterface(0xffffffff, true);
+    }
+
+    function testAddSelectorTracksFacetAndSelectors() public {
+        bytes4 alphaSelector = DiamondFacetOne.alpha.selector;
+        bytes4 betaSelector = DiamondFacetOne.beta.selector;
+
+        diamond.addSelector(address(facetOne), alphaSelector);
+        diamond.addSelector(address(facetOne), betaSelector);
+
+        assertTrue(diamond.facetAddress(alphaSelector) == address(facetOne), "alpha selector should route to facet one");
+        assertTrue(diamond.facetAddress(betaSelector) == address(facetOne), "beta selector should route to facet one");
+
+        address[] memory facetAddresses_ = diamond.facetAddresses();
+        assertTrue(facetAddresses_.length == 1, "one facet address expected");
+        assertTrue(facetAddresses_[0] == address(facetOne), "facet one should be registered");
+
+        bytes4[] memory selectors = diamond.facetFunctionSelectors(address(facetOne));
+        assertTrue(selectors.length == 2, "facet one should have two selectors");
+        assertTrue(selectors[0] == alphaSelector, "alpha selector order mismatch");
+        assertTrue(selectors[1] == betaSelector, "beta selector order mismatch");
+    }
+
+    function testAddingExistingSelectorReverts() public {
+        bytes4 alphaSelector = DiamondFacetOne.alpha.selector;
+        diamond.addSelector(address(facetOne), alphaSelector);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(LibDiamond.DiamondSelectorAlreadyExists.selector, alphaSelector, address(facetOne))
+        );
+        diamond.addSelector(address(facetTwo), alphaSelector);
+    }
+
+    function testReplaceSelectorMovesRoutingToNewFacet() public {
+        bytes4 alphaSelector = DiamondFacetOne.alpha.selector;
+        diamond.addSelector(address(facetOne), alphaSelector);
+
+        diamond.replaceSelector(address(facetTwo), alphaSelector);
+
+        assertTrue(diamond.facetAddress(alphaSelector) == address(facetTwo), "selector should route to facet two");
+        assertTrue(diamond.facetFunctionSelectors(address(facetOne)).length == 0, "facet one selectors should be empty");
+
+        bytes4[] memory facetTwoSelectors = diamond.facetFunctionSelectors(address(facetTwo));
+        assertTrue(facetTwoSelectors.length == 1, "facet two should own one selector");
+        assertTrue(facetTwoSelectors[0] == alphaSelector, "facet two selector mismatch");
+    }
+
+    function testReplacingSelectorWithSameFacetReverts() public {
+        bytes4 alphaSelector = DiamondFacetOne.alpha.selector;
+        diamond.addSelector(address(facetOne), alphaSelector);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(LibDiamond.DiamondReplaceWithSameFacet.selector, alphaSelector, address(facetOne))
+        );
+        diamond.replaceSelector(address(facetOne), alphaSelector);
+    }
+
+    function testRemoveSelectorCleansUpFacetAddressList() public {
+        bytes4 alphaSelector = DiamondFacetOne.alpha.selector;
+        bytes4 gammaSelector = DiamondFacetTwo.gamma.selector;
+
+        diamond.addSelector(address(facetOne), alphaSelector);
+        diamond.addSelector(address(facetTwo), gammaSelector);
+        diamond.removeSelector(alphaSelector);
+
+        assertTrue(diamond.facetAddress(alphaSelector) == address(0), "removed selector should not resolve");
+        address[] memory facetAddresses_ = diamond.facetAddresses();
+        assertTrue(facetAddresses_.length == 1, "one facet should remain");
+        assertTrue(facetAddresses_[0] == address(facetTwo), "facet two should remain active");
+    }
+
+    function testRemoveUnknownSelectorReverts() public {
+        VM.expectRevert(
+            abi.encodeWithSelector(LibDiamond.DiamondSelectorNotFound.selector, DiamondFacetOne.alpha.selector)
+        );
+        diamond.removeSelector(DiamondFacetOne.alpha.selector);
+    }
+
+    function testFacetsViewReturnsCurrentLayout() public {
+        bytes4 alphaSelector = DiamondFacetOne.alpha.selector;
+        bytes4 betaSelector = DiamondFacetOne.beta.selector;
+        bytes4 gammaSelector = DiamondFacetTwo.gamma.selector;
+
+        diamond.addSelector(address(facetOne), alphaSelector);
+        diamond.addSelector(address(facetOne), betaSelector);
+        diamond.addSelector(address(facetTwo), gammaSelector);
+
+        IDiamondLoupe.Facet[] memory diamondFacets = diamond.facets();
+        assertTrue(diamondFacets.length == 2, "two facets expected");
+
+        assertTrue(diamondFacets[0].facetAddress == address(facetOne), "facet one ordering mismatch");
+        assertTrue(diamondFacets[0].functionSelectors.length == 2, "facet one selector count mismatch");
+        assertTrue(diamondFacets[1].facetAddress == address(facetTwo), "facet two ordering mismatch");
+        assertTrue(diamondFacets[1].functionSelectors.length == 1, "facet two selector count mismatch");
+    }
+}

--- a/test/helpers/DiamondTestHarness.sol
+++ b/test/helpers/DiamondTestHarness.sol
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IDiamondLoupe} from "../../src/interfaces/IDiamondLoupe.sol";
+import {LibDiamond} from "../../src/diamond/libraries/LibDiamond.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+
+contract DiamondFacetOne {
+    function alpha() external pure returns (uint256) {
+        return 1;
+    }
+
+    function beta() external pure returns (uint256) {
+        return 2;
+    }
+}
+
+contract DiamondFacetTwo {
+    function gamma() external pure returns (uint256) {
+        return 3;
+    }
+
+    function delta() external pure returns (uint256) {
+        return 4;
+    }
+}
+
+contract DiamondLibraryHarness {
+    function owner() external view returns (address) {
+        return LibDiamond.contractOwner();
+    }
+
+    function setOwner(address newOwner) external {
+        LibDiamond.setContractOwner(newOwner);
+    }
+
+    function enforceOwner() external view returns (bool) {
+        LibDiamond.enforceIsContractOwner();
+        return true;
+    }
+
+    function supportsInterface(bytes4 interfaceId) external view returns (bool) {
+        return LibDiamond.supportsInterface(interfaceId);
+    }
+
+    function setSupportedInterface(bytes4 interfaceId, bool supported) external {
+        LibDiamond.setSupportedInterface(interfaceId, supported);
+    }
+
+    function addSelector(address facetAddress_, bytes4 selector) external {
+        LibDiamond.addSelector(facetAddress_, selector);
+    }
+
+    function replaceSelector(address facetAddress_, bytes4 selector) external {
+        LibDiamond.replaceSelector(facetAddress_, selector);
+    }
+
+    function removeSelector(bytes4 selector) external {
+        LibDiamond.removeSelector(selector);
+    }
+
+    function facetAddress(bytes4 selector) external view returns (address) {
+        return LibDiamond.facetAddress(selector);
+    }
+
+    function facetAddresses() external view returns (address[] memory) {
+        return LibDiamond.facetAddresses();
+    }
+
+    function facetFunctionSelectors(address facetAddress_) external view returns (bytes4[] memory) {
+        return LibDiamond.facetFunctionSelectors(facetAddress_);
+    }
+
+    function facets() external view returns (IDiamondLoupe.Facet[] memory) {
+        return LibDiamond.facets();
+    }
+}
+
+abstract contract DiamondFixture is TestBase {
+    address internal admin = address(0xA11CE);
+    address internal eve = address(0xE11E);
+
+    DiamondLibraryHarness internal diamond;
+    DiamondFacetOne internal facetOne;
+    DiamondFacetTwo internal facetTwo;
+
+    function setUp() public virtual {
+        diamond = new DiamondLibraryHarness();
+        facetOne = new DiamondFacetOne();
+        facetTwo = new DiamondFacetTwo();
+    }
+}


### PR DESCRIPTION
## Summary
- add local diamond interfaces for cut, loupe, and ERC-173 ownership support
- add diamond-safe storage layout for selector routing, facet metadata, interface support, and contract ownership
- add shared diamond bookkeeping helpers for owner enforcement, interface registration, selector management, and loupe views
- add focused tests covering selector add/replace/remove behavior, facet tracking, ownership, and interface registration
- update the repository structure docs to include the new diamond module paths

## Validation
- `forge test --offline --match-path test/DiamondFoundationCore.t.sol`
- `forge test --offline`

Closes #54