### PR TITLE
Document diamond init flow, upgrade process, and safety assumptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ forge fmt
 
 ## Module Docs
 - Access control: `docs/access-control.md`
+- Diamond core: `docs/diamond-core.md`
 - ERC-4626 vault: `docs/erc4626-vault.md`
 - Oracle adapter: `docs/oracle-adapter.md`
 - Pausability: `docs/pausable.md`
@@ -66,6 +67,7 @@ forge fmt
 - Ops docs index: `docs/ops/README.md`
 - Release checklist: `docs/ops/release-checklist.md`
 - Release notes template: `docs/ops/release-notes-template.md`
+- Diamond cut runbook: `docs/ops/runbook-diamond-cut.md`
 - Oracle incident runbook: `docs/ops/runbook-oracle-incident.md`
 - Pause/unpause runbook: `docs/ops/runbook-pause-unpause.md`
 - Upgrade execution runbook: `docs/ops/runbook-upgrade-execution.md`

--- a/docs/diamond-core.md
+++ b/docs/diamond-core.md
@@ -1,0 +1,94 @@
+# Diamond Core
+
+This document describes the diamond core behavior implemented in this repository,
+including bootstrap expectations, `diamondCut` init flow, selector ownership
+rules, and upgrade review guidance.
+
+## Contracts
+
+- `src/diamond/Diamond.sol`: base proxy with owner bootstrap and selector routing fallback.
+- `src/diamond/facets/DiamondCutFacet.sol`: owner-gated `diamondCut` entrypoint.
+- `src/diamond/facets/DiamondLoupeFacet.sol`: loupe reads + `IERC173` ownership surface.
+- `src/diamond/libraries/LibDiamond.sol`: selector/owner/interface bookkeeping and cut helpers.
+- `src/diamond/storage/LibDiamondStorage.sol`: canonical diamond storage slot layout.
+
+## Deployment And Bootstrap Flow
+
+Current `Diamond` constructor initializes only the owner:
+
+- deploy `Diamond(initialOwner)`.
+- deploy initial facets (`DiamondCutFacet`, `DiamondLoupeFacet`, others).
+- install initial selectors through a bootstrap path.
+
+In tests, bootstrap is done through `DiamondProxyHarness.installSelector(...)`.
+For production, use a deploy flow that installs initial selectors before regular
+operations begin (for example via a dedicated deploy/factory path).
+
+## `diamondCut` And Init Delegatecall Flow
+
+`DiamondCutFacet.diamondCut(...)` enforces owner-only access, then calls
+`LibDiamond.diamondCut(...)`.
+
+Guardrails enforced in `LibDiamond`:
+
+- empty selector arrays revert (`DiamondCutEmptySelectors`).
+- add/replace targets must contain code (`DiamondTargetHasNoCode`).
+- remove actions must use `facetAddress == address(0)`
+  (`DiamondCutRemoveFacetAddressNotZero`).
+- init calldata without init target reverts (`DiamondCutInitTargetRequired`).
+- init target without calldata reverts (`DiamondCutInitCalldataRequired`).
+- init delegatecall failures bubble via `DiamondCutInitFailed`.
+
+Execution order:
+
+1. Apply add/replace/remove selector mutations.
+2. Execute optional init delegatecall.
+3. Emit `DiamondCut` event from `DiamondCutFacet`.
+
+## Selector Ownership Rules
+
+- A selector maps to exactly one facet at a time.
+- Add rejects existing selectors (`DiamondSelectorAlreadyExists`).
+- Replace rejects unknown selectors and same-facet replacements.
+- Remove rejects unknown selectors (`DiamondSelectorNotFound`).
+- Facet address and selector arrays use swap-and-pop updates; array ordering can
+  change after removals.
+
+Loupe reads (`facets`, `facetAddresses`, `facetFunctionSelectors`,
+`facetAddress`) should be treated as the source of truth for live routing state.
+
+## Storage Discipline
+
+To stay diamond-safe:
+
+- keep mutable state in namespaced storage libraries (`src/*/storage`), not in
+  facet state variables.
+- keep storage structs append-only once deployed.
+- use explicit initializers and idempotency guards for new modules/facets.
+- review slot constants and struct layout changes before every cut.
+
+## Upgrade Review Checklist
+
+1. Verify cut intent: selectors added/replaced/removed are expected.
+2. Verify each facet target has deployed bytecode and reviewed source.
+3. Verify selector collisions are intentional and reviewed.
+4. Verify init target + calldata, including idempotency and access controls.
+5. Verify storage layout assumptions for every touched module.
+6. Execute post-cut checks:
+   - loupe snapshot matches expected routing.
+   - critical external calls succeed.
+   - ownership (`owner()`) is unchanged unless intentionally transferred.
+
+## Security Assumptions And Limits
+
+- Diamond owner authority is highly privileged; use multisig/governance in production.
+- This core does not include built-in timelock/governance policy for cuts.
+- Bootstrap/install strategy is deployment-specific and must be reviewed.
+- Safety depends on off-chain cut payload review and post-cut validation.
+
+## Test References
+
+- `test/DiamondFoundationCore.t.sol`
+- `test/DiamondProxyCore.t.sol`
+- `test/DiamondCutCore.t.sol`
+- `test/DiamondLoupeCore.t.sol`

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -4,6 +4,7 @@ This folder contains release and incident-response operational guides.
 
 - Release checklist: `docs/ops/release-checklist.md`
 - Release notes template: `docs/ops/release-notes-template.md`
+- Diamond cut runbook: `docs/ops/runbook-diamond-cut.md`
 - Oracle incident runbook: `docs/ops/runbook-oracle-incident.md`
 - Pause/unpause runbook: `docs/ops/runbook-pause-unpause.md`
 - Upgrade execution runbook: `docs/ops/runbook-upgrade-execution.md`

--- a/docs/ops/runbook-diamond-cut.md
+++ b/docs/ops/runbook-diamond-cut.md
@@ -1,0 +1,43 @@
+# Runbook: Diamond Cut Execution
+
+Use this runbook for production-facing selector upgrades on the diamond core.
+
+## Preconditions
+
+- Upgrade is reviewed and approved through your governance process.
+- Caller is the current diamond owner (`IERC173.owner()`).
+- Facet bytecode, init target, and init calldata are finalized.
+
+## Pre-Cut Checklist
+
+1. Build the exact selector diff (`add`, `replace`, `remove`).
+2. Confirm every add/replace facet target has runtime code.
+3. Confirm every remove action uses `facetAddress = address(0)`.
+4. Confirm no empty selector lists exist.
+5. If using init delegatecall:
+   - `init` target has code.
+   - calldata is non-empty.
+   - init routine is idempotent and storage-safe.
+
+## Execution
+
+1. Submit `diamondCut(cut, init, initCalldata)` from owner account.
+2. Wait for transaction finality.
+3. Record tx hash and emitted `DiamondCut` payload.
+
+## Post-Cut Verification
+
+1. Read loupe state:
+   - `facetAddresses()`
+   - `facetFunctionSelectors(address)`
+   - `facetAddress(selector)`
+2. Verify expected selector ownership matches planned diff.
+3. Run smoke checks on critical external functions.
+4. Verify owner is unchanged unless ownership transfer was planned.
+
+## Failure Handling
+
+- If the cut reverts, inspect revert reason and payload assumptions first.
+- Do not submit ad-hoc follow-up cuts without updating the reviewed diff.
+- If a bad cut succeeds, execute a reviewed corrective cut immediately and
+  consider pausing user-facing flows if available.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -68,7 +68,7 @@ upgrade, and vault modules.
 - Compromised privileged keys can still perform privileged actions.
 - Economic attacks and protocol-specific business logic exploits are out of scope for this base kit.
 - Oracle market manipulation resistance is feed/provider-specific and must be handled at integration and policy layers.
-- Diamond-specific `diamondCut` payload validation and multi-step governance workflows are deferred to the diamond milestone.
+- Diamond `diamondCut` flows include core guardrails, but governance policy (timelocks/multisig approvals) remains an integration responsibility.
 - The current upgrade guardrails check nonzero implementation; deeper bytecode/interface validation is protocol-specific and should be added where needed.
 - Direct token donations to vault addresses can create untracked surplus unless explicitly reconciled by integration policy.
 


### PR DESCRIPTION
## Summary
- add a dedicated diamond core guide covering bootstrap, `diamondCut` init flow, selector ownership, and storage discipline
- add a diamond cut runbook for pre-cut review, execution, and post-cut verification
- link the new docs from the README and ops index
- update the threat model to reflect the current diamond guardrail posture

## Validation
- `forge test --offline`

## Issue
- Closes #55