### PR TITLE
Consolidate ops docs and brand Keystone

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,92 +1,67 @@
-# smart-contracts
+# Keystone
 
 ![Solidity](https://img.shields.io/badge/Solidity-0.8.30-363636?logo=solidity)
 [![Foundry CI](https://github.com/amshirif/smart-contracts/actions/workflows/ci.yml/badge.svg)](https://github.com/amshirif/smart-contracts/actions/workflows/ci.yml)
 ![License](https://img.shields.io/github/license/amshirif/smart-contracts)
 
-Portfolio-focused Solidity modules built with Foundry. The codebase is kept
-dependency-light and "diamond-ready" so core modules can later be wrapped as
-facets without a full rewrite.
+Security-first, diamond-ready Solidity systems.
 
-## Goals
-- Security-first primitives with clear admin and upgrade boundaries.
-- Clean, testable modules with minimal external dependencies.
-- Diamond-ready storage patterns for future EIP-2535 integration.
-- Global and scope-level emergency controls for safer operations.
+`Keystone` is a portfolio-focused Solidity repository built to show
+security-first protocol engineering, dependency-light design, and
+deployment-backed validation. The codebase is intentionally diamond-ready, so
+core modules can evolve into facetized systems without rewriting storage or
+control-plane assumptions.
 
-## Structure
-- `src/access`: access control and upgrade-safety primitives.
-- `src/access/storage`: module-local storage libraries (diamond-ready slots).
-- `src/diamond`: diamond core primitives and shared routing helpers.
-- `src/diamond/facets`: diamond facet implementations.
-- `src/diamond/storage`: diamond routing and ownership storage layout.
-- `src/security`: security primitives such as reentrancy protection.
-- `src/security/storage`: module-local storage libraries (diamond-ready slots).
-- `src/oracle`: oracle adapter and feed safety primitives.
-- `src/oracle/storage`: module-local storage libraries (diamond-ready slots).
-- `src/upgrade`: upgrade authorization and execution guardrails.
-- `src/upgrade/storage`: module-local storage libraries (diamond-ready slots).
-- `src/vault`: ERC-4626 vault core and control-layer utilities.
-- `src/vault/storage`: module-local storage libraries (diamond-ready slots).
-- `src/interfaces`: local interfaces (ERC-165, `IAccessControl`, `IAccessControlTime`, `IERC20`, `IERC20Metadata`, `IERC4626`, `IERC4626VaultBase`, `IERC4626VaultControls`, `IOracleAdapter`, `IOracleFeed`, `IPausable`, `IReentrancyGuard`, `IUpgradeGuardrails`, etc.).
-- `src/libraries`: shared cross-module libraries.
-- `script`: Foundry deployment and bootstrap flows.
-- `deployments`: local deployment artifacts written by scripts.
-- `script/common`: shared Foundry script helpers and cheatcode interfaces.
-- `test`: split by concern (`*Core.t.sol`, `*Time.t.sol`, `*Integration.t.sol`).
-- `test/helpers`: shared test fixtures and harnesses.
-- `docs`: usage notes and design decisions.
+## Why This Repo Exists
 
-## Commands
+This repo is meant to demonstrate more than isolated contract snippets. It
+shows how access control, guard rails, oracle safety, vault logic, diamond
+routing, deployment scripts, rehearsal flows, and CI checks fit together as a
+reviewable engineering system.
+
+## What It Currently Demonstrates
+
+- A security-first control plane with RBAC, time-based permissions,
+  pausability, reentrancy protection, and upgrade guardrails.
+- Oracle safety patterns including validation bounds, stale-data handling,
+  circuit breakers, and controlled fallback behavior.
+- A diamond core with selector routing, cut/loupe support, ownership
+  introspection, and selector-integrity regression coverage.
+- Operational maturity through local bootstrap, smoke validation, upgrade
+  rehearsal, system-hardening flows, and matching CI gates.
+
+## Current Status
+
+Implemented milestones so far:
+
+- Access Control + Upgrade Safety Kit
+- Oracle Adapter + Circuit Breaker
+- Diamond Core (EIP-2535)
+- System-Level Testing & Hardening
+
+## Validation
+
+Run the highest-signal local checks with:
+
 ```shell
-forge build
-forge test
-forge coverage
-forge fmt
-anvil
-forge script script/DeployDiamondCore.s.sol:DeployDiamondCoreScript --rpc-url http://127.0.0.1:8545 --broadcast
+forge test --offline
 bash script/run-local-diamond-smoke.sh
 bash script/run-local-diamond-upgrade-rehearsal.sh
 bash script/run-local-system-hardening.sh
 ```
 
-## Testing
-- Convention guide: `docs/testing-conventions.md`
-- CI note: targeted system suites run broadly in the `System Hardening` workflow, while the full local hardening flow gates `milestone/**`, `main`, and manual runs
-- Vault foundation suite: `test/ERC4626VaultFoundationCore.t.sol`
-- Vault core suite: `test/ERC4626Core.t.sol`
-- Vault controls suite: `test/ERC4626VaultControlsCore.t.sol`
-- Vault accounting fuzz suite: `test/ERC4626VaultAccountingFuzz.t.sol`
-- Vault accounting invariant suite: `test/ERC4626VaultAccountingInvariant.t.sol`
-- Vault system stress invariant suite: `test/SystemVaultStressInvariant.t.sol`
-- Diamond core suites: `test/DiamondFoundationCore.t.sol`, `test/DiamondProxyCore.t.sol`, `test/DiamondCutCore.t.sol`, `test/DiamondLoupeCore.t.sol`, `test/DiamondSelectorIntegrityCore.t.sol`
-- Oracle hardening suite: `test/OracleAdapterCore.t.sol`, `test/OracleAdapterValidation.t.sol`, `test/OracleAdapterCircuitBreaker.t.sol`, `test/OracleAdapterFuzz.t.sol`
-- Oracle system failure suite: `test/SystemOracleFailureScenarios.t.sol`
-- Security CI/local checks: `docs/security-checks.md`
-- System hardening note: `docs/system-hardening.md`
+## Documentation
 
-## Module Docs
-- Access control: `docs/access-control.md`
-- Diamond core: `docs/diamond-core.md`
-- ERC-4626 vault: `docs/erc4626-vault.md`
-- Oracle adapter: `docs/oracle-adapter.md`
-- Pausability: `docs/pausable.md`
-- Reentrancy guard: `docs/reentrancy-guard.md`
-- Upgrade guardrails: `docs/upgrade-guardrails.md`
-- Threat model: `docs/threat-model.md`
+Architecture and module docs live in `docs/diamond-core.md`,
+`docs/oracle-adapter.md`, `docs/erc4626-vault.md`, and `docs/threat-model.md`.
 
-## Operations
-- Ops docs index: `docs/ops/README.md`
-- Release checklist: `docs/ops/release-checklist.md`
-- Release notes template: `docs/ops/release-notes-template.md`
-- Diamond cut runbook: `docs/ops/runbook-diamond-cut.md`
-- Oracle incident runbook: `docs/ops/runbook-oracle-incident.md`
-- Pause/unpause runbook: `docs/ops/runbook-pause-unpause.md`
-- Upgrade execution runbook: `docs/ops/runbook-upgrade-execution.md`
-- Milestone close checklist: `docs/ops/milestone-close-checklist.md`
-- Local diamond bootstrap: `docs/ops/local-diamond-bootstrap.md`
-- Local diamond smoke flow: `docs/ops/local-diamond-smoke.md`
+Operational guidance lives in `docs/ops/README.md`, with the end-to-end
+execution order collected in `docs/ops/runbook-system-hardening.md`.
+
+CI and local validation parity are documented in `docs/security-checks.md`.
 
 ## Tooling
-- Foundry docs: [book.getfoundry.sh](https://book.getfoundry.sh/)
-- GitHub Actions: `.github/workflows/ci.yml`, `.github/workflows/system-hardening.yml`, `.github/workflows/slither.yml`
+
+Built with Foundry. CI workflows live under `.github/workflows/`.
+
+Foundry docs: [book.getfoundry.sh](https://book.getfoundry.sh/)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="docs/assets/keystone-logo.svg" alt="Keystone logo" width="140" />
+</p>
+
 # Keystone
 
 ![Solidity](https://img.shields.io/badge/Solidity-0.8.30-363636?logo=solidity)

--- a/docs/assets/keystone-logo.svg
+++ b/docs/assets/keystone-logo.svg
@@ -1,0 +1,15 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">Keystone logo</title>
+  <desc id="desc">A geometric diamond mark with a highlighted central cut seam.</desc>
+  <path d="M128 28L212 92V164L128 228L44 164V92L128 28Z" fill="#111827"/>
+  <path d="M128 28L212 92L128 116L44 92L128 28Z" fill="#374151"/>
+  <path d="M44 92L128 116V228L44 164V92Z" fill="#1F2937"/>
+  <path d="M212 92L128 116V228L212 164V92Z" fill="#0F172A"/>
+  <path d="M128 28L152 98L128 116L104 98L128 28Z" fill="#C59D5F"/>
+  <path d="M128 116L152 98L212 92L128 228V116Z" fill="#7C5A2A"/>
+  <path d="M128 116L104 98L44 92L128 228V116Z" fill="#4B5563"/>
+  <path d="M128 40L195 91L195 161L128 212L61 161L61 91L128 40Z" stroke="#F9FAFB" stroke-width="6" stroke-linejoin="round"/>
+  <path d="M61 91L128 116L195 91" stroke="#F9FAFB" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M128 40L128 212" stroke="#C59D5F" stroke-width="8" stroke-linecap="round"/>
+  <path d="M104 98L128 116L152 98" stroke="#F9FAFB" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -1,13 +1,27 @@
 # Operations Docs
 
-This folder contains release and incident-response operational guides.
+This folder is the operator-facing guide set for deployment rehearsal,
+validation, incident response, and milestone hygiene.
 
-- Release checklist: `docs/ops/release-checklist.md`
-- Release notes template: `docs/ops/release-notes-template.md`
+## Start Here
+
+- System hardening runbook: `docs/ops/runbook-system-hardening.md`
+
+## Local Validation Flows
+
 - Local diamond bootstrap: `docs/ops/local-diamond-bootstrap.md`
 - Local diamond smoke flow: `docs/ops/local-diamond-smoke.md`
+- Local diamond upgrade rehearsal: `docs/ops/local-diamond-upgrade-rehearsal.md`
+
+## Runbooks
+
 - Diamond cut runbook: `docs/ops/runbook-diamond-cut.md`
 - Oracle incident runbook: `docs/ops/runbook-oracle-incident.md`
 - Pause/unpause runbook: `docs/ops/runbook-pause-unpause.md`
 - Upgrade execution runbook: `docs/ops/runbook-upgrade-execution.md`
+
+## Release And Milestone Hygiene
+
+- Release checklist: `docs/ops/release-checklist.md`
+- Release notes template: `docs/ops/release-notes-template.md`
 - Milestone close checklist: `docs/ops/milestone-close-checklist.md`

--- a/docs/ops/local-diamond-bootstrap.md
+++ b/docs/ops/local-diamond-bootstrap.md
@@ -59,6 +59,12 @@ Current fields:
 
 These outputs are intended to feed later E2E and upgrade rehearsal work.
 
+Downstream flows that consume this artifact:
+
+- `bash script/run-local-diamond-smoke.sh`
+- `bash script/run-local-diamond-upgrade-rehearsal.sh`
+- `bash script/run-local-system-hardening.sh`
+
 ## Follow-Up Smoke Checks
 
 After bootstrap, run the local smoke suite to validate live routing and a
@@ -67,3 +73,13 @@ reference admin state transition against the deployed environment:
 ```shell
 bash script/run-local-diamond-smoke.sh
 ```
+
+## Failure Interpretation
+
+- If Anvil never becomes reachable, inspect local RPC startup and port
+  conflicts first.
+- If the deployment artifact is missing or incomplete, do not continue to smoke
+  or rehearsal flows.
+- If constructor bootstrap or loupe installation fails, treat it as a diamond
+  deployment regression and inspect the deployment script output before
+  retrying.

--- a/docs/ops/local-diamond-smoke.md
+++ b/docs/ops/local-diamond-smoke.md
@@ -40,3 +40,23 @@ through a system proxy.
 
 This flow is intended to become the baseline smoke suite reused by later
 upgrade rehearsal and CI work.
+
+## Success Signals
+
+The flow succeeds only if all of the following hold:
+
+- the deployed diamond routes loupe selectors correctly
+- the live owner can be read and updated
+- ownership state remains correct after the transfer check
+- the script ends with `Local diamond smoke flow passed.`
+
+## Failure Interpretation
+
+- Artifact read failures usually mean bootstrap did not complete correctly.
+- Loupe or ownership mismatches indicate selector-routing or state-surface
+  regressions.
+- Ownership transfer validation failures indicate deployed admin flows are not
+  behaving as expected.
+
+Use this flow before the upgrade rehearsal when you want the simplest
+deployment-backed validation pass.

--- a/docs/ops/local-diamond-upgrade-rehearsal.md
+++ b/docs/ops/local-diamond-upgrade-rehearsal.md
@@ -1,0 +1,82 @@
+# Local Diamond Upgrade Rehearsal
+
+This flow exercises the deployment-backed diamond upgrade path used to validate
+cut behavior before milestone merges and before production-style operator
+changes.
+
+## What It Covers
+
+- boots a fresh local Anvil chain
+- deploys the reference diamond core
+- executes a successful upgrade path against the deployed diamond
+- validates selector ownership, loupe state, init-backed state, and owner
+  continuity
+- executes deliberate selector-collision and init-failure cuts
+- confirms failed cuts do not leave partial selector routing behind
+
+## Run
+
+```shell
+bash script/run-local-diamond-upgrade-rehearsal.sh
+```
+
+## Default Environment
+
+The runner uses Anvil defaults unless overridden:
+
+- `ANVIL_HOST=127.0.0.1`
+- `ANVIL_PORT=8545`
+- `ANVIL_CHAIN_ID=31337`
+- `PRIVATE_KEY=<anvil account 0>`
+
+It also clears proxy environment variables so local RPC calls are kept on the
+local node.
+
+## Output
+
+- deployment artifact: `deployments/diamond-core.local.json`
+- rehearsal artifact: `deployments/diamond-core.upgrade-rehearsal.local.json`
+- Anvil log: `.anvil-upgrade-rehearsal.log`
+
+The rehearsal artifact records the deployed addresses used by the successful and
+failed-cut checks:
+
+- `diamond`
+- `owner`
+- `upgradeFacet`
+- `initMock`
+- `collisionFacet`
+- `failureFacet`
+
+## Success Signals
+
+The flow succeeds only if all of the following hold:
+
+- the upgrade cut executes successfully
+- the expected selector owners remain in place after failure simulations
+- init-backed state remains readable after failed cuts
+- the owner is unchanged after the deliberate revert paths
+- the script ends with `Local diamond upgrade rehearsal passed.`
+
+## Failure Interpretation
+
+- `Selector collision rehearsal unexpectedly succeeded.`
+  - selector-collision protection regressed
+- `Collision rehearsal left partial selector routing in place.`
+  - failed-cut atomicity regressed
+- `Init-failure rehearsal unexpectedly succeeded.`
+  - init delegatecall failure was not enforced
+- `Init-failure rehearsal left partial selector routing in place.`
+  - init rollback regressed
+- `Owner changed during failed-cut rehearsal.`
+  - ownership continuity regressed across failed cuts
+- `Alpha route regressed...` or `Init-backed state regressed...`
+  - successful upgrade state was corrupted by later failed-cut attempts
+
+## Where It Fits
+
+Use this flow after the local smoke pass and before relying on the full
+system-hardening runner.
+
+It is also the local counterpart to the `System Hardening / Full Local
+Hardening Flow` CI job.

--- a/docs/ops/milestone-close-checklist.md
+++ b/docs/ops/milestone-close-checklist.md
@@ -24,6 +24,7 @@ Use this checklist before merging a milestone branch into `main`.
   - `forge build --sizes`
   - `forge test --offline`
   - `forge coverage --offline`
+  - `bash script/run-local-system-hardening.sh`
 
 ## 4. Security and Operations
 

--- a/docs/ops/release-checklist.md
+++ b/docs/ops/release-checklist.md
@@ -37,11 +37,15 @@ Required outcomes:
 - no build failures
 - no failing tests
 - coverage report generated and reviewed for regressions in touched modules
+- deployment-backed validation run where the release scope touches diamond or
+  system-hardening flows:
+  - `bash script/run-local-system-hardening.sh`
 
 ## 4. Security/Quality Gates
 
 - Confirm CI status is green for:
   - Foundry CI
+  - System Hardening
   - Slither
   - Dependency Review (when enabled)
 - Confirm no unresolved high-severity findings introduced by this release.

--- a/docs/ops/runbook-diamond-cut.md
+++ b/docs/ops/runbook-diamond-cut.md
@@ -18,6 +18,8 @@ Use this runbook for production-facing selector upgrades on the diamond core.
    - `init` target has code.
    - calldata is non-empty.
    - init routine is idempotent and storage-safe.
+6. Rehearse the cut path locally with:
+   - `bash script/run-local-diamond-upgrade-rehearsal.sh`
 
 ## Execution
 
@@ -33,7 +35,9 @@ Use this runbook for production-facing selector upgrades on the diamond core.
    - `facetAddress(selector)`
 2. Verify expected selector ownership matches planned diff.
 3. Run smoke checks on critical external functions.
-4. Verify owner is unchanged unless ownership transfer was planned.
+4. For broader branch validation, run:
+   - `bash script/run-local-system-hardening.sh`
+5. Verify owner is unchanged unless ownership transfer was planned.
 
 ## Failure Handling
 

--- a/docs/ops/runbook-system-hardening.md
+++ b/docs/ops/runbook-system-hardening.md
@@ -1,0 +1,85 @@
+# Runbook: System Hardening Validation
+
+Use this runbook when validating a milestone branch, reproducing CI failures, or
+reviewing the repository's deployment-backed safety checks end to end.
+
+## Recommended Local Execution Order
+
+1. Bootstrap the diamond core if you want the raw deployment step by itself:
+
+```shell
+forge script script/DeployDiamondCore.s.sol:DeployDiamondCoreScript \
+  --rpc-url http://127.0.0.1:8545 \
+  --broadcast
+```
+
+2. Run the local smoke flow:
+
+```shell
+bash script/run-local-diamond-smoke.sh
+```
+
+3. Run the local upgrade rehearsal:
+
+```shell
+bash script/run-local-diamond-upgrade-rehearsal.sh
+```
+
+4. Run the targeted system suites:
+
+```shell
+forge test --offline --match-path test/SystemVaultStressInvariant.t.sol
+forge test --offline --match-path test/SystemOracleFailureScenarios.t.sol
+```
+
+5. Run the full local hardening entrypoint when you want the entire sequence in
+one command:
+
+```shell
+bash script/run-local-system-hardening.sh
+```
+
+## Expected Outputs And Artifacts
+
+- Bootstrap writes `deployments/diamond-core.local.json`
+- Upgrade rehearsal writes `deployments/diamond-core.upgrade-rehearsal.local.json`
+- Smoke flow writes `.anvil-smoke.log`
+- Upgrade rehearsal writes `.anvil-upgrade-rehearsal.log`
+- Successful local flows end with:
+  - `Local diamond smoke flow passed.`
+  - `Local diamond upgrade rehearsal passed.`
+  - `Local system hardening flow passed.`
+
+## Failure Interpretation
+
+- Bootstrap failures usually indicate local RPC readiness problems, deploy
+  script issues, or missing artifact output.
+- Smoke flow failures point to ownership, loupe, selector routing, or live
+  state-transition regressions after deployment.
+- Upgrade rehearsal failures point to selector-collision handling, failed-cut
+  atomicity, init rollback, owner drift, or selector ownership drift.
+- Targeted system suite failures point to vault accounting/pause/reentrancy
+  regressions or oracle incident-handling regressions.
+- If the full hardening runner fails, inspect the first failing sub-step before
+  rerunning the full sequence.
+
+## CI Equivalents
+
+- `Foundry CI / Foundry Checks`
+  - baseline formatting, build, and full offline test suite
+- `System Hardening / Targeted System Suites`
+  - targeted vault/oracle system suites
+- `System Hardening / Full Local Hardening Flow`
+  - `bash script/run-local-system-hardening.sh`
+
+Use the local commands above to reproduce CI behavior before requesting review
+or after a failing run.
+
+## Assumptions
+
+- The flows assume deterministic local Anvil defaults unless environment
+  variables override them.
+- The operator sequence here is for the current diamond/system-hardening
+  milestone, not a future multi-module production deployment.
+- Remaining out-of-scope and trust assumptions are tracked in
+  `docs/system-hardening.md`.

--- a/docs/ops/runbook-upgrade-execution.md
+++ b/docs/ops/runbook-upgrade-execution.md
@@ -18,6 +18,9 @@ Use this runbook for guarded upgrade operations.
 - Confirm implementation address is final and deployed.
 - Confirm compatibility and migration assumptions.
 - Confirm rollback or cancel path is clear.
+- If the change touches the diamond upgrade path or system-level validation
+  surface, rehearse locally first:
+  - `bash script/run-local-diamond-upgrade-rehearsal.sh`
 
 ## Execution Flow
 
@@ -40,6 +43,9 @@ Use this runbook for guarded upgrade operations.
 
 - Confirm expected implementation is active (module-specific check).
 - Run smoke checks on critical paths.
+- For deployment-backed validation, run:
+  - `bash script/run-local-diamond-smoke.sh`
+  - `bash script/run-local-system-hardening.sh`
 - Record:
   - queued by / executed by
   - queue and execution timestamps

--- a/docs/security-checks.md
+++ b/docs/security-checks.md
@@ -14,6 +14,8 @@ This repository runs security-focused CI checks in addition to baseline Foundry 
     - `forge test --offline --match-path test/SystemOracleFailureScenarios.t.sol`
   - `Full Local Hardening Flow` runs on pushes to `main`/`milestone/**`, on manual dispatch, and on pull requests targeting `main` or `milestone/**`.
 - Scope: deployment bootstrap, smoke flow, upgrade rehearsal, vault stress invariants, and oracle failure scenarios.
+- Operational execution order and local reproduction context:
+  `docs/ops/runbook-system-hardening.md`
 
 ### Slither (`.github/workflows/slither.yml`)
 

--- a/docs/system-hardening.md
+++ b/docs/system-hardening.md
@@ -3,6 +3,9 @@
 This note defines the reproducible system-level hardening coverage added for
 issue `#69`.
 
+For the operator-facing execution order and failure interpretation, see
+`docs/ops/runbook-system-hardening.md`.
+
 ## What Is Simulated
 
 - Local diamond bootstrap and smoke validation through the Foundry deployment


### PR DESCRIPTION
## Summary
- rewrite the root README as a portfolio-style front page under the Keystone name
- add dedicated docs for local diamond upgrade rehearsal and the full system-hardening execution order
- tighten ops, security, release, and milestone docs so local and CI validation flows are cross-linked and easier to follow

## Included Work
- add `docs/ops/local-diamond-upgrade-rehearsal.md`
- add `docs/ops/runbook-system-hardening.md`
- update the root `README.md` branding and validation/documentation sections
- update ops runbooks, checklists, and security docs to reflect the current execution path

## Validation
- `git diff --check`

## Issue
- Closes #68