### PR TITLE
Milestone/diamond core

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ forge fmt
 - Vault controls suite: `test/ERC4626VaultControlsCore.t.sol`
 - Vault accounting fuzz suite: `test/ERC4626VaultAccountingFuzz.t.sol`
 - Vault accounting invariant suite: `test/ERC4626VaultAccountingInvariant.t.sol`
-- Diamond core suites: `test/DiamondFoundationCore.t.sol`, `test/DiamondProxyCore.t.sol`, `test/DiamondCutCore.t.sol`, `test/DiamondLoupeCore.t.sol`
+- Diamond core suites: `test/DiamondFoundationCore.t.sol`, `test/DiamondProxyCore.t.sol`, `test/DiamondCutCore.t.sol`, `test/DiamondLoupeCore.t.sol`, `test/DiamondSelectorIntegrityCore.t.sol`
 - Oracle hardening suite: `test/OracleAdapterCore.t.sol`, `test/OracleAdapterValidation.t.sol`, `test/OracleAdapterCircuitBreaker.t.sol`, `test/OracleAdapterFuzz.t.sol`
 - Security CI/local checks: `docs/security-checks.md`
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ facets without a full rewrite.
 ## Structure
 - `src/access`: access control and upgrade-safety primitives.
 - `src/access/storage`: module-local storage libraries (diamond-ready slots).
+- `src/diamond`: diamond core primitives and shared routing helpers.
+- `src/diamond/storage`: diamond routing and ownership storage layout.
 - `src/security`: security primitives such as reentrancy protection.
 - `src/security/storage`: module-local storage libraries (diamond-ready slots).
 - `src/oracle`: oracle adapter and feed safety primitives.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ facets without a full rewrite.
 - `src/access`: access control and upgrade-safety primitives.
 - `src/access/storage`: module-local storage libraries (diamond-ready slots).
 - `src/diamond`: diamond core primitives and shared routing helpers.
+- `src/diamond/facets`: diamond facet implementations.
 - `src/diamond/storage`: diamond routing and ownership storage layout.
 - `src/security`: security primitives such as reentrancy protection.
 - `src/security/storage`: module-local storage libraries (diamond-ready slots).
@@ -48,6 +49,7 @@ forge fmt
 - Vault controls suite: `test/ERC4626VaultControlsCore.t.sol`
 - Vault accounting fuzz suite: `test/ERC4626VaultAccountingFuzz.t.sol`
 - Vault accounting invariant suite: `test/ERC4626VaultAccountingInvariant.t.sol`
+- Diamond core suites: `test/DiamondFoundationCore.t.sol`, `test/DiamondProxyCore.t.sol`, `test/DiamondCutCore.t.sol`, `test/DiamondLoupeCore.t.sol`
 - Oracle hardening suite: `test/OracleAdapterCore.t.sol`, `test/OracleAdapterValidation.t.sol`, `test/OracleAdapterCircuitBreaker.t.sol`, `test/OracleAdapterFuzz.t.sol`
 - Security CI/local checks: `docs/security-checks.md`
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ forge fmt
 
 ## Module Docs
 - Access control: `docs/access-control.md`
+- Diamond core: `docs/diamond-core.md`
 - ERC-4626 vault: `docs/erc4626-vault.md`
 - Oracle adapter: `docs/oracle-adapter.md`
 - Pausability: `docs/pausable.md`
@@ -66,6 +67,7 @@ forge fmt
 - Ops docs index: `docs/ops/README.md`
 - Release checklist: `docs/ops/release-checklist.md`
 - Release notes template: `docs/ops/release-notes-template.md`
+- Diamond cut runbook: `docs/ops/runbook-diamond-cut.md`
 - Oracle incident runbook: `docs/ops/runbook-oracle-incident.md`
 - Pause/unpause runbook: `docs/ops/runbook-pause-unpause.md`
 - Upgrade execution runbook: `docs/ops/runbook-upgrade-execution.md`

--- a/docs/diamond-core.md
+++ b/docs/diamond-core.md
@@ -1,0 +1,94 @@
+# Diamond Core
+
+This document describes the diamond core behavior implemented in this repository,
+including bootstrap expectations, `diamondCut` init flow, selector ownership
+rules, and upgrade review guidance.
+
+## Contracts
+
+- `src/diamond/Diamond.sol`: base proxy with owner bootstrap and selector routing fallback.
+- `src/diamond/facets/DiamondCutFacet.sol`: owner-gated `diamondCut` entrypoint.
+- `src/diamond/facets/DiamondLoupeFacet.sol`: loupe reads + `IERC173` ownership surface.
+- `src/diamond/libraries/LibDiamond.sol`: selector/owner/interface bookkeeping and cut helpers.
+- `src/diamond/storage/LibDiamondStorage.sol`: canonical diamond storage slot layout.
+
+## Deployment And Bootstrap Flow
+
+Current `Diamond` constructor initializes only the owner:
+
+- deploy `Diamond(initialOwner)`.
+- deploy initial facets (`DiamondCutFacet`, `DiamondLoupeFacet`, others).
+- install initial selectors through a bootstrap path.
+
+In tests, bootstrap is done through `DiamondProxyHarness.installSelector(...)`.
+For production, use a deploy flow that installs initial selectors before regular
+operations begin (for example via a dedicated deploy/factory path).
+
+## `diamondCut` And Init Delegatecall Flow
+
+`DiamondCutFacet.diamondCut(...)` enforces owner-only access, then calls
+`LibDiamond.diamondCut(...)`.
+
+Guardrails enforced in `LibDiamond`:
+
+- empty selector arrays revert (`DiamondCutEmptySelectors`).
+- add/replace targets must contain code (`DiamondTargetHasNoCode`).
+- remove actions must use `facetAddress == address(0)`
+  (`DiamondCutRemoveFacetAddressNotZero`).
+- init calldata without init target reverts (`DiamondCutInitTargetRequired`).
+- init target without calldata reverts (`DiamondCutInitCalldataRequired`).
+- init delegatecall failures bubble via `DiamondCutInitFailed`.
+
+Execution order:
+
+1. Apply add/replace/remove selector mutations.
+2. Execute optional init delegatecall.
+3. Emit `DiamondCut` event from `DiamondCutFacet`.
+
+## Selector Ownership Rules
+
+- A selector maps to exactly one facet at a time.
+- Add rejects existing selectors (`DiamondSelectorAlreadyExists`).
+- Replace rejects unknown selectors and same-facet replacements.
+- Remove rejects unknown selectors (`DiamondSelectorNotFound`).
+- Facet address and selector arrays use swap-and-pop updates; array ordering can
+  change after removals.
+
+Loupe reads (`facets`, `facetAddresses`, `facetFunctionSelectors`,
+`facetAddress`) should be treated as the source of truth for live routing state.
+
+## Storage Discipline
+
+To stay diamond-safe:
+
+- keep mutable state in namespaced storage libraries (`src/*/storage`), not in
+  facet state variables.
+- keep storage structs append-only once deployed.
+- use explicit initializers and idempotency guards for new modules/facets.
+- review slot constants and struct layout changes before every cut.
+
+## Upgrade Review Checklist
+
+1. Verify cut intent: selectors added/replaced/removed are expected.
+2. Verify each facet target has deployed bytecode and reviewed source.
+3. Verify selector collisions are intentional and reviewed.
+4. Verify init target + calldata, including idempotency and access controls.
+5. Verify storage layout assumptions for every touched module.
+6. Execute post-cut checks:
+   - loupe snapshot matches expected routing.
+   - critical external calls succeed.
+   - ownership (`owner()`) is unchanged unless intentionally transferred.
+
+## Security Assumptions And Limits
+
+- Diamond owner authority is highly privileged; use multisig/governance in production.
+- This core does not include built-in timelock/governance policy for cuts.
+- Bootstrap/install strategy is deployment-specific and must be reviewed.
+- Safety depends on off-chain cut payload review and post-cut validation.
+
+## Test References
+
+- `test/DiamondFoundationCore.t.sol`
+- `test/DiamondProxyCore.t.sol`
+- `test/DiamondCutCore.t.sol`
+- `test/DiamondLoupeCore.t.sol`

--- a/docs/diamond-core.md
+++ b/docs/diamond-core.md
@@ -92,3 +92,4 @@ To stay diamond-safe:
 - `test/DiamondProxyCore.t.sol`
 - `test/DiamondCutCore.t.sol`
 - `test/DiamondLoupeCore.t.sol`
+- `test/DiamondSelectorIntegrityCore.t.sol`

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -4,6 +4,7 @@ This folder contains release and incident-response operational guides.
 
 - Release checklist: `docs/ops/release-checklist.md`
 - Release notes template: `docs/ops/release-notes-template.md`
+- Diamond cut runbook: `docs/ops/runbook-diamond-cut.md`
 - Oracle incident runbook: `docs/ops/runbook-oracle-incident.md`
 - Pause/unpause runbook: `docs/ops/runbook-pause-unpause.md`
 - Upgrade execution runbook: `docs/ops/runbook-upgrade-execution.md`

--- a/docs/ops/runbook-diamond-cut.md
+++ b/docs/ops/runbook-diamond-cut.md
@@ -1,0 +1,43 @@
+# Runbook: Diamond Cut Execution
+
+Use this runbook for production-facing selector upgrades on the diamond core.
+
+## Preconditions
+
+- Upgrade is reviewed and approved through your governance process.
+- Caller is the current diamond owner (`IERC173.owner()`).
+- Facet bytecode, init target, and init calldata are finalized.
+
+## Pre-Cut Checklist
+
+1. Build the exact selector diff (`add`, `replace`, `remove`).
+2. Confirm every add/replace facet target has runtime code.
+3. Confirm every remove action uses `facetAddress = address(0)`.
+4. Confirm no empty selector lists exist.
+5. If using init delegatecall:
+   - `init` target has code.
+   - calldata is non-empty.
+   - init routine is idempotent and storage-safe.
+
+## Execution
+
+1. Submit `diamondCut(cut, init, initCalldata)` from owner account.
+2. Wait for transaction finality.
+3. Record tx hash and emitted `DiamondCut` payload.
+
+## Post-Cut Verification
+
+1. Read loupe state:
+   - `facetAddresses()`
+   - `facetFunctionSelectors(address)`
+   - `facetAddress(selector)`
+2. Verify expected selector ownership matches planned diff.
+3. Run smoke checks on critical external functions.
+4. Verify owner is unchanged unless ownership transfer was planned.
+
+## Failure Handling
+
+- If the cut reverts, inspect revert reason and payload assumptions first.
+- Do not submit ad-hoc follow-up cuts without updating the reviewed diff.
+- If a bad cut succeeds, execute a reviewed corrective cut immediately and
+  consider pausing user-facing flows if available.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -68,7 +68,7 @@ upgrade, and vault modules.
 - Compromised privileged keys can still perform privileged actions.
 - Economic attacks and protocol-specific business logic exploits are out of scope for this base kit.
 - Oracle market manipulation resistance is feed/provider-specific and must be handled at integration and policy layers.
-- Diamond-specific `diamondCut` payload validation and multi-step governance workflows are deferred to the diamond milestone.
+- Diamond `diamondCut` flows include core guardrails, but governance policy (timelocks/multisig approvals) remains an integration responsibility.
 - The current upgrade guardrails check nonzero implementation; deeper bytecode/interface validation is protocol-specific and should be added where needed.
 - Direct token donations to vault addresses can create untracked surplus unless explicitly reconciled by integration policy.
 

--- a/src/diamond/Diamond.sol
+++ b/src/diamond/Diamond.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {LibDiamond} from "./libraries/LibDiamond.sol";
+
+/// @title Diamond
+/// @notice Base EIP-2535 proxy contract with selector routing and owner bootstrap.
+contract Diamond {
+    /// @notice Thrown when no facet is registered for the requested selector.
+    /// @param selector The unresolved selector.
+    error DiamondFunctionNotFound(bytes4 selector);
+
+    /// @param initialOwner The account that becomes the initial diamond owner.
+    constructor(address initialOwner) {
+        LibDiamond.setContractOwner(initialOwner);
+    }
+
+    /// @notice Accepts plain ETH transfers.
+    receive() external payable {}
+
+    /// @notice Delegates calls to the registered facet for `msg.sig`.
+    fallback() external payable {
+        address facet = LibDiamond.facetAddress(msg.sig);
+        if (facet == address(0)) {
+            revert DiamondFunctionNotFound(msg.sig);
+        }
+
+        assembly {
+            calldatacopy(0, 0, calldatasize())
+            let result := delegatecall(gas(), facet, 0, calldatasize(), 0, 0)
+            returndatacopy(0, 0, returndatasize())
+
+            switch result
+            case 0 { revert(0, returndatasize()) }
+            default { return(0, returndatasize()) }
+        }
+    }
+}

--- a/src/diamond/facets/DiamondCutFacet.sol
+++ b/src/diamond/facets/DiamondCutFacet.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IDiamondCut} from "../../interfaces/IDiamondCut.sol";
+import {LibDiamond} from "../libraries/LibDiamond.sol";
+
+/// @title DiamondCutFacet
+/// @notice Owner-gated selector mutation facet for EIP-2535 diamonds.
+contract DiamondCutFacet is IDiamondCut {
+    /// @notice Applies selector mutations and optional init delegatecall.
+    /// @param diamondCut_ The selector mutation payload.
+    /// @param init The optional init target for post-cut initialization.
+    /// @param initCalldata The optional init calldata executed after the cut.
+    function diamondCut(IDiamondCut.FacetCut[] calldata diamondCut_, address init, bytes calldata initCalldata)
+        external
+    {
+        LibDiamond.enforceIsContractOwner();
+        LibDiamond.diamondCut(diamondCut_, init, initCalldata);
+        emit DiamondCut(diamondCut_, init, initCalldata);
+    }
+}

--- a/src/diamond/facets/DiamondLoupeFacet.sol
+++ b/src/diamond/facets/DiamondLoupeFacet.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC173} from "../../interfaces/IERC173.sol";
+import {IDiamondLoupe} from "../../interfaces/IDiamondLoupe.sol";
+import {LibDiamond} from "../libraries/LibDiamond.sol";
+
+/// @title DiamondLoupeFacet
+/// @notice Facet metadata + ownership surface for EIP-2535 diamonds.
+contract DiamondLoupeFacet is IDiamondLoupe, IERC173 {
+    /// @notice Returns every facet and its selectors.
+    /// @return diamondFacets All active facets and their selectors.
+    function facets() external view returns (IDiamondLoupe.Facet[] memory diamondFacets) {
+        return LibDiamond.facets();
+    }
+
+    /// @notice Returns all selectors owned by `facetAddress_`.
+    /// @param facetAddress_ The facet address to inspect.
+    /// @return functionSelectors The selectors owned by the facet.
+    function facetFunctionSelectors(address facetAddress_) external view returns (bytes4[] memory functionSelectors) {
+        return LibDiamond.facetFunctionSelectors(facetAddress_);
+    }
+
+    /// @notice Returns every active facet address.
+    /// @return facetAddresses_ All active facet addresses.
+    function facetAddresses() external view returns (address[] memory facetAddresses_) {
+        return LibDiamond.facetAddresses();
+    }
+
+    /// @notice Returns the facet responsible for `functionSelector`.
+    /// @param functionSelector The selector to inspect.
+    /// @return facetAddress_ The owning facet address, or zero when unset.
+    function facetAddress(bytes4 functionSelector) external view returns (address facetAddress_) {
+        return LibDiamond.facetAddress(functionSelector);
+    }
+
+    /// @notice Returns the current owner.
+    /// @return contractOwner The current owner.
+    function owner() external view returns (address contractOwner) {
+        return LibDiamond.contractOwner();
+    }
+
+    /// @notice Transfers ownership to `newOwner`.
+    /// @param newOwner The new owner account.
+    function transferOwnership(address newOwner) external {
+        LibDiamond.enforceIsContractOwner();
+        LibDiamond.setContractOwner(newOwner);
+    }
+}

--- a/src/diamond/libraries/LibDiamond.sol
+++ b/src/diamond/libraries/LibDiamond.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
+import {IDiamondCut} from "../../interfaces/IDiamondCut.sol";
 import {IDiamondLoupe} from "../../interfaces/IDiamondLoupe.sol";
 import {LibDiamondStorage} from "../storage/LibDiamondStorage.sol";
 
@@ -24,6 +25,18 @@ library LibDiamond {
     error DiamondSelectorNotFound(bytes4 selector);
     /// @notice Thrown when replacing a selector with the same facet.
     error DiamondReplaceWithSameFacet(bytes4 selector, address facetAddress);
+    /// @notice Thrown when a facet cut contains no selectors.
+    error DiamondCutEmptySelectors();
+    /// @notice Thrown when removing selectors with a nonzero facet address.
+    error DiamondCutRemoveFacetAddressNotZero(address facetAddress);
+    /// @notice Thrown when a facet or init target has no code.
+    error DiamondTargetHasNoCode(address target);
+    /// @notice Thrown when init calldata is provided without an init target.
+    error DiamondCutInitTargetRequired();
+    /// @notice Thrown when an init target is provided without calldata.
+    error DiamondCutInitCalldataRequired();
+    /// @notice Thrown when the init delegatecall fails.
+    error DiamondCutInitFailed(address init, bytes reason);
 
     /// @notice Returns the current contract owner.
     /// @return owner_ The current contract owner.
@@ -180,6 +193,79 @@ library LibDiamond {
 
         if (selectors.length == 0) {
             _removeFacetAddress(diamondStorage, facetAddress_);
+        }
+    }
+
+    /// @notice Applies a full diamond cut and optional init delegatecall.
+    /// @param diamondCut_ The selector mutations to apply.
+    /// @param init The optional init target for post-cut initialization.
+    /// @param initCalldata The optional init calldata.
+    function diamondCut(IDiamondCut.FacetCut[] calldata diamondCut_, address init, bytes calldata initCalldata)
+        internal
+    {
+        uint256 cutLength = diamondCut_.length;
+        for (uint256 i = 0; i < cutLength; i++) {
+            IDiamondCut.FacetCut calldata facetCut = diamondCut_[i];
+            bytes4[] calldata selectors = facetCut.functionSelectors;
+            uint256 selectorCount = selectors.length;
+            if (selectorCount == 0) {
+                revert DiamondCutEmptySelectors();
+            }
+
+            if (facetCut.action == IDiamondCut.FacetCutAction.Add) {
+                _enforceTargetHasCode(facetCut.facetAddress);
+                for (uint256 j = 0; j < selectorCount; j++) {
+                    addSelector(facetCut.facetAddress, selectors[j]);
+                }
+                continue;
+            }
+
+            if (facetCut.action == IDiamondCut.FacetCutAction.Replace) {
+                _enforceTargetHasCode(facetCut.facetAddress);
+                for (uint256 j = 0; j < selectorCount; j++) {
+                    replaceSelector(facetCut.facetAddress, selectors[j]);
+                }
+                continue;
+            }
+
+            if (facetCut.facetAddress != address(0)) {
+                revert DiamondCutRemoveFacetAddressNotZero(facetCut.facetAddress);
+            }
+            for (uint256 j = 0; j < selectorCount; j++) {
+                removeSelector(selectors[j]);
+            }
+        }
+
+        initializeDiamondCut(init, initCalldata);
+    }
+
+    /// @notice Executes the optional init delegatecall after a cut.
+    /// @param init The optional init target for post-cut initialization.
+    /// @param initCalldata The optional init calldata.
+    function initializeDiamondCut(address init, bytes calldata initCalldata) internal {
+        if (init == address(0)) {
+            if (initCalldata.length != 0) {
+                revert DiamondCutInitTargetRequired();
+            }
+            return;
+        }
+        if (initCalldata.length == 0) {
+            revert DiamondCutInitCalldataRequired();
+        }
+
+        _enforceTargetHasCode(init);
+
+        (bool success, bytes memory reason) = init.delegatecall(initCalldata);
+        if (!success) {
+            revert DiamondCutInitFailed(init, reason);
+        }
+    }
+
+    /// @dev Reverts when `target` has no runtime code.
+    /// @param target The facet or init target to validate.
+    function _enforceTargetHasCode(address target) private view {
+        if (target.code.length == 0) {
+            revert DiamondTargetHasNoCode(target);
         }
     }
 

--- a/src/diamond/libraries/LibDiamond.sol
+++ b/src/diamond/libraries/LibDiamond.sol
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IDiamondLoupe} from "../../interfaces/IDiamondLoupe.sol";
+import {LibDiamondStorage} from "../storage/LibDiamondStorage.sol";
+
+/// @title LibDiamond
+/// @notice Shared diamond bookkeeping helpers for ownership, interfaces, and selector routing.
+library LibDiamond {
+    /// @notice Emitted when ownership changes.
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /// @notice Thrown when a zero owner is provided.
+    error DiamondOwnerZeroAddress();
+    /// @notice Thrown when `account` is not the current owner.
+    error DiamondUnauthorized(address account, address owner);
+    /// @notice Thrown when a zero facet address is provided.
+    error DiamondFacetAddressZero();
+    /// @notice Thrown when an invalid ERC-165 interface id is registered.
+    error DiamondInvalidInterfaceId(bytes4 interfaceId);
+    /// @notice Thrown when a selector already exists on another facet.
+    error DiamondSelectorAlreadyExists(bytes4 selector, address existingFacet);
+    /// @notice Thrown when a selector is not currently installed.
+    error DiamondSelectorNotFound(bytes4 selector);
+    /// @notice Thrown when replacing a selector with the same facet.
+    error DiamondReplaceWithSameFacet(bytes4 selector, address facetAddress);
+
+    /// @notice Returns the current contract owner.
+    /// @return owner_ The current contract owner.
+    function contractOwner() internal view returns (address owner_) {
+        return LibDiamondStorage.layout().contractOwner;
+    }
+
+    /// @notice Sets the current contract owner and emits the ERC-173 event.
+    /// @param newOwner The new owner account.
+    function setContractOwner(address newOwner) internal {
+        if (newOwner == address(0)) {
+            revert DiamondOwnerZeroAddress();
+        }
+
+        LibDiamondStorage.Layout storage diamondStorage = LibDiamondStorage.layout();
+        address previousOwner = diamondStorage.contractOwner;
+        diamondStorage.contractOwner = newOwner;
+
+        emit OwnershipTransferred(previousOwner, newOwner);
+    }
+
+    /// @notice Reverts unless `msg.sender` is the current owner.
+    function enforceIsContractOwner() internal view {
+        address owner = contractOwner();
+        if (msg.sender != owner) {
+            revert DiamondUnauthorized(msg.sender, owner);
+        }
+    }
+
+    /// @notice Returns whether the diamond supports `interfaceId`.
+    /// @param interfaceId The interface identifier to inspect.
+    /// @return True if the interface is marked as supported.
+    function supportsInterface(bytes4 interfaceId) internal view returns (bool) {
+        return LibDiamondStorage.layout().supportedInterfaces[interfaceId];
+    }
+
+    /// @notice Sets support for `interfaceId`.
+    /// @param interfaceId The interface identifier to update.
+    /// @param supported Whether the interface is supported.
+    function setSupportedInterface(bytes4 interfaceId, bool supported) internal {
+        if (interfaceId == 0xffffffff) {
+            revert DiamondInvalidInterfaceId(interfaceId);
+        }
+
+        LibDiamondStorage.layout().supportedInterfaces[interfaceId] = supported;
+    }
+
+    /// @notice Returns the facet responsible for `selector`.
+    /// @param selector The selector to inspect.
+    /// @return facetAddress_ The owning facet address, or zero when unset.
+    function facetAddress(bytes4 selector) internal view returns (address facetAddress_) {
+        return LibDiamondStorage.layout().selectorData[selector].facetAddress;
+    }
+
+    /// @notice Returns all active facet addresses.
+    /// @return facetAddresses_ Active facet addresses.
+    function facetAddresses() internal view returns (address[] memory facetAddresses_) {
+        return LibDiamondStorage.layout().facetAddresses;
+    }
+
+    /// @notice Returns all selectors owned by `facetAddress_`.
+    /// @param facetAddress_ The facet address to inspect.
+    /// @return selectors The facet selectors.
+    function facetFunctionSelectors(address facetAddress_) internal view returns (bytes4[] memory selectors) {
+        return LibDiamondStorage.layout().facetData[facetAddress_].selectors;
+    }
+
+    /// @notice Returns all facets and selectors for loupe queries.
+    /// @return diamondFacets Active facets and their selectors.
+    function facets() internal view returns (IDiamondLoupe.Facet[] memory diamondFacets) {
+        LibDiamondStorage.Layout storage diamondStorage = LibDiamondStorage.layout();
+        uint256 facetCount = diamondStorage.facetAddresses.length;
+        diamondFacets = new IDiamondLoupe.Facet[](facetCount);
+
+        for (uint256 i = 0; i < facetCount; i++) {
+            address facetAddress_ = diamondStorage.facetAddresses[i];
+            diamondFacets[i] = IDiamondLoupe.Facet({
+                facetAddress: facetAddress_, functionSelectors: facetFunctionSelectors(facetAddress_)
+            });
+        }
+    }
+
+    /// @notice Returns true when `selector` is installed.
+    /// @param selector The selector to inspect.
+    /// @return True if the selector exists.
+    function selectorExists(bytes4 selector) internal view returns (bool) {
+        return facetAddress(selector) != address(0);
+    }
+
+    /// @notice Adds `selector` to `facetAddress_`.
+    /// @param facetAddress_ The facet that will own the selector.
+    /// @param selector The selector to add.
+    function addSelector(address facetAddress_, bytes4 selector) internal {
+        if (facetAddress_ == address(0)) {
+            revert DiamondFacetAddressZero();
+        }
+
+        address existingFacet = facetAddress(selector);
+        if (existingFacet != address(0)) {
+            revert DiamondSelectorAlreadyExists(selector, existingFacet);
+        }
+
+        LibDiamondStorage.Layout storage diamondStorage = LibDiamondStorage.layout();
+        _addFacetIfMissing(diamondStorage, facetAddress_);
+
+        uint256 selectorPosition = diamondStorage.facetData[facetAddress_].selectors.length;
+        diamondStorage.selectorData[selector] =
+            LibDiamondStorage.SelectorData({facetAddress: facetAddress_, selectorPosition: uint96(selectorPosition)});
+        diamondStorage.facetData[facetAddress_].selectors.push(selector);
+    }
+
+    /// @notice Replaces the current owner of `selector` with `facetAddress_`.
+    /// @param facetAddress_ The new facet address.
+    /// @param selector The selector to replace.
+    function replaceSelector(address facetAddress_, bytes4 selector) internal {
+        if (facetAddress_ == address(0)) {
+            revert DiamondFacetAddressZero();
+        }
+
+        address existingFacet = facetAddress(selector);
+        if (existingFacet == address(0)) {
+            revert DiamondSelectorNotFound(selector);
+        }
+        if (existingFacet == facetAddress_) {
+            revert DiamondReplaceWithSameFacet(selector, facetAddress_);
+        }
+
+        removeSelector(selector);
+        addSelector(facetAddress_, selector);
+    }
+
+    /// @notice Removes `selector` from its current facet.
+    /// @param selector The selector to remove.
+    function removeSelector(bytes4 selector) internal {
+        LibDiamondStorage.Layout storage diamondStorage = LibDiamondStorage.layout();
+        LibDiamondStorage.SelectorData memory selectorData = diamondStorage.selectorData[selector];
+        address facetAddress_ = selectorData.facetAddress;
+        if (facetAddress_ == address(0)) {
+            revert DiamondSelectorNotFound(selector);
+        }
+
+        bytes4[] storage selectors = diamondStorage.facetData[facetAddress_].selectors;
+        uint256 selectorPosition = selectorData.selectorPosition;
+        uint256 lastSelectorPosition = selectors.length - 1;
+
+        if (selectorPosition != lastSelectorPosition) {
+            bytes4 lastSelector = selectors[lastSelectorPosition];
+            selectors[selectorPosition] = lastSelector;
+            diamondStorage.selectorData[lastSelector].selectorPosition = uint96(selectorPosition);
+        }
+
+        selectors.pop();
+        delete diamondStorage.selectorData[selector];
+
+        if (selectors.length == 0) {
+            _removeFacetAddress(diamondStorage, facetAddress_);
+        }
+    }
+
+    /// @dev Adds `facetAddress_` to the active facet list when missing.
+    /// @param diamondStorage The diamond layout.
+    /// @param facetAddress_ The facet address to add.
+    function _addFacetIfMissing(LibDiamondStorage.Layout storage diamondStorage, address facetAddress_) private {
+        if (diamondStorage.facetData[facetAddress_].selectors.length != 0) {
+            return;
+        }
+
+        diamondStorage.facetData[facetAddress_].facetAddressPosition = diamondStorage.facetAddresses.length;
+        diamondStorage.facetAddresses.push(facetAddress_);
+    }
+
+    /// @dev Removes `facetAddress_` from the active facet list.
+    /// @param diamondStorage The diamond layout.
+    /// @param facetAddress_ The facet address to remove.
+    function _removeFacetAddress(LibDiamondStorage.Layout storage diamondStorage, address facetAddress_) private {
+        uint256 facetAddressPosition = diamondStorage.facetData[facetAddress_].facetAddressPosition;
+        uint256 lastFacetAddressPosition = diamondStorage.facetAddresses.length - 1;
+
+        if (facetAddressPosition != lastFacetAddressPosition) {
+            address lastFacetAddress = diamondStorage.facetAddresses[lastFacetAddressPosition];
+            diamondStorage.facetAddresses[facetAddressPosition] = lastFacetAddress;
+            diamondStorage.facetData[lastFacetAddress].facetAddressPosition = facetAddressPosition;
+        }
+
+        diamondStorage.facetAddresses.pop();
+        delete diamondStorage.facetData[facetAddress_].facetAddressPosition;
+    }
+}

--- a/src/diamond/storage/LibDiamondStorage.sol
+++ b/src/diamond/storage/LibDiamondStorage.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title LibDiamondStorage
+/// @notice Diamond storage layout for selector routing, facet metadata, and ownership.
+library LibDiamondStorage {
+    /// @dev Storage slot for the diamond layout.
+    bytes32 internal constant STORAGE_SLOT = keccak256("smart-contracts.diamond.storage");
+
+    /// @notice Selector routing metadata.
+    struct SelectorData {
+        address facetAddress;
+        uint96 selectorPosition;
+    }
+
+    /// @notice Selector collection metadata for one facet.
+    struct FacetData {
+        bytes4[] selectors;
+        uint256 facetAddressPosition;
+    }
+
+    /// @notice Full diamond storage layout.
+    struct Layout {
+        mapping(bytes4 => SelectorData) selectorData;
+        mapping(address => FacetData) facetData;
+        address[] facetAddresses;
+        mapping(bytes4 => bool) supportedInterfaces;
+        address contractOwner;
+    }
+
+    /// @notice Returns the storage layout for the diamond state.
+    /// @return l The storage layout pointer.
+    function layout() internal pure returns (Layout storage l) {
+        bytes32 slot = STORAGE_SLOT;
+        assembly {
+            l.slot := slot
+        }
+    }
+}

--- a/src/interfaces/IDiamondCut.sol
+++ b/src/interfaces/IDiamondCut.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title IDiamondCut
+/// @notice EIP-2535 cut interface for adding, replacing, and removing selectors.
+interface IDiamondCut {
+    /// @notice Selector mutation action.
+    enum FacetCutAction {
+        Add,
+        Replace,
+        Remove
+    }
+
+    /// @notice Facet cut payload.
+    struct FacetCut {
+        address facetAddress;
+        FacetCutAction action;
+        bytes4[] functionSelectors;
+    }
+
+    /// @notice Emitted when selectors are added, replaced, or removed.
+    /// @param diamondCut The selector mutation payload.
+    /// @param init The optional init target for post-cut initialization.
+    /// @param initCalldata The optional init calldata executed after the cut.
+    event DiamondCut(FacetCut[] diamondCut, address init, bytes initCalldata);
+
+    /// @notice Applies selector mutations to the diamond.
+    /// @param diamondCut The selector mutation payload.
+    /// @param init The optional init target for post-cut initialization.
+    /// @param initCalldata The optional init calldata executed after the cut.
+    function diamondCut(FacetCut[] calldata diamondCut, address init, bytes calldata initCalldata) external;
+}

--- a/src/interfaces/IDiamondLoupe.sol
+++ b/src/interfaces/IDiamondLoupe.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title IDiamondLoupe
+/// @notice EIP-2535 loupe interface for facet and selector introspection.
+interface IDiamondLoupe {
+    /// @notice Facet metadata returned by loupe queries.
+    struct Facet {
+        address facetAddress;
+        bytes4[] functionSelectors;
+    }
+
+    /// @notice Returns every facet and its selectors.
+    /// @return diamondFacets All active facets and their selectors.
+    function facets() external view returns (Facet[] memory diamondFacets);
+
+    /// @notice Returns all selectors owned by `facetAddress`.
+    /// @param facetAddress The facet address to inspect.
+    /// @return functionSelectors The selectors owned by the facet.
+    function facetFunctionSelectors(address facetAddress) external view returns (bytes4[] memory functionSelectors);
+
+    /// @notice Returns every active facet address.
+    /// @return facetAddresses All active facet addresses.
+    function facetAddresses() external view returns (address[] memory facetAddresses);
+
+    /// @notice Returns the facet responsible for `functionSelector`.
+    /// @param functionSelector The selector to inspect.
+    /// @return facetAddress The owning facet address, or zero when unset.
+    function facetAddress(bytes4 functionSelector) external view returns (address facetAddress);
+}

--- a/src/interfaces/IERC173.sol
+++ b/src/interfaces/IERC173.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title IERC173
+/// @notice Ownership interface used by diamonds and proxy-like deployments.
+interface IERC173 {
+    /// @notice Emitted when ownership changes.
+    /// @param previousOwner The previous owner.
+    /// @param newOwner The new owner.
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /// @notice Returns the current owner.
+    /// @return contractOwner The current owner.
+    function owner() external view returns (address contractOwner);
+
+    /// @notice Transfers ownership to `newOwner`.
+    /// @param newOwner The new owner account.
+    function transferOwnership(address newOwner) external;
+}

--- a/test/DiamondCutCore.t.sol
+++ b/test/DiamondCutCore.t.sol
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Diamond} from "../src/diamond/Diamond.sol";
+import {DiamondCutFacet} from "../src/diamond/facets/DiamondCutFacet.sol";
+import {IDiamondCut} from "../src/interfaces/IDiamondCut.sol";
+import {LibDiamond} from "../src/diamond/libraries/LibDiamond.sol";
+import {
+    DiamondFacetOne,
+    DiamondFacetReplacement,
+    DiamondInitMock,
+    DiamondProxyHarness,
+    TestBase
+} from "./helpers/DiamondTestHarness.sol";
+
+contract DiamondCutCoreTest is TestBase {
+    event DiamondCut(IDiamondCut.FacetCut[] diamondCut, address init, bytes initCalldata);
+
+    address internal admin = address(0xA11CE);
+    address internal eve = address(0xE11E);
+
+    DiamondProxyHarness internal diamond;
+    DiamondCutFacet internal cutFacet;
+    DiamondFacetOne internal facetOne;
+    DiamondFacetReplacement internal facetReplacement;
+    DiamondInitMock internal initMock;
+
+    function setUp() public {
+        diamond = new DiamondProxyHarness(admin);
+        cutFacet = new DiamondCutFacet();
+        facetOne = new DiamondFacetOne();
+        facetReplacement = new DiamondFacetReplacement();
+        initMock = new DiamondInitMock();
+
+        diamond.installSelector(address(cutFacet), DiamondCutFacet.diamondCut.selector);
+    }
+
+    function testOwnerCanAddSelectorViaDiamondCut() public {
+        IDiamondCut.FacetCut[] memory cut =
+            _buildSingleCut(address(facetOne), IDiamondCut.FacetCutAction.Add, DiamondFacetOne.version.selector);
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+
+        (bool success, bytes memory returndata) = address(diamond).call(abi.encodeCall(DiamondFacetOne.version, ()));
+        assertTrue(success, "version call should succeed");
+        assertTrue(abi.decode(returndata, (uint256)) == 1, "version should route to facet one");
+    }
+
+    function testDiamondCutEmitsEvent() public {
+        IDiamondCut.FacetCut[] memory cut =
+            _buildSingleCut(address(facetOne), IDiamondCut.FacetCutAction.Add, DiamondFacetOne.version.selector);
+
+        VM.expectEmit(false, false, false, true, address(diamond));
+        emit DiamondCut(cut, address(0), "");
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function testNonOwnerCannotDiamondCut() public {
+        IDiamondCut.FacetCut[] memory cut =
+            _buildSingleCut(address(facetOne), IDiamondCut.FacetCutAction.Add, DiamondFacetOne.version.selector);
+
+        VM.prank(eve);
+        VM.expectRevert(abi.encodeWithSelector(LibDiamond.DiamondUnauthorized.selector, eve, admin));
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function testReplaceSelectorViaDiamondCut() public {
+        IDiamondCut.FacetCut[] memory addCut =
+            _buildSingleCut(address(facetOne), IDiamondCut.FacetCutAction.Add, DiamondFacetOne.version.selector);
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(addCut, address(0), "");
+
+        IDiamondCut.FacetCut[] memory replaceCut = _buildSingleCut(
+            address(facetReplacement), IDiamondCut.FacetCutAction.Replace, DiamondFacetReplacement.version.selector
+        );
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(replaceCut, address(0), "");
+
+        (bool success, bytes memory returndata) = address(diamond).call(abi.encodeCall(DiamondFacetOne.version, ()));
+        assertTrue(success, "replaced selector call should succeed");
+        assertTrue(abi.decode(returndata, (uint256)) == 2, "version should route to replacement facet");
+    }
+
+    function testRemoveSelectorViaDiamondCut() public {
+        IDiamondCut.FacetCut[] memory addCut =
+            _buildSingleCut(address(facetOne), IDiamondCut.FacetCutAction.Add, DiamondFacetOne.version.selector);
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(addCut, address(0), "");
+
+        IDiamondCut.FacetCut[] memory removeCut =
+            _buildSingleCut(address(0), IDiamondCut.FacetCutAction.Remove, DiamondFacetOne.version.selector);
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(removeCut, address(0), "");
+
+        (bool success, bytes memory returndata) = address(diamond).call(abi.encodeCall(DiamondFacetOne.version, ()));
+        assertFalse(success, "removed selector call should fail");
+        assertTrue(
+            keccak256(returndata)
+                == keccak256(
+                    abi.encodeWithSelector(Diamond.DiamondFunctionNotFound.selector, DiamondFacetOne.version.selector)
+                ),
+            "removed selector revert mismatch"
+        );
+    }
+
+    function testInitDelegatecallRunsAfterCut() public {
+        IDiamondCut.FacetCut[] memory cut =
+            _buildSingleCut(address(initMock), IDiamondCut.FacetCutAction.Add, DiamondInitMock.readValue.selector);
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond))
+            .diamondCut(cut, address(initMock), abi.encodeCall(DiamondInitMock.initializeValue, (42)));
+
+        (bool success, bytes memory returndata) = address(diamond).call(abi.encodeCall(DiamondInitMock.readValue, ()));
+        assertTrue(success, "readValue call should succeed");
+        assertTrue(abi.decode(returndata, (uint256)) == 42, "init delegatecall value mismatch");
+    }
+
+    function testCutRejectsTargetWithoutCode() public {
+        IDiamondCut.FacetCut[] memory cut =
+            _buildSingleCut(eve, IDiamondCut.FacetCutAction.Add, DiamondFacetOne.version.selector);
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(LibDiamond.DiamondTargetHasNoCode.selector, eve));
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function testCutRejectsRemoveWithNonZeroFacetAddress() public {
+        IDiamondCut.FacetCut[] memory cut =
+            _buildSingleCut(address(facetOne), IDiamondCut.FacetCutAction.Remove, DiamondFacetOne.version.selector);
+
+        VM.prank(admin);
+        VM.expectRevert(
+            abi.encodeWithSelector(LibDiamond.DiamondCutRemoveFacetAddressNotZero.selector, address(facetOne))
+        );
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function testCutRejectsInitCalldataWithoutTarget() public {
+        IDiamondCut.FacetCut[] memory cut =
+            _buildSingleCut(address(facetOne), IDiamondCut.FacetCutAction.Add, DiamondFacetOne.version.selector);
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(LibDiamond.DiamondCutInitTargetRequired.selector));
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), abi.encodeCall(DiamondInitMock.initializeValue, (1)));
+    }
+
+    function testCutRejectsInitTargetWithoutCalldata() public {
+        IDiamondCut.FacetCut[] memory cut =
+            _buildSingleCut(address(facetOne), IDiamondCut.FacetCutAction.Add, DiamondFacetOne.version.selector);
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(LibDiamond.DiamondCutInitCalldataRequired.selector));
+        IDiamondCut(address(diamond)).diamondCut(cut, address(initMock), "");
+    }
+
+    function testCutBubblesInitFailure() public {
+        IDiamondCut.FacetCut[] memory cut =
+            _buildSingleCut(address(facetOne), IDiamondCut.FacetCutAction.Add, DiamondFacetOne.version.selector);
+        bytes memory initCalldata = abi.encodeCall(DiamondInitMock.revertInit, ());
+        bytes memory revertReason = abi.encodeWithSelector(DiamondInitMock.InitFailure.selector);
+
+        VM.prank(admin);
+        VM.expectRevert(
+            abi.encodeWithSelector(LibDiamond.DiamondCutInitFailed.selector, address(initMock), revertReason)
+        );
+        IDiamondCut(address(diamond)).diamondCut(cut, address(initMock), initCalldata);
+    }
+
+    function testCutRejectsEmptySelectorList() public {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(facetOne), action: IDiamondCut.FacetCutAction.Add, functionSelectors: new bytes4[](0)
+        });
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(LibDiamond.DiamondCutEmptySelectors.selector));
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _buildSingleCut(address facetAddress, IDiamondCut.FacetCutAction action, bytes4 selector)
+        internal
+        pure
+        returns (IDiamondCut.FacetCut[] memory cut)
+    {
+        cut = new IDiamondCut.FacetCut[](1);
+        bytes4[] memory selectors = new bytes4[](1);
+        selectors[0] = selector;
+        cut[0] = IDiamondCut.FacetCut({facetAddress: facetAddress, action: action, functionSelectors: selectors});
+    }
+}

--- a/test/DiamondFoundationCore.t.sol
+++ b/test/DiamondFoundationCore.t.sol
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
+import {LibDiamond} from "../src/diamond/libraries/LibDiamond.sol";
+import {DiamondFixture, DiamondFacetOne, DiamondFacetTwo} from "./helpers/DiamondTestHarness.sol";
+
+contract DiamondFoundationCoreTest is DiamondFixture {
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    function testOwnerCanBeSetAndRead() public {
+        diamond.setOwner(admin);
+        assertTrue(diamond.owner() == admin, "owner should be updated");
+    }
+
+    function testOwnerTransferEmitsEvent() public {
+        VM.expectEmit(true, true, false, true, address(diamond));
+        emit OwnershipTransferred(address(0), admin);
+
+        diamond.setOwner(admin);
+    }
+
+    function testOwnerZeroAddressReverts() public {
+        VM.expectRevert(abi.encodeWithSelector(LibDiamond.DiamondOwnerZeroAddress.selector));
+        diamond.setOwner(address(0));
+    }
+
+    function testOwnerEnforcementRevertsForNonOwner() public {
+        diamond.setOwner(admin);
+
+        VM.prank(eve);
+        VM.expectRevert(abi.encodeWithSelector(LibDiamond.DiamondUnauthorized.selector, eve, admin));
+        diamond.enforceOwner();
+    }
+
+    function testSupportedInterfaceRoundTrip() public {
+        bytes4 interfaceId = 0x1f931c1c;
+        diamond.setSupportedInterface(interfaceId, true);
+        assertTrue(diamond.supportsInterface(interfaceId), "interface support should be enabled");
+
+        diamond.setSupportedInterface(interfaceId, false);
+        assertFalse(diamond.supportsInterface(interfaceId), "interface support should be disabled");
+    }
+
+    function testInvalidInterfaceIdReverts() public {
+        VM.expectRevert(abi.encodeWithSelector(LibDiamond.DiamondInvalidInterfaceId.selector, bytes4(0xffffffff)));
+        diamond.setSupportedInterface(0xffffffff, true);
+    }
+
+    function testAddSelectorTracksFacetAndSelectors() public {
+        bytes4 alphaSelector = DiamondFacetOne.alpha.selector;
+        bytes4 betaSelector = DiamondFacetOne.beta.selector;
+
+        diamond.addSelector(address(facetOne), alphaSelector);
+        diamond.addSelector(address(facetOne), betaSelector);
+
+        assertTrue(diamond.facetAddress(alphaSelector) == address(facetOne), "alpha selector should route to facet one");
+        assertTrue(diamond.facetAddress(betaSelector) == address(facetOne), "beta selector should route to facet one");
+
+        address[] memory facetAddresses_ = diamond.facetAddresses();
+        assertTrue(facetAddresses_.length == 1, "one facet address expected");
+        assertTrue(facetAddresses_[0] == address(facetOne), "facet one should be registered");
+
+        bytes4[] memory selectors = diamond.facetFunctionSelectors(address(facetOne));
+        assertTrue(selectors.length == 2, "facet one should have two selectors");
+        assertTrue(selectors[0] == alphaSelector, "alpha selector order mismatch");
+        assertTrue(selectors[1] == betaSelector, "beta selector order mismatch");
+    }
+
+    function testAddingExistingSelectorReverts() public {
+        bytes4 alphaSelector = DiamondFacetOne.alpha.selector;
+        diamond.addSelector(address(facetOne), alphaSelector);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(LibDiamond.DiamondSelectorAlreadyExists.selector, alphaSelector, address(facetOne))
+        );
+        diamond.addSelector(address(facetTwo), alphaSelector);
+    }
+
+    function testReplaceSelectorMovesRoutingToNewFacet() public {
+        bytes4 alphaSelector = DiamondFacetOne.alpha.selector;
+        diamond.addSelector(address(facetOne), alphaSelector);
+
+        diamond.replaceSelector(address(facetTwo), alphaSelector);
+
+        assertTrue(diamond.facetAddress(alphaSelector) == address(facetTwo), "selector should route to facet two");
+        assertTrue(diamond.facetFunctionSelectors(address(facetOne)).length == 0, "facet one selectors should be empty");
+
+        bytes4[] memory facetTwoSelectors = diamond.facetFunctionSelectors(address(facetTwo));
+        assertTrue(facetTwoSelectors.length == 1, "facet two should own one selector");
+        assertTrue(facetTwoSelectors[0] == alphaSelector, "facet two selector mismatch");
+    }
+
+    function testReplacingSelectorWithSameFacetReverts() public {
+        bytes4 alphaSelector = DiamondFacetOne.alpha.selector;
+        diamond.addSelector(address(facetOne), alphaSelector);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(LibDiamond.DiamondReplaceWithSameFacet.selector, alphaSelector, address(facetOne))
+        );
+        diamond.replaceSelector(address(facetOne), alphaSelector);
+    }
+
+    function testRemoveSelectorCleansUpFacetAddressList() public {
+        bytes4 alphaSelector = DiamondFacetOne.alpha.selector;
+        bytes4 gammaSelector = DiamondFacetTwo.gamma.selector;
+
+        diamond.addSelector(address(facetOne), alphaSelector);
+        diamond.addSelector(address(facetTwo), gammaSelector);
+        diamond.removeSelector(alphaSelector);
+
+        assertTrue(diamond.facetAddress(alphaSelector) == address(0), "removed selector should not resolve");
+        address[] memory facetAddresses_ = diamond.facetAddresses();
+        assertTrue(facetAddresses_.length == 1, "one facet should remain");
+        assertTrue(facetAddresses_[0] == address(facetTwo), "facet two should remain active");
+    }
+
+    function testRemoveUnknownSelectorReverts() public {
+        VM.expectRevert(
+            abi.encodeWithSelector(LibDiamond.DiamondSelectorNotFound.selector, DiamondFacetOne.alpha.selector)
+        );
+        diamond.removeSelector(DiamondFacetOne.alpha.selector);
+    }
+
+    function testFacetsViewReturnsCurrentLayout() public {
+        bytes4 alphaSelector = DiamondFacetOne.alpha.selector;
+        bytes4 betaSelector = DiamondFacetOne.beta.selector;
+        bytes4 gammaSelector = DiamondFacetTwo.gamma.selector;
+
+        diamond.addSelector(address(facetOne), alphaSelector);
+        diamond.addSelector(address(facetOne), betaSelector);
+        diamond.addSelector(address(facetTwo), gammaSelector);
+
+        IDiamondLoupe.Facet[] memory diamondFacets = diamond.facets();
+        assertTrue(diamondFacets.length == 2, "two facets expected");
+
+        assertTrue(diamondFacets[0].facetAddress == address(facetOne), "facet one ordering mismatch");
+        assertTrue(diamondFacets[0].functionSelectors.length == 2, "facet one selector count mismatch");
+        assertTrue(diamondFacets[1].facetAddress == address(facetTwo), "facet two ordering mismatch");
+        assertTrue(diamondFacets[1].functionSelectors.length == 1, "facet two selector count mismatch");
+    }
+}

--- a/test/DiamondLoupeCore.t.sol
+++ b/test/DiamondLoupeCore.t.sol
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {DiamondFacetOne, DiamondFacetTwo, DiamondProxyHarness, TestBase} from "./helpers/DiamondTestHarness.sol";
+import {DiamondLoupeFacet} from "../src/diamond/facets/DiamondLoupeFacet.sol";
+import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
+import {IERC173} from "../src/interfaces/IERC173.sol";
+import {LibDiamond} from "../src/diamond/libraries/LibDiamond.sol";
+
+contract DiamondLoupeCoreTest is TestBase {
+    address internal admin = address(0xA11CE);
+    address internal eve = address(0xE11E);
+
+    DiamondProxyHarness internal diamond;
+    DiamondLoupeFacet internal loupeFacet;
+    DiamondFacetOne internal facetOne;
+    DiamondFacetTwo internal facetTwo;
+
+    function setUp() public {
+        diamond = new DiamondProxyHarness(admin);
+        loupeFacet = new DiamondLoupeFacet();
+        facetOne = new DiamondFacetOne();
+        facetTwo = new DiamondFacetTwo();
+
+        _installLoupeSelectors();
+        diamond.installSelector(address(facetOne), DiamondFacetOne.alpha.selector);
+        diamond.installSelector(address(facetOne), DiamondFacetOne.beta.selector);
+        diamond.installSelector(address(facetTwo), DiamondFacetTwo.gamma.selector);
+    }
+
+    function testLoupeFacetAddressesAndSelectorLookups() public view {
+        IDiamondLoupe loupe = IDiamondLoupe(address(diamond));
+        address[] memory facetAddresses_ = loupe.facetAddresses();
+
+        assertTrue(facetAddresses_.length == 3, "facet address count mismatch");
+        assertTrue(facetAddresses_[0] == address(loupeFacet), "loupe facet ordering mismatch");
+        assertTrue(facetAddresses_[1] == address(facetOne), "facet one ordering mismatch");
+        assertTrue(facetAddresses_[2] == address(facetTwo), "facet two ordering mismatch");
+
+        assertTrue(
+            loupe.facetAddress(DiamondLoupeFacet.facets.selector) == address(loupeFacet),
+            "loupe selector should resolve to loupe facet"
+        );
+        assertTrue(
+            loupe.facetAddress(DiamondFacetOne.alpha.selector) == address(facetOne),
+            "alpha selector should resolve to facet one"
+        );
+        assertTrue(
+            loupe.facetAddress(DiamondFacetTwo.gamma.selector) == address(facetTwo),
+            "gamma selector should resolve to facet two"
+        );
+        assertTrue(loupe.facetAddress(0xdeadbeef) == address(0), "unknown selector should resolve to zero");
+    }
+
+    function testLoupeFacetFunctionSelectorsAndFacetsSnapshot() public view {
+        IDiamondLoupe loupe = IDiamondLoupe(address(diamond));
+
+        bytes4[] memory loupeSelectors = loupe.facetFunctionSelectors(address(loupeFacet));
+        bytes4[] memory facetOneSelectors = loupe.facetFunctionSelectors(address(facetOne));
+        bytes4[] memory facetTwoSelectors = loupe.facetFunctionSelectors(address(facetTwo));
+        bytes4[] memory unknownFacetSelectors = loupe.facetFunctionSelectors(eve);
+
+        assertTrue(loupeSelectors.length == 6, "loupe selector count mismatch");
+        assertTrue(facetOneSelectors.length == 2, "facet one selector count mismatch");
+        assertTrue(facetTwoSelectors.length == 1, "facet two selector count mismatch");
+        assertTrue(unknownFacetSelectors.length == 0, "unknown facet should have no selectors");
+
+        IDiamondLoupe.Facet[] memory facets_ = loupe.facets();
+        assertTrue(facets_.length == 3, "facets snapshot count mismatch");
+        assertTrue(facets_[0].facetAddress == address(loupeFacet), "loupe snapshot ordering mismatch");
+        assertTrue(facets_[1].facetAddress == address(facetOne), "facet one snapshot ordering mismatch");
+        assertTrue(facets_[2].facetAddress == address(facetTwo), "facet two snapshot ordering mismatch");
+    }
+
+    function testOwnershipSurfaceReportsCurrentOwner() public view {
+        assertTrue(IERC173(address(diamond)).owner() == admin, "owner view mismatch");
+    }
+
+    function testOwnerCanTransferOwnershipThroughLoupeFacet() public {
+        VM.prank(admin);
+        IERC173(address(diamond)).transferOwnership(eve);
+
+        assertTrue(IERC173(address(diamond)).owner() == eve, "ownership transfer mismatch");
+    }
+
+    function testNonOwnerCannotTransferOwnership() public {
+        VM.prank(eve);
+        VM.expectRevert(abi.encodeWithSelector(LibDiamond.DiamondUnauthorized.selector, eve, admin));
+        IERC173(address(diamond)).transferOwnership(eve);
+    }
+
+    function testTransferOwnershipZeroAddressReverts() public {
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(LibDiamond.DiamondOwnerZeroAddress.selector));
+        IERC173(address(diamond)).transferOwnership(address(0));
+    }
+
+    function testLoupeReflectsLiveSelectorReplaceAndRemove() public {
+        IDiamondLoupe loupe = IDiamondLoupe(address(diamond));
+
+        assertTrue(
+            loupe.facetAddress(DiamondFacetOne.alpha.selector) == address(facetOne), "alpha should start on facet one"
+        );
+
+        diamond.replaceSelector(address(facetTwo), DiamondFacetOne.alpha.selector);
+        assertTrue(
+            loupe.facetAddress(DiamondFacetOne.alpha.selector) == address(facetTwo), "alpha should move to facet two"
+        );
+
+        bytes4[] memory facetOneSelectorsAfterReplace = loupe.facetFunctionSelectors(address(facetOne));
+        assertTrue(facetOneSelectorsAfterReplace.length == 1, "facet one selector count after replace mismatch");
+        assertTrue(facetOneSelectorsAfterReplace[0] == DiamondFacetOne.beta.selector, "beta should remain on facet one");
+
+        diamond.removeSelector(DiamondFacetOne.alpha.selector);
+        assertTrue(loupe.facetAddress(DiamondFacetOne.alpha.selector) == address(0), "alpha should be removed");
+
+        bytes4[] memory facetTwoSelectorsAfterRemove = loupe.facetFunctionSelectors(address(facetTwo));
+        assertTrue(facetTwoSelectorsAfterRemove.length == 1, "facet two selector count after remove mismatch");
+        assertTrue(
+            facetTwoSelectorsAfterRemove[0] == DiamondFacetTwo.gamma.selector, "gamma should remain on facet two"
+        );
+    }
+
+    function _installLoupeSelectors() internal {
+        diamond.installSelector(address(loupeFacet), DiamondLoupeFacet.facets.selector);
+        diamond.installSelector(address(loupeFacet), DiamondLoupeFacet.facetFunctionSelectors.selector);
+        diamond.installSelector(address(loupeFacet), DiamondLoupeFacet.facetAddresses.selector);
+        diamond.installSelector(address(loupeFacet), DiamondLoupeFacet.facetAddress.selector);
+        diamond.installSelector(address(loupeFacet), DiamondLoupeFacet.owner.selector);
+        diamond.installSelector(address(loupeFacet), DiamondLoupeFacet.transferOwnership.selector);
+    }
+}

--- a/test/DiamondProxyCore.t.sol
+++ b/test/DiamondProxyCore.t.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Diamond} from "../src/diamond/Diamond.sol";
+import {DiamondFacetOne, DiamondFacetTwo, DiamondProxyHarness, TestBase} from "./helpers/DiamondTestHarness.sol";
+
+contract DiamondProxyCoreTest is TestBase {
+    address internal admin = address(0xA11CE);
+    address internal eve = address(0xE11E);
+
+    DiamondProxyHarness internal diamond;
+    DiamondFacetOne internal facetOne;
+    DiamondFacetTwo internal facetTwo;
+
+    function setUp() public {
+        diamond = new DiamondProxyHarness(admin);
+        facetOne = new DiamondFacetOne();
+        facetTwo = new DiamondFacetTwo();
+    }
+
+    function testConstructorBootstrapsOwner() public view {
+        assertTrue(diamond.owner() == admin, "initial owner mismatch");
+    }
+
+    function testFallbackRoutesSelectorToInstalledFacet() public {
+        diamond.installSelector(address(facetOne), DiamondFacetOne.alpha.selector);
+
+        (bool success, bytes memory returndata) = address(diamond).call(abi.encodeCall(DiamondFacetOne.alpha, ()));
+
+        assertTrue(success, "alpha call should succeed");
+        assertTrue(abi.decode(returndata, (uint256)) == 1, "alpha return mismatch");
+    }
+
+    function testFallbackRoutesMultipleFacetSelectors() public {
+        diamond.installSelector(address(facetOne), DiamondFacetOne.alpha.selector);
+        diamond.installSelector(address(facetTwo), DiamondFacetTwo.gamma.selector);
+
+        (bool alphaSuccess, bytes memory alphaReturndata) =
+            address(diamond).call(abi.encodeCall(DiamondFacetOne.alpha, ()));
+        (bool gammaSuccess, bytes memory gammaReturndata) =
+            address(diamond).call(abi.encodeCall(DiamondFacetTwo.gamma, ()));
+
+        assertTrue(alphaSuccess, "alpha call should succeed");
+        assertTrue(gammaSuccess, "gamma call should succeed");
+        assertTrue(abi.decode(alphaReturndata, (uint256)) == 1, "alpha return mismatch");
+        assertTrue(abi.decode(gammaReturndata, (uint256)) == 3, "gamma return mismatch");
+    }
+
+    function testDelegatecallPreservesOriginalCaller() public {
+        diamond.installSelector(address(facetOne), DiamondFacetOne.caller.selector);
+
+        VM.prank(eve);
+        (bool success, bytes memory returndata) = address(diamond).call(abi.encodeCall(DiamondFacetOne.caller, ()));
+
+        assertTrue(success, "caller call should succeed");
+        assertTrue(abi.decode(returndata, (address)) == eve, "delegated caller mismatch");
+    }
+
+    function testUnknownSelectorRevertsCleanly() public {
+        (bool success, bytes memory returndata) = address(diamond).call(hex"deadbeef");
+
+        assertFalse(success, "unknown selector call should fail");
+        assertTrue(
+            keccak256(returndata)
+                == keccak256(abi.encodeWithSelector(Diamond.DiamondFunctionNotFound.selector, bytes4(0xdeadbeef))),
+            "unknown selector revert mismatch"
+        );
+    }
+}

--- a/test/DiamondSelectorIntegrityCore.t.sol
+++ b/test/DiamondSelectorIntegrityCore.t.sol
@@ -1,0 +1,281 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Diamond} from "../src/diamond/Diamond.sol";
+import {DiamondCutFacet} from "../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../src/diamond/facets/DiamondLoupeFacet.sol";
+import {IDiamondCut} from "../src/interfaces/IDiamondCut.sol";
+import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
+import {LibDiamond} from "../src/diamond/libraries/LibDiamond.sol";
+import {
+    DiamondFacetAlphaReplacement,
+    DiamondFacetOne,
+    DiamondFacetTwo,
+    DiamondProxyHarness,
+    TestBase
+} from "./helpers/DiamondTestHarness.sol";
+
+contract DiamondSelectorIntegrityCoreTest is TestBase {
+    address internal admin = address(0xA11CE);
+    address internal eve = address(0xE11E);
+
+    DiamondProxyHarness internal diamond;
+    DiamondCutFacet internal cutFacet;
+    DiamondLoupeFacet internal loupeFacet;
+    DiamondFacetOne internal facetOne;
+    DiamondFacetTwo internal facetTwo;
+    DiamondFacetAlphaReplacement internal alphaReplacement;
+
+    function setUp() public {
+        diamond = new DiamondProxyHarness(admin);
+        cutFacet = new DiamondCutFacet();
+        loupeFacet = new DiamondLoupeFacet();
+        facetOne = new DiamondFacetOne();
+        facetTwo = new DiamondFacetTwo();
+        alphaReplacement = new DiamondFacetAlphaReplacement();
+
+        _bootstrapCoreFacets();
+    }
+
+    function testMultiFacetCutRoutesExternalCallsAndLoupeQueries() public {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](2);
+        cut[0] = _buildCut(address(facetOne), IDiamondCut.FacetCutAction.Add, _facetOneSelectors());
+        cut[1] = _buildCut(address(facetTwo), IDiamondCut.FacetCutAction.Add, _facetTwoSelectors());
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+
+        _assertCallReturnsUint256(abi.encodeCall(DiamondFacetOne.alpha, ()), 1, "alpha routing mismatch");
+        _assertCallReturnsUint256(abi.encodeCall(DiamondFacetOne.beta, ()), 2, "beta routing mismatch");
+        _assertCallReturnsUint256(abi.encodeCall(DiamondFacetTwo.gamma, ()), 3, "gamma routing mismatch");
+        _assertCallReturnsUint256(abi.encodeCall(DiamondFacetTwo.delta, ()), 4, "delta routing mismatch");
+
+        VM.prank(eve);
+        (bool success, bytes memory returndata) = address(diamond).call(abi.encodeCall(DiamondFacetOne.caller, ()));
+        assertTrue(success, "caller routing should succeed");
+        assertTrue(abi.decode(returndata, (address)) == eve, "caller routing should preserve msg.sender");
+
+        IDiamondLoupe loupe = IDiamondLoupe(address(diamond));
+        bytes4[] memory facetOneSelectors = loupe.facetFunctionSelectors(address(facetOne));
+        bytes4[] memory facetTwoSelectors = loupe.facetFunctionSelectors(address(facetTwo));
+
+        assertTrue(facetOneSelectors.length == 3, "facet one selector count mismatch");
+        assertTrue(_containsSelector(facetOneSelectors, DiamondFacetOne.alpha.selector), "facet one missing alpha");
+        assertTrue(_containsSelector(facetOneSelectors, DiamondFacetOne.beta.selector), "facet one missing beta");
+        assertTrue(_containsSelector(facetOneSelectors, DiamondFacetOne.caller.selector), "facet one missing caller");
+
+        assertTrue(facetTwoSelectors.length == 2, "facet two selector count mismatch");
+        assertTrue(_containsSelector(facetTwoSelectors, DiamondFacetTwo.gamma.selector), "facet two missing gamma");
+        assertTrue(_containsSelector(facetTwoSelectors, DiamondFacetTwo.delta.selector), "facet two missing delta");
+    }
+
+    function testSelectorCollisionRevertsAtomically() public {
+        IDiamondCut.FacetCut[] memory installCut = new IDiamondCut.FacetCut[](1);
+        installCut[0] = _buildCut(
+            address(facetOne), IDiamondCut.FacetCutAction.Add, _singleSelector(DiamondFacetOne.alpha.selector)
+        );
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(installCut, address(0), "");
+
+        IDiamondCut.FacetCut[] memory collisionCut = new IDiamondCut.FacetCut[](2);
+        collisionCut[0] = _buildCut(
+            address(facetTwo), IDiamondCut.FacetCutAction.Add, _singleSelector(DiamondFacetTwo.delta.selector)
+        );
+        collisionCut[1] = _buildCut(
+            address(alphaReplacement),
+            IDiamondCut.FacetCutAction.Add,
+            _singleSelector(DiamondFacetAlphaReplacement.alpha.selector)
+        );
+
+        VM.prank(admin);
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                LibDiamond.DiamondSelectorAlreadyExists.selector,
+                DiamondFacetAlphaReplacement.alpha.selector,
+                address(facetOne)
+            )
+        );
+        IDiamondCut(address(diamond)).diamondCut(collisionCut, address(0), "");
+
+        IDiamondLoupe loupe = IDiamondLoupe(address(diamond));
+        assertTrue(
+            loupe.facetAddress(DiamondFacetOne.alpha.selector) == address(facetOne),
+            "existing alpha route should remain unchanged"
+        );
+        assertTrue(
+            loupe.facetAddress(DiamondFacetTwo.delta.selector) == address(0),
+            "delta should not be partially installed after revert"
+        );
+        _assertSelectorMissing(DiamondFacetTwo.delta.selector, abi.encodeCall(DiamondFacetTwo.delta, ()));
+    }
+
+    function testUpgradeDiffUpdatesRoutingBeforeAndAfterCuts() public {
+        IDiamondCut.FacetCut[] memory initialCut = new IDiamondCut.FacetCut[](2);
+        initialCut[0] = _buildCut(
+            address(facetOne),
+            IDiamondCut.FacetCutAction.Add,
+            _selectors(DiamondFacetOne.alpha.selector, DiamondFacetOne.beta.selector)
+        );
+        initialCut[1] = _buildCut(
+            address(facetTwo), IDiamondCut.FacetCutAction.Add, _singleSelector(DiamondFacetTwo.gamma.selector)
+        );
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(initialCut, address(0), "");
+
+        _assertCallReturnsUint256(abi.encodeCall(DiamondFacetOne.alpha, ()), 1, "alpha should route to facet one");
+        _assertCallReturnsUint256(abi.encodeCall(DiamondFacetOne.beta, ()), 2, "beta should route to facet one");
+        _assertCallReturnsUint256(abi.encodeCall(DiamondFacetTwo.gamma, ()), 3, "gamma should route to facet two");
+
+        IDiamondCut.FacetCut[] memory upgradeCut = new IDiamondCut.FacetCut[](3);
+        upgradeCut[0] = _buildCut(
+            address(alphaReplacement),
+            IDiamondCut.FacetCutAction.Replace,
+            _singleSelector(DiamondFacetOne.alpha.selector)
+        );
+        upgradeCut[1] =
+            _buildCut(address(0), IDiamondCut.FacetCutAction.Remove, _singleSelector(DiamondFacetOne.beta.selector));
+        upgradeCut[2] = _buildCut(
+            address(alphaReplacement),
+            IDiamondCut.FacetCutAction.Add,
+            _singleSelector(DiamondFacetAlphaReplacement.epsilon.selector)
+        );
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(upgradeCut, address(0), "");
+
+        _assertCallReturnsUint256(
+            abi.encodeCall(DiamondFacetAlphaReplacement.alpha, ()), 11, "alpha should route to replacement facet"
+        );
+        _assertCallReturnsUint256(abi.encodeCall(DiamondFacetTwo.gamma, ()), 3, "gamma should remain unchanged");
+        _assertCallReturnsUint256(
+            abi.encodeCall(DiamondFacetAlphaReplacement.epsilon, ()), 5, "epsilon should route to replacement facet"
+        );
+        _assertSelectorMissing(DiamondFacetOne.beta.selector, abi.encodeCall(DiamondFacetOne.beta, ()));
+    }
+
+    function testLoupeReflectsFreshStateAfterUpgradeDiff() public {
+        IDiamondCut.FacetCut[] memory initialCut = new IDiamondCut.FacetCut[](1);
+        initialCut[0] = _buildCut(address(facetOne), IDiamondCut.FacetCutAction.Add, _facetOneSelectors());
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(initialCut, address(0), "");
+
+        IDiamondLoupe loupe = IDiamondLoupe(address(diamond));
+        bytes4[] memory initialSelectors = loupe.facetFunctionSelectors(address(facetOne));
+        assertTrue(initialSelectors.length == 3, "initial selector count mismatch");
+
+        IDiamondCut.FacetCut[] memory upgradeCut = new IDiamondCut.FacetCut[](3);
+        upgradeCut[0] = _buildCut(
+            address(alphaReplacement),
+            IDiamondCut.FacetCutAction.Replace,
+            _singleSelector(DiamondFacetOne.alpha.selector)
+        );
+        upgradeCut[1] = _buildCut(
+            address(0),
+            IDiamondCut.FacetCutAction.Remove,
+            _selectors(DiamondFacetOne.beta.selector, DiamondFacetOne.caller.selector)
+        );
+        upgradeCut[2] = _buildCut(
+            address(alphaReplacement),
+            IDiamondCut.FacetCutAction.Add,
+            _selectors(DiamondFacetAlphaReplacement.epsilon.selector, DiamondFacetOne.caller.selector)
+        );
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(upgradeCut, address(0), "");
+
+        bytes4[] memory refreshedOldFacetSelectors = loupe.facetFunctionSelectors(address(facetOne));
+        bytes4[] memory refreshedReplacementSelectors = loupe.facetFunctionSelectors(address(alphaReplacement));
+
+        assertTrue(refreshedOldFacetSelectors.length == 0, "facet one should no longer own selectors");
+        assertTrue(refreshedReplacementSelectors.length == 3, "replacement facet selector count mismatch");
+        assertTrue(
+            _containsSelector(refreshedReplacementSelectors, DiamondFacetAlphaReplacement.alpha.selector),
+            "replacement facet missing alpha"
+        );
+        assertTrue(
+            _containsSelector(refreshedReplacementSelectors, DiamondFacetAlphaReplacement.epsilon.selector),
+            "replacement facet missing epsilon"
+        );
+        assertTrue(
+            _containsSelector(refreshedReplacementSelectors, DiamondFacetOne.caller.selector),
+            "replacement facet missing caller"
+        );
+        assertTrue(
+            loupe.facetAddress(DiamondFacetOne.alpha.selector) == address(alphaReplacement),
+            "loupe should point alpha to replacement facet"
+        );
+        assertTrue(
+            loupe.facetAddress(DiamondFacetOne.beta.selector) == address(0), "loupe should report removed beta as unset"
+        );
+    }
+
+    function _bootstrapCoreFacets() internal {
+        diamond.installSelector(address(cutFacet), DiamondCutFacet.diamondCut.selector);
+        diamond.installSelector(address(loupeFacet), DiamondLoupeFacet.facets.selector);
+        diamond.installSelector(address(loupeFacet), DiamondLoupeFacet.facetFunctionSelectors.selector);
+        diamond.installSelector(address(loupeFacet), DiamondLoupeFacet.facetAddresses.selector);
+        diamond.installSelector(address(loupeFacet), DiamondLoupeFacet.facetAddress.selector);
+        diamond.installSelector(address(loupeFacet), DiamondLoupeFacet.owner.selector);
+        diamond.installSelector(address(loupeFacet), DiamondLoupeFacet.transferOwnership.selector);
+    }
+
+    function _buildCut(address facetAddress, IDiamondCut.FacetCutAction action, bytes4[] memory selectors)
+        internal
+        pure
+        returns (IDiamondCut.FacetCut memory)
+    {
+        return IDiamondCut.FacetCut({facetAddress: facetAddress, action: action, functionSelectors: selectors});
+    }
+
+    function _facetOneSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](3);
+        selectors[0] = DiamondFacetOne.alpha.selector;
+        selectors[1] = DiamondFacetOne.beta.selector;
+        selectors[2] = DiamondFacetOne.caller.selector;
+    }
+
+    function _facetTwoSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](2);
+        selectors[0] = DiamondFacetTwo.gamma.selector;
+        selectors[1] = DiamondFacetTwo.delta.selector;
+    }
+
+    function _singleSelector(bytes4 selector) internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](1);
+        selectors[0] = selector;
+    }
+
+    function _selectors(bytes4 first, bytes4 second) internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](2);
+        selectors[0] = first;
+        selectors[1] = second;
+    }
+
+    function _assertCallReturnsUint256(bytes memory callData, uint256 expectedValue, string memory message) internal {
+        (bool success, bytes memory returndata) = address(diamond).call(callData);
+        assertTrue(success, message);
+        assertTrue(abi.decode(returndata, (uint256)) == expectedValue, message);
+    }
+
+    function _assertSelectorMissing(bytes4 selector, bytes memory callData) internal {
+        (bool success, bytes memory returndata) = address(diamond).call(callData);
+        assertFalse(success, "missing selector call should revert");
+        assertTrue(
+            keccak256(returndata)
+                == keccak256(abi.encodeWithSelector(Diamond.DiamondFunctionNotFound.selector, selector)),
+            "missing selector revert mismatch"
+        );
+    }
+
+    function _containsSelector(bytes4[] memory selectors, bytes4 selector) internal pure returns (bool) {
+        for (uint256 i = 0; i < selectors.length; i++) {
+            if (selectors[i] == selector) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/test/helpers/DiamondTestHarness.sol
+++ b/test/helpers/DiamondTestHarness.sol
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IDiamondLoupe} from "../../src/interfaces/IDiamondLoupe.sol";
+import {LibDiamond} from "../../src/diamond/libraries/LibDiamond.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+
+contract DiamondFacetOne {
+    function alpha() external pure returns (uint256) {
+        return 1;
+    }
+
+    function beta() external pure returns (uint256) {
+        return 2;
+    }
+}
+
+contract DiamondFacetTwo {
+    function gamma() external pure returns (uint256) {
+        return 3;
+    }
+
+    function delta() external pure returns (uint256) {
+        return 4;
+    }
+}
+
+contract DiamondLibraryHarness {
+    function owner() external view returns (address) {
+        return LibDiamond.contractOwner();
+    }
+
+    function setOwner(address newOwner) external {
+        LibDiamond.setContractOwner(newOwner);
+    }
+
+    function enforceOwner() external view returns (bool) {
+        LibDiamond.enforceIsContractOwner();
+        return true;
+    }
+
+    function supportsInterface(bytes4 interfaceId) external view returns (bool) {
+        return LibDiamond.supportsInterface(interfaceId);
+    }
+
+    function setSupportedInterface(bytes4 interfaceId, bool supported) external {
+        LibDiamond.setSupportedInterface(interfaceId, supported);
+    }
+
+    function addSelector(address facetAddress_, bytes4 selector) external {
+        LibDiamond.addSelector(facetAddress_, selector);
+    }
+
+    function replaceSelector(address facetAddress_, bytes4 selector) external {
+        LibDiamond.replaceSelector(facetAddress_, selector);
+    }
+
+    function removeSelector(bytes4 selector) external {
+        LibDiamond.removeSelector(selector);
+    }
+
+    function facetAddress(bytes4 selector) external view returns (address) {
+        return LibDiamond.facetAddress(selector);
+    }
+
+    function facetAddresses() external view returns (address[] memory) {
+        return LibDiamond.facetAddresses();
+    }
+
+    function facetFunctionSelectors(address facetAddress_) external view returns (bytes4[] memory) {
+        return LibDiamond.facetFunctionSelectors(facetAddress_);
+    }
+
+    function facets() external view returns (IDiamondLoupe.Facet[] memory) {
+        return LibDiamond.facets();
+    }
+}
+
+abstract contract DiamondFixture is TestBase {
+    address internal admin = address(0xA11CE);
+    address internal eve = address(0xE11E);
+
+    DiamondLibraryHarness internal diamond;
+    DiamondFacetOne internal facetOne;
+    DiamondFacetTwo internal facetTwo;
+
+    function setUp() public virtual {
+        diamond = new DiamondLibraryHarness();
+        facetOne = new DiamondFacetOne();
+        facetTwo = new DiamondFacetTwo();
+    }
+}

--- a/test/helpers/DiamondTestHarness.sol
+++ b/test/helpers/DiamondTestHarness.sol
@@ -32,6 +32,20 @@ contract DiamondFacetReplacement {
     }
 }
 
+contract DiamondFacetAlphaReplacement {
+    function alpha() external pure returns (uint256) {
+        return 11;
+    }
+
+    function epsilon() external pure returns (uint256) {
+        return 5;
+    }
+
+    function caller() external view returns (address) {
+        return msg.sender;
+    }
+}
+
 contract DiamondFacetTwo {
     function gamma() external pure returns (uint256) {
         return 3;

--- a/test/helpers/DiamondTestHarness.sol
+++ b/test/helpers/DiamondTestHarness.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
+import {Diamond} from "../../src/diamond/Diamond.sol";
 import {IDiamondLoupe} from "../../src/interfaces/IDiamondLoupe.sol";
 import {LibDiamond} from "../../src/diamond/libraries/LibDiamond.sol";
 import {TestBase} from "./AccessControlTestHarness.sol";
@@ -12,6 +13,10 @@ contract DiamondFacetOne {
 
     function beta() external pure returns (uint256) {
         return 2;
+    }
+
+    function caller() external view returns (address) {
+        return msg.sender;
     }
 }
 
@@ -73,6 +78,18 @@ contract DiamondLibraryHarness {
 
     function facets() external view returns (IDiamondLoupe.Facet[] memory) {
         return LibDiamond.facets();
+    }
+}
+
+contract DiamondProxyHarness is Diamond {
+    constructor(address initialOwner) Diamond(initialOwner) {}
+
+    function owner() external view returns (address) {
+        return LibDiamond.contractOwner();
+    }
+
+    function installSelector(address facetAddress_, bytes4 selector) external {
+        LibDiamond.addSelector(facetAddress_, selector);
     }
 }
 

--- a/test/helpers/DiamondTestHarness.sol
+++ b/test/helpers/DiamondTestHarness.sol
@@ -134,6 +134,14 @@ contract DiamondProxyHarness is Diamond {
     function installSelector(address facetAddress_, bytes4 selector) external {
         LibDiamond.addSelector(facetAddress_, selector);
     }
+
+    function replaceSelector(address facetAddress_, bytes4 selector) external {
+        LibDiamond.replaceSelector(facetAddress_, selector);
+    }
+
+    function removeSelector(bytes4 selector) external {
+        LibDiamond.removeSelector(selector);
+    }
 }
 
 abstract contract DiamondFixture is TestBase {

--- a/test/helpers/DiamondTestHarness.sol
+++ b/test/helpers/DiamondTestHarness.sol
@@ -2,7 +2,9 @@
 pragma solidity ^0.8.30;
 
 import {Diamond} from "../../src/diamond/Diamond.sol";
+import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
 import {IDiamondLoupe} from "../../src/interfaces/IDiamondLoupe.sol";
+import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
 import {LibDiamond} from "../../src/diamond/libraries/LibDiamond.sol";
 import {TestBase} from "./AccessControlTestHarness.sol";
 
@@ -18,6 +20,16 @@ contract DiamondFacetOne {
     function caller() external view returns (address) {
         return msg.sender;
     }
+
+    function version() external pure returns (uint256) {
+        return 1;
+    }
+}
+
+contract DiamondFacetReplacement {
+    function version() external pure returns (uint256) {
+        return 2;
+    }
 }
 
 contract DiamondFacetTwo {
@@ -27,6 +39,37 @@ contract DiamondFacetTwo {
 
     function delta() external pure returns (uint256) {
         return 4;
+    }
+}
+
+library LibDiamondInitTestStorage {
+    bytes32 internal constant STORAGE_SLOT = keccak256("smart-contracts.test.diamond-init.storage");
+
+    struct Layout {
+        uint256 value;
+    }
+
+    function layout() internal pure returns (Layout storage l) {
+        bytes32 slot = STORAGE_SLOT;
+        assembly {
+            l.slot := slot
+        }
+    }
+}
+
+contract DiamondInitMock {
+    error InitFailure();
+
+    function initializeValue(uint256 value_) external {
+        LibDiamondInitTestStorage.layout().value = value_;
+    }
+
+    function readValue() external view returns (uint256) {
+        return LibDiamondInitTestStorage.layout().value;
+    }
+
+    function revertInit() external pure {
+        revert InitFailure();
     }
 }
 


### PR DESCRIPTION
## Summary
- add the diamond core foundation with local `IDiamondCut`, `IDiamondLoupe`, and `IERC173` interfaces, diamond-safe storage layout, and shared `LibDiamond` routing helpers
- implement the base `Diamond` proxy, `DiamondCutFacet`, and `DiamondLoupeFacet`, including ownership introspection and live loupe views
- add core test coverage for routing, selector add/replace/remove behavior, init delegatecall flow, ownership, loupe reads, and selector integrity regressions
- document bootstrap expectations, diamond cut review/execution flow, storage discipline, and operational safety guidance

## Included Work
- `#54` Create diamond interfaces, storage layout, and shared library foundation
- `#55` Document diamond init flow, upgrade process, and safety assumptions
- `#56` Add selector integrity, upgrade diff, and end-to-end routing tests
- `#57` Implement DiamondLoupe facet and ownership introspection support

## Validation
- `forge test --offline`

## Outcome
- selector routing, cut operations, and loupe reads are implemented and test-covered
- ownership and introspection surfaces are available through the diamond
- docs describe how to bootstrap, review, and execute safe diamond upgrades

## Issue
- Closes #22
