### PR TITLE
Add Anvil-backed smoke flow for deployed diamond core

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ facets without a full rewrite.
 - `src/libraries`: shared cross-module libraries.
 - `script`: Foundry deployment and bootstrap flows.
 - `deployments`: local deployment artifacts written by scripts.
+- `script/common`: shared Foundry script helpers and cheatcode interfaces.
 - `test`: split by concern (`*Core.t.sol`, `*Time.t.sol`, `*Integration.t.sol`).
 - `test/helpers`: shared test fixtures and harnesses.
 - `docs`: usage notes and design decisions.
@@ -44,6 +45,7 @@ forge coverage
 forge fmt
 anvil
 forge script script/DeployDiamondCore.s.sol:DeployDiamondCoreScript --rpc-url http://127.0.0.1:8545 --broadcast
+bash script/run-local-diamond-smoke.sh
 ```
 
 ## Testing
@@ -77,6 +79,7 @@ forge script script/DeployDiamondCore.s.sol:DeployDiamondCoreScript --rpc-url ht
 - Upgrade execution runbook: `docs/ops/runbook-upgrade-execution.md`
 - Milestone close checklist: `docs/ops/milestone-close-checklist.md`
 - Local diamond bootstrap: `docs/ops/local-diamond-bootstrap.md`
+- Local diamond smoke flow: `docs/ops/local-diamond-smoke.md`
 
 ## Tooling
 - Foundry docs: [book.getfoundry.sh](https://book.getfoundry.sh/)

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -5,6 +5,7 @@ This folder contains release and incident-response operational guides.
 - Release checklist: `docs/ops/release-checklist.md`
 - Release notes template: `docs/ops/release-notes-template.md`
 - Local diamond bootstrap: `docs/ops/local-diamond-bootstrap.md`
+- Local diamond smoke flow: `docs/ops/local-diamond-smoke.md`
 - Diamond cut runbook: `docs/ops/runbook-diamond-cut.md`
 - Oracle incident runbook: `docs/ops/runbook-oracle-incident.md`
 - Pause/unpause runbook: `docs/ops/runbook-pause-unpause.md`

--- a/docs/ops/local-diamond-bootstrap.md
+++ b/docs/ops/local-diamond-bootstrap.md
@@ -58,3 +58,12 @@ Current fields:
 - `diamondLoupeFacet`
 
 These outputs are intended to feed later E2E and upgrade rehearsal work.
+
+## Follow-Up Smoke Checks
+
+After bootstrap, run the local smoke suite to validate live routing and a
+reference admin state transition against the deployed environment:
+
+```shell
+bash script/run-local-diamond-smoke.sh
+```

--- a/docs/ops/local-diamond-smoke.md
+++ b/docs/ops/local-diamond-smoke.md
@@ -1,0 +1,42 @@
+# Local Diamond Smoke Flow
+
+This repo now includes a deterministic local smoke flow for the deployed diamond
+core.
+
+## What It Covers
+
+- boots a fresh local Anvil chain
+- deploys the reference diamond core through the Foundry bootstrap script
+- validates live loupe and ownership routing from the deployment artifact
+- executes a real ownership transfer on the deployed diamond
+- revalidates the post-transfer state
+
+The smoke flow runs against deployed contracts on a local RPC target rather than
+only isolated harnesses.
+
+## Run
+
+```shell
+bash script/run-local-diamond-smoke.sh
+```
+
+## Default Environment
+
+The runner uses Anvil defaults unless overridden:
+
+- `ANVIL_HOST=127.0.0.1`
+- `ANVIL_PORT=8545`
+- `ANVIL_CHAIN_ID=31337`
+- `PRIVATE_KEY=<anvil account 0>`
+- `NEXT_OWNER_PRIVATE_KEY=<deterministic local test key>`
+
+It also clears proxy environment variables so local RPC calls do not get routed
+through a system proxy.
+
+## Output
+
+- deployment artifact: `deployments/diamond-core.local.json`
+- Anvil log: `.anvil-smoke.log`
+
+This flow is intended to become the baseline smoke suite reused by later
+upgrade rehearsal and CI work.

--- a/script/DeployDiamondCore.s.sol
+++ b/script/DeployDiamondCore.s.sol
@@ -7,33 +7,11 @@ import {DiamondLoupeFacet} from "../src/diamond/facets/DiamondLoupeFacet.sol";
 import {IDiamondCut} from "../src/interfaces/IDiamondCut.sol";
 import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
 import {IERC173} from "../src/interfaces/IERC173.sol";
-
-interface Vm {
-    function addr(uint256 privateKey) external returns (address);
-    function envUint(string calldata name) external returns (uint256);
-    function projectRoot() external view returns (string memory);
-    function serializeAddress(string calldata objectKey, string calldata valueKey, address value)
-        external
-        returns (string memory);
-    function serializeString(string calldata objectKey, string calldata valueKey, string calldata value)
-        external
-        returns (string memory);
-    function serializeUint(string calldata objectKey, string calldata valueKey, uint256 value)
-        external
-        returns (string memory);
-    function startBroadcast(uint256 privateKey) external;
-    function stopBroadcast() external;
-    function writeJson(string calldata json, string calldata path) external;
-}
+import {DiamondCoreScriptBase} from "./common/DiamondCoreScriptBase.sol";
 
 /// @title DeployDiamondCoreScript
 /// @notice Reference local deployment flow for a bootstrapped diamond core.
-contract DeployDiamondCoreScript {
-    Vm internal constant VM = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
-
-    string internal constant DEPLOYMENT_OBJECT = "diamondCore";
-    string internal constant OUTPUT_RELATIVE_PATH = "/deployments/diamond-core.local.json";
-
+contract DeployDiamondCoreScript is DiamondCoreScriptBase {
     /// @notice Deploys `Diamond`, `DiamondCutFacet`, and `DiamondLoupeFacet`, then bootstraps loupe selectors.
     /// @dev Requires `PRIVATE_KEY` to be set in the environment.
     /// @return diamondAddress The deployed diamond proxy.
@@ -101,7 +79,7 @@ contract DeployDiamondCoreScript {
         json = VM.serializeAddress(DEPLOYMENT_OBJECT, "diamond", diamondAddress);
         json = VM.serializeAddress(DEPLOYMENT_OBJECT, "diamondCutFacet", cutFacetAddress);
         json = VM.serializeAddress(DEPLOYMENT_OBJECT, "diamondLoupeFacet", loupeFacetAddress);
-        VM.writeJson(json, string.concat(VM.projectRoot(), OUTPUT_RELATIVE_PATH));
+        VM.writeJson(json, deploymentArtifactPath());
     }
 
     function _loupeSelectors() internal pure returns (bytes4[] memory selectors) {

--- a/script/SmokeDiamondCore.s.sol
+++ b/script/SmokeDiamondCore.s.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {DiamondCutFacet} from "../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../src/diamond/facets/DiamondLoupeFacet.sol";
+import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
+import {IERC173} from "../src/interfaces/IERC173.sol";
+import {DiamondCoreScriptBase} from "./common/DiamondCoreScriptBase.sol";
+
+/// @title SmokeDiamondCoreScript
+/// @notice Anvil-backed smoke flow that validates a deployed local diamond core artifact.
+contract SmokeDiamondCoreScript is DiamondCoreScriptBase {
+    /// @notice Runs deterministic post-bootstrap smoke checks against the local deployment artifact.
+    /// @dev Requires `PRIVATE_KEY` and `NEXT_OWNER_PRIVATE_KEY` to be set in the environment.
+    /// @return diamondAddress The validated diamond address.
+    function run() external returns (address diamondAddress) {
+        uint256 ownerPrivateKey = VM.envUint("PRIVATE_KEY");
+        uint256 nextOwnerPrivateKey = VM.envUint("NEXT_OWNER_PRIVATE_KEY");
+        address owner = VM.addr(ownerPrivateKey);
+        address nextOwner = VM.addr(nextOwnerPrivateKey);
+        address cutFacetAddress;
+        address loupeFacetAddress;
+
+        require(nextOwner != owner, "smoke next owner matches owner");
+
+        (diamondAddress, cutFacetAddress, loupeFacetAddress) = _loadDeploymentArtifact();
+
+        _validateBootstrap(diamondAddress, owner, cutFacetAddress, loupeFacetAddress);
+        _exerciseOwnershipTransfer(diamondAddress, ownerPrivateKey, nextOwner);
+        _validatePostTransfer(diamondAddress, nextOwner, cutFacetAddress, loupeFacetAddress);
+    }
+
+    function _loadDeploymentArtifact()
+        internal
+        view
+        returns (address diamondAddress, address cutFacet, address loupeFacet)
+    {
+        string memory json = VM.readFile(deploymentArtifactPath());
+        diamondAddress = VM.parseJsonAddress(json, ".diamond");
+        cutFacet = VM.parseJsonAddress(json, ".diamondCutFacet");
+        loupeFacet = VM.parseJsonAddress(json, ".diamondLoupeFacet");
+
+        require(diamondAddress != address(0), "smoke diamond missing");
+        require(cutFacet != address(0), "smoke cut facet missing");
+        require(loupeFacet != address(0), "smoke loupe facet missing");
+    }
+
+    function _validateBootstrap(
+        address diamondAddress,
+        address owner,
+        address cutFacetAddress,
+        address loupeFacetAddress
+    ) internal view {
+        IERC173 ownership = IERC173(diamondAddress);
+        IDiamondLoupe loupe = IDiamondLoupe(diamondAddress);
+
+        require(ownership.owner() == owner, "smoke bootstrap owner mismatch");
+        require(
+            loupe.facetAddress(DiamondCutFacet.diamondCut.selector) == cutFacetAddress,
+            "smoke diamondCut selector mismatch"
+        );
+        require(
+            loupe.facetAddress(DiamondLoupeFacet.owner.selector) == loupeFacetAddress, "smoke owner selector mismatch"
+        );
+
+        address[] memory facetAddresses = loupe.facetAddresses();
+        require(facetAddresses.length == 2, "smoke facet address count mismatch");
+        require(facetAddresses[0] == cutFacetAddress, "smoke cut facet address mismatch");
+        require(facetAddresses[1] == loupeFacetAddress, "smoke loupe facet address mismatch");
+
+        bytes4[] memory cutSelectors = loupe.facetFunctionSelectors(cutFacetAddress);
+        require(cutSelectors.length == 1, "smoke cut selector count mismatch");
+        require(cutSelectors[0] == DiamondCutFacet.diamondCut.selector, "smoke cut selector value mismatch");
+
+        bytes4[] memory loupeSelectors = loupe.facetFunctionSelectors(loupeFacetAddress);
+        require(loupeSelectors.length == 6, "smoke loupe selector count mismatch");
+
+        IDiamondLoupe.Facet[] memory snapshot = loupe.facets();
+        require(snapshot.length == 2, "smoke facets snapshot count mismatch");
+        require(snapshot[0].facetAddress == cutFacetAddress, "smoke snapshot cut facet mismatch");
+        require(snapshot[1].facetAddress == loupeFacetAddress, "smoke snapshot loupe facet mismatch");
+    }
+
+    function _exerciseOwnershipTransfer(address diamondAddress, uint256 ownerPrivateKey, address nextOwner) internal {
+        VM.startBroadcast(ownerPrivateKey);
+        IERC173(diamondAddress).transferOwnership(nextOwner);
+        VM.stopBroadcast();
+    }
+
+    function _validatePostTransfer(
+        address diamondAddress,
+        address nextOwner,
+        address cutFacetAddress,
+        address loupeFacetAddress
+    ) internal view {
+        IERC173 ownership = IERC173(diamondAddress);
+        IDiamondLoupe loupe = IDiamondLoupe(diamondAddress);
+
+        require(ownership.owner() == nextOwner, "smoke post-transfer owner mismatch");
+        require(
+            loupe.facetAddress(DiamondCutFacet.diamondCut.selector) == cutFacetAddress,
+            "smoke post-transfer cut selector mismatch"
+        );
+        require(
+            loupe.facetAddress(DiamondLoupeFacet.transferOwnership.selector) == loupeFacetAddress,
+            "smoke post-transfer ownership routing mismatch"
+        );
+    }
+}

--- a/script/common/DiamondCoreScriptBase.sol
+++ b/script/common/DiamondCoreScriptBase.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Vm} from "./Vm.sol";
+
+/// @title DiamondCoreScriptBase
+/// @notice Shared Foundry script helpers for local diamond core deployment and smoke flows.
+abstract contract DiamondCoreScriptBase {
+    /// @dev Foundry cheatcode address.
+    Vm internal constant VM = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    /// @dev Deployment artifact root object.
+    string internal constant DEPLOYMENT_OBJECT = "diamondCore";
+    /// @dev Relative output path for the local diamond core deployment artifact.
+    string internal constant OUTPUT_RELATIVE_PATH = "/deployments/diamond-core.local.json";
+
+    /// @notice Returns the absolute path to the local deployment artifact.
+    function deploymentArtifactPath() internal view returns (string memory) {
+        return string.concat(VM.projectRoot(), OUTPUT_RELATIVE_PATH);
+    }
+}

--- a/script/common/Vm.sol
+++ b/script/common/Vm.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title Vm
+/// @notice Minimal Foundry cheatcode interface shared by local deployment and smoke scripts.
+interface Vm {
+    function addr(uint256 privateKey) external returns (address);
+    function envUint(string calldata name) external returns (uint256);
+    function parseJsonAddress(string calldata json, string calldata key) external pure returns (address);
+    function projectRoot() external view returns (string memory);
+    function readFile(string calldata path) external view returns (string memory);
+    function serializeAddress(string calldata objectKey, string calldata valueKey, address value)
+        external
+        returns (string memory);
+    function serializeString(string calldata objectKey, string calldata valueKey, string calldata value)
+        external
+        returns (string memory);
+    function serializeUint(string calldata objectKey, string calldata valueKey, uint256 value)
+        external
+        returns (string memory);
+    function startBroadcast(uint256 privateKey) external;
+    function stopBroadcast() external;
+    function writeJson(string calldata json, string calldata path) external;
+}

--- a/script/run-local-diamond-smoke.sh
+++ b/script/run-local-diamond-smoke.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ANVIL_HOST="${ANVIL_HOST:-127.0.0.1}"
+ANVIL_PORT="${ANVIL_PORT:-8545}"
+ANVIL_CHAIN_ID="${ANVIL_CHAIN_ID:-31337}"
+RPC_URL="${RPC_URL:-http://${ANVIL_HOST}:${ANVIL_PORT}}"
+ANVIL_LOG_PATH="${ANVIL_LOG_PATH:-${ROOT_DIR}/.anvil-smoke.log}"
+PRIVATE_KEY="${PRIVATE_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}"
+NEXT_OWNER_PRIVATE_KEY="${NEXT_OWNER_PRIVATE_KEY:-0x59c6995e998f97a5a0044976f094538e0d7bafad8d4d49d7dc1f6c4b2f6e6d5f}"
+
+export PRIVATE_KEY
+export NEXT_OWNER_PRIVATE_KEY
+export NO_PROXY="${NO_PROXY:-127.0.0.1,localhost}"
+unset HTTP_PROXY HTTPS_PROXY ALL_PROXY http_proxy https_proxy all_proxy
+
+ANVIL_PID=""
+
+cleanup() {
+  if [[ -n "${ANVIL_PID}" ]] && kill -0 "${ANVIL_PID}" >/dev/null 2>&1; then
+    kill "${ANVIL_PID}" >/dev/null 2>&1 || true
+    wait "${ANVIL_PID}" >/dev/null 2>&1 || true
+  fi
+}
+
+trap cleanup EXIT
+
+rm -f "${ROOT_DIR}/deployments/diamond-core.local.json"
+
+anvil --host "${ANVIL_HOST}" --port "${ANVIL_PORT}" --chain-id "${ANVIL_CHAIN_ID}" >"${ANVIL_LOG_PATH}" 2>&1 &
+ANVIL_PID="$!"
+
+for _ in {1..30}; do
+  if cast block-number --rpc-url "${RPC_URL}" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+if ! cast block-number --rpc-url "${RPC_URL}" >/dev/null 2>&1; then
+  echo "Anvil did not become ready. See ${ANVIL_LOG_PATH}."
+  exit 1
+fi
+
+cd "${ROOT_DIR}"
+
+forge script script/DeployDiamondCore.s.sol:DeployDiamondCoreScript --rpc-url "${RPC_URL}" --broadcast
+forge script script/SmokeDiamondCore.s.sol:SmokeDiamondCoreScript --rpc-url "${RPC_URL}" --broadcast
+
+echo "Local diamond smoke flow passed."


### PR DESCRIPTION
## Summary
- add a live smoke script that reads the local deployment artifact, validates live loupe and ownership routing, and executes a real ownership transfer on the deployed diamond
- add a one-command Anvil runner that boots a fresh local chain, deploys the reference diamond core, and runs the smoke flow end-to-end
- factor common Foundry script helpers into a shared base so local deploy and smoke scripts use the same artifact path and cheatcode surface
- document the local smoke flow and link it from the existing bootstrap and ops docs

## Validation
- `forge test --offline`
- `bash script/run-local-diamond-smoke.sh`

## Issue
- Closes #71