### PR TITLE
feat: add DiamondCut facet and upgrade execution flow

### DIFF
--- a/src/diamond/facets/DiamondCutFacet.sol
+++ b/src/diamond/facets/DiamondCutFacet.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IDiamondCut} from "../../interfaces/IDiamondCut.sol";
+import {LibDiamond} from "../libraries/LibDiamond.sol";
+
+/// @title DiamondCutFacet
+/// @notice Owner-gated selector mutation facet for EIP-2535 diamonds.
+contract DiamondCutFacet is IDiamondCut {
+    /// @notice Applies selector mutations and optional init delegatecall.
+    /// @param diamondCut_ The selector mutation payload.
+    /// @param init The optional init target for post-cut initialization.
+    /// @param initCalldata The optional init calldata executed after the cut.
+    function diamondCut(IDiamondCut.FacetCut[] calldata diamondCut_, address init, bytes calldata initCalldata)
+        external
+    {
+        LibDiamond.enforceIsContractOwner();
+        LibDiamond.diamondCut(diamondCut_, init, initCalldata);
+        emit DiamondCut(diamondCut_, init, initCalldata);
+    }
+}

--- a/src/diamond/libraries/LibDiamond.sol
+++ b/src/diamond/libraries/LibDiamond.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
+import {IDiamondCut} from "../../interfaces/IDiamondCut.sol";
 import {IDiamondLoupe} from "../../interfaces/IDiamondLoupe.sol";
 import {LibDiamondStorage} from "../storage/LibDiamondStorage.sol";
 
@@ -24,6 +25,18 @@ library LibDiamond {
     error DiamondSelectorNotFound(bytes4 selector);
     /// @notice Thrown when replacing a selector with the same facet.
     error DiamondReplaceWithSameFacet(bytes4 selector, address facetAddress);
+    /// @notice Thrown when a facet cut contains no selectors.
+    error DiamondCutEmptySelectors();
+    /// @notice Thrown when removing selectors with a nonzero facet address.
+    error DiamondCutRemoveFacetAddressNotZero(address facetAddress);
+    /// @notice Thrown when a facet or init target has no code.
+    error DiamondTargetHasNoCode(address target);
+    /// @notice Thrown when init calldata is provided without an init target.
+    error DiamondCutInitTargetRequired();
+    /// @notice Thrown when an init target is provided without calldata.
+    error DiamondCutInitCalldataRequired();
+    /// @notice Thrown when the init delegatecall fails.
+    error DiamondCutInitFailed(address init, bytes reason);
 
     /// @notice Returns the current contract owner.
     /// @return owner_ The current contract owner.
@@ -180,6 +193,79 @@ library LibDiamond {
 
         if (selectors.length == 0) {
             _removeFacetAddress(diamondStorage, facetAddress_);
+        }
+    }
+
+    /// @notice Applies a full diamond cut and optional init delegatecall.
+    /// @param diamondCut_ The selector mutations to apply.
+    /// @param init The optional init target for post-cut initialization.
+    /// @param initCalldata The optional init calldata.
+    function diamondCut(IDiamondCut.FacetCut[] calldata diamondCut_, address init, bytes calldata initCalldata)
+        internal
+    {
+        uint256 cutLength = diamondCut_.length;
+        for (uint256 i = 0; i < cutLength; i++) {
+            IDiamondCut.FacetCut calldata facetCut = diamondCut_[i];
+            bytes4[] calldata selectors = facetCut.functionSelectors;
+            uint256 selectorCount = selectors.length;
+            if (selectorCount == 0) {
+                revert DiamondCutEmptySelectors();
+            }
+
+            if (facetCut.action == IDiamondCut.FacetCutAction.Add) {
+                _enforceTargetHasCode(facetCut.facetAddress);
+                for (uint256 j = 0; j < selectorCount; j++) {
+                    addSelector(facetCut.facetAddress, selectors[j]);
+                }
+                continue;
+            }
+
+            if (facetCut.action == IDiamondCut.FacetCutAction.Replace) {
+                _enforceTargetHasCode(facetCut.facetAddress);
+                for (uint256 j = 0; j < selectorCount; j++) {
+                    replaceSelector(facetCut.facetAddress, selectors[j]);
+                }
+                continue;
+            }
+
+            if (facetCut.facetAddress != address(0)) {
+                revert DiamondCutRemoveFacetAddressNotZero(facetCut.facetAddress);
+            }
+            for (uint256 j = 0; j < selectorCount; j++) {
+                removeSelector(selectors[j]);
+            }
+        }
+
+        initializeDiamondCut(init, initCalldata);
+    }
+
+    /// @notice Executes the optional init delegatecall after a cut.
+    /// @param init The optional init target for post-cut initialization.
+    /// @param initCalldata The optional init calldata.
+    function initializeDiamondCut(address init, bytes calldata initCalldata) internal {
+        if (init == address(0)) {
+            if (initCalldata.length != 0) {
+                revert DiamondCutInitTargetRequired();
+            }
+            return;
+        }
+        if (initCalldata.length == 0) {
+            revert DiamondCutInitCalldataRequired();
+        }
+
+        _enforceTargetHasCode(init);
+
+        (bool success, bytes memory reason) = init.delegatecall(initCalldata);
+        if (!success) {
+            revert DiamondCutInitFailed(init, reason);
+        }
+    }
+
+    /// @dev Reverts when `target` has no runtime code.
+    /// @param target The facet or init target to validate.
+    function _enforceTargetHasCode(address target) private view {
+        if (target.code.length == 0) {
+            revert DiamondTargetHasNoCode(target);
         }
     }
 

--- a/test/DiamondCutCore.t.sol
+++ b/test/DiamondCutCore.t.sol
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Diamond} from "../src/diamond/Diamond.sol";
+import {DiamondCutFacet} from "../src/diamond/facets/DiamondCutFacet.sol";
+import {IDiamondCut} from "../src/interfaces/IDiamondCut.sol";
+import {LibDiamond} from "../src/diamond/libraries/LibDiamond.sol";
+import {
+    DiamondFacetOne,
+    DiamondFacetReplacement,
+    DiamondInitMock,
+    DiamondProxyHarness,
+    TestBase
+} from "./helpers/DiamondTestHarness.sol";
+
+contract DiamondCutCoreTest is TestBase {
+    event DiamondCut(IDiamondCut.FacetCut[] diamondCut, address init, bytes initCalldata);
+
+    address internal admin = address(0xA11CE);
+    address internal eve = address(0xE11E);
+
+    DiamondProxyHarness internal diamond;
+    DiamondCutFacet internal cutFacet;
+    DiamondFacetOne internal facetOne;
+    DiamondFacetReplacement internal facetReplacement;
+    DiamondInitMock internal initMock;
+
+    function setUp() public {
+        diamond = new DiamondProxyHarness(admin);
+        cutFacet = new DiamondCutFacet();
+        facetOne = new DiamondFacetOne();
+        facetReplacement = new DiamondFacetReplacement();
+        initMock = new DiamondInitMock();
+
+        diamond.installSelector(address(cutFacet), DiamondCutFacet.diamondCut.selector);
+    }
+
+    function testOwnerCanAddSelectorViaDiamondCut() public {
+        IDiamondCut.FacetCut[] memory cut =
+            _buildSingleCut(address(facetOne), IDiamondCut.FacetCutAction.Add, DiamondFacetOne.version.selector);
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+
+        (bool success, bytes memory returndata) = address(diamond).call(abi.encodeCall(DiamondFacetOne.version, ()));
+        assertTrue(success, "version call should succeed");
+        assertTrue(abi.decode(returndata, (uint256)) == 1, "version should route to facet one");
+    }
+
+    function testDiamondCutEmitsEvent() public {
+        IDiamondCut.FacetCut[] memory cut =
+            _buildSingleCut(address(facetOne), IDiamondCut.FacetCutAction.Add, DiamondFacetOne.version.selector);
+
+        VM.expectEmit(false, false, false, true, address(diamond));
+        emit DiamondCut(cut, address(0), "");
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function testNonOwnerCannotDiamondCut() public {
+        IDiamondCut.FacetCut[] memory cut =
+            _buildSingleCut(address(facetOne), IDiamondCut.FacetCutAction.Add, DiamondFacetOne.version.selector);
+
+        VM.prank(eve);
+        VM.expectRevert(abi.encodeWithSelector(LibDiamond.DiamondUnauthorized.selector, eve, admin));
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function testReplaceSelectorViaDiamondCut() public {
+        IDiamondCut.FacetCut[] memory addCut =
+            _buildSingleCut(address(facetOne), IDiamondCut.FacetCutAction.Add, DiamondFacetOne.version.selector);
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(addCut, address(0), "");
+
+        IDiamondCut.FacetCut[] memory replaceCut = _buildSingleCut(
+            address(facetReplacement), IDiamondCut.FacetCutAction.Replace, DiamondFacetReplacement.version.selector
+        );
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(replaceCut, address(0), "");
+
+        (bool success, bytes memory returndata) = address(diamond).call(abi.encodeCall(DiamondFacetOne.version, ()));
+        assertTrue(success, "replaced selector call should succeed");
+        assertTrue(abi.decode(returndata, (uint256)) == 2, "version should route to replacement facet");
+    }
+
+    function testRemoveSelectorViaDiamondCut() public {
+        IDiamondCut.FacetCut[] memory addCut =
+            _buildSingleCut(address(facetOne), IDiamondCut.FacetCutAction.Add, DiamondFacetOne.version.selector);
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(addCut, address(0), "");
+
+        IDiamondCut.FacetCut[] memory removeCut =
+            _buildSingleCut(address(0), IDiamondCut.FacetCutAction.Remove, DiamondFacetOne.version.selector);
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(removeCut, address(0), "");
+
+        (bool success, bytes memory returndata) = address(diamond).call(abi.encodeCall(DiamondFacetOne.version, ()));
+        assertFalse(success, "removed selector call should fail");
+        assertTrue(
+            keccak256(returndata)
+                == keccak256(
+                    abi.encodeWithSelector(Diamond.DiamondFunctionNotFound.selector, DiamondFacetOne.version.selector)
+                ),
+            "removed selector revert mismatch"
+        );
+    }
+
+    function testInitDelegatecallRunsAfterCut() public {
+        IDiamondCut.FacetCut[] memory cut =
+            _buildSingleCut(address(initMock), IDiamondCut.FacetCutAction.Add, DiamondInitMock.readValue.selector);
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond))
+            .diamondCut(cut, address(initMock), abi.encodeCall(DiamondInitMock.initializeValue, (42)));
+
+        (bool success, bytes memory returndata) = address(diamond).call(abi.encodeCall(DiamondInitMock.readValue, ()));
+        assertTrue(success, "readValue call should succeed");
+        assertTrue(abi.decode(returndata, (uint256)) == 42, "init delegatecall value mismatch");
+    }
+
+    function testCutRejectsTargetWithoutCode() public {
+        IDiamondCut.FacetCut[] memory cut =
+            _buildSingleCut(eve, IDiamondCut.FacetCutAction.Add, DiamondFacetOne.version.selector);
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(LibDiamond.DiamondTargetHasNoCode.selector, eve));
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function testCutRejectsRemoveWithNonZeroFacetAddress() public {
+        IDiamondCut.FacetCut[] memory cut =
+            _buildSingleCut(address(facetOne), IDiamondCut.FacetCutAction.Remove, DiamondFacetOne.version.selector);
+
+        VM.prank(admin);
+        VM.expectRevert(
+            abi.encodeWithSelector(LibDiamond.DiamondCutRemoveFacetAddressNotZero.selector, address(facetOne))
+        );
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function testCutRejectsInitCalldataWithoutTarget() public {
+        IDiamondCut.FacetCut[] memory cut =
+            _buildSingleCut(address(facetOne), IDiamondCut.FacetCutAction.Add, DiamondFacetOne.version.selector);
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(LibDiamond.DiamondCutInitTargetRequired.selector));
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), abi.encodeCall(DiamondInitMock.initializeValue, (1)));
+    }
+
+    function testCutRejectsInitTargetWithoutCalldata() public {
+        IDiamondCut.FacetCut[] memory cut =
+            _buildSingleCut(address(facetOne), IDiamondCut.FacetCutAction.Add, DiamondFacetOne.version.selector);
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(LibDiamond.DiamondCutInitCalldataRequired.selector));
+        IDiamondCut(address(diamond)).diamondCut(cut, address(initMock), "");
+    }
+
+    function testCutBubblesInitFailure() public {
+        IDiamondCut.FacetCut[] memory cut =
+            _buildSingleCut(address(facetOne), IDiamondCut.FacetCutAction.Add, DiamondFacetOne.version.selector);
+        bytes memory initCalldata = abi.encodeCall(DiamondInitMock.revertInit, ());
+        bytes memory revertReason = abi.encodeWithSelector(DiamondInitMock.InitFailure.selector);
+
+        VM.prank(admin);
+        VM.expectRevert(
+            abi.encodeWithSelector(LibDiamond.DiamondCutInitFailed.selector, address(initMock), revertReason)
+        );
+        IDiamondCut(address(diamond)).diamondCut(cut, address(initMock), initCalldata);
+    }
+
+    function testCutRejectsEmptySelectorList() public {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(facetOne), action: IDiamondCut.FacetCutAction.Add, functionSelectors: new bytes4[](0)
+        });
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(LibDiamond.DiamondCutEmptySelectors.selector));
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _buildSingleCut(address facetAddress, IDiamondCut.FacetCutAction action, bytes4 selector)
+        internal
+        pure
+        returns (IDiamondCut.FacetCut[] memory cut)
+    {
+        cut = new IDiamondCut.FacetCut[](1);
+        bytes4[] memory selectors = new bytes4[](1);
+        selectors[0] = selector;
+        cut[0] = IDiamondCut.FacetCut({facetAddress: facetAddress, action: action, functionSelectors: selectors});
+    }
+}

--- a/test/helpers/DiamondTestHarness.sol
+++ b/test/helpers/DiamondTestHarness.sol
@@ -2,7 +2,9 @@
 pragma solidity ^0.8.30;
 
 import {Diamond} from "../../src/diamond/Diamond.sol";
+import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
 import {IDiamondLoupe} from "../../src/interfaces/IDiamondLoupe.sol";
+import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
 import {LibDiamond} from "../../src/diamond/libraries/LibDiamond.sol";
 import {TestBase} from "./AccessControlTestHarness.sol";
 
@@ -18,6 +20,16 @@ contract DiamondFacetOne {
     function caller() external view returns (address) {
         return msg.sender;
     }
+
+    function version() external pure returns (uint256) {
+        return 1;
+    }
+}
+
+contract DiamondFacetReplacement {
+    function version() external pure returns (uint256) {
+        return 2;
+    }
 }
 
 contract DiamondFacetTwo {
@@ -27,6 +39,37 @@ contract DiamondFacetTwo {
 
     function delta() external pure returns (uint256) {
         return 4;
+    }
+}
+
+library LibDiamondInitTestStorage {
+    bytes32 internal constant STORAGE_SLOT = keccak256("smart-contracts.test.diamond-init.storage");
+
+    struct Layout {
+        uint256 value;
+    }
+
+    function layout() internal pure returns (Layout storage l) {
+        bytes32 slot = STORAGE_SLOT;
+        assembly {
+            l.slot := slot
+        }
+    }
+}
+
+contract DiamondInitMock {
+    error InitFailure();
+
+    function initializeValue(uint256 value_) external {
+        LibDiamondInitTestStorage.layout().value = value_;
+    }
+
+    function readValue() external view returns (uint256) {
+        return LibDiamondInitTestStorage.layout().value;
+    }
+
+    function revertInit() external pure {
+        revert InitFailure();
     }
 }
 


### PR DESCRIPTION
## Summary
- add `DiamondCutFacet` with owner-gated `diamondCut` entrypoint
- implement selector mutation orchestration in `LibDiamond` for add/replace/remove operations
- add optional post-cut init delegatecall support with strict validation for target/code/calldata combinations
- add explicit custom errors for invalid cut payloads and init failures
- add focused tests for authorized/unauthorized cut paths, selector lifecycle, event emission, init success, and init failure handling

## Validation
- `forge test --offline --match-path test/DiamondCutCore.t.sol`
- `forge test --offline`

Closes #58