### PR TITLE
feat: add Diamond proxy selector routing and fallback

### DIFF
--- a/src/diamond/Diamond.sol
+++ b/src/diamond/Diamond.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {LibDiamond} from "./libraries/LibDiamond.sol";
+
+/// @title Diamond
+/// @notice Base EIP-2535 proxy contract with selector routing and owner bootstrap.
+contract Diamond {
+    /// @notice Thrown when no facet is registered for the requested selector.
+    /// @param selector The unresolved selector.
+    error DiamondFunctionNotFound(bytes4 selector);
+
+    /// @param initialOwner The account that becomes the initial diamond owner.
+    constructor(address initialOwner) {
+        LibDiamond.setContractOwner(initialOwner);
+    }
+
+    /// @notice Accepts plain ETH transfers.
+    receive() external payable {}
+
+    /// @notice Delegates calls to the registered facet for `msg.sig`.
+    fallback() external payable {
+        address facet = LibDiamond.facetAddress(msg.sig);
+        if (facet == address(0)) {
+            revert DiamondFunctionNotFound(msg.sig);
+        }
+
+        assembly {
+            calldatacopy(0, 0, calldatasize())
+            let result := delegatecall(gas(), facet, 0, calldatasize(), 0, 0)
+            returndatacopy(0, 0, returndatasize())
+
+            switch result
+            case 0 { revert(0, returndatasize()) }
+            default { return(0, returndatasize()) }
+        }
+    }
+}

--- a/test/DiamondProxyCore.t.sol
+++ b/test/DiamondProxyCore.t.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Diamond} from "../src/diamond/Diamond.sol";
+import {DiamondFacetOne, DiamondFacetTwo, DiamondProxyHarness, TestBase} from "./helpers/DiamondTestHarness.sol";
+
+contract DiamondProxyCoreTest is TestBase {
+    address internal admin = address(0xA11CE);
+    address internal eve = address(0xE11E);
+
+    DiamondProxyHarness internal diamond;
+    DiamondFacetOne internal facetOne;
+    DiamondFacetTwo internal facetTwo;
+
+    function setUp() public {
+        diamond = new DiamondProxyHarness(admin);
+        facetOne = new DiamondFacetOne();
+        facetTwo = new DiamondFacetTwo();
+    }
+
+    function testConstructorBootstrapsOwner() public view {
+        assertTrue(diamond.owner() == admin, "initial owner mismatch");
+    }
+
+    function testFallbackRoutesSelectorToInstalledFacet() public {
+        diamond.installSelector(address(facetOne), DiamondFacetOne.alpha.selector);
+
+        (bool success, bytes memory returndata) = address(diamond).call(abi.encodeCall(DiamondFacetOne.alpha, ()));
+
+        assertTrue(success, "alpha call should succeed");
+        assertTrue(abi.decode(returndata, (uint256)) == 1, "alpha return mismatch");
+    }
+
+    function testFallbackRoutesMultipleFacetSelectors() public {
+        diamond.installSelector(address(facetOne), DiamondFacetOne.alpha.selector);
+        diamond.installSelector(address(facetTwo), DiamondFacetTwo.gamma.selector);
+
+        (bool alphaSuccess, bytes memory alphaReturndata) =
+            address(diamond).call(abi.encodeCall(DiamondFacetOne.alpha, ()));
+        (bool gammaSuccess, bytes memory gammaReturndata) =
+            address(diamond).call(abi.encodeCall(DiamondFacetTwo.gamma, ()));
+
+        assertTrue(alphaSuccess, "alpha call should succeed");
+        assertTrue(gammaSuccess, "gamma call should succeed");
+        assertTrue(abi.decode(alphaReturndata, (uint256)) == 1, "alpha return mismatch");
+        assertTrue(abi.decode(gammaReturndata, (uint256)) == 3, "gamma return mismatch");
+    }
+
+    function testDelegatecallPreservesOriginalCaller() public {
+        diamond.installSelector(address(facetOne), DiamondFacetOne.caller.selector);
+
+        VM.prank(eve);
+        (bool success, bytes memory returndata) = address(diamond).call(abi.encodeCall(DiamondFacetOne.caller, ()));
+
+        assertTrue(success, "caller call should succeed");
+        assertTrue(abi.decode(returndata, (address)) == eve, "delegated caller mismatch");
+    }
+
+    function testUnknownSelectorRevertsCleanly() public {
+        (bool success, bytes memory returndata) = address(diamond).call(hex"deadbeef");
+
+        assertFalse(success, "unknown selector call should fail");
+        assertTrue(
+            keccak256(returndata)
+                == keccak256(abi.encodeWithSelector(Diamond.DiamondFunctionNotFound.selector, bytes4(0xdeadbeef))),
+            "unknown selector revert mismatch"
+        );
+    }
+}

--- a/test/helpers/DiamondTestHarness.sol
+++ b/test/helpers/DiamondTestHarness.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
+import {Diamond} from "../../src/diamond/Diamond.sol";
 import {IDiamondLoupe} from "../../src/interfaces/IDiamondLoupe.sol";
 import {LibDiamond} from "../../src/diamond/libraries/LibDiamond.sol";
 import {TestBase} from "./AccessControlTestHarness.sol";
@@ -12,6 +13,10 @@ contract DiamondFacetOne {
 
     function beta() external pure returns (uint256) {
         return 2;
+    }
+
+    function caller() external view returns (address) {
+        return msg.sender;
     }
 }
 
@@ -73,6 +78,18 @@ contract DiamondLibraryHarness {
 
     function facets() external view returns (IDiamondLoupe.Facet[] memory) {
         return LibDiamond.facets();
+    }
+}
+
+contract DiamondProxyHarness is Diamond {
+    constructor(address initialOwner) Diamond(initialOwner) {}
+
+    function owner() external view returns (address) {
+        return LibDiamond.contractOwner();
+    }
+
+    function installSelector(address facetAddress_, bytes4 selector) external {
+        LibDiamond.addSelector(facetAddress_, selector);
     }
 }
 


### PR DESCRIPTION
## Summary
- add the base `Diamond` proxy with constructor owner bootstrap, `receive`, and selector-routing fallback behavior
- route fallback calls through diamond selector storage using delegatecall and revert cleanly for unknown selectors
- extend the diamond harness to exercise routed calls and delegated caller behavior
- add focused proxy tests for owner bootstrap, single/multi-facet routing, delegated `msg.sender`, and missing selector handling

## Validation
- `forge test --offline --match-path test/DiamondProxyCore.t.sol`
- `forge test --offline`

Closes #59