### PR TITLE
Add split-gate CI for system hardening

### DIFF
--- a/.github/workflows/system-hardening.yml
+++ b/.github/workflows/system-hardening.yml
@@ -37,6 +37,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-foundry-cache-
 
+      - name: Build With Sizes
+        run: forge build --sizes
+
       - name: Run System Vault Stress Invariants
         run: forge test --offline --match-path test/SystemVaultStressInvariant.t.sol
 
@@ -70,6 +73,9 @@ jobs:
           key: ${{ runner.os }}-foundry-cache-${{ hashFiles('foundry.toml') }}
           restore-keys: |
             ${{ runner.os }}-foundry-cache-
+
+      - name: Build With Sizes
+        run: forge build --sizes
 
       - name: Run Full Local Hardening Flow
         run: bash script/run-local-system-hardening.sh

--- a/.github/workflows/system-hardening.yml
+++ b/.github/workflows/system-hardening.yml
@@ -1,0 +1,75 @@
+name: System Hardening
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - "milestone/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: system-hardening-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  system-suites:
+    name: Targeted System Suites
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      - name: Cache Foundry Artifacts
+        uses: actions/cache@v4
+        with:
+          path: ~/.foundry/cache
+          key: ${{ runner.os }}-foundry-cache-${{ hashFiles('foundry.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-foundry-cache-
+
+      - name: Run System Vault Stress Invariants
+        run: forge test --offline --match-path test/SystemVaultStressInvariant.t.sol
+
+      - name: Run System Oracle Failure Scenarios
+        run: forge test --offline --match-path test/SystemOracleFailureScenarios.t.sol
+
+  system-hardening-e2e:
+    name: Full Local Hardening Flow
+    runs-on: ubuntu-latest
+    if: >-
+      ${{
+        github.event_name == 'workflow_dispatch' ||
+        github.event_name == 'push' ||
+        (github.event_name == 'pull_request' &&
+          (github.base_ref == 'main' || startsWith(github.base_ref, 'milestone/')))
+      }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      - name: Cache Foundry Artifacts
+        uses: actions/cache@v4
+        with:
+          path: ~/.foundry/cache
+          key: ${{ runner.os }}-foundry-cache-${{ hashFiles('foundry.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-foundry-cache-
+
+      - name: Run Full Local Hardening Flow
+        run: bash script/run-local-system-hardening.sh

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ bash script/run-local-system-hardening.sh
 
 ## Testing
 - Convention guide: `docs/testing-conventions.md`
+- CI note: targeted system suites run broadly in the `System Hardening` workflow, while the full local hardening flow gates `milestone/**`, `main`, and manual runs
 - Vault foundation suite: `test/ERC4626VaultFoundationCore.t.sol`
 - Vault core suite: `test/ERC4626Core.t.sol`
 - Vault controls suite: `test/ERC4626VaultControlsCore.t.sol`
@@ -88,3 +89,4 @@ bash script/run-local-system-hardening.sh
 
 ## Tooling
 - Foundry docs: [book.getfoundry.sh](https://book.getfoundry.sh/)
+- GitHub Actions: `.github/workflows/ci.yml`, `.github/workflows/system-hardening.yml`, `.github/workflows/slither.yml`

--- a/docs/security-checks.md
+++ b/docs/security-checks.md
@@ -4,6 +4,17 @@ This repository runs security-focused CI checks in addition to baseline Foundry 
 
 ## CI Policy
 
+### System Hardening (`.github/workflows/system-hardening.yml`)
+
+- Trigger: pull requests, pushes to `main` and `milestone/**`, manual dispatch.
+- Tooling: GitHub Actions + Foundry.
+- Policy:
+  - `Targeted System Suites` runs on every workflow trigger and executes:
+    - `forge test --offline --match-path test/SystemVaultStressInvariant.t.sol`
+    - `forge test --offline --match-path test/SystemOracleFailureScenarios.t.sol`
+  - `Full Local Hardening Flow` runs on pushes to `main`/`milestone/**`, on manual dispatch, and on pull requests targeting `main` or `milestone/**`.
+- Scope: deployment bootstrap, smoke flow, upgrade rehearsal, vault stress invariants, and oracle failure scenarios.
+
 ### Slither (`.github/workflows/slither.yml`)
 
 - Trigger: pull requests, pushes to `main` and `milestone/**`, manual dispatch.
@@ -22,6 +33,18 @@ This repository runs security-focused CI checks in addition to baseline Foundry 
     `ENABLE_PRIVATE_DEPENDENCY_REVIEW=true` is set.
 
 ## Local Reproduction
+
+### System Hardening
+
+Run the same bounded and full entrypoints locally:
+
+```bash
+forge test --offline --match-path test/SystemVaultStressInvariant.t.sol
+forge test --offline --match-path test/SystemOracleFailureScenarios.t.sol
+bash script/run-local-system-hardening.sh
+```
+
+Use the targeted suites for faster iteration and the full hardening runner for the same deployment-backed flow used by the higher-signal CI gate.
 
 ### Slither
 


### PR DESCRIPTION
## Summary
- add a dedicated `System Hardening` workflow instead of overloading the baseline Foundry CI job
- run the bounded system suites on every workflow trigger and reserve the full local hardening flow for milestone/main/manual paths
- document the split-gate policy and the matching local reproduction commands in the repo docs

## Validation
- `forge test --offline --match-path test/SystemVaultStressInvariant.t.sol`
- `forge test --offline --match-path test/SystemOracleFailureScenarios.t.sol`
- `bash script/run-local-system-hardening.sh`

## Issue
- Closes #70
