### PR TITLE
Add shared token facet foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ bash script/run-local-system-hardening.sh
 ## Documentation
 
 Architecture and module docs live in `docs/diamond-core.md`,
-`docs/oracle-adapter.md`, `docs/erc4626-vault.md`, and `docs/threat-model.md`.
+`docs/oracle-adapter.md`, `docs/erc4626-vault.md`, `docs/token-facets.md`, and
+`docs/threat-model.md`.
 
 Operational guidance lives in `docs/ops/README.md`, with the end-to-end
 execution order collected in `docs/ops/runbook-system-hardening.md`.

--- a/docs/token-facets.md
+++ b/docs/token-facets.md
@@ -1,0 +1,69 @@
+## Token Facet Foundation
+
+This document defines the shared foundation for hosted token facets in the
+diamond roadmap.
+
+### Shared Interfaces
+
+The token foundation introduces:
+
+- `IERC20Permit` for future EIP-2612 support on the ERC-20 side
+- `IERC721`, `IERC721Metadata`, and `IERC721Receiver` for the ERC-721 side
+- `IERC20TokenBase` and `IERC721TokenBase` for foundation-specific init/error
+  surfaces used by the base contracts
+
+### Storage Conventions
+
+Hosted token facets use separate fixed storage slots:
+
+- ERC-20: `keccak256("smart-contracts.token.erc20.storage")`
+- ERC-721: `keccak256("smart-contracts.token.erc721.storage")`
+
+The milestone intentionally keeps those layouts separate so ERC-20 and ERC-721
+facets can coexist in one diamond without balance, allowance, ownership, or
+metadata collisions.
+
+### Initializer Pattern
+
+Each hosted token standard owns its own one-time initializer:
+
+- `_initializeErc20Token(...)`
+- `_initializeErc721Token(...)`
+
+The initializer guards are per-token-standard, not global to the diamond. That
+lets one diamond host both token systems while still preventing duplicate init
+for either storage layout.
+
+### Access Control And Pause Rules
+
+The shared token constants library defines the canonical integration surface for
+later facets:
+
+- roles:
+  - `TOKEN_ADMIN_ROLE`
+  - `ERC20_MINTER_ROLE`
+  - `ERC20_BURNER_ROLE`
+  - `ERC721_MINTER_ROLE`
+  - `ERC721_BURNER_ROLE`
+  - `ERC721_METADATA_ROLE`
+- pause scopes:
+  - `ERC20_TRANSFER_SCOPE`
+  - `ERC20_APPROVAL_SCOPE`
+  - `ERC721_TRANSFER_SCOPE`
+  - `ERC721_APPROVAL_SCOPE`
+
+Later ERC20/721 facet issues should reuse those identifiers rather than invent
+parallel role or pause namespaces.
+
+### ERC165 Notes
+
+ERC-20 does not rely on ERC-165. ERC-721 does, and the shared ERC-721 base
+advertises:
+
+- `IERC165`
+- `IERC721`
+- `IERC721Metadata`
+
+When ERC-721 is installed behind a diamond, the init or deployment flow should
+ensure the diamond-level interface surface remains consistent with the facet
+selectors that are actually installed.

--- a/src/interfaces/IERC20Permit.sol
+++ b/src/interfaces/IERC20Permit.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title IERC20Permit
+/// @notice EIP-2612 permit extension interface.
+interface IERC20Permit {
+    /// @notice Sets `value` allowance from `owner` to `spender` using a signed approval.
+    /// @param owner Token owner.
+    /// @param spender Approved spender.
+    /// @param value Allowance amount.
+    /// @param deadline Signature expiration timestamp.
+    /// @param v Recovery identifier.
+    /// @param r Signature component.
+    /// @param s Signature component.
+    function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s)
+        external;
+
+    /// @notice Returns the current permit nonce for `owner`.
+    /// @param owner Token owner.
+    /// @return The current nonce.
+    function nonces(address owner) external view returns (uint256);
+
+    /// @notice Returns the EIP-712 domain separator used for permit signatures.
+    /// @return The domain separator.
+    function DOMAIN_SEPARATOR() external view returns (bytes32);
+}

--- a/src/interfaces/IERC20TokenBase.sol
+++ b/src/interfaces/IERC20TokenBase.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC20Metadata} from "./IERC20Metadata.sol";
+
+/// @title IERC20TokenBase
+/// @notice Interface for shared ERC-20 token foundation helpers.
+interface IERC20TokenBase is IERC20Metadata {
+    /// @notice Thrown when the ERC-20 initializer runs more than once.
+    error ERC20TokenAlreadyInitialized();
+    /// @notice Thrown when mutating helpers run before initialization.
+    error ERC20TokenNotInitialized();
+    /// @notice Thrown when a required account is the zero address.
+    error ERC20TokenZeroAddress();
+    /// @notice Thrown when an account balance is insufficient.
+    error ERC20TokenInsufficientBalance(address account, uint256 available, uint256 required);
+    /// @notice Thrown when allowance is insufficient.
+    error ERC20TokenInsufficientAllowance(address owner, address spender, uint256 available, uint256 required);
+
+    /// @notice Returns true when ERC-20 storage is initialized.
+    /// @return True if initialized.
+    function isErc20Initialized() external view returns (bool);
+}

--- a/src/interfaces/IERC721.sol
+++ b/src/interfaces/IERC721.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC165} from "./IERC165.sol";
+
+/// @title IERC721
+/// @notice ERC-721 non-fungible token standard interface.
+interface IERC721 is IERC165 {
+    /// @notice Emitted when `tokenId` transfers from `from` to `to`.
+    event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
+
+    /// @notice Emitted when `owner` approves `approved` for `tokenId`.
+    event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId);
+
+    /// @notice Emitted when `owner` enables or disables `operator`.
+    event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
+
+    /// @notice Returns the token count owned by `owner`.
+    /// @param owner The account to query.
+    /// @return The balance for `owner`.
+    function balanceOf(address owner) external view returns (uint256);
+
+    /// @notice Returns the owner of `tokenId`.
+    /// @param tokenId The token identifier.
+    /// @return The token owner.
+    function ownerOf(uint256 tokenId) external view returns (address);
+
+    /// @notice Safely transfers `tokenId` from `from` to `to`.
+    /// @param from The current owner.
+    /// @param to The receiver.
+    /// @param tokenId The token identifier.
+    function safeTransferFrom(address from, address to, uint256 tokenId) external;
+
+    /// @notice Transfers `tokenId` from `from` to `to`.
+    /// @param from The current owner.
+    /// @param to The receiver.
+    /// @param tokenId The token identifier.
+    function transferFrom(address from, address to, uint256 tokenId) external;
+
+    /// @notice Approves `to` to manage `tokenId`.
+    /// @param to Approved account.
+    /// @param tokenId The token identifier.
+    function approve(address to, uint256 tokenId) external;
+
+    /// @notice Enables or disables `operator` for caller-owned tokens.
+    /// @param operator The operator account.
+    /// @param approved True to approve, false to revoke.
+    function setApprovalForAll(address operator, bool approved) external;
+
+    /// @notice Returns the approved account for `tokenId`.
+    /// @param tokenId The token identifier.
+    /// @return The approved account, or zero if none.
+    function getApproved(uint256 tokenId) external view returns (address);
+
+    /// @notice Returns whether `operator` is approved for all of `owner`'s tokens.
+    /// @param owner Token owner.
+    /// @param operator Operator account.
+    /// @return True if approved.
+    function isApprovedForAll(address owner, address operator) external view returns (bool);
+
+    /// @notice Safely transfers `tokenId` from `from` to `to` with `data`.
+    /// @param from The current owner.
+    /// @param to The receiver.
+    /// @param tokenId The token identifier.
+    /// @param data Additional receiver data.
+    function safeTransferFrom(address from, address to, uint256 tokenId, bytes calldata data) external;
+}

--- a/src/interfaces/IERC721Metadata.sol
+++ b/src/interfaces/IERC721Metadata.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC721} from "./IERC721.sol";
+
+/// @title IERC721Metadata
+/// @notice ERC-721 metadata extension interface.
+interface IERC721Metadata is IERC721 {
+    /// @notice Returns token collection name.
+    /// @return The collection name.
+    function name() external view returns (string memory);
+
+    /// @notice Returns token collection symbol.
+    /// @return The collection symbol.
+    function symbol() external view returns (string memory);
+
+    /// @notice Returns the metadata URI for `tokenId`.
+    /// @param tokenId The token identifier.
+    /// @return The token metadata URI.
+    function tokenURI(uint256 tokenId) external view returns (string memory);
+}

--- a/src/interfaces/IERC721Receiver.sol
+++ b/src/interfaces/IERC721Receiver.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title IERC721Receiver
+/// @notice Interface for contracts that can receive safe ERC-721 transfers.
+interface IERC721Receiver {
+    /// @notice Handles receipt of an ERC-721 token.
+    /// @param operator The account that initiated the transfer.
+    /// @param from The previous owner.
+    /// @param tokenId The token identifier.
+    /// @param data Additional transfer data.
+    /// @return The selector to confirm receipt.
+    function onERC721Received(address operator, address from, uint256 tokenId, bytes calldata data)
+        external
+        returns (bytes4);
+}

--- a/src/interfaces/IERC721TokenBase.sol
+++ b/src/interfaces/IERC721TokenBase.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC721Metadata} from "./IERC721Metadata.sol";
+
+/// @title IERC721TokenBase
+/// @notice Interface for shared ERC-721 token foundation helpers.
+interface IERC721TokenBase is IERC721Metadata {
+    /// @notice Thrown when the ERC-721 initializer runs more than once.
+    error ERC721TokenAlreadyInitialized();
+    /// @notice Thrown when mutating helpers run before initialization.
+    error ERC721TokenNotInitialized();
+    /// @notice Thrown when a required account is the zero address.
+    error ERC721TokenZeroAddress();
+    /// @notice Thrown when `owner` is invalid for the requested operation.
+    error ERC721TokenInvalidOwner(address owner);
+    /// @notice Thrown when a token does not exist.
+    error ERC721TokenNonexistentToken(uint256 tokenId);
+    /// @notice Thrown when a mint targets an existing token.
+    error ERC721TokenAlreadyMinted(uint256 tokenId);
+    /// @notice Thrown when `from` is not the current owner of `tokenId`.
+    error ERC721TokenIncorrectOwner(address from, uint256 tokenId, address actualOwner);
+    /// @notice Thrown when a receiver does not implement `IERC721Receiver`.
+    error ERC721TokenUnsafeReceiver(address receiver);
+    /// @notice Thrown when `owner` tries to set themselves as operator.
+    error ERC721TokenInvalidOperator(address owner, address operator);
+
+    /// @notice Returns true when ERC-721 storage is initialized.
+    /// @return True if initialized.
+    function isErc721Initialized() external view returns (bool);
+}

--- a/src/token/ERC20TokenBase.sol
+++ b/src/token/ERC20TokenBase.sol
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC20TokenBase} from "../interfaces/IERC20TokenBase.sol";
+import {LibERC20TokenStorage} from "./storage/LibERC20TokenStorage.sol";
+
+/// @title ERC20TokenBase
+/// @notice Diamond-ready ERC-20 token foundation with initializer and shared storage helpers.
+abstract contract ERC20TokenBase is IERC20TokenBase {
+    /// @notice Returns true when ERC-20 storage is initialized.
+    /// @return True if initialized.
+    function isErc20Initialized() public view returns (bool) {
+        return LibERC20TokenStorage.layout().initialized;
+    }
+
+    /// @notice Returns ERC-20 token name.
+    /// @return The token name.
+    function name() public view virtual returns (string memory) {
+        return LibERC20TokenStorage.layout().name;
+    }
+
+    /// @notice Returns ERC-20 token symbol.
+    /// @return The token symbol.
+    function symbol() public view virtual returns (string memory) {
+        return LibERC20TokenStorage.layout().symbol;
+    }
+
+    /// @notice Returns ERC-20 token decimals.
+    /// @return The token decimals.
+    function decimals() public view virtual returns (uint8) {
+        return LibERC20TokenStorage.layout().decimals;
+    }
+
+    /// @notice Returns total token supply.
+    /// @return The current total supply.
+    function totalSupply() public view virtual returns (uint256) {
+        return LibERC20TokenStorage.layout().totalSupply;
+    }
+
+    /// @notice Returns balance for `account`.
+    /// @param account The account to query.
+    /// @return The token balance.
+    function balanceOf(address account) public view virtual returns (uint256) {
+        return LibERC20TokenStorage.layout().balances[account];
+    }
+
+    /// @notice Returns allowance from `owner` to `spender`.
+    /// @param owner Token owner.
+    /// @param spender Approved spender.
+    /// @return Remaining allowance.
+    function allowance(address owner, address spender) public view virtual returns (uint256) {
+        return LibERC20TokenStorage.layout().allowances[owner][spender];
+    }
+
+    /// @dev Initializes ERC-20 metadata and shared storage.
+    /// @param tokenName The ERC-20 token name.
+    /// @param tokenSymbol The ERC-20 token symbol.
+    /// @param tokenDecimals The ERC-20 token decimals.
+    function _initializeErc20Token(string memory tokenName, string memory tokenSymbol, uint8 tokenDecimals) internal {
+        LibERC20TokenStorage.Layout storage layout = LibERC20TokenStorage.layout();
+        if (layout.initialized) {
+            revert ERC20TokenAlreadyInitialized();
+        }
+
+        layout.initialized = true;
+        layout.name = tokenName;
+        layout.symbol = tokenSymbol;
+        layout.decimals = tokenDecimals;
+    }
+
+    /// @dev Mints `value` tokens to `to`.
+    /// @param to Recipient account.
+    /// @param value Amount to mint.
+    function _mintTokens(address to, uint256 value) internal {
+        _requireInitialized();
+        _requireNonZeroAddress(to);
+
+        LibERC20TokenStorage.Layout storage layout = LibERC20TokenStorage.layout();
+        layout.totalSupply += value;
+        layout.balances[to] += value;
+
+        emit Transfer(address(0), to, value);
+    }
+
+    /// @dev Burns `value` tokens from `from`.
+    /// @param from Token owner.
+    /// @param value Amount to burn.
+    function _burnTokens(address from, uint256 value) internal {
+        _requireInitialized();
+        _requireNonZeroAddress(from);
+
+        LibERC20TokenStorage.Layout storage layout = LibERC20TokenStorage.layout();
+        uint256 fromBalance = layout.balances[from];
+        if (fromBalance < value) {
+            revert ERC20TokenInsufficientBalance(from, fromBalance, value);
+        }
+
+        unchecked {
+            layout.balances[from] = fromBalance - value;
+            layout.totalSupply -= value;
+        }
+
+        emit Transfer(from, address(0), value);
+    }
+
+    /// @dev Transfers `value` tokens from `from` to `to`.
+    /// @param from Token sender.
+    /// @param to Token receiver.
+    /// @param value Amount to transfer.
+    function _transferTokens(address from, address to, uint256 value) internal {
+        _requireInitialized();
+        _requireNonZeroAddress(from);
+        _requireNonZeroAddress(to);
+
+        LibERC20TokenStorage.Layout storage layout = LibERC20TokenStorage.layout();
+        uint256 fromBalance = layout.balances[from];
+        if (fromBalance < value) {
+            revert ERC20TokenInsufficientBalance(from, fromBalance, value);
+        }
+
+        unchecked {
+            layout.balances[from] = fromBalance - value;
+        }
+        layout.balances[to] += value;
+
+        emit Transfer(from, to, value);
+    }
+
+    /// @dev Sets allowance from `owner` to `spender`.
+    /// @param owner Token owner.
+    /// @param spender Approved spender.
+    /// @param value New allowance value.
+    function _setAllowance(address owner, address spender, uint256 value) internal {
+        _requireInitialized();
+        _requireNonZeroAddress(owner);
+
+        LibERC20TokenStorage.layout().allowances[owner][spender] = value;
+        emit Approval(owner, spender, value);
+    }
+
+    /// @dev Consumes allowance from `owner` to `spender`.
+    /// @dev Infinite allowance (`type(uint256).max`) is not decremented.
+    /// @param owner Token owner.
+    /// @param spender Approved spender.
+    /// @param value Amount to consume.
+    function _spendAllowance(address owner, address spender, uint256 value) internal {
+        _requireInitialized();
+        _requireNonZeroAddress(owner);
+
+        uint256 currentAllowance = allowance(owner, spender);
+        if (currentAllowance == type(uint256).max) {
+            return;
+        }
+        if (currentAllowance < value) {
+            revert ERC20TokenInsufficientAllowance(owner, spender, currentAllowance, value);
+        }
+
+        unchecked {
+            _setAllowance(owner, spender, currentAllowance - value);
+        }
+    }
+
+    /// @dev Reverts when ERC-20 storage has not been initialized.
+    function _requireInitialized() internal view {
+        if (!isErc20Initialized()) {
+            revert ERC20TokenNotInitialized();
+        }
+    }
+
+    /// @dev Reverts when `account` is zero.
+    /// @param account The account to validate.
+    function _requireNonZeroAddress(address account) internal pure {
+        if (account == address(0)) {
+            revert ERC20TokenZeroAddress();
+        }
+    }
+}

--- a/src/token/ERC721TokenBase.sol
+++ b/src/token/ERC721TokenBase.sol
@@ -1,0 +1,326 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC165} from "../interfaces/IERC165.sol";
+import {IERC721} from "../interfaces/IERC721.sol";
+import {IERC721Metadata} from "../interfaces/IERC721Metadata.sol";
+import {IERC721Receiver} from "../interfaces/IERC721Receiver.sol";
+import {IERC721TokenBase} from "../interfaces/IERC721TokenBase.sol";
+import {LibERC721TokenStorage} from "./storage/LibERC721TokenStorage.sol";
+
+/// @title ERC721TokenBase
+/// @notice Diamond-ready ERC-721 token foundation with initializer, metadata, and shared storage helpers.
+abstract contract ERC721TokenBase is IERC721TokenBase {
+    /// @notice Returns true when this contract implements `interfaceId`.
+    /// @param interfaceId The interface identifier.
+    /// @return True when supported.
+    function supportsInterface(bytes4 interfaceId) public view virtual returns (bool) {
+        return interfaceId == type(IERC165).interfaceId || interfaceId == type(IERC721).interfaceId
+            || interfaceId == type(IERC721Metadata).interfaceId;
+    }
+
+    /// @notice Returns true when ERC-721 storage is initialized.
+    /// @return True if initialized.
+    function isErc721Initialized() public view returns (bool) {
+        return LibERC721TokenStorage.layout().initialized;
+    }
+
+    /// @notice Returns ERC-721 collection name.
+    /// @return The collection name.
+    function name() public view virtual returns (string memory) {
+        return LibERC721TokenStorage.layout().name;
+    }
+
+    /// @notice Returns ERC-721 collection symbol.
+    /// @return The collection symbol.
+    function symbol() public view virtual returns (string memory) {
+        return LibERC721TokenStorage.layout().symbol;
+    }
+
+    /// @notice Returns the current token owner.
+    /// @param tokenId The token identifier.
+    /// @return The token owner.
+    function ownerOf(uint256 tokenId) public view virtual returns (address) {
+        return _requireOwned(tokenId);
+    }
+
+    /// @notice Returns token balance for `owner`.
+    /// @param owner The account to query.
+    /// @return The token balance.
+    function balanceOf(address owner) public view virtual returns (uint256) {
+        if (owner == address(0)) {
+            revert ERC721TokenInvalidOwner(owner);
+        }
+        return LibERC721TokenStorage.layout().balances[owner];
+    }
+
+    /// @notice Returns the approved account for `tokenId`.
+    /// @param tokenId The token identifier.
+    /// @return The approved account, or zero when unset.
+    function getApproved(uint256 tokenId) public view virtual returns (address) {
+        _requireOwned(tokenId);
+        return LibERC721TokenStorage.layout().tokenApprovals[tokenId];
+    }
+
+    /// @notice Returns whether `operator` is approved for all of `owner`'s tokens.
+    /// @param owner Token owner.
+    /// @param operator Operator account.
+    /// @return True when approved.
+    function isApprovedForAll(address owner, address operator) public view virtual returns (bool) {
+        return LibERC721TokenStorage.layout().operatorApprovals[owner][operator];
+    }
+
+    /// @notice Returns metadata URI for `tokenId`.
+    /// @param tokenId The token identifier.
+    /// @return The token metadata URI.
+    function tokenURI(uint256 tokenId) public view virtual returns (string memory) {
+        _requireOwned(tokenId);
+
+        LibERC721TokenStorage.Layout storage layout = LibERC721TokenStorage.layout();
+        string memory explicitTokenUri = layout.tokenURIs[tokenId];
+        if (bytes(explicitTokenUri).length != 0) {
+            return explicitTokenUri;
+        }
+        if (bytes(layout.baseURI).length == 0) {
+            return "";
+        }
+        return string.concat(layout.baseURI, _toString(tokenId));
+    }
+
+    /// @notice Returns current live token count tracked by the foundation.
+    /// @return The token count.
+    function totalSupply() public view returns (uint256) {
+        return LibERC721TokenStorage.layout().totalSupply;
+    }
+
+    /// @dev Initializes ERC-721 metadata and shared storage.
+    /// @param tokenName The collection name.
+    /// @param tokenSymbol The collection symbol.
+    /// @param defaultBaseURI Default base URI for tokens without explicit URI.
+    function _initializeErc721Token(string memory tokenName, string memory tokenSymbol, string memory defaultBaseURI)
+        internal
+    {
+        LibERC721TokenStorage.Layout storage layout = LibERC721TokenStorage.layout();
+        if (layout.initialized) {
+            revert ERC721TokenAlreadyInitialized();
+        }
+
+        layout.initialized = true;
+        layout.name = tokenName;
+        layout.symbol = tokenSymbol;
+        layout.baseURI = defaultBaseURI;
+    }
+
+    /// @dev Mints `tokenId` to `to`.
+    /// @param to Recipient account.
+    /// @param tokenId The token identifier.
+    function _mintToken(address to, uint256 tokenId) internal {
+        _requireInitialized();
+        if (to == address(0)) {
+            revert ERC721TokenZeroAddress();
+        }
+        if (_exists(tokenId)) {
+            revert ERC721TokenAlreadyMinted(tokenId);
+        }
+
+        LibERC721TokenStorage.Layout storage layout = LibERC721TokenStorage.layout();
+        layout.owners[tokenId] = to;
+        layout.balances[to] += 1;
+        layout.totalSupply += 1;
+
+        emit Transfer(address(0), to, tokenId);
+    }
+
+    /// @dev Safely mints `tokenId` to `to`.
+    /// @param to Recipient account.
+    /// @param tokenId The token identifier.
+    /// @param data Additional receiver data.
+    function _safeMintToken(address to, uint256 tokenId, bytes memory data) internal {
+        _mintToken(to, tokenId);
+        _checkOnErc721Received(address(0), to, tokenId, data);
+    }
+
+    /// @dev Burns `tokenId`.
+    /// @param tokenId The token identifier.
+    function _burnToken(uint256 tokenId) internal {
+        _requireInitialized();
+
+        LibERC721TokenStorage.Layout storage layout = LibERC721TokenStorage.layout();
+        address owner_ = _requireOwned(tokenId);
+
+        unchecked {
+            layout.balances[owner_] -= 1;
+            layout.totalSupply -= 1;
+        }
+
+        delete layout.owners[tokenId];
+        delete layout.tokenApprovals[tokenId];
+        delete layout.tokenURIs[tokenId];
+
+        emit Transfer(owner_, address(0), tokenId);
+    }
+
+    /// @dev Transfers `tokenId` from `from` to `to`.
+    /// @param from Current token owner.
+    /// @param to Token receiver.
+    /// @param tokenId The token identifier.
+    function _transferToken(address from, address to, uint256 tokenId) internal {
+        _requireInitialized();
+        if (to == address(0)) {
+            revert ERC721TokenZeroAddress();
+        }
+
+        address owner_ = _requireOwned(tokenId);
+        if (owner_ != from) {
+            revert ERC721TokenIncorrectOwner(from, tokenId, owner_);
+        }
+
+        LibERC721TokenStorage.Layout storage layout = LibERC721TokenStorage.layout();
+        delete layout.tokenApprovals[tokenId];
+
+        unchecked {
+            layout.balances[from] -= 1;
+        }
+        layout.balances[to] += 1;
+        layout.owners[tokenId] = to;
+
+        emit Transfer(from, to, tokenId);
+    }
+
+    /// @dev Safely transfers `tokenId` from `from` to `to`.
+    /// @param from Current token owner.
+    /// @param to Token receiver.
+    /// @param tokenId The token identifier.
+    /// @param data Additional receiver data.
+    function _safeTransferToken(address from, address to, uint256 tokenId, bytes memory data) internal {
+        _transferToken(from, to, tokenId);
+        _checkOnErc721Received(from, to, tokenId, data);
+    }
+
+    /// @dev Sets approved account for `tokenId`.
+    /// @param to Approved account, or zero to clear.
+    /// @param tokenId The token identifier.
+    function _approveToken(address to, uint256 tokenId) internal {
+        _requireInitialized();
+        _requireOwned(tokenId);
+
+        LibERC721TokenStorage.layout().tokenApprovals[tokenId] = to;
+        emit Approval(ownerOf(tokenId), to, tokenId);
+    }
+
+    /// @dev Enables or disables `operator` for all of `owner`'s tokens.
+    /// @param owner Token owner.
+    /// @param operator Operator account.
+    /// @param approved True to approve, false to revoke.
+    function _setApprovalForAll(address owner, address operator, bool approved) internal {
+        _requireInitialized();
+        if (owner == address(0) || operator == address(0)) {
+            revert ERC721TokenZeroAddress();
+        }
+        if (owner == operator) {
+            revert ERC721TokenInvalidOperator(owner, operator);
+        }
+
+        LibERC721TokenStorage.layout().operatorApprovals[owner][operator] = approved;
+        emit ApprovalForAll(owner, operator, approved);
+    }
+
+    /// @dev Sets the base URI used for tokens without explicit URI.
+    /// @param baseUri The new base URI.
+    function _setBaseURI(string memory baseUri) internal {
+        _requireInitialized();
+        LibERC721TokenStorage.layout().baseURI = baseUri;
+    }
+
+    /// @dev Sets explicit metadata URI for `tokenId`.
+    /// @param tokenId The token identifier.
+    /// @param uri The explicit metadata URI.
+    function _setTokenURI(uint256 tokenId, string memory uri) internal {
+        _requireInitialized();
+        _requireOwned(tokenId);
+        LibERC721TokenStorage.layout().tokenURIs[tokenId] = uri;
+    }
+
+    /// @dev Returns whether `tokenId` exists.
+    /// @param tokenId The token identifier.
+    /// @return True when the token exists.
+    function _exists(uint256 tokenId) internal view returns (bool) {
+        return _ownerOf(tokenId) != address(0);
+    }
+
+    /// @dev Returns the raw owner for `tokenId`, or zero when absent.
+    /// @param tokenId The token identifier.
+    /// @return The raw owner address.
+    function _ownerOf(uint256 tokenId) internal view returns (address) {
+        return LibERC721TokenStorage.layout().owners[tokenId];
+    }
+
+    /// @dev Returns whether `spender` can manage `tokenId`.
+    /// @param spender The account to check.
+    /// @param tokenId The token identifier.
+    /// @return True when `spender` is owner or approved.
+    function _isApprovedOrOwner(address spender, uint256 tokenId) internal view returns (bool) {
+        address owner_ = _requireOwned(tokenId);
+        return spender == owner_ || getApproved(tokenId) == spender || isApprovedForAll(owner_, spender);
+    }
+
+    /// @dev Returns token owner or reverts when token does not exist.
+    /// @param tokenId The token identifier.
+    /// @return owner_ The token owner.
+    function _requireOwned(uint256 tokenId) internal view returns (address owner_) {
+        owner_ = _ownerOf(tokenId);
+        if (owner_ == address(0)) {
+            revert ERC721TokenNonexistentToken(tokenId);
+        }
+    }
+
+    /// @dev Reverts when ERC-721 storage has not been initialized.
+    function _requireInitialized() internal view {
+        if (!isErc721Initialized()) {
+            revert ERC721TokenNotInitialized();
+        }
+    }
+
+    /// @dev Reverts when `to` cannot receive safe ERC-721 transfers.
+    /// @param from Previous token owner.
+    /// @param to Receiver account.
+    /// @param tokenId The token identifier.
+    /// @param data Additional receiver data.
+    function _checkOnErc721Received(address from, address to, uint256 tokenId, bytes memory data) internal {
+        if (to.code.length == 0) {
+            return;
+        }
+
+        try IERC721Receiver(to).onERC721Received(msg.sender, from, tokenId, data) returns (bytes4 retval) {
+            if (retval != IERC721Receiver.onERC721Received.selector) {
+                revert ERC721TokenUnsafeReceiver(to);
+            }
+        } catch {
+            revert ERC721TokenUnsafeReceiver(to);
+        }
+    }
+
+    /// @dev Converts `value` to its decimal string representation.
+    /// @param value The value to stringify.
+    /// @return The decimal string.
+    function _toString(uint256 value) private pure returns (string memory) {
+        if (value == 0) {
+            return "0";
+        }
+
+        uint256 temp = value;
+        uint256 digits;
+        while (temp != 0) {
+            digits++;
+            temp /= 10;
+        }
+
+        bytes memory buffer = new bytes(digits);
+        while (value != 0) {
+            digits -= 1;
+            buffer[digits] = bytes1(uint8(48 + uint256(value % 10)));
+            value /= 10;
+        }
+        return string(buffer);
+    }
+}

--- a/src/token/libraries/LibTokenFacetConstants.sol
+++ b/src/token/libraries/LibTokenFacetConstants.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title LibTokenFacetConstants
+/// @notice Shared role and pause-scope identifiers for hosted token facets.
+library LibTokenFacetConstants {
+    /// @notice Role for token-level administrative configuration.
+    bytes32 internal constant TOKEN_ADMIN_ROLE = keccak256("TOKEN_ADMIN_ROLE");
+    /// @notice Role for ERC-20 mint operations.
+    bytes32 internal constant ERC20_MINTER_ROLE = keccak256("ERC20_MINTER_ROLE");
+    /// @notice Role for ERC-20 burn operations.
+    bytes32 internal constant ERC20_BURNER_ROLE = keccak256("ERC20_BURNER_ROLE");
+    /// @notice Role for ERC-721 mint operations.
+    bytes32 internal constant ERC721_MINTER_ROLE = keccak256("ERC721_MINTER_ROLE");
+    /// @notice Role for ERC-721 burn operations.
+    bytes32 internal constant ERC721_BURNER_ROLE = keccak256("ERC721_BURNER_ROLE");
+    /// @notice Role for ERC-721 metadata updates.
+    bytes32 internal constant ERC721_METADATA_ROLE = keccak256("ERC721_METADATA_ROLE");
+
+    /// @notice Pause scope for ERC-20 transfers.
+    bytes32 internal constant ERC20_TRANSFER_SCOPE = keccak256("ERC20_TRANSFER_SCOPE");
+    /// @notice Pause scope for ERC-20 approvals.
+    bytes32 internal constant ERC20_APPROVAL_SCOPE = keccak256("ERC20_APPROVAL_SCOPE");
+    /// @notice Pause scope for ERC-721 transfers.
+    bytes32 internal constant ERC721_TRANSFER_SCOPE = keccak256("ERC721_TRANSFER_SCOPE");
+    /// @notice Pause scope for ERC-721 approvals.
+    bytes32 internal constant ERC721_APPROVAL_SCOPE = keccak256("ERC721_APPROVAL_SCOPE");
+}

--- a/src/token/storage/LibERC20TokenStorage.sol
+++ b/src/token/storage/LibERC20TokenStorage.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title LibERC20TokenStorage
+/// @notice Diamond-safe storage layout for hosted ERC-20 facets.
+library LibERC20TokenStorage {
+    /// @dev Storage slot for ERC-20 token layout.
+    bytes32 internal constant STORAGE_SLOT = keccak256("smart-contracts.token.erc20.storage");
+
+    /// @notice ERC-20 token storage layout.
+    struct Layout {
+        bool initialized;
+        uint8 decimals;
+        string name;
+        string symbol;
+        uint256 totalSupply;
+        mapping(address => uint256) balances;
+        mapping(address => mapping(address => uint256)) allowances;
+    }
+
+    /// @notice Returns the ERC-20 storage layout.
+    /// @return l The storage layout pointer.
+    function layout() internal pure returns (Layout storage l) {
+        bytes32 slot = STORAGE_SLOT;
+        assembly {
+            l.slot := slot
+        }
+    }
+}

--- a/src/token/storage/LibERC721TokenStorage.sol
+++ b/src/token/storage/LibERC721TokenStorage.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title LibERC721TokenStorage
+/// @notice Diamond-safe storage layout for hosted ERC-721 facets.
+library LibERC721TokenStorage {
+    /// @dev Storage slot for ERC-721 token layout.
+    bytes32 internal constant STORAGE_SLOT = keccak256("smart-contracts.token.erc721.storage");
+
+    /// @notice ERC-721 token storage layout.
+    struct Layout {
+        bool initialized;
+        string name;
+        string symbol;
+        string baseURI;
+        uint256 totalSupply;
+        mapping(uint256 => address) owners;
+        mapping(address => uint256) balances;
+        mapping(uint256 => address) tokenApprovals;
+        mapping(address => mapping(address => bool)) operatorApprovals;
+        mapping(uint256 => string) tokenURIs;
+    }
+
+    /// @notice Returns the ERC-721 storage layout.
+    /// @return l The storage layout pointer.
+    function layout() internal pure returns (Layout storage l) {
+        bytes32 slot = STORAGE_SLOT;
+        assembly {
+            l.slot := slot
+        }
+    }
+}

--- a/test/TokenFacetFoundationCore.t.sol
+++ b/test/TokenFacetFoundationCore.t.sol
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC165} from "../src/interfaces/IERC165.sol";
+import {IERC20TokenBase} from "../src/interfaces/IERC20TokenBase.sol";
+import {IERC721} from "../src/interfaces/IERC721.sol";
+import {IERC721Metadata} from "../src/interfaces/IERC721Metadata.sol";
+import {IERC721Receiver} from "../src/interfaces/IERC721Receiver.sol";
+import {IERC721TokenBase} from "../src/interfaces/IERC721TokenBase.sol";
+import {TokenFacetFoundationFixture} from "./helpers/TokenFacetFoundationTestHarness.sol";
+
+contract TokenFacetFoundationCoreTest is TokenFacetFoundationFixture {
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+    event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
+
+    function testStorageSlotsAndConstantsAreDistinct() public pure {
+        assertTrue(erc20StorageSlot() != erc721StorageSlot(), "token storage slots should differ");
+        assertTrue(tokenAdminRole() != erc20MinterRole(), "token roles should differ");
+        assertTrue(erc20TransferScope() != erc721ApprovalScope(), "token pause scopes should differ");
+    }
+
+    function testErc20InitializerSetsMetadata() public {
+        erc20.initialize("Facet Token", "FTKN", 18);
+
+        assertTrue(erc20.isErc20Initialized(), "erc20 should initialize");
+        assertTrue(keccak256(bytes(erc20.name())) == keccak256(bytes("Facet Token")), "erc20 name should initialize");
+        assertTrue(keccak256(bytes(erc20.symbol())) == keccak256(bytes("FTKN")), "erc20 symbol should initialize");
+        assertTrue(erc20.decimals() == 18, "erc20 decimals should initialize");
+    }
+
+    function testErc20InitializerRevertsWhenCalledTwice() public {
+        erc20.initialize("Facet Token", "FTKN", 18);
+
+        VM.expectRevert(abi.encodeWithSelector(IERC20TokenBase.ERC20TokenAlreadyInitialized.selector));
+        erc20.initialize("Facet Token", "FTKN", 18);
+    }
+
+    function testErc20HelpersUpdateSupplyBalancesAndAllowance() public {
+        erc20.initialize("Facet Token", "FTKN", 18);
+
+        VM.expectEmit(true, true, false, true, address(erc20));
+        emit Transfer(address(0), admin, 100);
+        erc20.mint(admin, 100);
+
+        VM.expectEmit(true, true, false, true, address(erc20));
+        emit Approval(admin, bob, 40);
+        erc20.approveTokens(admin, bob, 40);
+
+        VM.expectEmit(true, true, false, true, address(erc20));
+        emit Approval(admin, bob, 15);
+        erc20.spendAllowance(admin, bob, 25);
+
+        VM.expectEmit(true, true, false, true, address(erc20));
+        emit Transfer(admin, eve, 55);
+        erc20.transferTokens(admin, eve, 55);
+
+        VM.expectEmit(true, true, false, true, address(erc20));
+        emit Transfer(admin, address(0), 15);
+        erc20.burn(admin, 15);
+
+        assertTrue(erc20.totalSupply() == 85, "erc20 total supply mismatch");
+        assertTrue(erc20.balanceOf(admin) == 30, "admin balance mismatch");
+        assertTrue(erc20.balanceOf(eve) == 55, "eve balance mismatch");
+        assertTrue(erc20.allowance(admin, bob) == 15, "allowance should decrement");
+    }
+
+    function testErc20InfiniteAllowanceDoesNotDecrement() public {
+        erc20.initialize("Facet Token", "FTKN", 18);
+        erc20.approveTokens(admin, bob, type(uint256).max);
+        erc20.spendAllowance(admin, bob, 50);
+
+        assertTrue(erc20.allowance(admin, bob) == type(uint256).max, "infinite allowance should remain unchanged");
+    }
+
+    function testErc20GuardsForUninitializedAndZeroAddress() public {
+        VM.expectRevert(abi.encodeWithSelector(IERC20TokenBase.ERC20TokenNotInitialized.selector));
+        erc20.mint(admin, 1);
+
+        erc20.initialize("Facet Token", "FTKN", 18);
+
+        VM.expectRevert(abi.encodeWithSelector(IERC20TokenBase.ERC20TokenZeroAddress.selector));
+        erc20.mint(address(0), 1);
+
+        erc20.mint(admin, 10);
+        VM.expectRevert(abi.encodeWithSelector(IERC20TokenBase.ERC20TokenInsufficientBalance.selector, admin, 10, 11));
+        erc20.burn(admin, 11);
+    }
+
+    function testErc721InitializerSetsMetadataAndSupportsInterfaces() public {
+        erc721.initialize("Facet NFT", "FNFT", "ipfs://facet/");
+
+        assertTrue(erc721.isErc721Initialized(), "erc721 should initialize");
+        assertTrue(keccak256(bytes(erc721.name())) == keccak256(bytes("Facet NFT")), "erc721 name should initialize");
+        assertTrue(keccak256(bytes(erc721.symbol())) == keccak256(bytes("FNFT")), "erc721 symbol should initialize");
+        assertTrue(erc721.supportsInterface(type(IERC165).interfaceId), "erc165 should be supported");
+        assertTrue(erc721.supportsInterface(type(IERC721).interfaceId), "erc721 should be supported");
+        assertTrue(erc721.supportsInterface(type(IERC721Metadata).interfaceId), "erc721 metadata should be supported");
+        assertFalse(erc721.supportsInterface(0xffffffff), "unexpected interface support");
+    }
+
+    function testErc721InitializerRevertsWhenCalledTwice() public {
+        erc721.initialize("Facet NFT", "FNFT", "ipfs://facet/");
+
+        VM.expectRevert(abi.encodeWithSelector(IERC721TokenBase.ERC721TokenAlreadyInitialized.selector));
+        erc721.initialize("Facet NFT", "FNFT", "ipfs://facet/");
+    }
+
+    function testErc721HelpersUpdateOwnershipApprovalsAndMetadata() public {
+        erc721.initialize("Facet NFT", "FNFT", "ipfs://facet/");
+
+        erc721.mint(admin, 1);
+
+        erc721.approveToken(bob, 1);
+
+        VM.expectEmit(true, true, false, true, address(erc721));
+        emit ApprovalForAll(admin, eve, true);
+        erc721.setApprovalForAll(admin, eve, true);
+
+        erc721.setTokenURI(1, "ipfs://facet/custom-1");
+        assertTrue(
+            keccak256(bytes(erc721.tokenURI(1))) == keccak256(bytes("ipfs://facet/custom-1")),
+            "explicit token uri mismatch"
+        );
+
+        erc721.transferTokens(admin, eve, 1);
+
+        assertTrue(erc721.ownerOf(1) == eve, "owner should update");
+        assertTrue(erc721.balanceOf(admin) == 0, "admin nft balance should decrement");
+        assertTrue(erc721.balanceOf(eve) == 1, "eve nft balance should increment");
+        assertTrue(erc721.getApproved(1) == address(0), "approval should clear on transfer");
+        assertTrue(erc721.isApprovedOrOwner(eve, 1), "new owner should be approved or owner");
+    }
+
+    function testErc721TokenUriFallsBackToBaseUriPlusTokenId() public {
+        erc721.initialize("Facet NFT", "FNFT", "ipfs://facet/");
+        erc721.mint(admin, 7);
+
+        assertTrue(
+            keccak256(bytes(erc721.tokenURI(7))) == keccak256(bytes("ipfs://facet/7")),
+            "base uri fallback should append token id"
+        );
+
+        erc721.setBaseURI("https://example.com/meta/");
+        assertTrue(
+            keccak256(bytes(erc721.tokenURI(7))) == keccak256(bytes("https://example.com/meta/7")),
+            "updated base uri should be reflected"
+        );
+    }
+
+    function testErc721SafeTransferCallsReceiver() public {
+        bytes memory payload = hex"1234";
+
+        erc721.initialize("Facet NFT", "FNFT", "ipfs://facet/");
+        erc721.mint(admin, 1);
+        erc721.safeTransferTokens(admin, address(receiver), 1, payload);
+
+        assertTrue(erc721.ownerOf(1) == address(receiver), "receiver should own token");
+        assertTrue(receiver.lastOperator() == address(this), "receiver should record operator");
+        assertTrue(receiver.lastFrom() == admin, "receiver should record sender");
+        assertTrue(receiver.lastTokenId() == 1, "receiver should record token id");
+        assertTrue(keccak256(receiver.lastData()) == keccak256(payload), "receiver should record data");
+    }
+
+    function testErc721SafeTransferRejectorReverts() public {
+        erc721.initialize("Facet NFT", "FNFT", "ipfs://facet/");
+        erc721.mint(admin, 1);
+
+        VM.expectRevert(abi.encodeWithSelector(IERC721TokenBase.ERC721TokenUnsafeReceiver.selector, address(rejector)));
+        erc721.safeTransferTokens(admin, address(rejector), 1, "");
+    }
+
+    function testErc721BurnClearsOwnershipAndSupply() public {
+        erc721.initialize("Facet NFT", "FNFT", "ipfs://facet/");
+        erc721.mint(admin, 1);
+
+        erc721.burn(1);
+
+        assertTrue(erc721.totalSupply() == 0, "erc721 total supply should decrement");
+        assertTrue(erc721.balanceOf(admin) == 0, "erc721 owner balance should decrement");
+
+        VM.expectRevert(abi.encodeWithSelector(IERC721TokenBase.ERC721TokenNonexistentToken.selector, 1));
+        erc721.ownerOf(1);
+    }
+
+    function testErc721GuardsForZeroAddressAndInvalidOperator() public {
+        VM.expectRevert(abi.encodeWithSelector(IERC721TokenBase.ERC721TokenNotInitialized.selector));
+        erc721.mint(admin, 1);
+
+        erc721.initialize("Facet NFT", "FNFT", "ipfs://facet/");
+
+        VM.expectRevert(abi.encodeWithSelector(IERC721TokenBase.ERC721TokenZeroAddress.selector));
+        erc721.mint(address(0), 1);
+
+        VM.expectRevert(abi.encodeWithSelector(IERC721TokenBase.ERC721TokenInvalidOwner.selector, address(0)));
+        erc721.balanceOf(address(0));
+
+        VM.expectRevert(abi.encodeWithSelector(IERC721TokenBase.ERC721TokenInvalidOperator.selector, admin, admin));
+        erc721.setApprovalForAll(admin, admin, true);
+    }
+}

--- a/test/helpers/TokenFacetFoundationTestHarness.sol
+++ b/test/helpers/TokenFacetFoundationTestHarness.sol
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC165} from "../../src/interfaces/IERC165.sol";
+import {IERC721Receiver} from "../../src/interfaces/IERC721Receiver.sol";
+import {ERC20TokenBase} from "../../src/token/ERC20TokenBase.sol";
+import {ERC721TokenBase} from "../../src/token/ERC721TokenBase.sol";
+import {LibERC20TokenStorage} from "../../src/token/storage/LibERC20TokenStorage.sol";
+import {LibERC721TokenStorage} from "../../src/token/storage/LibERC721TokenStorage.sol";
+import {LibTokenFacetConstants} from "../../src/token/libraries/LibTokenFacetConstants.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+
+contract ERC20TokenBaseHarness is ERC20TokenBase {
+    function initialize(string calldata tokenName, string calldata tokenSymbol, uint8 tokenDecimals) external {
+        _initializeErc20Token(tokenName, tokenSymbol, tokenDecimals);
+    }
+
+    function transfer(address to, uint256 value) external returns (bool) {
+        _transferTokens(msg.sender, to, value);
+        return true;
+    }
+
+    function approve(address spender, uint256 value) external returns (bool) {
+        _setAllowance(msg.sender, spender, value);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 value) external returns (bool) {
+        _spendAllowance(from, msg.sender, value);
+        _transferTokens(from, to, value);
+        return true;
+    }
+
+    function mint(address to, uint256 value) external {
+        _mintTokens(to, value);
+    }
+
+    function burn(address from, uint256 value) external {
+        _burnTokens(from, value);
+    }
+
+    function transferTokens(address from, address to, uint256 value) external {
+        _transferTokens(from, to, value);
+    }
+
+    function approveTokens(address owner, address spender, uint256 value) external {
+        _setAllowance(owner, spender, value);
+    }
+
+    function spendAllowance(address owner, address spender, uint256 value) external {
+        _spendAllowance(owner, spender, value);
+    }
+}
+
+contract ERC721TokenBaseHarness is ERC721TokenBase {
+    function initialize(string calldata tokenName, string calldata tokenSymbol, string calldata baseUri) external {
+        _initializeErc721Token(tokenName, tokenSymbol, baseUri);
+    }
+
+    function safeTransferFrom(address from, address to, uint256 tokenId) external {
+        _safeTransferToken(from, to, tokenId, "");
+    }
+
+    function transferFrom(address from, address to, uint256 tokenId) external {
+        _transferToken(from, to, tokenId);
+    }
+
+    function approve(address to, uint256 tokenId) external {
+        _approveToken(to, tokenId);
+    }
+
+    function setApprovalForAll(address operator, bool approved) external {
+        _setApprovalForAll(msg.sender, operator, approved);
+    }
+
+    function safeTransferFrom(address from, address to, uint256 tokenId, bytes calldata data) external {
+        _safeTransferToken(from, to, tokenId, data);
+    }
+
+    function mint(address to, uint256 tokenId) external {
+        _mintToken(to, tokenId);
+    }
+
+    function safeMint(address to, uint256 tokenId, bytes calldata data) external {
+        _safeMintToken(to, tokenId, data);
+    }
+
+    function burn(uint256 tokenId) external {
+        _burnToken(tokenId);
+    }
+
+    function transferTokens(address from, address to, uint256 tokenId) external {
+        _transferToken(from, to, tokenId);
+    }
+
+    function safeTransferTokens(address from, address to, uint256 tokenId, bytes calldata data) external {
+        _safeTransferToken(from, to, tokenId, data);
+    }
+
+    function approveToken(address to, uint256 tokenId) external {
+        _approveToken(to, tokenId);
+    }
+
+    function setApprovalForAll(address owner, address operator, bool approved) external {
+        _setApprovalForAll(owner, operator, approved);
+    }
+
+    function setBaseURI(string calldata baseUri) external {
+        _setBaseURI(baseUri);
+    }
+
+    function setTokenURI(uint256 tokenId, string calldata uri) external {
+        _setTokenURI(tokenId, uri);
+    }
+
+    function isApprovedOrOwner(address spender, uint256 tokenId) external view returns (bool) {
+        return _isApprovedOrOwner(spender, tokenId);
+    }
+
+    function supportsInterface(bytes4 interfaceId) public view override returns (bool) {
+        return super.supportsInterface(interfaceId);
+    }
+}
+
+contract ERC721ReceiverMock is IERC721Receiver {
+    bytes4 internal _response;
+    address internal _lastOperator;
+    address internal _lastFrom;
+    uint256 internal _lastTokenId;
+    bytes internal _lastData;
+
+    constructor(bytes4 response_) {
+        _response = response_;
+    }
+
+    function onERC721Received(address operator, address from, uint256 tokenId, bytes calldata data)
+        external
+        returns (bytes4)
+    {
+        _lastOperator = operator;
+        _lastFrom = from;
+        _lastTokenId = tokenId;
+        _lastData = data;
+        return _response;
+    }
+
+    function lastOperator() external view returns (address) {
+        return _lastOperator;
+    }
+
+    function lastFrom() external view returns (address) {
+        return _lastFrom;
+    }
+
+    function lastTokenId() external view returns (uint256) {
+        return _lastTokenId;
+    }
+
+    function lastData() external view returns (bytes memory) {
+        return _lastData;
+    }
+}
+
+contract ERC721ReceiverRejector {}
+
+abstract contract TokenFacetFoundationFixture is TestBase {
+    address internal admin = address(0xA11CE);
+    address internal bob = address(0xB0B);
+    address internal eve = address(0xE11E);
+
+    ERC20TokenBaseHarness internal erc20;
+    ERC721TokenBaseHarness internal erc721;
+    ERC721ReceiverMock internal receiver;
+    ERC721ReceiverRejector internal rejector;
+
+    function setUp() public virtual {
+        erc20 = new ERC20TokenBaseHarness();
+        erc721 = new ERC721TokenBaseHarness();
+        receiver = new ERC721ReceiverMock(IERC721Receiver.onERC721Received.selector);
+        rejector = new ERC721ReceiverRejector();
+    }
+
+    function erc20StorageSlot() public pure returns (bytes32) {
+        return LibERC20TokenStorage.STORAGE_SLOT;
+    }
+
+    function erc721StorageSlot() public pure returns (bytes32) {
+        return LibERC721TokenStorage.STORAGE_SLOT;
+    }
+
+    function tokenAdminRole() public pure returns (bytes32) {
+        return LibTokenFacetConstants.TOKEN_ADMIN_ROLE;
+    }
+
+    function erc20MinterRole() public pure returns (bytes32) {
+        return LibTokenFacetConstants.ERC20_MINTER_ROLE;
+    }
+
+    function erc721MetadataRole() public pure returns (bytes32) {
+        return LibTokenFacetConstants.ERC721_METADATA_ROLE;
+    }
+
+    function erc20TransferScope() public pure returns (bytes32) {
+        return LibTokenFacetConstants.ERC20_TRANSFER_SCOPE;
+    }
+
+    function erc721ApprovalScope() public pure returns (bytes32) {
+        return LibTokenFacetConstants.ERC721_APPROVAL_SCOPE;
+    }
+
+    function supportsErc721(bytes4 interfaceId) public view returns (bool) {
+        return erc721.supportsInterface(interfaceId);
+    }
+
+    function supportsErc165(bytes4 interfaceId) public pure returns (bool) {
+        return interfaceId == type(IERC165).interfaceId;
+    }
+}


### PR DESCRIPTION
## Summary
- add the shared token interfaces, storage-slot conventions, and role/scope constants for the Diamond Token Facets milestone
- introduce reusable ERC20 and ERC721 base layers with diamond-safe initialization, metadata handling, and shared internal storage helpers
- add focused tests and docs covering initializer guards, storage separation, ERC721 interface support, safe receiver behavior, and token foundation assumptions

## Included Work
- add `IERC20Permit`, `IERC20TokenBase`, `IERC721`, `IERC721Metadata`, `IERC721Receiver`, and `IERC721TokenBase`
- add `ERC20TokenBase`, `ERC721TokenBase`, and the shared token storage/constants libraries
- add `TokenFacetFoundationCore.t.sol` and its harnesses
- add `docs/token-facets.md` and link the token docs from the README

## Validation
- `forge test --offline --match-path test/TokenFacetFoundationCore.t.sol`
- `forge test --offline`

## Issue
- Closes #80