### PR TITLE
Add Foundry diamond bootstrap deployment flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ facets without a full rewrite.
 - `src/vault/storage`: module-local storage libraries (diamond-ready slots).
 - `src/interfaces`: local interfaces (ERC-165, `IAccessControl`, `IAccessControlTime`, `IERC20`, `IERC20Metadata`, `IERC4626`, `IERC4626VaultBase`, `IERC4626VaultControls`, `IOracleAdapter`, `IOracleFeed`, `IPausable`, `IReentrancyGuard`, `IUpgradeGuardrails`, etc.).
 - `src/libraries`: shared cross-module libraries.
+- `script`: Foundry deployment and bootstrap flows.
+- `deployments`: local deployment artifacts written by scripts.
 - `test`: split by concern (`*Core.t.sol`, `*Time.t.sol`, `*Integration.t.sol`).
 - `test/helpers`: shared test fixtures and harnesses.
 - `docs`: usage notes and design decisions.
@@ -40,6 +42,8 @@ forge build
 forge test
 forge coverage
 forge fmt
+anvil
+forge script script/DeployDiamondCore.s.sol:DeployDiamondCoreScript --rpc-url http://127.0.0.1:8545 --broadcast
 ```
 
 ## Testing
@@ -72,6 +76,7 @@ forge fmt
 - Pause/unpause runbook: `docs/ops/runbook-pause-unpause.md`
 - Upgrade execution runbook: `docs/ops/runbook-upgrade-execution.md`
 - Milestone close checklist: `docs/ops/milestone-close-checklist.md`
+- Local diamond bootstrap: `docs/ops/local-diamond-bootstrap.md`
 
 ## Tooling
 - Foundry docs: [book.getfoundry.sh](https://book.getfoundry.sh/)

--- a/deployments/.gitignore
+++ b/deployments/.gitignore
@@ -1,0 +1,2 @@
+*.json
+!.gitignore

--- a/docs/diamond-core.md
+++ b/docs/diamond-core.md
@@ -14,15 +14,17 @@ rules, and upgrade review guidance.
 
 ## Deployment And Bootstrap Flow
 
-Current `Diamond` constructor initializes only the owner:
+Current `Diamond` constructor bootstraps the owner and initial cut facet:
 
-- deploy `Diamond(initialOwner)`.
-- deploy initial facets (`DiamondCutFacet`, `DiamondLoupeFacet`, others).
-- install initial selectors through a bootstrap path.
+- deploy `DiamondCutFacet`.
+- deploy `Diamond(initialOwner, initialCutFacet)`.
+- deploy remaining initial facets (`DiamondLoupeFacet`, others).
+- install additional selectors through `diamondCut`.
 
-In tests, bootstrap is done through `DiamondProxyHarness.installSelector(...)`.
-For production, use a deploy flow that installs initial selectors before regular
-operations begin (for example via a dedicated deploy/factory path).
+In tests, extra selectors can still be installed through
+`DiamondProxyHarness.installSelector(...)`. For production, the constructor now
+bootstraps `diamondCut`, and the deploy flow should use that to install the
+rest of the initial selector set before regular operations begin.
 
 ## `diamondCut` And Init Delegatecall Flow
 

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -4,6 +4,7 @@ This folder contains release and incident-response operational guides.
 
 - Release checklist: `docs/ops/release-checklist.md`
 - Release notes template: `docs/ops/release-notes-template.md`
+- Local diamond bootstrap: `docs/ops/local-diamond-bootstrap.md`
 - Diamond cut runbook: `docs/ops/runbook-diamond-cut.md`
 - Oracle incident runbook: `docs/ops/runbook-oracle-incident.md`
 - Pause/unpause runbook: `docs/ops/runbook-pause-unpause.md`

--- a/docs/ops/local-diamond-bootstrap.md
+++ b/docs/ops/local-diamond-bootstrap.md
@@ -1,0 +1,60 @@
+# Local Diamond Bootstrap
+
+This repo now includes a reference Foundry script for bootstrapping the diamond
+core on a local Anvil chain.
+
+## What It Deploys
+
+- `DiamondCutFacet`
+- `Diamond(initialOwner, initialCutFacet)`
+- `DiamondLoupeFacet`
+
+The script installs `diamondCut` during the diamond constructor bootstrap, then
+uses `diamondCut` to add the loupe selectors.
+
+## Prerequisites
+
+- `anvil`
+- `forge`
+- `PRIVATE_KEY` set to the funded Anvil account you want to deploy from
+
+Example Anvil default key:
+
+```shell
+export PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+```
+
+## Run
+
+Start Anvil:
+
+```shell
+anvil
+```
+
+Deploy and bootstrap the diamond core:
+
+```shell
+forge script script/DeployDiamondCore.s.sol:DeployDiamondCoreScript \
+  --rpc-url http://127.0.0.1:8545 \
+  --broadcast
+```
+
+## Output
+
+The script writes deployment artifacts to:
+
+```text
+deployments/diamond-core.local.json
+```
+
+Current fields:
+
+- `network`
+- `chainId`
+- `owner`
+- `diamond`
+- `diamondCutFacet`
+- `diamondLoupeFacet`
+
+These outputs are intended to feed later E2E and upgrade rehearsal work.

--- a/foundry.toml
+++ b/foundry.toml
@@ -2,5 +2,6 @@
 src = "src"
 out = "out"
 libs = ["lib"]
+fs_permissions = [{ access = "read-write", path = "./deployments" }]
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/script/DeployDiamondCore.s.sol
+++ b/script/DeployDiamondCore.s.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Diamond} from "../src/diamond/Diamond.sol";
+import {DiamondCutFacet} from "../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../src/diamond/facets/DiamondLoupeFacet.sol";
+import {IDiamondCut} from "../src/interfaces/IDiamondCut.sol";
+import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
+import {IERC173} from "../src/interfaces/IERC173.sol";
+
+interface Vm {
+    function addr(uint256 privateKey) external returns (address);
+    function envUint(string calldata name) external returns (uint256);
+    function projectRoot() external view returns (string memory);
+    function serializeAddress(string calldata objectKey, string calldata valueKey, address value)
+        external
+        returns (string memory);
+    function serializeString(string calldata objectKey, string calldata valueKey, string calldata value)
+        external
+        returns (string memory);
+    function serializeUint(string calldata objectKey, string calldata valueKey, uint256 value)
+        external
+        returns (string memory);
+    function startBroadcast(uint256 privateKey) external;
+    function stopBroadcast() external;
+    function writeJson(string calldata json, string calldata path) external;
+}
+
+/// @title DeployDiamondCoreScript
+/// @notice Reference local deployment flow for a bootstrapped diamond core.
+contract DeployDiamondCoreScript {
+    Vm internal constant VM = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    string internal constant DEPLOYMENT_OBJECT = "diamondCore";
+    string internal constant OUTPUT_RELATIVE_PATH = "/deployments/diamond-core.local.json";
+
+    /// @notice Deploys `Diamond`, `DiamondCutFacet`, and `DiamondLoupeFacet`, then bootstraps loupe selectors.
+    /// @dev Requires `PRIVATE_KEY` to be set in the environment.
+    /// @return diamondAddress The deployed diamond proxy.
+    /// @return cutFacetAddress The deployed cut facet.
+    /// @return loupeFacetAddress The deployed loupe facet.
+    function run() external returns (address diamondAddress, address cutFacetAddress, address loupeFacetAddress) {
+        uint256 deployerPrivateKey = VM.envUint("PRIVATE_KEY");
+        address owner = VM.addr(deployerPrivateKey);
+
+        VM.startBroadcast(deployerPrivateKey);
+
+        DiamondCutFacet cutFacet = new DiamondCutFacet();
+        Diamond diamond = new Diamond(owner, address(cutFacet));
+        DiamondLoupeFacet loupeFacet = new DiamondLoupeFacet();
+
+        IDiamondCut.FacetCut[] memory initialCut = new IDiamondCut.FacetCut[](1);
+        initialCut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(loupeFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: _loupeSelectors()
+        });
+        IDiamondCut(address(diamond)).diamondCut(initialCut, address(0), "");
+
+        VM.stopBroadcast();
+
+        diamondAddress = address(diamond);
+        cutFacetAddress = address(cutFacet);
+        loupeFacetAddress = address(loupeFacet);
+
+        _validateBootstrap(diamondAddress, owner, cutFacetAddress, loupeFacetAddress);
+        _writeDeploymentArtifact(owner, diamondAddress, cutFacetAddress, loupeFacetAddress);
+    }
+
+    function _validateBootstrap(
+        address diamondAddress,
+        address owner,
+        address cutFacetAddress,
+        address loupeFacetAddress
+    ) internal view {
+        IERC173 ownership = IERC173(diamondAddress);
+        IDiamondLoupe loupe = IDiamondLoupe(diamondAddress);
+
+        require(ownership.owner() == owner, "diamond owner mismatch");
+        require(
+            loupe.facetAddress(DiamondCutFacet.diamondCut.selector) == cutFacetAddress,
+            "diamondCut selector bootstrap mismatch"
+        );
+        require(
+            loupe.facetAddress(DiamondLoupeFacet.facets.selector) == loupeFacetAddress,
+            "loupe facets selector bootstrap mismatch"
+        );
+        require(loupe.facetFunctionSelectors(loupeFacetAddress).length == 6, "loupe selector count mismatch");
+        require(loupe.facetAddresses().length == 2, "facet address count mismatch");
+    }
+
+    function _writeDeploymentArtifact(
+        address owner,
+        address diamondAddress,
+        address cutFacetAddress,
+        address loupeFacetAddress
+    ) internal {
+        string memory json = VM.serializeString(DEPLOYMENT_OBJECT, "network", "local-anvil");
+        json = VM.serializeUint(DEPLOYMENT_OBJECT, "chainId", block.chainid);
+        json = VM.serializeAddress(DEPLOYMENT_OBJECT, "owner", owner);
+        json = VM.serializeAddress(DEPLOYMENT_OBJECT, "diamond", diamondAddress);
+        json = VM.serializeAddress(DEPLOYMENT_OBJECT, "diamondCutFacet", cutFacetAddress);
+        json = VM.serializeAddress(DEPLOYMENT_OBJECT, "diamondLoupeFacet", loupeFacetAddress);
+        VM.writeJson(json, string.concat(VM.projectRoot(), OUTPUT_RELATIVE_PATH));
+    }
+
+    function _loupeSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](6);
+        selectors[0] = DiamondLoupeFacet.facets.selector;
+        selectors[1] = DiamondLoupeFacet.facetFunctionSelectors.selector;
+        selectors[2] = DiamondLoupeFacet.facetAddresses.selector;
+        selectors[3] = DiamondLoupeFacet.facetAddress.selector;
+        selectors[4] = DiamondLoupeFacet.owner.selector;
+        selectors[5] = DiamondLoupeFacet.transferOwnership.selector;
+    }
+}

--- a/src/diamond/Diamond.sol
+++ b/src/diamond/Diamond.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
+import {IDiamondCut} from "../interfaces/IDiamondCut.sol";
 import {LibDiamond} from "./libraries/LibDiamond.sol";
 
 /// @title Diamond
@@ -11,8 +12,11 @@ contract Diamond {
     error DiamondFunctionNotFound(bytes4 selector);
 
     /// @param initialOwner The account that becomes the initial diamond owner.
-    constructor(address initialOwner) {
+    /// @param initialCutFacet The initial cut facet installed during bootstrap.
+    constructor(address initialOwner, address initialCutFacet) {
         LibDiamond.setContractOwner(initialOwner);
+        LibDiamond.enforceHasContractCode(initialCutFacet);
+        LibDiamond.addSelector(initialCutFacet, IDiamondCut.diamondCut.selector);
     }
 
     /// @notice Accepts plain ETH transfers.

--- a/src/diamond/libraries/LibDiamond.sol
+++ b/src/diamond/libraries/LibDiamond.sol
@@ -44,6 +44,12 @@ library LibDiamond {
         return LibDiamondStorage.layout().contractOwner;
     }
 
+    /// @notice Reverts when `target` has no runtime code.
+    /// @param target The facet or init target to validate.
+    function enforceHasContractCode(address target) internal view {
+        _enforceTargetHasCode(target);
+    }
+
     /// @notice Sets the current contract owner and emits the ERC-173 event.
     /// @param newOwner The new owner account.
     function setContractOwner(address newOwner) internal {

--- a/test/DiamondCutCore.t.sol
+++ b/test/DiamondCutCore.t.sol
@@ -26,13 +26,11 @@ contract DiamondCutCoreTest is TestBase {
     DiamondInitMock internal initMock;
 
     function setUp() public {
-        diamond = new DiamondProxyHarness(admin);
         cutFacet = new DiamondCutFacet();
+        diamond = new DiamondProxyHarness(admin, address(cutFacet));
         facetOne = new DiamondFacetOne();
         facetReplacement = new DiamondFacetReplacement();
         initMock = new DiamondInitMock();
-
-        diamond.installSelector(address(cutFacet), DiamondCutFacet.diamondCut.selector);
     }
 
     function testOwnerCanAddSelectorViaDiamondCut() public {

--- a/test/DiamondLoupeCore.t.sol
+++ b/test/DiamondLoupeCore.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.30;
 
 import {DiamondFacetOne, DiamondFacetTwo, DiamondProxyHarness, TestBase} from "./helpers/DiamondTestHarness.sol";
+import {DiamondCutFacet} from "../src/diamond/facets/DiamondCutFacet.sol";
 import {DiamondLoupeFacet} from "../src/diamond/facets/DiamondLoupeFacet.sol";
 import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
 import {IERC173} from "../src/interfaces/IERC173.sol";
@@ -12,12 +13,14 @@ contract DiamondLoupeCoreTest is TestBase {
     address internal eve = address(0xE11E);
 
     DiamondProxyHarness internal diamond;
+    DiamondCutFacet internal cutFacet;
     DiamondLoupeFacet internal loupeFacet;
     DiamondFacetOne internal facetOne;
     DiamondFacetTwo internal facetTwo;
 
     function setUp() public {
-        diamond = new DiamondProxyHarness(admin);
+        cutFacet = new DiamondCutFacet();
+        diamond = new DiamondProxyHarness(admin, address(cutFacet));
         loupeFacet = new DiamondLoupeFacet();
         facetOne = new DiamondFacetOne();
         facetTwo = new DiamondFacetTwo();
@@ -32,14 +35,19 @@ contract DiamondLoupeCoreTest is TestBase {
         IDiamondLoupe loupe = IDiamondLoupe(address(diamond));
         address[] memory facetAddresses_ = loupe.facetAddresses();
 
-        assertTrue(facetAddresses_.length == 3, "facet address count mismatch");
-        assertTrue(facetAddresses_[0] == address(loupeFacet), "loupe facet ordering mismatch");
-        assertTrue(facetAddresses_[1] == address(facetOne), "facet one ordering mismatch");
-        assertTrue(facetAddresses_[2] == address(facetTwo), "facet two ordering mismatch");
+        assertTrue(facetAddresses_.length == 4, "facet address count mismatch");
+        assertTrue(facetAddresses_[0] == address(cutFacet), "cut facet ordering mismatch");
+        assertTrue(facetAddresses_[1] == address(loupeFacet), "loupe facet ordering mismatch");
+        assertTrue(facetAddresses_[2] == address(facetOne), "facet one ordering mismatch");
+        assertTrue(facetAddresses_[3] == address(facetTwo), "facet two ordering mismatch");
 
         assertTrue(
             loupe.facetAddress(DiamondLoupeFacet.facets.selector) == address(loupeFacet),
             "loupe selector should resolve to loupe facet"
+        );
+        assertTrue(
+            loupe.facetAddress(DiamondCutFacet.diamondCut.selector) == address(cutFacet),
+            "diamondCut selector should resolve to cut facet"
         );
         assertTrue(
             loupe.facetAddress(DiamondFacetOne.alpha.selector) == address(facetOne),
@@ -55,21 +63,24 @@ contract DiamondLoupeCoreTest is TestBase {
     function testLoupeFacetFunctionSelectorsAndFacetsSnapshot() public view {
         IDiamondLoupe loupe = IDiamondLoupe(address(diamond));
 
+        bytes4[] memory cutSelectors = loupe.facetFunctionSelectors(address(cutFacet));
         bytes4[] memory loupeSelectors = loupe.facetFunctionSelectors(address(loupeFacet));
         bytes4[] memory facetOneSelectors = loupe.facetFunctionSelectors(address(facetOne));
         bytes4[] memory facetTwoSelectors = loupe.facetFunctionSelectors(address(facetTwo));
         bytes4[] memory unknownFacetSelectors = loupe.facetFunctionSelectors(eve);
 
+        assertTrue(cutSelectors.length == 1, "cut facet selector count mismatch");
         assertTrue(loupeSelectors.length == 6, "loupe selector count mismatch");
         assertTrue(facetOneSelectors.length == 2, "facet one selector count mismatch");
         assertTrue(facetTwoSelectors.length == 1, "facet two selector count mismatch");
         assertTrue(unknownFacetSelectors.length == 0, "unknown facet should have no selectors");
 
         IDiamondLoupe.Facet[] memory facets_ = loupe.facets();
-        assertTrue(facets_.length == 3, "facets snapshot count mismatch");
-        assertTrue(facets_[0].facetAddress == address(loupeFacet), "loupe snapshot ordering mismatch");
-        assertTrue(facets_[1].facetAddress == address(facetOne), "facet one snapshot ordering mismatch");
-        assertTrue(facets_[2].facetAddress == address(facetTwo), "facet two snapshot ordering mismatch");
+        assertTrue(facets_.length == 4, "facets snapshot count mismatch");
+        assertTrue(facets_[0].facetAddress == address(cutFacet), "cut snapshot ordering mismatch");
+        assertTrue(facets_[1].facetAddress == address(loupeFacet), "loupe snapshot ordering mismatch");
+        assertTrue(facets_[2].facetAddress == address(facetOne), "facet one snapshot ordering mismatch");
+        assertTrue(facets_[3].facetAddress == address(facetTwo), "facet two snapshot ordering mismatch");
     }
 
     function testOwnershipSurfaceReportsCurrentOwner() public view {

--- a/test/DiamondProxyCore.t.sol
+++ b/test/DiamondProxyCore.t.sol
@@ -2,6 +2,9 @@
 pragma solidity ^0.8.30;
 
 import {Diamond} from "../src/diamond/Diamond.sol";
+import {DiamondCutFacet} from "../src/diamond/facets/DiamondCutFacet.sol";
+import {IDiamondCut} from "../src/interfaces/IDiamondCut.sol";
+import {LibDiamond} from "../src/diamond/libraries/LibDiamond.sol";
 import {DiamondFacetOne, DiamondFacetTwo, DiamondProxyHarness, TestBase} from "./helpers/DiamondTestHarness.sol";
 
 contract DiamondProxyCoreTest is TestBase {
@@ -9,17 +12,40 @@ contract DiamondProxyCoreTest is TestBase {
     address internal eve = address(0xE11E);
 
     DiamondProxyHarness internal diamond;
+    DiamondCutFacet internal cutFacet;
     DiamondFacetOne internal facetOne;
     DiamondFacetTwo internal facetTwo;
 
     function setUp() public {
-        diamond = new DiamondProxyHarness(admin);
+        cutFacet = new DiamondCutFacet();
+        diamond = new DiamondProxyHarness(admin, address(cutFacet));
         facetOne = new DiamondFacetOne();
         facetTwo = new DiamondFacetTwo();
     }
 
     function testConstructorBootstrapsOwner() public view {
         assertTrue(diamond.owner() == admin, "initial owner mismatch");
+    }
+
+    function testConstructorBootstrapsInitialCutFacet() public {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        bytes4[] memory selectors = new bytes4[](1);
+        selectors[0] = DiamondFacetOne.alpha.selector;
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(facetOne), action: IDiamondCut.FacetCutAction.Add, functionSelectors: selectors
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+
+        (bool success, bytes memory returndata) = address(diamond).call(abi.encodeCall(DiamondFacetOne.alpha, ()));
+        assertTrue(success, "alpha call should succeed after constructor bootstrap");
+        assertTrue(abi.decode(returndata, (uint256)) == 1, "alpha return mismatch after constructor bootstrap");
+    }
+
+    function testConstructorRejectsInitialCutFacetWithoutCode() public {
+        VM.expectRevert(abi.encodeWithSelector(LibDiamond.DiamondTargetHasNoCode.selector, eve));
+        new DiamondProxyHarness(admin, eve);
     }
 
     function testFallbackRoutesSelectorToInstalledFacet() public {

--- a/test/DiamondSelectorIntegrityCore.t.sol
+++ b/test/DiamondSelectorIntegrityCore.t.sol
@@ -27,8 +27,8 @@ contract DiamondSelectorIntegrityCoreTest is TestBase {
     DiamondFacetAlphaReplacement internal alphaReplacement;
 
     function setUp() public {
-        diamond = new DiamondProxyHarness(admin);
         cutFacet = new DiamondCutFacet();
+        diamond = new DiamondProxyHarness(admin, address(cutFacet));
         loupeFacet = new DiamondLoupeFacet();
         facetOne = new DiamondFacetOne();
         facetTwo = new DiamondFacetTwo();
@@ -213,7 +213,6 @@ contract DiamondSelectorIntegrityCoreTest is TestBase {
     }
 
     function _bootstrapCoreFacets() internal {
-        diamond.installSelector(address(cutFacet), DiamondCutFacet.diamondCut.selector);
         diamond.installSelector(address(loupeFacet), DiamondLoupeFacet.facets.selector);
         diamond.installSelector(address(loupeFacet), DiamondLoupeFacet.facetFunctionSelectors.selector);
         diamond.installSelector(address(loupeFacet), DiamondLoupeFacet.facetAddresses.selector);

--- a/test/helpers/DiamondTestHarness.sol
+++ b/test/helpers/DiamondTestHarness.sol
@@ -139,7 +139,7 @@ contract DiamondLibraryHarness {
 }
 
 contract DiamondProxyHarness is Diamond {
-    constructor(address initialOwner) Diamond(initialOwner) {}
+    constructor(address initialOwner, address initialCutFacet) Diamond(initialOwner, initialCutFacet) {}
 
     function owner() external view returns (address) {
         return LibDiamond.contractOwner();


### PR DESCRIPTION
## Summary
- bootstrap `diamondCut` in the `Diamond` constructor by accepting an initial cut facet during deployment
- add a Foundry deployment script that deploys the diamond core, installs loupe selectors, validates the bootstrap, and writes a local deployment artifact
- update diamond core tests to use the production bootstrap path and document the local bootstrap workflow
- allow script artifact output under `deployments/` via Foundry file-system permissions

## Validation
- `forge test --offline`
- `forge script script/DeployDiamondCore.s.sol:DeployDiamondCoreScript --rpc-url http://127.0.0.1:8545 --broadcast`

## Issue
- Closes #72