### PR TITLE
Add system-level invariants and failure simulations

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ anvil
 forge script script/DeployDiamondCore.s.sol:DeployDiamondCoreScript --rpc-url http://127.0.0.1:8545 --broadcast
 bash script/run-local-diamond-smoke.sh
 bash script/run-local-diamond-upgrade-rehearsal.sh
+bash script/run-local-system-hardening.sh
 ```
 
 ## Testing
@@ -56,9 +57,12 @@ bash script/run-local-diamond-upgrade-rehearsal.sh
 - Vault controls suite: `test/ERC4626VaultControlsCore.t.sol`
 - Vault accounting fuzz suite: `test/ERC4626VaultAccountingFuzz.t.sol`
 - Vault accounting invariant suite: `test/ERC4626VaultAccountingInvariant.t.sol`
+- Vault system stress invariant suite: `test/SystemVaultStressInvariant.t.sol`
 - Diamond core suites: `test/DiamondFoundationCore.t.sol`, `test/DiamondProxyCore.t.sol`, `test/DiamondCutCore.t.sol`, `test/DiamondLoupeCore.t.sol`, `test/DiamondSelectorIntegrityCore.t.sol`
 - Oracle hardening suite: `test/OracleAdapterCore.t.sol`, `test/OracleAdapterValidation.t.sol`, `test/OracleAdapterCircuitBreaker.t.sol`, `test/OracleAdapterFuzz.t.sol`
+- Oracle system failure suite: `test/SystemOracleFailureScenarios.t.sol`
 - Security CI/local checks: `docs/security-checks.md`
+- System hardening note: `docs/system-hardening.md`
 
 ## Module Docs
 - Access control: `docs/access-control.md`

--- a/docs/system-hardening.md
+++ b/docs/system-hardening.md
@@ -1,0 +1,39 @@
+# System Hardening
+
+This note defines the reproducible system-level hardening coverage added for
+issue `#69`.
+
+## What Is Simulated
+
+- Local diamond bootstrap and smoke validation through the Foundry deployment
+  flow.
+- Local diamond upgrade rehearsal, including successful cuts, init-backed state
+  checks, and failed-cut atomicity checks.
+- Stateful vault stress coverage across deposit, mint, withdraw, redeem,
+  pause/unpause, fee configuration, limit configuration, and reentrant asset
+  callback attempts.
+- Deterministic oracle incident handling across stale/invalid live reads,
+  circuit-breaker trips, fallback-mode activation, reset/recovery, and source
+  rotation.
+
+## What Remains Out Of Scope
+
+- Real market or economic attack simulation.
+- Multisig or governance workflow simulation.
+- External provider or network instability beyond deterministic mocked failure
+  cases.
+- Full protocol composition beyond the current toolkit modules.
+
+## Reproducible Entry Points
+
+Use these commands locally:
+
+```bash
+bash script/run-local-system-hardening.sh
+forge test --offline --match-path test/SystemVaultStressInvariant.t.sol
+forge test --offline --match-path test/SystemOracleFailureScenarios.t.sol
+```
+
+The top-level hardening runner passes only when the local deployment bootstrap,
+smoke flow, upgrade rehearsal, failed-cut postconditions, and both new
+system-level suites all succeed.

--- a/script/run-local-system-hardening.sh
+++ b/script/run-local-system-hardening.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+export NO_PROXY="${NO_PROXY:-127.0.0.1,localhost}"
+unset HTTP_PROXY HTTPS_PROXY ALL_PROXY http_proxy https_proxy all_proxy
+
+cd "${ROOT_DIR}"
+
+echo "==> Running local diamond smoke flow"
+bash script/run-local-diamond-smoke.sh
+
+echo "==> Running local diamond upgrade rehearsal"
+bash script/run-local-diamond-upgrade-rehearsal.sh
+
+echo "==> Running system vault stress invariant suite"
+forge test --offline --match-path test/SystemVaultStressInvariant.t.sol
+
+echo "==> Running system oracle failure scenarios"
+forge test --offline --match-path test/SystemOracleFailureScenarios.t.sol
+
+echo "Local system hardening flow passed."

--- a/test/SystemOracleFailureScenarios.t.sol
+++ b/test/SystemOracleFailureScenarios.t.sol
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {
+    MalformedDecimalsFeed,
+    MalformedRoundDataFeed,
+    OracleAdapterFixture
+} from "./helpers/OracleAdapterTestHarness.sol";
+import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
+import {IOracleAdapter} from "../src/interfaces/IOracleAdapter.sol";
+
+contract SystemOracleFailureScenariosTest is OracleAdapterFixture {
+    function testHealthyToStaleBreakerFallbackResetRecoverySequence() public {
+        bytes32 oracleGuardianRole = adapter.ORACLE_GUARDIAN_ROLE();
+
+        IOracleAdapter.OracleQuote memory healthyQuote = adapter.quote();
+        _assertQuote(healthyQuote, 100_000_000, feedAUpdatedAt, 8, "healthy source should be used initially");
+
+        uint64 staleUpdatedAt = currentTime - maxStaleness - 1;
+        feedA.setLatestRoundData(1, 100_000_000, staleUpdatedAt, staleUpdatedAt, 1);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IOracleAdapter.OracleAdapterStaleQuote.selector, staleUpdatedAt, currentTime, maxStaleness
+            )
+        );
+        adapter.quote();
+
+        VM.prank(admin);
+        adapter.setFallbackQuote(91, 888_000, 8);
+        VM.prank(admin);
+        adapter.setFallbackMode(IOracleAdapter.FallbackMode.UseConfiguredQuote);
+        VM.prank(admin);
+        adapter.grantRole(oracleGuardianRole, bob);
+
+        VM.prank(bob);
+        adapter.tripCircuitBreaker();
+
+        IOracleAdapter.OracleQuote memory breakerQuote = adapter.quote();
+        _assertQuote(breakerQuote, 91, 888_000, 8, "breaker should return configured fallback quote");
+
+        VM.prank(admin);
+        adapter.resetCircuitBreaker();
+
+        IOracleAdapter.OracleQuote memory degradedQuote = adapter.quote();
+        _assertQuote(degradedQuote, 91, 888_000, 8, "stale source should still fall back after reset");
+
+        VM.prank(admin);
+        adapter.setOracleSource(address(feedB));
+
+        IOracleAdapter.OracleQuote memory recoveredQuote = adapter.quote();
+        _assertQuote(
+            recoveredQuote, 2_000_000_000_000_000_000, feedBUpdatedAt, 18, "healthy rotated source should recover"
+        );
+    }
+
+    function testGuardianAndAdminIncidentRolesRemainSeparatedDuringFailureHandling() public {
+        bytes32 oracleAdminRole = adapter.ORACLE_ADMIN_ROLE();
+        bytes32 oracleGuardianRole = adapter.ORACLE_GUARDIAN_ROLE();
+
+        VM.prank(admin);
+        adapter.grantRole(oracleGuardianRole, bob);
+
+        VM.prank(bob);
+        adapter.tripCircuitBreaker();
+        assertTrue(adapter.circuitBreakerActive(), "guardian should be able to trip the breaker");
+
+        VM.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, oracleAdminRole));
+        VM.prank(bob);
+        adapter.resetCircuitBreaker();
+
+        VM.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, oracleAdminRole));
+        VM.prank(bob);
+        adapter.setOracleSource(address(feedB));
+
+        VM.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, oracleAdminRole));
+        VM.prank(bob);
+        adapter.setFallbackMode(IOracleAdapter.FallbackMode.UseConfiguredQuote);
+
+        VM.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, oracleAdminRole));
+        VM.prank(bob);
+        adapter.setFallbackQuote(1, 1, 8);
+
+        VM.prank(admin);
+        adapter.setFallbackQuote(77, 700_000, 8);
+        VM.prank(admin);
+        adapter.setFallbackMode(IOracleAdapter.FallbackMode.UseConfiguredQuote);
+        VM.prank(admin);
+        adapter.resetCircuitBreaker();
+
+        assertFalse(adapter.circuitBreakerActive(), "admin should retain reset authority");
+    }
+
+    function testMalformedSourceRotationStillFailsClosedInStrictMode() public {
+        MalformedRoundDataFeed malformedRoundFeed = new MalformedRoundDataFeed();
+        MalformedDecimalsFeed malformedDecimalsFeed = new MalformedDecimalsFeed();
+
+        VM.prank(admin);
+        adapter.setOracleSource(address(malformedRoundFeed));
+
+        VM.expectRevert(abi.encodeWithSelector(IOracleAdapter.OracleAdapterLiveReadFailed.selector));
+        adapter.quote();
+
+        VM.prank(admin);
+        adapter.setOracleSource(address(malformedDecimalsFeed));
+
+        VM.expectRevert(abi.encodeWithSelector(IOracleAdapter.OracleAdapterLiveReadFailed.selector));
+        adapter.quote();
+
+        VM.prank(admin);
+        adapter.setOracleSource(address(feedB));
+
+        IOracleAdapter.OracleQuote memory recoveredQuote = adapter.quote();
+        _assertQuote(
+            recoveredQuote,
+            2_000_000_000_000_000_000,
+            feedBUpdatedAt,
+            18,
+            "strict mode should recover only after a healthy source rotation"
+        );
+    }
+
+    function testFallbackModeRequiresConfiguredQuoteAcrossFailureTransitions() public {
+        VM.prank(admin);
+        adapter.setFallbackMode(IOracleAdapter.FallbackMode.UseConfiguredQuote);
+        feedA.setRevertLatestRoundData(true);
+
+        VM.expectRevert(abi.encodeWithSelector(IOracleAdapter.OracleAdapterFallbackUnavailable.selector));
+        adapter.quote();
+
+        VM.prank(admin);
+        adapter.setFallbackQuote(55, 777_000, 8);
+
+        IOracleAdapter.OracleQuote memory liveFailureFallbackQuote = adapter.quote();
+        _assertQuote(liveFailureFallbackQuote, 55, 777_000, 8, "configured fallback should serve failed live reads");
+
+        VM.prank(admin);
+        adapter.tripCircuitBreaker();
+
+        IOracleAdapter.OracleQuote memory breakerFallbackQuote = adapter.quote();
+        _assertQuote(breakerFallbackQuote, 55, 777_000, 8, "same fallback should serve breaker conditions");
+
+        VM.prank(admin);
+        adapter.clearFallbackQuote();
+
+        VM.expectRevert(abi.encodeWithSelector(IOracleAdapter.OracleAdapterFallbackUnavailable.selector));
+        adapter.quote();
+    }
+
+    function testBoundsAndSourceChangesDoNotBypassValidationPolicy() public {
+        VM.prank(admin);
+        adapter.setValidationBounds(90_000_000, 110_000_000, true);
+
+        IOracleAdapter.OracleQuote memory inRangeQuote = adapter.quote();
+        _assertQuote(inRangeQuote, 100_000_000, feedAUpdatedAt, 8, "in-range live quote should succeed");
+
+        VM.prank(admin);
+        adapter.setOracleSource(address(feedB));
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IOracleAdapter.OracleAdapterAnswerOutOfBounds.selector,
+                int256(2_000_000_000_000_000_000),
+                int256(90_000_000),
+                int256(110_000_000)
+            )
+        );
+        adapter.quote();
+
+        VM.prank(admin);
+        adapter.setFallbackQuote(101_000_000, 777_100, 8);
+        VM.prank(admin);
+        adapter.setFallbackMode(IOracleAdapter.FallbackMode.UseConfiguredQuote);
+
+        IOracleAdapter.OracleQuote memory fallbackQuote = adapter.quote();
+        _assertQuote(fallbackQuote, 101_000_000, 777_100, 8, "fallback mode should still reject unhealthy live data");
+
+        VM.prank(admin);
+        adapter.setOracleSource(address(feedA));
+
+        IOracleAdapter.OracleQuote memory recoveredQuote = adapter.quote();
+        _assertQuote(recoveredQuote, 100_000_000, feedAUpdatedAt, 8, "healthy source should restore live reads");
+    }
+
+    function _assertQuote(
+        IOracleAdapter.OracleQuote memory observed,
+        int256 expectedValue,
+        uint64 expectedUpdatedAt,
+        uint8 expectedDecimals,
+        string memory reason
+    ) internal pure {
+        require(
+            observed.value == expectedValue && observed.updatedAt == expectedUpdatedAt
+                && observed.decimals == expectedDecimals,
+            reason
+        );
+    }
+}

--- a/test/SystemVaultStressInvariant.t.sol
+++ b/test/SystemVaultStressInvariant.t.sol
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol";
+import {IPausable} from "../src/interfaces/IPausable.sol";
+import {IReentrancyGuard} from "../src/interfaces/IReentrancyGuard.sol";
+import {ERC4626VaultControlsHarness} from "./helpers/ERC4626VaultControlsTestHarness.sol";
+import {SystemVaultStressFixture} from "./helpers/SystemVaultStressTestHarness.sol";
+
+contract SystemVaultStressInvariantTest is SystemVaultStressFixture {
+    function targetContracts() external view returns (address[] memory contracts) {
+        contracts = new address[](1);
+        contracts[0] = address(this);
+    }
+
+    function actionDeposit(uint8 actorSeed, uint96 assetsRaw) external {
+        address actor = _actor(actorSeed);
+        uint256 maxAssets = _min(vault.maxDeposit(actor), asset.balanceOf(actor));
+        uint256 assets = _boundAmount(assetsRaw, maxAssets);
+        if (assets == 0 || vault.previewDeposit(assets) == 0) {
+            return;
+        }
+
+        VM.prank(actor);
+        vault.deposit(assets, actor);
+
+        _assertCoreAccountingAligned();
+    }
+
+    function actionMint(uint8 actorSeed, uint96 sharesRaw) external {
+        address actor = _actor(actorSeed);
+        uint256 feasibleShares = vault.previewDeposit(asset.balanceOf(actor));
+        uint256 maxShares = _min(vault.maxMint(actor), feasibleShares);
+        uint256 shares = _boundAmount(sharesRaw, maxShares);
+        if (shares == 0) {
+            return;
+        }
+
+        uint256 requiredAssets = vault.previewMint(shares);
+        if (requiredAssets == 0 || requiredAssets > asset.balanceOf(actor)) {
+            return;
+        }
+
+        VM.prank(actor);
+        vault.mint(shares, actor);
+
+        _assertCoreAccountingAligned();
+    }
+
+    function actionWithdraw(uint8 actorSeed, uint96 assetsRaw) external {
+        address actor = _actor(actorSeed);
+        uint256 assets = _boundAmount(assetsRaw, vault.maxWithdraw(actor));
+        if (assets == 0) {
+            return;
+        }
+
+        VM.prank(actor);
+        vault.withdraw(assets, actor, actor);
+
+        _assertCoreAccountingAligned();
+    }
+
+    function actionRedeem(uint8 actorSeed, uint96 sharesRaw) external {
+        address actor = _actor(actorSeed);
+        uint256 shares = _boundAmount(sharesRaw, vault.maxRedeem(actor));
+        if (shares == 0 || vault.previewRedeem(shares) == 0) {
+            return;
+        }
+
+        VM.prank(actor);
+        vault.redeem(shares, actor, actor);
+
+        _assertCoreAccountingAligned();
+    }
+
+    function actionPauseToggle(bool shouldPause) external {
+        if (shouldPause) {
+            _pauseIfNeeded();
+        } else {
+            _unpauseIfNeeded();
+        }
+
+        _assertCoreAccountingAligned();
+    }
+
+    function actionSetFeeConfig(uint16 depositFeeRaw, uint16 withdrawFeeRaw) external {
+        AccountingSnapshot memory beforeSnapshot = _snapshotAccounting();
+
+        uint16 depositFeeBps = uint16(uint256(depositFeeRaw) % 2_001);
+        uint16 withdrawFeeBps = uint16(uint256(withdrawFeeRaw) % 2_001);
+
+        VM.prank(admin);
+        vault.setFeeConfig(depositFeeBps, withdrawFeeBps, feeSink);
+
+        _assertAccountingUnchanged(beforeSnapshot, "fee config updates should not mutate accounting state");
+        _assertCoreAccountingAligned();
+    }
+
+    function actionSetLimitConfig(
+        uint96 totalCapRaw,
+        uint96 depositRaw,
+        uint96 mintRaw,
+        uint96 withdrawRaw,
+        uint96 redeemRaw
+    ) external {
+        AccountingSnapshot memory beforeSnapshot = _snapshotAccounting();
+
+        uint256 currentAssets = vault.totalAssets();
+        uint128 maxTotalAssets =
+            totalCapRaw % 4 == 0 ? 0 : uint128(currentAssets + (uint256(totalCapRaw) % INITIAL_ASSET_SUPPLY) + 1);
+        uint128 maxDeposit = depositRaw % 4 == 0 ? 0 : uint128((uint256(depositRaw) % INITIAL_ASSETS) + 1);
+        uint128 maxMint = mintRaw % 4 == 0 ? 0 : uint128((uint256(mintRaw) % INITIAL_ASSETS) + 1);
+        uint128 maxWithdraw = withdrawRaw % 4 == 0 ? 0 : uint128((uint256(withdrawRaw) % INITIAL_ASSETS) + 1);
+        uint128 maxRedeem = redeemRaw % 4 == 0 ? 0 : uint128((uint256(redeemRaw) % INITIAL_ASSETS) + 1);
+
+        VM.prank(admin);
+        vault.setLimitConfig(maxTotalAssets, maxDeposit, maxMint, maxWithdraw, maxRedeem);
+
+        _assertAccountingUnchanged(beforeSnapshot, "limit config updates should not mutate accounting state");
+        _assertCoreAccountingAligned();
+    }
+
+    function actionPausedDepositAttempt(uint8 actorSeed, uint96 assetsRaw) external {
+        address actor = _actor(actorSeed);
+        uint256 assets = _boundAmount(assetsRaw, asset.balanceOf(actor));
+        if (assets == 0) {
+            return;
+        }
+
+        _pauseIfNeeded();
+        AccountingSnapshot memory beforeSnapshot = _snapshotAccounting();
+
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+        VM.prank(actor);
+        vault.deposit(assets, actor);
+
+        _assertAccountingUnchanged(beforeSnapshot, "paused deposit attempts must not mutate accounting");
+        _assertCoreAccountingAligned();
+    }
+
+    function actionPausedWithdrawAttempt(uint8 actorSeed, uint96 assetsRaw) external {
+        address actor = _actor(actorSeed);
+        uint256 actorShares = vault.balanceOf(actor);
+        if (actorShares == 0) {
+            return;
+        }
+
+        uint256 withdrawAssets = _boundAmount(assetsRaw, vault.previewRedeem(actorShares));
+        if (withdrawAssets == 0) {
+            return;
+        }
+
+        _pauseIfNeeded();
+        AccountingSnapshot memory beforeSnapshot = _snapshotAccounting();
+
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+        VM.prank(actor);
+        vault.withdraw(withdrawAssets, actor, actor);
+
+        _assertAccountingUnchanged(beforeSnapshot, "paused withdraw attempts must not mutate accounting");
+        _assertCoreAccountingAligned();
+    }
+
+    function actionReentrantDepositAttempt(uint8 actorSeed, uint96 assetsRaw) external {
+        if (vault.paused()) {
+            return;
+        }
+
+        address actor = _actor(actorSeed);
+        uint256 maxAssets = _min(vault.maxDeposit(actor), asset.balanceOf(actor));
+        uint256 assets = _boundAmount(assetsRaw, maxAssets);
+        if (assets == 0 || vault.previewDeposit(assets) == 0) {
+            return;
+        }
+
+        asset.configureReentry(address(vault), abi.encodeCall(ERC4626VaultControlsHarness.probeNonReentrant, ()), true);
+
+        VM.prank(actor);
+        vault.deposit(assets, actor);
+
+        assertTrue(asset.reentryAttemptBlocked(), "reentrant callback should be blocked during deposit");
+        assertFalse(vault.reentrancyGuardEntered(), "reentrancy guard should exit cleanly after deposit");
+
+        asset.configureReentry(address(0), new bytes(0), false);
+
+        _assertCoreAccountingAligned();
+    }
+
+    function invariantManagedAssetsTrackUnderlyingBalance() public view {
+        assertTrue(
+            vault.totalAssets() == asset.balanceOf(address(vault)),
+            "managed assets should match vault-held underlying after every successful action"
+        );
+    }
+
+    function invariantShareSupplyMatchesTrackedActorBalances() public view {
+        assertTrue(
+            vault.totalSupply() == _sumActorShareBalances(),
+            "total share supply should remain equal to tracked actor balances"
+        );
+    }
+
+    function invariantTrackedUnderlyingRemainsConserved() public view {
+        assertTrue(
+            _trackedUnderlyingTotal() == INITIAL_ASSET_SUPPLY,
+            "underlying balance should remain conserved across actors, vault, and fee sink"
+        );
+    }
+
+    function invariantPausedStateZeroesMutatingMaxFunctions() public view {
+        if (!vault.paused()) {
+            return;
+        }
+
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            address actor = actors[i];
+            assertTrue(vault.maxDeposit(actor) == 0, "paused vault should expose zero maxDeposit");
+            assertTrue(vault.maxMint(actor) == 0, "paused vault should expose zero maxMint");
+            assertTrue(vault.maxWithdraw(actor) == 0, "paused vault should expose zero maxWithdraw");
+            assertTrue(vault.maxRedeem(actor) == 0, "paused vault should expose zero maxRedeem");
+        }
+    }
+
+    function invariantConfiguredCapIsNotExceeded() public view {
+        (uint128 maxTotalAssets,,,,) = vault.limitConfig();
+        if (maxTotalAssets == 0) {
+            return;
+        }
+
+        assertTrue(vault.totalAssets() <= maxTotalAssets, "configured total-assets cap should not be exceeded");
+    }
+}

--- a/test/helpers/SystemVaultStressTestHarness.sol
+++ b/test/helpers/SystemVaultStressTestHarness.sol
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IPausable} from "../../src/interfaces/IPausable.sol";
+import {ReentrantMockVaultAsset, ERC4626VaultControlsHarness} from "./ERC4626VaultControlsTestHarness.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+
+abstract contract SystemVaultStressFixture is TestBase {
+    struct AccountingSnapshot {
+        uint256 totalAssets;
+        uint256 totalSupply;
+        uint256 vaultUnderlyingBalance;
+        uint256 feeSinkBalance;
+        uint256 actorUnderlyingBalanceSum;
+        uint256 actorShareBalanceSum;
+    }
+
+    uint256 internal constant INITIAL_ASSETS = 1_000_000;
+    uint256 internal constant ACTOR_COUNT = 3;
+    uint256 internal constant INITIAL_ASSET_SUPPLY = INITIAL_ASSETS * ACTOR_COUNT;
+
+    address internal admin = address(0xA11CE);
+    address internal bob = address(0xB0B);
+    address internal carol = address(0xCA11);
+    address internal dave = address(0xD0D);
+    address internal feeSink = address(0xFEE);
+
+    ReentrantMockVaultAsset internal asset;
+    ERC4626VaultControlsHarness internal vault;
+    address[ACTOR_COUNT] internal actors;
+
+    function setUp() public virtual {
+        asset = new ReentrantMockVaultAsset();
+        vault = new ERC4626VaultControlsHarness(admin, address(asset), "Vault Share", "vSHARE");
+
+        actors[0] = bob;
+        actors[1] = carol;
+        actors[2] = dave;
+
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            address actor = actors[i];
+            asset.mint(actor, INITIAL_ASSETS);
+            VM.prank(actor);
+            asset.approve(address(vault), type(uint256).max);
+        }
+
+        VM.prank(admin);
+        vault.setFeeConfig(0, 0, feeSink);
+    }
+
+    function _actor(uint8 seed) internal view returns (address) {
+        return actors[uint256(seed) % ACTOR_COUNT];
+    }
+
+    function _boundAmount(uint256 raw, uint256 max) internal pure returns (uint256) {
+        if (max == 0) {
+            return 0;
+        }
+        return (raw % max) + 1;
+    }
+
+    function _min(uint256 x, uint256 y) internal pure returns (uint256) {
+        return x < y ? x : y;
+    }
+
+    function _sumActorShareBalances() internal view returns (uint256 sum) {
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            sum += vault.balanceOf(actors[i]);
+        }
+    }
+
+    function _sumActorAssetBalances() internal view returns (uint256 sum) {
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            sum += asset.balanceOf(actors[i]);
+        }
+    }
+
+    function _trackedUnderlyingTotal() internal view returns (uint256) {
+        return _sumActorAssetBalances() + asset.balanceOf(address(vault)) + asset.balanceOf(feeSink);
+    }
+
+    function _snapshotAccounting() internal view returns (AccountingSnapshot memory snapshot) {
+        snapshot.totalAssets = vault.totalAssets();
+        snapshot.totalSupply = vault.totalSupply();
+        snapshot.vaultUnderlyingBalance = asset.balanceOf(address(vault));
+        snapshot.feeSinkBalance = asset.balanceOf(feeSink);
+        snapshot.actorUnderlyingBalanceSum = _sumActorAssetBalances();
+        snapshot.actorShareBalanceSum = _sumActorShareBalances();
+    }
+
+    function _assertAccountingUnchanged(AccountingSnapshot memory beforeSnapshot, string memory reason) internal view {
+        AccountingSnapshot memory afterSnapshot = _snapshotAccounting();
+        assertTrue(afterSnapshot.totalAssets == beforeSnapshot.totalAssets, reason);
+        assertTrue(afterSnapshot.totalSupply == beforeSnapshot.totalSupply, reason);
+        assertTrue(afterSnapshot.vaultUnderlyingBalance == beforeSnapshot.vaultUnderlyingBalance, reason);
+        assertTrue(afterSnapshot.feeSinkBalance == beforeSnapshot.feeSinkBalance, reason);
+        assertTrue(afterSnapshot.actorUnderlyingBalanceSum == beforeSnapshot.actorUnderlyingBalanceSum, reason);
+        assertTrue(afterSnapshot.actorShareBalanceSum == beforeSnapshot.actorShareBalanceSum, reason);
+    }
+
+    function _assertCoreAccountingAligned() internal view {
+        assertTrue(
+            vault.totalAssets() == asset.balanceOf(address(vault)),
+            "managed assets and vault-held underlying should remain aligned"
+        );
+        assertTrue(
+            vault.totalSupply() == _sumActorShareBalances(),
+            "share supply should remain equal to tracked actor balances"
+        );
+        assertTrue(
+            _trackedUnderlyingTotal() == INITIAL_ASSET_SUPPLY,
+            "tracked underlying should remain conserved across actors, vault, and fee sink"
+        );
+    }
+
+    function _pauseIfNeeded() internal {
+        if (!vault.paused()) {
+            VM.prank(admin);
+            vault.pause();
+        }
+    }
+
+    function _unpauseIfNeeded() internal {
+        if (vault.paused()) {
+            VM.prank(admin);
+            vault.unpause();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a stateful vault stress invariant suite covering pause transitions, fee/limit config churn, and reentrant asset callback attempts
- add deterministic oracle failure scenario coverage for stale/invalid feeds, breaker handling, fallback policy, and source rotation recovery
- add a one-command local system hardening runner that chains diamond smoke, upgrade rehearsal, and the new system suites
- document the simulated hardening scope, reproducible commands, and system-level coverage entrypoints

## Validation
- `forge fmt`
- `forge test --offline --match-path test/SystemVaultStressInvariant.t.sol`
- `forge test --offline --match-path test/SystemOracleFailureScenarios.t.sol`
- `forge test --offline`
- `bash script/run-local-system-hardening.sh`

## Issue
- Closes #69
