### PR TITLE
Add DiamondLoupe facet and ownership introspection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ facets without a full rewrite.
 - `src/access`: access control and upgrade-safety primitives.
 - `src/access/storage`: module-local storage libraries (diamond-ready slots).
 - `src/diamond`: diamond core primitives and shared routing helpers.
+- `src/diamond/facets`: diamond facet implementations.
 - `src/diamond/storage`: diamond routing and ownership storage layout.
 - `src/security`: security primitives such as reentrancy protection.
 - `src/security/storage`: module-local storage libraries (diamond-ready slots).
@@ -48,6 +49,7 @@ forge fmt
 - Vault controls suite: `test/ERC4626VaultControlsCore.t.sol`
 - Vault accounting fuzz suite: `test/ERC4626VaultAccountingFuzz.t.sol`
 - Vault accounting invariant suite: `test/ERC4626VaultAccountingInvariant.t.sol`
+- Diamond core suites: `test/DiamondFoundationCore.t.sol`, `test/DiamondProxyCore.t.sol`, `test/DiamondCutCore.t.sol`, `test/DiamondLoupeCore.t.sol`
 - Oracle hardening suite: `test/OracleAdapterCore.t.sol`, `test/OracleAdapterValidation.t.sol`, `test/OracleAdapterCircuitBreaker.t.sol`, `test/OracleAdapterFuzz.t.sol`
 - Security CI/local checks: `docs/security-checks.md`
 

--- a/src/diamond/facets/DiamondLoupeFacet.sol
+++ b/src/diamond/facets/DiamondLoupeFacet.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC173} from "../../interfaces/IERC173.sol";
+import {IDiamondLoupe} from "../../interfaces/IDiamondLoupe.sol";
+import {LibDiamond} from "../libraries/LibDiamond.sol";
+
+/// @title DiamondLoupeFacet
+/// @notice Facet metadata + ownership surface for EIP-2535 diamonds.
+contract DiamondLoupeFacet is IDiamondLoupe, IERC173 {
+    /// @notice Returns every facet and its selectors.
+    /// @return diamondFacets All active facets and their selectors.
+    function facets() external view returns (IDiamondLoupe.Facet[] memory diamondFacets) {
+        return LibDiamond.facets();
+    }
+
+    /// @notice Returns all selectors owned by `facetAddress_`.
+    /// @param facetAddress_ The facet address to inspect.
+    /// @return functionSelectors The selectors owned by the facet.
+    function facetFunctionSelectors(address facetAddress_) external view returns (bytes4[] memory functionSelectors) {
+        return LibDiamond.facetFunctionSelectors(facetAddress_);
+    }
+
+    /// @notice Returns every active facet address.
+    /// @return facetAddresses_ All active facet addresses.
+    function facetAddresses() external view returns (address[] memory facetAddresses_) {
+        return LibDiamond.facetAddresses();
+    }
+
+    /// @notice Returns the facet responsible for `functionSelector`.
+    /// @param functionSelector The selector to inspect.
+    /// @return facetAddress_ The owning facet address, or zero when unset.
+    function facetAddress(bytes4 functionSelector) external view returns (address facetAddress_) {
+        return LibDiamond.facetAddress(functionSelector);
+    }
+
+    /// @notice Returns the current owner.
+    /// @return contractOwner The current owner.
+    function owner() external view returns (address contractOwner) {
+        return LibDiamond.contractOwner();
+    }
+
+    /// @notice Transfers ownership to `newOwner`.
+    /// @param newOwner The new owner account.
+    function transferOwnership(address newOwner) external {
+        LibDiamond.enforceIsContractOwner();
+        LibDiamond.setContractOwner(newOwner);
+    }
+}

--- a/test/DiamondLoupeCore.t.sol
+++ b/test/DiamondLoupeCore.t.sol
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {DiamondFacetOne, DiamondFacetTwo, DiamondProxyHarness, TestBase} from "./helpers/DiamondTestHarness.sol";
+import {DiamondLoupeFacet} from "../src/diamond/facets/DiamondLoupeFacet.sol";
+import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
+import {IERC173} from "../src/interfaces/IERC173.sol";
+import {LibDiamond} from "../src/diamond/libraries/LibDiamond.sol";
+
+contract DiamondLoupeCoreTest is TestBase {
+    address internal admin = address(0xA11CE);
+    address internal eve = address(0xE11E);
+
+    DiamondProxyHarness internal diamond;
+    DiamondLoupeFacet internal loupeFacet;
+    DiamondFacetOne internal facetOne;
+    DiamondFacetTwo internal facetTwo;
+
+    function setUp() public {
+        diamond = new DiamondProxyHarness(admin);
+        loupeFacet = new DiamondLoupeFacet();
+        facetOne = new DiamondFacetOne();
+        facetTwo = new DiamondFacetTwo();
+
+        _installLoupeSelectors();
+        diamond.installSelector(address(facetOne), DiamondFacetOne.alpha.selector);
+        diamond.installSelector(address(facetOne), DiamondFacetOne.beta.selector);
+        diamond.installSelector(address(facetTwo), DiamondFacetTwo.gamma.selector);
+    }
+
+    function testLoupeFacetAddressesAndSelectorLookups() public view {
+        IDiamondLoupe loupe = IDiamondLoupe(address(diamond));
+        address[] memory facetAddresses_ = loupe.facetAddresses();
+
+        assertTrue(facetAddresses_.length == 3, "facet address count mismatch");
+        assertTrue(facetAddresses_[0] == address(loupeFacet), "loupe facet ordering mismatch");
+        assertTrue(facetAddresses_[1] == address(facetOne), "facet one ordering mismatch");
+        assertTrue(facetAddresses_[2] == address(facetTwo), "facet two ordering mismatch");
+
+        assertTrue(
+            loupe.facetAddress(DiamondLoupeFacet.facets.selector) == address(loupeFacet),
+            "loupe selector should resolve to loupe facet"
+        );
+        assertTrue(
+            loupe.facetAddress(DiamondFacetOne.alpha.selector) == address(facetOne),
+            "alpha selector should resolve to facet one"
+        );
+        assertTrue(
+            loupe.facetAddress(DiamondFacetTwo.gamma.selector) == address(facetTwo),
+            "gamma selector should resolve to facet two"
+        );
+        assertTrue(loupe.facetAddress(0xdeadbeef) == address(0), "unknown selector should resolve to zero");
+    }
+
+    function testLoupeFacetFunctionSelectorsAndFacetsSnapshot() public view {
+        IDiamondLoupe loupe = IDiamondLoupe(address(diamond));
+
+        bytes4[] memory loupeSelectors = loupe.facetFunctionSelectors(address(loupeFacet));
+        bytes4[] memory facetOneSelectors = loupe.facetFunctionSelectors(address(facetOne));
+        bytes4[] memory facetTwoSelectors = loupe.facetFunctionSelectors(address(facetTwo));
+        bytes4[] memory unknownFacetSelectors = loupe.facetFunctionSelectors(eve);
+
+        assertTrue(loupeSelectors.length == 6, "loupe selector count mismatch");
+        assertTrue(facetOneSelectors.length == 2, "facet one selector count mismatch");
+        assertTrue(facetTwoSelectors.length == 1, "facet two selector count mismatch");
+        assertTrue(unknownFacetSelectors.length == 0, "unknown facet should have no selectors");
+
+        IDiamondLoupe.Facet[] memory facets_ = loupe.facets();
+        assertTrue(facets_.length == 3, "facets snapshot count mismatch");
+        assertTrue(facets_[0].facetAddress == address(loupeFacet), "loupe snapshot ordering mismatch");
+        assertTrue(facets_[1].facetAddress == address(facetOne), "facet one snapshot ordering mismatch");
+        assertTrue(facets_[2].facetAddress == address(facetTwo), "facet two snapshot ordering mismatch");
+    }
+
+    function testOwnershipSurfaceReportsCurrentOwner() public view {
+        assertTrue(IERC173(address(diamond)).owner() == admin, "owner view mismatch");
+    }
+
+    function testOwnerCanTransferOwnershipThroughLoupeFacet() public {
+        VM.prank(admin);
+        IERC173(address(diamond)).transferOwnership(eve);
+
+        assertTrue(IERC173(address(diamond)).owner() == eve, "ownership transfer mismatch");
+    }
+
+    function testNonOwnerCannotTransferOwnership() public {
+        VM.prank(eve);
+        VM.expectRevert(abi.encodeWithSelector(LibDiamond.DiamondUnauthorized.selector, eve, admin));
+        IERC173(address(diamond)).transferOwnership(eve);
+    }
+
+    function testTransferOwnershipZeroAddressReverts() public {
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(LibDiamond.DiamondOwnerZeroAddress.selector));
+        IERC173(address(diamond)).transferOwnership(address(0));
+    }
+
+    function testLoupeReflectsLiveSelectorReplaceAndRemove() public {
+        IDiamondLoupe loupe = IDiamondLoupe(address(diamond));
+
+        assertTrue(
+            loupe.facetAddress(DiamondFacetOne.alpha.selector) == address(facetOne), "alpha should start on facet one"
+        );
+
+        diamond.replaceSelector(address(facetTwo), DiamondFacetOne.alpha.selector);
+        assertTrue(
+            loupe.facetAddress(DiamondFacetOne.alpha.selector) == address(facetTwo), "alpha should move to facet two"
+        );
+
+        bytes4[] memory facetOneSelectorsAfterReplace = loupe.facetFunctionSelectors(address(facetOne));
+        assertTrue(facetOneSelectorsAfterReplace.length == 1, "facet one selector count after replace mismatch");
+        assertTrue(facetOneSelectorsAfterReplace[0] == DiamondFacetOne.beta.selector, "beta should remain on facet one");
+
+        diamond.removeSelector(DiamondFacetOne.alpha.selector);
+        assertTrue(loupe.facetAddress(DiamondFacetOne.alpha.selector) == address(0), "alpha should be removed");
+
+        bytes4[] memory facetTwoSelectorsAfterRemove = loupe.facetFunctionSelectors(address(facetTwo));
+        assertTrue(facetTwoSelectorsAfterRemove.length == 1, "facet two selector count after remove mismatch");
+        assertTrue(
+            facetTwoSelectorsAfterRemove[0] == DiamondFacetTwo.gamma.selector, "gamma should remain on facet two"
+        );
+    }
+
+    function _installLoupeSelectors() internal {
+        diamond.installSelector(address(loupeFacet), DiamondLoupeFacet.facets.selector);
+        diamond.installSelector(address(loupeFacet), DiamondLoupeFacet.facetFunctionSelectors.selector);
+        diamond.installSelector(address(loupeFacet), DiamondLoupeFacet.facetAddresses.selector);
+        diamond.installSelector(address(loupeFacet), DiamondLoupeFacet.facetAddress.selector);
+        diamond.installSelector(address(loupeFacet), DiamondLoupeFacet.owner.selector);
+        diamond.installSelector(address(loupeFacet), DiamondLoupeFacet.transferOwnership.selector);
+    }
+}

--- a/test/helpers/DiamondTestHarness.sol
+++ b/test/helpers/DiamondTestHarness.sol
@@ -134,6 +134,14 @@ contract DiamondProxyHarness is Diamond {
     function installSelector(address facetAddress_, bytes4 selector) external {
         LibDiamond.addSelector(facetAddress_, selector);
     }
+
+    function replaceSelector(address facetAddress_, bytes4 selector) external {
+        LibDiamond.replaceSelector(facetAddress_, selector);
+    }
+
+    function removeSelector(bytes4 selector) external {
+        LibDiamond.removeSelector(selector);
+    }
 }
 
 abstract contract DiamondFixture is TestBase {


### PR DESCRIPTION
## Summary
- add `DiamondLoupeFacet` implementing `IDiamondLoupe` and `IERC173` surfaces
- add selector replace/remove helpers in the diamond test harness
- add `DiamondLoupeCore` tests for loupe reads, ownership transfer, and live routing updates
- update README testing/module structure references

## Validation
- `forge fmt --check`
- `forge test --offline`

## Issue
- Closes #57