### PR TITLE
Add local diamond upgrade rehearsal coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ forge fmt
 anvil
 forge script script/DeployDiamondCore.s.sol:DeployDiamondCoreScript --rpc-url http://127.0.0.1:8545 --broadcast
 bash script/run-local-diamond-smoke.sh
+bash script/run-local-diamond-upgrade-rehearsal.sh
 ```
 
 ## Testing

--- a/script/RehearseDiamondUpgrade.s.sol
+++ b/script/RehearseDiamondUpgrade.s.sol
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {DiamondCutFacet} from "../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../src/diamond/facets/DiamondLoupeFacet.sol";
+import {IDiamondCut} from "../src/interfaces/IDiamondCut.sol";
+import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
+import {IERC173} from "../src/interfaces/IERC173.sol";
+import {DiamondCoreScriptBase} from "./common/DiamondCoreScriptBase.sol";
+import {
+    DiamondUpgradeCollisionFacet,
+    DiamondUpgradeFailureFacet,
+    DiamondUpgradeFacetV1,
+    DiamondUpgradeFacetV2,
+    DiamondUpgradeInitMock,
+    DiamondUpgradeStateFacet
+} from "./helpers/DiamondUpgradeRehearsalFixtures.sol";
+
+/// @title RehearseDiamondUpgradeScript
+/// @notice Rehearses a realistic local diamond upgrade and validates the post-cut state.
+contract RehearseDiamondUpgradeScript is DiamondCoreScriptBase {
+    string internal constant REHEARSAL_OBJECT = "diamondCoreUpgradeRehearsal";
+    string internal constant REHEARSAL_OUTPUT_RELATIVE_PATH = "/deployments/diamond-core.upgrade-rehearsal.local.json";
+
+    /// @notice Runs a local upgrade rehearsal against the deployed diamond core artifact.
+    /// @dev Requires `PRIVATE_KEY` to point at the current diamond owner.
+    /// @return diamondAddress The upgraded diamond address.
+    function run() external returns (address diamondAddress) {
+        uint256 ownerPrivateKey = VM.envUint("PRIVATE_KEY");
+        address owner = VM.addr(ownerPrivateKey);
+        DeploymentArtifact memory deployment = loadDeploymentArtifact();
+
+        diamondAddress = deployment.diamond;
+
+        _validateBaseDeployment(diamondAddress, owner, deployment.diamondCutFacet, deployment.diamondLoupeFacet);
+
+        VM.startBroadcast(ownerPrivateKey);
+
+        DiamondUpgradeFacetV1 baselineFacet = new DiamondUpgradeFacetV1();
+        DiamondUpgradeFacetV2 upgradeFacet = new DiamondUpgradeFacetV2();
+        DiamondUpgradeStateFacet stateFacet = new DiamondUpgradeStateFacet();
+        DiamondUpgradeInitMock initMock = new DiamondUpgradeInitMock();
+        DiamondUpgradeCollisionFacet collisionFacet = new DiamondUpgradeCollisionFacet();
+        DiamondUpgradeFailureFacet failureFacet = new DiamondUpgradeFailureFacet();
+
+        IDiamondCut(address(diamondAddress)).diamondCut(_baselineCut(address(baselineFacet)), address(0), "");
+        IDiamondCut(address(diamondAddress))
+            .diamondCut(
+                _upgradeCut(address(upgradeFacet), address(stateFacet)),
+                address(initMock),
+                abi.encodeCall(DiamondUpgradeInitMock.initializeValue, (42))
+            );
+
+        VM.stopBroadcast();
+
+        _validatePostCutChecklist(
+            diamondAddress,
+            owner,
+            deployment.diamondCutFacet,
+            deployment.diamondLoupeFacet,
+            address(baselineFacet),
+            address(upgradeFacet),
+            address(stateFacet)
+        );
+
+        _writeRehearsalArtifact(
+            owner,
+            diamondAddress,
+            deployment.diamondCutFacet,
+            deployment.diamondLoupeFacet,
+            address(baselineFacet),
+            address(upgradeFacet),
+            address(stateFacet),
+            address(initMock),
+            address(collisionFacet),
+            address(failureFacet)
+        );
+    }
+
+    function _validateBaseDeployment(
+        address diamondAddress,
+        address owner,
+        address cutFacetAddress,
+        address loupeFacetAddress
+    ) internal view {
+        IERC173 ownership = IERC173(diamondAddress);
+        IDiamondLoupe loupe = IDiamondLoupe(diamondAddress);
+
+        require(ownership.owner() == owner, "upgrade base owner mismatch");
+        require(
+            loupe.facetAddress(DiamondCutFacet.diamondCut.selector) == cutFacetAddress,
+            "upgrade base cut selector mismatch"
+        );
+        require(
+            loupe.facetAddress(DiamondLoupeFacet.facets.selector) == loupeFacetAddress,
+            "upgrade base loupe selector mismatch"
+        );
+        require(loupe.facetAddresses().length == 2, "upgrade base facet count mismatch");
+    }
+
+    function _validatePostCutChecklist(
+        address diamondAddress,
+        address owner,
+        address cutFacetAddress,
+        address loupeFacetAddress,
+        address baselineFacetAddress,
+        address upgradeFacetAddress,
+        address stateFacetAddress
+    ) internal view {
+        IERC173 ownership = IERC173(diamondAddress);
+        IDiamondLoupe loupe = IDiamondLoupe(diamondAddress);
+
+        require(ownership.owner() == owner, "upgrade owner continuity mismatch");
+
+        address[] memory facetAddresses = loupe.facetAddresses();
+        require(facetAddresses.length == 4, "upgrade post-cut facet count mismatch");
+        require(_containsAddress(facetAddresses, cutFacetAddress), "upgrade missing cut facet");
+        require(_containsAddress(facetAddresses, loupeFacetAddress), "upgrade missing loupe facet");
+        require(_containsAddress(facetAddresses, upgradeFacetAddress), "upgrade missing replacement facet");
+        require(_containsAddress(facetAddresses, stateFacetAddress), "upgrade missing state facet");
+
+        bytes4[] memory upgradeSelectors = loupe.facetFunctionSelectors(upgradeFacetAddress);
+        require(upgradeSelectors.length == 3, "upgrade replacement selector count mismatch");
+        require(_containsSelector(upgradeSelectors, DiamondUpgradeFacetV2.alpha.selector), "upgrade missing alpha");
+        require(_containsSelector(upgradeSelectors, DiamondUpgradeFacetV2.epsilon.selector), "upgrade missing epsilon");
+        require(_containsSelector(upgradeSelectors, DiamondUpgradeFacetV2.caller.selector), "upgrade missing caller");
+        require(
+            loupe.facetFunctionSelectors(baselineFacetAddress).length == 0, "upgrade baseline selectors not cleared"
+        );
+
+        bytes4[] memory stateSelectors = loupe.facetFunctionSelectors(stateFacetAddress);
+        require(stateSelectors.length == 1, "upgrade state selector count mismatch");
+        require(stateSelectors[0] == DiamondUpgradeStateFacet.readValue.selector, "upgrade readValue selector mismatch");
+
+        require(
+            loupe.facetAddress(DiamondCutFacet.diamondCut.selector) == cutFacetAddress,
+            "upgrade cut selector ownership mismatch"
+        );
+        require(
+            loupe.facetAddress(DiamondLoupeFacet.facets.selector) == loupeFacetAddress,
+            "upgrade loupe selector ownership mismatch"
+        );
+        require(
+            loupe.facetAddress(DiamondUpgradeFacetV2.alpha.selector) == upgradeFacetAddress,
+            "upgrade alpha selector ownership mismatch"
+        );
+        require(
+            loupe.facetAddress(DiamondUpgradeFacetV2.caller.selector) == upgradeFacetAddress,
+            "upgrade caller selector ownership mismatch"
+        );
+        require(
+            loupe.facetAddress(DiamondUpgradeFacetV2.epsilon.selector) == upgradeFacetAddress,
+            "upgrade epsilon selector ownership mismatch"
+        );
+        require(
+            loupe.facetAddress(DiamondUpgradeStateFacet.readValue.selector) == stateFacetAddress,
+            "upgrade readValue selector ownership mismatch"
+        );
+        require(
+            loupe.facetAddress(DiamondUpgradeFacetV1.beta.selector) == address(0),
+            "upgrade removed beta selector still routed"
+        );
+
+        IDiamondLoupe.Facet[] memory snapshot = loupe.facets();
+        require(snapshot.length == 4, "upgrade loupe snapshot count mismatch");
+
+        _assertCallReturnsUint256(
+            diamondAddress, abi.encodeCall(DiamondUpgradeFacetV2.alpha, ()), 11, "upgrade alpha call mismatch"
+        );
+        _assertCallReturnsUint256(
+            diamondAddress, abi.encodeCall(DiamondUpgradeFacetV2.epsilon, ()), 5, "upgrade epsilon call mismatch"
+        );
+        _assertCallReturnsUint256(
+            diamondAddress, abi.encodeCall(DiamondUpgradeStateFacet.readValue, ()), 42, "upgrade init value mismatch"
+        );
+    }
+
+    function _baselineCut(address baselineFacetAddress) internal pure returns (IDiamondCut.FacetCut[] memory cut) {
+        cut = new IDiamondCut.FacetCut[](1);
+        bytes4[] memory selectors = new bytes4[](3);
+        selectors[0] = DiamondUpgradeFacetV1.alpha.selector;
+        selectors[1] = DiamondUpgradeFacetV1.beta.selector;
+        selectors[2] = DiamondUpgradeFacetV1.caller.selector;
+
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: baselineFacetAddress, action: IDiamondCut.FacetCutAction.Add, functionSelectors: selectors
+        });
+    }
+
+    function _upgradeCut(address upgradeFacetAddress, address stateFacetAddress)
+        internal
+        pure
+        returns (IDiamondCut.FacetCut[] memory cut)
+    {
+        cut = new IDiamondCut.FacetCut[](4);
+
+        bytes4[] memory replaceSelectors = new bytes4[](2);
+        replaceSelectors[0] = DiamondUpgradeFacetV2.alpha.selector;
+        replaceSelectors[1] = DiamondUpgradeFacetV2.caller.selector;
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: upgradeFacetAddress,
+            action: IDiamondCut.FacetCutAction.Replace,
+            functionSelectors: replaceSelectors
+        });
+
+        bytes4[] memory removeSelectors = new bytes4[](1);
+        removeSelectors[0] = DiamondUpgradeFacetV1.beta.selector;
+        cut[1] = IDiamondCut.FacetCut({
+            facetAddress: address(0), action: IDiamondCut.FacetCutAction.Remove, functionSelectors: removeSelectors
+        });
+
+        bytes4[] memory addUpgradeSelectors = new bytes4[](1);
+        addUpgradeSelectors[0] = DiamondUpgradeFacetV2.epsilon.selector;
+        cut[2] = IDiamondCut.FacetCut({
+            facetAddress: upgradeFacetAddress,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: addUpgradeSelectors
+        });
+
+        bytes4[] memory addStateSelectors = new bytes4[](1);
+        addStateSelectors[0] = DiamondUpgradeStateFacet.readValue.selector;
+        cut[3] = IDiamondCut.FacetCut({
+            facetAddress: stateFacetAddress,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: addStateSelectors
+        });
+    }
+
+    function _writeRehearsalArtifact(
+        address owner,
+        address diamondAddress,
+        address cutFacetAddress,
+        address loupeFacetAddress,
+        address baselineFacetAddress,
+        address upgradeFacetAddress,
+        address stateFacetAddress,
+        address initMockAddress,
+        address collisionFacetAddress,
+        address failureFacetAddress
+    ) internal {
+        string memory json = VM.serializeString(REHEARSAL_OBJECT, "network", "local-anvil");
+        json = VM.serializeUint(REHEARSAL_OBJECT, "chainId", block.chainid);
+        json = VM.serializeAddress(REHEARSAL_OBJECT, "owner", owner);
+        json = VM.serializeAddress(REHEARSAL_OBJECT, "diamond", diamondAddress);
+        json = VM.serializeAddress(REHEARSAL_OBJECT, "diamondCutFacet", cutFacetAddress);
+        json = VM.serializeAddress(REHEARSAL_OBJECT, "diamondLoupeFacet", loupeFacetAddress);
+        json = VM.serializeAddress(REHEARSAL_OBJECT, "baselineFacet", baselineFacetAddress);
+        json = VM.serializeAddress(REHEARSAL_OBJECT, "upgradeFacet", upgradeFacetAddress);
+        json = VM.serializeAddress(REHEARSAL_OBJECT, "stateFacet", stateFacetAddress);
+        json = VM.serializeAddress(REHEARSAL_OBJECT, "initMock", initMockAddress);
+        json = VM.serializeAddress(REHEARSAL_OBJECT, "collisionFacet", collisionFacetAddress);
+        json = VM.serializeAddress(REHEARSAL_OBJECT, "failureFacet", failureFacetAddress);
+        VM.writeJson(json, string.concat(VM.projectRoot(), REHEARSAL_OUTPUT_RELATIVE_PATH));
+    }
+
+    function _assertCallReturnsUint256(
+        address diamondAddress,
+        bytes memory callData,
+        uint256 expectedValue,
+        string memory message
+    ) internal view {
+        (bool success, bytes memory returndata) = diamondAddress.staticcall(callData);
+        require(success, message);
+        require(abi.decode(returndata, (uint256)) == expectedValue, message);
+    }
+
+    function _containsAddress(address[] memory values, address expected) internal pure returns (bool) {
+        uint256 length = values.length;
+        for (uint256 i = 0; i < length; i++) {
+            if (values[i] == expected) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    function _containsSelector(bytes4[] memory values, bytes4 expected) internal pure returns (bool) {
+        uint256 length = values.length;
+        for (uint256 i = 0; i < length; i++) {
+            if (values[i] == expected) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/script/SmokeDiamondCore.s.sol
+++ b/script/SmokeDiamondCore.s.sol
@@ -18,31 +18,16 @@ contract SmokeDiamondCoreScript is DiamondCoreScriptBase {
         uint256 nextOwnerPrivateKey = VM.envUint("NEXT_OWNER_PRIVATE_KEY");
         address owner = VM.addr(ownerPrivateKey);
         address nextOwner = VM.addr(nextOwnerPrivateKey);
-        address cutFacetAddress;
-        address loupeFacetAddress;
+        DeploymentArtifact memory deployment;
 
         require(nextOwner != owner, "smoke next owner matches owner");
 
-        (diamondAddress, cutFacetAddress, loupeFacetAddress) = _loadDeploymentArtifact();
+        deployment = loadDeploymentArtifact();
+        diamondAddress = deployment.diamond;
 
-        _validateBootstrap(diamondAddress, owner, cutFacetAddress, loupeFacetAddress);
+        _validateBootstrap(diamondAddress, owner, deployment.diamondCutFacet, deployment.diamondLoupeFacet);
         _exerciseOwnershipTransfer(diamondAddress, ownerPrivateKey, nextOwner);
-        _validatePostTransfer(diamondAddress, nextOwner, cutFacetAddress, loupeFacetAddress);
-    }
-
-    function _loadDeploymentArtifact()
-        internal
-        view
-        returns (address diamondAddress, address cutFacet, address loupeFacet)
-    {
-        string memory json = VM.readFile(deploymentArtifactPath());
-        diamondAddress = VM.parseJsonAddress(json, ".diamond");
-        cutFacet = VM.parseJsonAddress(json, ".diamondCutFacet");
-        loupeFacet = VM.parseJsonAddress(json, ".diamondLoupeFacet");
-
-        require(diamondAddress != address(0), "smoke diamond missing");
-        require(cutFacet != address(0), "smoke cut facet missing");
-        require(loupeFacet != address(0), "smoke loupe facet missing");
+        _validatePostTransfer(diamondAddress, nextOwner, deployment.diamondCutFacet, deployment.diamondLoupeFacet);
     }
 
     function _validateBootstrap(

--- a/script/common/DiamondCoreScriptBase.sol
+++ b/script/common/DiamondCoreScriptBase.sol
@@ -6,6 +6,13 @@ import {Vm} from "./Vm.sol";
 /// @title DiamondCoreScriptBase
 /// @notice Shared Foundry script helpers for local diamond core deployment and smoke flows.
 abstract contract DiamondCoreScriptBase {
+    /// @notice Parsed addresses from the local deployment artifact.
+    struct DeploymentArtifact {
+        address diamond;
+        address diamondCutFacet;
+        address diamondLoupeFacet;
+    }
+
     /// @dev Foundry cheatcode address.
     Vm internal constant VM = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
 
@@ -17,5 +24,18 @@ abstract contract DiamondCoreScriptBase {
     /// @notice Returns the absolute path to the local deployment artifact.
     function deploymentArtifactPath() internal view returns (string memory) {
         return string.concat(VM.projectRoot(), OUTPUT_RELATIVE_PATH);
+    }
+
+    /// @notice Loads the local deployment artifact and returns its canonical diamond addresses.
+    function loadDeploymentArtifact() internal view returns (DeploymentArtifact memory deployment) {
+        string memory json = VM.readFile(deploymentArtifactPath());
+
+        deployment.diamond = VM.parseJsonAddress(json, ".diamond");
+        deployment.diamondCutFacet = VM.parseJsonAddress(json, ".diamondCutFacet");
+        deployment.diamondLoupeFacet = VM.parseJsonAddress(json, ".diamondLoupeFacet");
+
+        require(deployment.diamond != address(0), "deployment artifact diamond missing");
+        require(deployment.diamondCutFacet != address(0), "deployment artifact cut facet missing");
+        require(deployment.diamondLoupeFacet != address(0), "deployment artifact loupe facet missing");
     }
 }

--- a/script/helpers/DiamondUpgradeRehearsalFixtures.sol
+++ b/script/helpers/DiamondUpgradeRehearsalFixtures.sol
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title DiamondUpgradeFacetV1
+/// @notice Baseline facet used by the local upgrade rehearsal flow.
+contract DiamondUpgradeFacetV1 {
+    function alpha() external pure returns (uint256) {
+        return 1;
+    }
+
+    function beta() external pure returns (uint256) {
+        return 2;
+    }
+
+    function caller() external view returns (address) {
+        return msg.sender;
+    }
+}
+
+/// @title DiamondUpgradeFacetV2
+/// @notice Replacement facet used by the local upgrade rehearsal flow.
+contract DiamondUpgradeFacetV2 {
+    function alpha() external pure returns (uint256) {
+        return 11;
+    }
+
+    function epsilon() external pure returns (uint256) {
+        return 5;
+    }
+
+    function caller() external view returns (address) {
+        return msg.sender;
+    }
+}
+
+/// @title DiamondUpgradeCollisionFacet
+/// @notice Facet that intentionally collides on `alpha()` for failed-cut rehearsal coverage.
+contract DiamondUpgradeCollisionFacet {
+    function gamma() external pure returns (uint256) {
+        return 3;
+    }
+
+    function alpha() external pure returns (uint256) {
+        return 77;
+    }
+}
+
+/// @title DiamondUpgradeFailureFacet
+/// @notice Facet used to prove init failures do not leave partial routing state.
+contract DiamondUpgradeFailureFacet {
+    function zeta() external pure returns (uint256) {
+        return 6;
+    }
+}
+
+library LibDiamondUpgradeRehearsalStorage {
+    bytes32 internal constant STORAGE_SLOT = keccak256("smart-contracts.script.diamond-upgrade-rehearsal.storage");
+
+    struct Layout {
+        uint256 value;
+    }
+
+    function layout() internal pure returns (Layout storage l) {
+        bytes32 slot = STORAGE_SLOT;
+        assembly {
+            l.slot := slot
+        }
+    }
+}
+
+/// @title DiamondUpgradeStateFacet
+/// @notice Read surface for the storage value set during init rehearsal.
+contract DiamondUpgradeStateFacet {
+    function readValue() external view returns (uint256) {
+        return LibDiamondUpgradeRehearsalStorage.layout().value;
+    }
+}
+
+/// @title DiamondUpgradeInitMock
+/// @notice Init delegatecall target for successful and failed upgrade rehearsal paths.
+contract DiamondUpgradeInitMock {
+    error InitFailure();
+
+    function initializeValue(uint256 value_) external {
+        LibDiamondUpgradeRehearsalStorage.layout().value = value_;
+    }
+
+    function revertInit() external pure {
+        revert InitFailure();
+    }
+}

--- a/script/run-local-diamond-upgrade-rehearsal.sh
+++ b/script/run-local-diamond-upgrade-rehearsal.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ANVIL_HOST="${ANVIL_HOST:-127.0.0.1}"
+ANVIL_PORT="${ANVIL_PORT:-8545}"
+ANVIL_CHAIN_ID="${ANVIL_CHAIN_ID:-31337}"
+RPC_URL="${RPC_URL:-http://${ANVIL_HOST}:${ANVIL_PORT}}"
+ANVIL_LOG_PATH="${ANVIL_LOG_PATH:-${ROOT_DIR}/.anvil-upgrade-rehearsal.log}"
+PRIVATE_KEY="${PRIVATE_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}"
+DEPLOYMENT_ARTIFACT="${ROOT_DIR}/deployments/diamond-core.local.json"
+REHEARSAL_ARTIFACT="${ROOT_DIR}/deployments/diamond-core.upgrade-rehearsal.local.json"
+ZERO_ADDRESS="0x0000000000000000000000000000000000000000"
+
+export PRIVATE_KEY
+export NO_PROXY="${NO_PROXY:-127.0.0.1,localhost}"
+unset HTTP_PROXY HTTPS_PROXY ALL_PROXY http_proxy https_proxy all_proxy
+
+ANVIL_PID=""
+
+cleanup() {
+  if [[ -n "${ANVIL_PID}" ]] && kill -0 "${ANVIL_PID}" >/dev/null 2>&1; then
+    kill "${ANVIL_PID}" >/dev/null 2>&1 || true
+    wait "${ANVIL_PID}" >/dev/null 2>&1 || true
+  fi
+}
+
+trap cleanup EXIT
+
+json_value() {
+  python3 -c 'import json, sys; print(json.load(open(sys.argv[1], "r", encoding="utf-8"))[sys.argv[2]])' "$1" "$2"
+}
+
+rm -f "${DEPLOYMENT_ARTIFACT}" "${REHEARSAL_ARTIFACT}"
+
+anvil --host "${ANVIL_HOST}" --port "${ANVIL_PORT}" --chain-id "${ANVIL_CHAIN_ID}" >"${ANVIL_LOG_PATH}" 2>&1 &
+ANVIL_PID="$!"
+
+for _ in {1..30}; do
+  if cast block-number --rpc-url "${RPC_URL}" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+if ! cast block-number --rpc-url "${RPC_URL}" >/dev/null 2>&1; then
+  echo "Anvil did not become ready. See ${ANVIL_LOG_PATH}."
+  exit 1
+fi
+
+cd "${ROOT_DIR}"
+
+forge script script/DeployDiamondCore.s.sol:DeployDiamondCoreScript --rpc-url "${RPC_URL}" --broadcast
+forge script script/RehearseDiamondUpgrade.s.sol:RehearseDiamondUpgradeScript --rpc-url "${RPC_URL}" --broadcast
+
+DIAMOND_ADDRESS="$(json_value "${REHEARSAL_ARTIFACT}" diamond)"
+OWNER_ADDRESS="$(json_value "${REHEARSAL_ARTIFACT}" owner)"
+UPGRADE_FACET="$(json_value "${REHEARSAL_ARTIFACT}" upgradeFacet)"
+INIT_MOCK="$(json_value "${REHEARSAL_ARTIFACT}" initMock)"
+COLLISION_FACET="$(json_value "${REHEARSAL_ARTIFACT}" collisionFacet)"
+FAILURE_FACET="$(json_value "${REHEARSAL_ARTIFACT}" failureFacet)"
+
+ALPHA_SELECTOR="$(cast sig "alpha()")"
+GAMMA_SELECTOR="$(cast sig "gamma()")"
+ZETA_SELECTOR="$(cast sig "zeta()")"
+COLLISION_ERROR_SELECTOR="$(cast sig "DiamondSelectorAlreadyExists(bytes4,address)")"
+INIT_FAILURE_ERROR_SELECTOR="$(cast sig "DiamondCutInitFailed(address,bytes)")"
+REVERT_INIT_CALLDATA="$(cast calldata "revertInit()")"
+
+if collision_output=$(cast send \
+  "${DIAMOND_ADDRESS}" \
+  "diamondCut((address,uint8,bytes4[])[],address,bytes)" \
+  "[( ${COLLISION_FACET}, 0, [${GAMMA_SELECTOR},${ALPHA_SELECTOR}] )]" \
+  "${ZERO_ADDRESS}" \
+  "0x" \
+  --rpc-url "${RPC_URL}" \
+  --private-key "${PRIVATE_KEY}" 2>&1); then
+  echo "Selector collision rehearsal unexpectedly succeeded."
+  exit 1
+fi
+
+if [[ "${collision_output}" != *"${COLLISION_ERROR_SELECTOR}"* ]]; then
+  echo "Selector collision rehearsal reverted with an unexpected error."
+  echo "${collision_output}"
+  exit 1
+fi
+
+gamma_owner="$(cast call "${DIAMOND_ADDRESS}" "facetAddress(bytes4)(address)" "${GAMMA_SELECTOR}" --rpc-url "${RPC_URL}")"
+if [[ "${gamma_owner,,}" != "${ZERO_ADDRESS,,}" ]]; then
+  echo "Collision rehearsal left partial selector routing in place."
+  exit 1
+fi
+
+if init_failure_output=$(cast send \
+  "${DIAMOND_ADDRESS}" \
+  "diamondCut((address,uint8,bytes4[])[],address,bytes)" \
+  "[( ${FAILURE_FACET}, 0, [${ZETA_SELECTOR}] )]" \
+  "${INIT_MOCK}" \
+  "${REVERT_INIT_CALLDATA}" \
+  --rpc-url "${RPC_URL}" \
+  --private-key "${PRIVATE_KEY}" 2>&1); then
+  echo "Init-failure rehearsal unexpectedly succeeded."
+  exit 1
+fi
+
+if [[ "${init_failure_output}" != *"${INIT_FAILURE_ERROR_SELECTOR}"* ]]; then
+  echo "Init-failure rehearsal reverted with an unexpected error."
+  echo "${init_failure_output}"
+  exit 1
+fi
+
+zeta_owner="$(cast call "${DIAMOND_ADDRESS}" "facetAddress(bytes4)(address)" "${ZETA_SELECTOR}" --rpc-url "${RPC_URL}")"
+if [[ "${zeta_owner,,}" != "${ZERO_ADDRESS,,}" ]]; then
+  echo "Init-failure rehearsal left partial selector routing in place."
+  exit 1
+fi
+
+owner_after="$(cast call "${DIAMOND_ADDRESS}" "owner()(address)" --rpc-url "${RPC_URL}")"
+if [[ "${owner_after,,}" != "${OWNER_ADDRESS,,}" ]]; then
+  echo "Owner changed during failed-cut rehearsal."
+  exit 1
+fi
+
+alpha_owner="$(cast call "${DIAMOND_ADDRESS}" "facetAddress(bytes4)(address)" "${ALPHA_SELECTOR}" --rpc-url "${RPC_URL}")"
+if [[ "${alpha_owner,,}" != "${UPGRADE_FACET,,}" ]]; then
+  echo "Alpha selector ownership changed unexpectedly after failed-cut rehearsal."
+  exit 1
+fi
+
+alpha_value="$(cast call "${DIAMOND_ADDRESS}" "alpha()(uint256)" --rpc-url "${RPC_URL}")"
+if [[ "${alpha_value}" != "11" ]]; then
+  echo "Alpha route regressed after failed-cut rehearsal."
+  exit 1
+fi
+
+read_value="$(cast call "${DIAMOND_ADDRESS}" "readValue()(uint256)" --rpc-url "${RPC_URL}")"
+if [[ "${read_value}" != "42" ]]; then
+  echo "Init-backed state regressed after failed-cut rehearsal."
+  exit 1
+fi
+
+echo "Local diamond upgrade rehearsal passed."


### PR DESCRIPTION
## Summary
- add a local upgrade rehearsal script that installs baseline selectors, executes a real `diamondCut` upgrade, validates loupe diff and selector ownership, and confirms init delegatecall state on the deployed diamond
- add dedicated rehearsal fixtures for baseline, replacement, collision, failure, and init/state validation facets used by the local flow
- add a one-command Anvil runner that deploys the diamond core, runs the successful upgrade rehearsal, executes expected failed cuts with `cast send`, and asserts no partial routing state is left behind
- refactor the shared script base so deployment consumers can load the local diamond artifact through one canonical helper, and update the smoke flow to use it

## Validation
- `forge test --offline`
- `bash script/run-local-diamond-upgrade-rehearsal.sh`

## Issue
- Closes #67