### PR TITLE
Complete Diamond Token Facets milestone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: stable
+          version: 1.4.3
 
       - name: Cache Foundry Artifacts
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         run: forge fmt --check
 
       - name: Build With Sizes
-        run: forge build --sizes
+        run: forge build --sizes --skip script
 
       - name: Run Offline Tests
         run: forge test --offline

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: stable
+          version: 1.4.3
 
       - name: Run Slither (fail on high)
         uses: crytic/slither-action@v0.4.1

--- a/.github/workflows/system-hardening.yml
+++ b/.github/workflows/system-hardening.yml
@@ -38,7 +38,7 @@ jobs:
             ${{ runner.os }}-foundry-cache-
 
       - name: Build With Sizes
-        run: forge build --sizes
+        run: forge build --sizes --skip script
 
       - name: Run System Vault Stress Invariants
         run: forge test --offline --match-path test/SystemVaultStressInvariant.t.sol
@@ -75,7 +75,7 @@ jobs:
             ${{ runner.os }}-foundry-cache-
 
       - name: Build With Sizes
-        run: forge build --sizes
+        run: forge build --sizes --skip script
 
       - name: Run Full Local Hardening Flow
         run: bash script/run-local-system-hardening.sh

--- a/.github/workflows/system-hardening.yml
+++ b/.github/workflows/system-hardening.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: stable
+          version: 1.4.3
 
       - name: Cache Foundry Artifacts
         uses: actions/cache@v4
@@ -64,7 +64,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: stable
+          version: 1.4.3
 
       - name: Cache Foundry Artifacts
         uses: actions/cache@v4

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ bash script/run-local-system-hardening.sh
 ## Documentation
 
 Architecture and module docs live in `docs/diamond-core.md`,
-`docs/oracle-adapter.md`, `docs/erc4626-vault.md`, and `docs/threat-model.md`.
+`docs/oracle-adapter.md`, `docs/erc4626-vault.md`, `docs/token-facets.md`, and
+`docs/threat-model.md`.
 
 Operational guidance lives in `docs/ops/README.md`, with the end-to-end
 execution order collected in `docs/ops/runbook-system-hardening.md`.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ execution order collected in `docs/ops/runbook-system-hardening.md`.
 
 CI and local validation parity are documented in `docs/security-checks.md`.
 
+Token facet deployment notes live in `docs/token-facets.md`, including the
+current reference rule that standard ERC20 and ERC721 surfaces are deployed as
+separate diamond hosts because their selectors collide.
+
 ## Tooling
 
 Built with Foundry. CI workflows live under `.github/workflows/`.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ reviewable engineering system.
   circuit breakers, and controlled fallback behavior.
 - A diamond core with selector routing, cut/loupe support, ownership
   introspection, and selector-integrity regression coverage.
+- Hosted ERC20 and ERC721 token facets deployed behind separate diamond hosts,
+  with init, selector ownership, Permit/metadata support, and host-level
+  hardening coverage.
 - Operational maturity through local bootstrap, smoke validation, upgrade
   rehearsal, system-hardening flows, and matching CI gates.
 
@@ -41,6 +44,7 @@ Implemented milestones so far:
 - Access Control + Upgrade Safety Kit
 - Oracle Adapter + Circuit Breaker
 - Diamond Core (EIP-2535)
+- Diamond Token Facets
 - System-Level Testing & Hardening
 
 ## Validation
@@ -65,9 +69,9 @@ execution order collected in `docs/ops/runbook-system-hardening.md`.
 
 CI and local validation parity are documented in `docs/security-checks.md`.
 
-Token facet deployment notes live in `docs/token-facets.md`, including the
-current reference rule that standard ERC20 and ERC721 surfaces are deployed as
-separate diamond hosts because their selectors collide.
+Token-host architecture and safety assumptions live in `docs/token-facets.md`,
+including the init model, selector ownership rules, separate-host deployment
+constraint, and token-host upgrade assumptions.
 
 ## Tooling
 

--- a/docs/security-checks.md
+++ b/docs/security-checks.md
@@ -48,6 +48,21 @@ bash script/run-local-system-hardening.sh
 
 Use the targeted suites for faster iteration and the full hardening runner for the same deployment-backed flow used by the higher-signal CI gate.
 
+### Token Hosts
+
+The diamond token milestone also has reviewer-facing validation suites for the
+separate ERC20-host and ERC721-host deployment model:
+
+```bash
+forge test --offline --match-path test/DiamondTokenDeploymentIntegration.t.sol
+forge test --offline --match-path test/DiamondTokenHostHardening.t.sol
+forge test --offline --match-path test/DiamondErc20HostInvariant.t.sol
+forge test --offline --match-path test/DiamondErc721HostInvariant.t.sol
+```
+
+Use these to reproduce token-host deployment, selector ownership, replace and
+reinstall persistence, and diamond-routed invariant coverage locally.
+
 ### Slither
 
 Install and run the same high-severity gate locally:

--- a/docs/token-facets.md
+++ b/docs/token-facets.md
@@ -67,3 +67,47 @@ advertises:
 When ERC-721 is installed behind a diamond, the init or deployment flow should
 ensure the diamond-level interface surface remains consistent with the facet
 selectors that are actually installed.
+
+### Selector Collision Constraint
+
+ERC20 and ERC721 storage layouts are intentionally separate and can coexist
+without storage collision. Their raw external selector surfaces cannot.
+
+The standard interfaces collide on shared selectors such as:
+
+- `name()`
+- `symbol()`
+- `totalSupply()`
+- `balanceOf(address)`
+- `supportsInterface(bytes4)` once shared control and ERC165 surfaces are
+  included
+
+That means one diamond cannot expose both standards unchanged at the same
+address. The reference deployment model in this repo is therefore:
+
+- one diamond hosting ERC20
+- one diamond hosting ERC721
+
+If both standards ever need to coexist in one host, that future design will
+need namespaced selectors or a different routing surface.
+
+### Reference Host Deployment Model
+
+The current reference deployment scripts install and initialize token facets as
+separate host flows:
+
+- `script/DeployDiamondErc20Host.s.sol`
+- `script/DeployDiamondErc721Host.s.sol`
+
+Each flow:
+
+- deploys a fresh diamond core
+- installs loupe selectors
+- installs one token facet selector set
+- immediately calls the token initializer through the diamond
+- validates selector ownership and initialized token metadata
+
+Deployment artifacts are written separately for replayable local validation:
+
+- `deployments/diamond-erc20.local.json`
+- `deployments/diamond-erc721.local.json`

--- a/docs/token-facets.md
+++ b/docs/token-facets.md
@@ -1,0 +1,69 @@
+## Token Facet Foundation
+
+This document defines the shared foundation for hosted token facets in the
+diamond roadmap.
+
+### Shared Interfaces
+
+The token foundation introduces:
+
+- `IERC20Permit` for future EIP-2612 support on the ERC-20 side
+- `IERC721`, `IERC721Metadata`, and `IERC721Receiver` for the ERC-721 side
+- `IERC20TokenBase` and `IERC721TokenBase` for foundation-specific init/error
+  surfaces used by the base contracts
+
+### Storage Conventions
+
+Hosted token facets use separate fixed storage slots:
+
+- ERC-20: `keccak256("smart-contracts.token.erc20.storage")`
+- ERC-721: `keccak256("smart-contracts.token.erc721.storage")`
+
+The milestone intentionally keeps those layouts separate so ERC-20 and ERC-721
+facets can coexist in one diamond without balance, allowance, ownership, or
+metadata collisions.
+
+### Initializer Pattern
+
+Each hosted token standard owns its own one-time initializer:
+
+- `_initializeErc20Token(...)`
+- `_initializeErc721Token(...)`
+
+The initializer guards are per-token-standard, not global to the diamond. That
+lets one diamond host both token systems while still preventing duplicate init
+for either storage layout.
+
+### Access Control And Pause Rules
+
+The shared token constants library defines the canonical integration surface for
+later facets:
+
+- roles:
+  - `TOKEN_ADMIN_ROLE`
+  - `ERC20_MINTER_ROLE`
+  - `ERC20_BURNER_ROLE`
+  - `ERC721_MINTER_ROLE`
+  - `ERC721_BURNER_ROLE`
+  - `ERC721_METADATA_ROLE`
+- pause scopes:
+  - `ERC20_TRANSFER_SCOPE`
+  - `ERC20_APPROVAL_SCOPE`
+  - `ERC721_TRANSFER_SCOPE`
+  - `ERC721_APPROVAL_SCOPE`
+
+Later ERC20/721 facet issues should reuse those identifiers rather than invent
+parallel role or pause namespaces.
+
+### ERC165 Notes
+
+ERC-20 does not rely on ERC-165. ERC-721 does, and the shared ERC-721 base
+advertises:
+
+- `IERC165`
+- `IERC721`
+- `IERC721Metadata`
+
+When ERC-721 is installed behind a diamond, the init or deployment flow should
+ensure the diamond-level interface surface remains consistent with the facet
+selectors that are actually installed.

--- a/docs/token-facets.md
+++ b/docs/token-facets.md
@@ -1,113 +1,231 @@
-## Token Facet Foundation
+# Diamond Token Facets
 
-This document defines the shared foundation for hosted token facets in the
-diamond roadmap.
+This document is the canonical guide for the hosted token model implemented in
+the `Diamond Token Facets` milestone.
 
-### Shared Interfaces
+The current supported deployment model is:
 
-The token foundation introduces:
+- one ERC20-hosted diamond
+- one ERC721-hosted diamond
 
-- `IERC20Permit` for future EIP-2612 support on the ERC-20 side
-- `IERC721`, `IERC721Metadata`, and `IERC721Receiver` for the ERC-721 side
-- `IERC20TokenBase` and `IERC721TokenBase` for foundation-specific init/error
-  surfaces used by the base contracts
+That split is intentional. The repo preserves standard ERC20 and ERC721
+external surfaces, and those standards collide on shared selectors such as
+`name()`, `symbol()`, `balanceOf(address)`, and `totalSupply()`. One diamond
+cannot expose both standards unchanged at the same address without namespacing
+or a different routing model.
 
-### Storage Conventions
+## Supported Hosts
 
-Hosted token facets use separate fixed storage slots:
+### ERC20 Host
 
-- ERC-20: `keccak256("smart-contracts.token.erc20.storage")`
-- ERC-721: `keccak256("smart-contracts.token.erc721.storage")`
+The ERC20 host installs:
 
-The milestone intentionally keeps those layouts separate so ERC-20 and ERC-721
-facets can coexist in one diamond without balance, allowance, ownership, or
-metadata collisions.
+- ERC20 metadata selectors
+- core ERC20 state-changing selectors
+- EIP-2612 Permit selectors
+- shared control selectors for access control, pause scopes, and
+  `supportsInterface`
 
-### Initializer Pattern
-
-Each hosted token standard owns its own one-time initializer:
-
-- `_initializeErc20Token(...)`
-- `_initializeErc721Token(...)`
-
-The initializer guards are per-token-standard, not global to the diamond. That
-lets one diamond host both token systems while still preventing duplicate init
-for either storage layout.
-
-### Access Control And Pause Rules
-
-The shared token constants library defines the canonical integration surface for
-later facets:
-
-- roles:
-  - `TOKEN_ADMIN_ROLE`
-  - `ERC20_MINTER_ROLE`
-  - `ERC20_BURNER_ROLE`
-  - `ERC721_MINTER_ROLE`
-  - `ERC721_BURNER_ROLE`
-  - `ERC721_METADATA_ROLE`
-- pause scopes:
-  - `ERC20_TRANSFER_SCOPE`
-  - `ERC20_APPROVAL_SCOPE`
-  - `ERC721_TRANSFER_SCOPE`
-  - `ERC721_APPROVAL_SCOPE`
-
-Later ERC20/721 facet issues should reuse those identifiers rather than invent
-parallel role or pause namespaces.
-
-### ERC165 Notes
-
-ERC-20 does not rely on ERC-165. ERC-721 does, and the shared ERC-721 base
-advertises:
-
-- `IERC165`
-- `IERC721`
-- `IERC721Metadata`
-
-When ERC-721 is installed behind a diamond, the init or deployment flow should
-ensure the diamond-level interface surface remains consistent with the facet
-selectors that are actually installed.
-
-### Selector Collision Constraint
-
-ERC20 and ERC721 storage layouts are intentionally separate and can coexist
-without storage collision. Their raw external selector surfaces cannot.
-
-The standard interfaces collide on shared selectors such as:
-
-- `name()`
-- `symbol()`
-- `totalSupply()`
-- `balanceOf(address)`
-- `supportsInterface(bytes4)` once shared control and ERC165 surfaces are
-  included
-
-That means one diamond cannot expose both standards unchanged at the same
-address. The reference deployment model in this repo is therefore:
-
-- one diamond hosting ERC20
-- one diamond hosting ERC721
-
-If both standards ever need to coexist in one host, that future design will
-need namespaced selectors or a different routing surface.
-
-### Reference Host Deployment Model
-
-The current reference deployment scripts install and initialize token facets as
-separate host flows:
+Reference deployment flow:
 
 - `script/DeployDiamondErc20Host.s.sol`
-- `script/DeployDiamondErc721Host.s.sol`
 
-Each flow:
-
-- deploys a fresh diamond core
-- installs loupe selectors
-- installs one token facet selector set
-- immediately calls the token initializer through the diamond
-- validates selector ownership and initialized token metadata
-
-Deployment artifacts are written separately for replayable local validation:
+Reference artifact:
 
 - `deployments/diamond-erc20.local.json`
+
+### ERC721 Host
+
+The ERC721 host installs:
+
+- ERC721 core selectors
+- ERC721 metadata selectors
+- hosted mint, burn, and metadata-management selectors
+- shared control selectors for access control, pause scopes, and
+  `supportsInterface`
+
+Reference deployment flow:
+
+- `script/DeployDiamondErc721Host.s.sol`
+
+Reference artifact:
+
 - `deployments/diamond-erc721.local.json`
+
+## Initialization Model
+
+Each token standard owns its own one-time initializer and is initialized through
+the diamond after the facet selectors are installed.
+
+### ERC20
+
+Initializer:
+
+- `initializeErc20(string name, string symbol, uint8 decimals, address admin)`
+
+Initialization seeds:
+
+- token metadata
+- Permit domain state
+- shared control state when the host is first initialized
+- role assignments for the provided `admin`
+
+Initialization expectations:
+
+- idempotent per ERC20 host
+- second initialization reverts
+- Permit uses the token name, version `"1"`, current `chainid`, and diamond
+  address for the domain separator
+
+### ERC721
+
+Initializer:
+
+- `initializeErc721(string name, string symbol, string baseURI, address admin)`
+
+Initialization seeds:
+
+- token metadata and base URI
+- shared control state when the host is first initialized
+- role assignments for the provided `admin`
+
+Initialization expectations:
+
+- idempotent per ERC721 host
+- second initialization reverts
+
+## Role Model And Pause Scopes
+
+Hosted token facets reuse the shared control plane. They do not maintain a
+token-local access-control or pause system.
+
+### Shared Admin Roles
+
+- `DEFAULT_ADMIN_ROLE`
+- `TOKEN_ADMIN_ROLE`
+- `PAUSER_ROLE`
+
+`TOKEN_ADMIN_ROLE` is administered by `DEFAULT_ADMIN_ROLE`.
+
+### ERC20 Roles
+
+- `ERC20_MINTER_ROLE`
+- `ERC20_BURNER_ROLE`
+
+Both are administered by `TOKEN_ADMIN_ROLE`.
+
+### ERC721 Roles
+
+- `ERC721_MINTER_ROLE`
+- `ERC721_BURNER_ROLE`
+- `ERC721_METADATA_ROLE`
+
+All are administered by `TOKEN_ADMIN_ROLE`.
+
+### Pause Scopes
+
+ERC20 host:
+
+- `ERC20_TRANSFER_SCOPE`
+  - gates `transfer`, `mint`, and `burn`
+- `ERC20_APPROVAL_SCOPE`
+  - gates `approve`, `permit`, and approval-dependent `transferFrom`
+
+ERC721 host:
+
+- `ERC721_TRANSFER_SCOPE`
+  - gates `transferFrom`, both `safeTransferFrom` overloads, `mint`, `safeMint`,
+    and `burn`
+- `ERC721_APPROVAL_SCOPE`
+  - gates `approve` and `setApprovalForAll`
+
+Metadata updates on the ERC721 host are role-gated but not controlled by the
+transfer or approval pause scopes.
+
+## Storage And Upgrade Assumptions
+
+The token facets use fixed storage slots:
+
+- ERC20: `keccak256("smart-contracts.token.erc20.storage")`
+- ERC721: `keccak256("smart-contracts.token.erc721.storage")`
+
+Those layouts are separate, so ERC20 and ERC721 state do not collide at the
+storage level. The repo still deploys them as separate hosts because the raw
+selector surfaces collide.
+
+Hosted token state lives in the diamond, not in the facet contract bytecode.
+That means the supported replace/remove/re-add flows preserve state as long as:
+
+- the replacement facet preserves the same storage layout
+- the relevant selectors are reinstalled
+- the upgrade does not rely on re-initialization
+
+Current hardening coverage explicitly validates persistence for:
+
+- ERC20 balances, allowances, Permit nonces, roles, and pause state
+- ERC721 ownership, approvals, operator approvals, metadata, roles, and pause
+  state
+
+## Selector Ownership Model
+
+For the reference token hosts:
+
+- `DiamondCutFacet` owns `diamondCut`
+- `DiamondLoupeFacet` owns loupe and ownership-introspection selectors
+- the token facet owns its token selectors
+- the token facet also owns the shared control selectors installed for that host
+
+In practice, that means the token facet owns selectors such as:
+
+- `supportsInterface(bytes4)`
+- `hasRole(bytes32,address)`
+- `grantRole(bytes32,address)`
+- `pauseScope(bytes32)`
+- `unpauseScope(bytes32)`
+- `scopePaused(bytes32)`
+- token role and scope getter selectors
+
+That selector ownership model is part of the supported upgrade story. When a
+token facet is replaced, the shared control selectors move with it for that
+host.
+
+## Supported Interface Surface
+
+### ERC20 Host
+
+The ERC20 host exposes:
+
+- ERC20 core + metadata
+- `IERC20Permit`
+- hosted ERC20 facet admin hooks
+- `IAccessControl`
+- `IPausable`
+- `IERC165`
+
+### ERC721 Host
+
+The ERC721 host exposes:
+
+- ERC721 core + metadata
+- hosted ERC721 facet admin hooks
+- `IAccessControl`
+- `IPausable`
+- `IERC165`
+
+## Safety Notes For Reviewers
+
+- Separate-host deployment is the supported model for this milestone.
+- No selector namespacing is used.
+- Re-initialization is not part of replace/remove/re-add flows.
+- Facet upgrades must preserve storage layout and hosted selector intent.
+- Shared control selectors are treated as part of the token host surface, not as
+  independent infrastructure selectors.
+
+## Validation References
+
+The implemented token-host model is covered by:
+
+- `test/DiamondTokenDeploymentIntegration.t.sol`
+- `test/DiamondTokenHostHardening.t.sol`
+- `test/DiamondErc20HostInvariant.t.sol`
+- `test/DiamondErc721HostInvariant.t.sol`

--- a/script/DeployDiamondErc20Host.s.sol
+++ b/script/DeployDiamondErc20Host.s.sol
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {DiamondCutFacet} from "../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../src/diamond/facets/DiamondLoupeFacet.sol";
+import {IDiamondCut} from "../src/interfaces/IDiamondCut.sol";
+import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
+import {IERC165} from "../src/interfaces/IERC165.sol";
+import {IERC20Metadata} from "../src/interfaces/IERC20Metadata.sol";
+import {IERC20Permit} from "../src/interfaces/IERC20Permit.sol";
+import {IERC20TokenFacet} from "../src/interfaces/IERC20TokenFacet.sol";
+import {ERC20TokenFacet} from "../src/token/facets/ERC20TokenFacet.sol";
+import {LibTokenFacetDeploymentSelectors} from "../src/token/libraries/LibTokenFacetDeploymentSelectors.sol";
+import {DiamondTokenHostScriptBase} from "./common/DiamondTokenHostScriptBase.sol";
+
+/// @title DeployDiamondErc20HostScript
+/// @notice Reference local deployment flow for an ERC20-hosted diamond.
+contract DeployDiamondErc20HostScript is DiamondTokenHostScriptBase {
+    string internal constant TOKEN_OBJECT = "diamondErc20Host";
+    string internal constant TOKEN_OUTPUT_RELATIVE_PATH = "/deployments/diamond-erc20.local.json";
+
+    /// @notice Deploys and initializes a reference ERC20-hosted diamond.
+    /// @dev Requires `PRIVATE_KEY` to be set in the environment.
+    function run() external returns (address diamondAddress, address tokenFacetAddress) {
+        uint256 deployerPrivateKey = VM.envUint("PRIVATE_KEY");
+        address owner = VM.addr(deployerPrivateKey);
+        address cutFacetAddress;
+        address loupeFacetAddress;
+
+        VM.startBroadcast(deployerPrivateKey);
+
+        (diamondAddress, cutFacetAddress, loupeFacetAddress) = _deployDiamondCore(owner);
+        ERC20TokenFacet tokenFacet = new ERC20TokenFacet();
+        tokenFacetAddress = address(tokenFacet);
+
+        IDiamondCut.FacetCut[] memory tokenCut = new IDiamondCut.FacetCut[](1);
+        tokenCut[0] = IDiamondCut.FacetCut({
+            facetAddress: tokenFacetAddress,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibTokenFacetDeploymentSelectors.erc20HostSelectors()
+        });
+        IDiamondCut(diamondAddress).diamondCut(tokenCut, address(0), "");
+        IERC20TokenFacet(diamondAddress).initializeErc20("Facet Token", "FTKN", 18, owner);
+
+        VM.stopBroadcast();
+
+        _validateErc20Host(diamondAddress, owner, cutFacetAddress, loupeFacetAddress, tokenFacetAddress);
+        _writeTokenDeploymentArtifact(
+            TOKEN_OBJECT,
+            TOKEN_OUTPUT_RELATIVE_PATH,
+            "erc20",
+            owner,
+            diamondAddress,
+            cutFacetAddress,
+            loupeFacetAddress,
+            tokenFacetAddress
+        );
+    }
+
+    function _validateErc20Host(
+        address diamondAddress,
+        address owner,
+        address cutFacetAddress,
+        address loupeFacetAddress,
+        address tokenFacetAddress
+    ) internal view {
+        _validateDiamondCore(diamondAddress, owner, cutFacetAddress, loupeFacetAddress);
+
+        IDiamondLoupe loupe = IDiamondLoupe(diamondAddress);
+        IERC20TokenFacet token = IERC20TokenFacet(diamondAddress);
+        address[] memory facetAddresses = loupe.facetAddresses();
+        bytes4[] memory tokenSelectors = loupe.facetFunctionSelectors(tokenFacetAddress);
+
+        require(facetAddresses.length == 3, "erc20 host facet count mismatch");
+        require(_containsAddress(facetAddresses, cutFacetAddress), "erc20 host missing cut facet");
+        require(_containsAddress(facetAddresses, loupeFacetAddress), "erc20 host missing loupe facet");
+        require(_containsAddress(facetAddresses, tokenFacetAddress), "erc20 host missing token facet");
+        require(
+            tokenSelectors.length == LibTokenFacetDeploymentSelectors.erc20HostSelectors().length,
+            "erc20 host selector count mismatch"
+        );
+        require(token.isErc20Initialized(), "erc20 host not initialized");
+        require(keccak256(bytes(token.name())) == keccak256(bytes("Facet Token")), "erc20 host name mismatch");
+        require(keccak256(bytes(token.symbol())) == keccak256(bytes("FTKN")), "erc20 host symbol mismatch");
+        require(token.decimals() == 18, "erc20 host decimals mismatch");
+        require(token.hasRole(token.DEFAULT_ADMIN_ROLE(), owner), "erc20 host default admin missing");
+        require(token.hasRole(token.TOKEN_ADMIN_ROLE(), owner), "erc20 host token admin missing");
+        require(token.hasRole(token.ERC20_MINTER_ROLE(), owner), "erc20 host minter missing");
+        require(token.hasRole(token.ERC20_BURNER_ROLE(), owner), "erc20 host burner missing");
+        require(token.hasRole(token.PAUSER_ROLE(), owner), "erc20 host pauser missing");
+        require(token.supportsInterface(type(IERC165).interfaceId), "erc20 host missing erc165");
+        require(token.supportsInterface(type(IERC20Permit).interfaceId), "erc20 host missing permit");
+        require(token.supportsInterface(type(IERC20TokenFacet).interfaceId), "erc20 host missing facet interface");
+
+        _requireSelectorOwner(loupe, DiamondCutFacet.diamondCut.selector, cutFacetAddress, "erc20 host cut owner");
+        _requireSelectorOwner(loupe, DiamondLoupeFacet.facets.selector, loupeFacetAddress, "erc20 host loupe owner");
+        _requireSelectorOwner(
+            loupe, IERC20TokenFacet.initializeErc20.selector, tokenFacetAddress, "erc20 host init owner"
+        );
+        _requireSelectorOwner(loupe, IERC20Metadata.name.selector, tokenFacetAddress, "erc20 host name owner");
+        _requireSelectorOwner(
+            loupe, IERC20TokenFacet.TOKEN_ADMIN_ROLE.selector, tokenFacetAddress, "erc20 host token admin owner"
+        );
+        _requireSelectorOwner(loupe, IERC20Permit.permit.selector, tokenFacetAddress, "erc20 host permit owner");
+        _requireSelectorOwner(loupe, IERC165.supportsInterface.selector, tokenFacetAddress, "erc20 host erc165 owner");
+    }
+
+    function _requireSelectorOwner(IDiamondLoupe loupe, bytes4 selector, address expected, string memory message)
+        internal
+        view
+    {
+        require(loupe.facetAddress(selector) == expected, message);
+    }
+}

--- a/script/DeployDiamondErc721Host.s.sol
+++ b/script/DeployDiamondErc721Host.s.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {DiamondCutFacet} from "../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../src/diamond/facets/DiamondLoupeFacet.sol";
+import {IDiamondCut} from "../src/interfaces/IDiamondCut.sol";
+import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
+import {IERC165} from "../src/interfaces/IERC165.sol";
+import {IERC721} from "../src/interfaces/IERC721.sol";
+import {IERC721Metadata} from "../src/interfaces/IERC721Metadata.sol";
+import {IERC721TokenFacet} from "../src/interfaces/IERC721TokenFacet.sol";
+import {ERC721TokenFacet} from "../src/token/facets/ERC721TokenFacet.sol";
+import {LibTokenFacetDeploymentSelectors} from "../src/token/libraries/LibTokenFacetDeploymentSelectors.sol";
+import {DiamondTokenHostScriptBase} from "./common/DiamondTokenHostScriptBase.sol";
+
+/// @title DeployDiamondErc721HostScript
+/// @notice Reference local deployment flow for an ERC721-hosted diamond.
+contract DeployDiamondErc721HostScript is DiamondTokenHostScriptBase {
+    string internal constant TOKEN_OBJECT = "diamondErc721Host";
+    string internal constant TOKEN_OUTPUT_RELATIVE_PATH = "/deployments/diamond-erc721.local.json";
+
+    /// @notice Deploys and initializes a reference ERC721-hosted diamond.
+    /// @dev Requires `PRIVATE_KEY` to be set in the environment.
+    function run() external returns (address diamondAddress, address tokenFacetAddress) {
+        uint256 deployerPrivateKey = VM.envUint("PRIVATE_KEY");
+        address owner = VM.addr(deployerPrivateKey);
+        address cutFacetAddress;
+        address loupeFacetAddress;
+
+        VM.startBroadcast(deployerPrivateKey);
+
+        (diamondAddress, cutFacetAddress, loupeFacetAddress) = _deployDiamondCore(owner);
+        ERC721TokenFacet tokenFacet = new ERC721TokenFacet();
+        tokenFacetAddress = address(tokenFacet);
+
+        IDiamondCut.FacetCut[] memory tokenCut = new IDiamondCut.FacetCut[](1);
+        tokenCut[0] = IDiamondCut.FacetCut({
+            facetAddress: tokenFacetAddress,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibTokenFacetDeploymentSelectors.erc721HostSelectors()
+        });
+        IDiamondCut(diamondAddress).diamondCut(tokenCut, address(0), "");
+        IERC721TokenFacet(diamondAddress).initializeErc721("Facet NFT", "FNFT", "ipfs://facet/", owner);
+
+        VM.stopBroadcast();
+
+        _validateErc721Host(diamondAddress, owner, cutFacetAddress, loupeFacetAddress, tokenFacetAddress);
+        _writeTokenDeploymentArtifact(
+            TOKEN_OBJECT,
+            TOKEN_OUTPUT_RELATIVE_PATH,
+            "erc721",
+            owner,
+            diamondAddress,
+            cutFacetAddress,
+            loupeFacetAddress,
+            tokenFacetAddress
+        );
+    }
+
+    function _validateErc721Host(
+        address diamondAddress,
+        address owner,
+        address cutFacetAddress,
+        address loupeFacetAddress,
+        address tokenFacetAddress
+    ) internal view {
+        _validateDiamondCore(diamondAddress, owner, cutFacetAddress, loupeFacetAddress);
+
+        IDiamondLoupe loupe = IDiamondLoupe(diamondAddress);
+        IERC721TokenFacet token = IERC721TokenFacet(diamondAddress);
+        address[] memory facetAddresses = loupe.facetAddresses();
+        bytes4[] memory tokenSelectors = loupe.facetFunctionSelectors(tokenFacetAddress);
+
+        require(facetAddresses.length == 3, "erc721 host facet count mismatch");
+        require(_containsAddress(facetAddresses, cutFacetAddress), "erc721 host missing cut facet");
+        require(_containsAddress(facetAddresses, loupeFacetAddress), "erc721 host missing loupe facet");
+        require(_containsAddress(facetAddresses, tokenFacetAddress), "erc721 host missing token facet");
+        require(
+            tokenSelectors.length == LibTokenFacetDeploymentSelectors.erc721HostSelectors().length,
+            "erc721 host selector count mismatch"
+        );
+        require(token.isErc721Initialized(), "erc721 host not initialized");
+        require(keccak256(bytes(token.name())) == keccak256(bytes("Facet NFT")), "erc721 host name mismatch");
+        require(keccak256(bytes(token.symbol())) == keccak256(bytes("FNFT")), "erc721 host symbol mismatch");
+        require(token.totalSupply() == 0, "erc721 host initial supply mismatch");
+        require(token.hasRole(token.DEFAULT_ADMIN_ROLE(), owner), "erc721 host default admin missing");
+        require(token.hasRole(token.TOKEN_ADMIN_ROLE(), owner), "erc721 host token admin missing");
+        require(token.hasRole(token.ERC721_MINTER_ROLE(), owner), "erc721 host minter missing");
+        require(token.hasRole(token.ERC721_BURNER_ROLE(), owner), "erc721 host burner missing");
+        require(token.hasRole(token.ERC721_METADATA_ROLE(), owner), "erc721 host metadata missing");
+        require(token.hasRole(token.PAUSER_ROLE(), owner), "erc721 host pauser missing");
+        require(token.supportsInterface(type(IERC165).interfaceId), "erc721 host missing erc165");
+        require(token.supportsInterface(type(IERC721).interfaceId), "erc721 host missing erc721");
+        require(token.supportsInterface(type(IERC721Metadata).interfaceId), "erc721 host missing metadata");
+        require(token.supportsInterface(type(IERC721TokenFacet).interfaceId), "erc721 host missing facet interface");
+
+        _requireSelectorOwner(loupe, DiamondCutFacet.diamondCut.selector, cutFacetAddress, "erc721 host cut owner");
+        _requireSelectorOwner(loupe, DiamondLoupeFacet.facets.selector, loupeFacetAddress, "erc721 host loupe owner");
+        _requireSelectorOwner(
+            loupe, IERC721TokenFacet.initializeErc721.selector, tokenFacetAddress, "erc721 host init owner"
+        );
+        _requireSelectorOwner(loupe, IERC721Metadata.name.selector, tokenFacetAddress, "erc721 host name owner");
+        _requireSelectorOwner(
+            loupe, IERC721TokenFacet.ERC721_METADATA_ROLE.selector, tokenFacetAddress, "erc721 host metadata owner"
+        );
+        _requireSelectorOwner(loupe, IERC721.ownerOf.selector, tokenFacetAddress, "erc721 host ownerOf owner");
+        _requireSelectorOwner(loupe, IERC165.supportsInterface.selector, tokenFacetAddress, "erc721 host erc165 owner");
+    }
+
+    function _requireSelectorOwner(IDiamondLoupe loupe, bytes4 selector, address expected, string memory message)
+        internal
+        view
+    {
+        require(loupe.facetAddress(selector) == expected, message);
+    }
+}

--- a/script/common/DiamondTokenHostScriptBase.sol
+++ b/script/common/DiamondTokenHostScriptBase.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Diamond} from "../../src/diamond/Diamond.sol";
+import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
+import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
+import {IDiamondLoupe} from "../../src/interfaces/IDiamondLoupe.sol";
+import {IERC173} from "../../src/interfaces/IERC173.sol";
+import {LibTokenFacetDeploymentSelectors} from "../../src/token/libraries/LibTokenFacetDeploymentSelectors.sol";
+import {DiamondCoreScriptBase} from "./DiamondCoreScriptBase.sol";
+
+/// @title DiamondTokenHostScriptBase
+/// @notice Shared deployment helpers for reference token-hosted diamonds.
+abstract contract DiamondTokenHostScriptBase is DiamondCoreScriptBase {
+    /// @notice Parsed addresses from a token host deployment artifact.
+    struct TokenHostDeploymentArtifact {
+        address diamond;
+        address diamondCutFacet;
+        address diamondLoupeFacet;
+        address tokenFacet;
+        address owner;
+        uint256 chainId;
+        string tokenStandard;
+    }
+
+    function _deployDiamondCore(address owner)
+        internal
+        returns (address diamondAddress, address cutFacetAddress, address loupeFacetAddress)
+    {
+        DiamondCutFacet cutFacet = new DiamondCutFacet();
+        Diamond diamond = new Diamond(owner, address(cutFacet));
+        DiamondLoupeFacet loupeFacet = new DiamondLoupeFacet();
+
+        IDiamondCut.FacetCut[] memory initialCut = new IDiamondCut.FacetCut[](1);
+        initialCut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(loupeFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibTokenFacetDeploymentSelectors.loupeSelectors()
+        });
+        IDiamondCut(address(diamond)).diamondCut(initialCut, address(0), "");
+
+        diamondAddress = address(diamond);
+        cutFacetAddress = address(cutFacet);
+        loupeFacetAddress = address(loupeFacet);
+    }
+
+    function _validateDiamondCore(
+        address diamondAddress,
+        address owner,
+        address cutFacetAddress,
+        address loupeFacetAddress
+    ) internal view {
+        IERC173 ownership = IERC173(diamondAddress);
+        IDiamondLoupe loupe = IDiamondLoupe(diamondAddress);
+
+        require(ownership.owner() == owner, "token host owner mismatch");
+        require(
+            loupe.facetAddress(DiamondCutFacet.diamondCut.selector) == cutFacetAddress,
+            "token host cut selector mismatch"
+        );
+        require(
+            loupe.facetAddress(DiamondLoupeFacet.facets.selector) == loupeFacetAddress,
+            "token host loupe selector mismatch"
+        );
+    }
+
+    function _writeTokenDeploymentArtifact(
+        string memory objectKey,
+        string memory outputRelativePath,
+        string memory tokenStandard,
+        address owner,
+        address diamondAddress,
+        address cutFacetAddress,
+        address loupeFacetAddress,
+        address tokenFacetAddress
+    ) internal {
+        string memory json = VM.serializeString(objectKey, "network", "local-anvil");
+        json = VM.serializeUint(objectKey, "chainId", block.chainid);
+        json = VM.serializeString(objectKey, "tokenStandard", tokenStandard);
+        json = VM.serializeAddress(objectKey, "owner", owner);
+        json = VM.serializeAddress(objectKey, "diamond", diamondAddress);
+        json = VM.serializeAddress(objectKey, "diamondCutFacet", cutFacetAddress);
+        json = VM.serializeAddress(objectKey, "diamondLoupeFacet", loupeFacetAddress);
+        json = VM.serializeAddress(objectKey, "tokenFacet", tokenFacetAddress);
+        VM.writeJson(json, string.concat(VM.projectRoot(), outputRelativePath));
+    }
+
+    function _containsAddress(address[] memory addresses, address expected) internal pure returns (bool) {
+        for (uint256 i = 0; i < addresses.length; i++) {
+            if (addresses[i] == expected) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    function _containsSelector(bytes4[] memory selectors, bytes4 selector) internal pure returns (bool) {
+        for (uint256 i = 0; i < selectors.length; i++) {
+            if (selectors[i] == selector) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/interfaces/IERC20Permit.sol
+++ b/src/interfaces/IERC20Permit.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title IERC20Permit
+/// @notice EIP-2612 permit extension interface.
+interface IERC20Permit {
+    /// @notice Sets `value` allowance from `owner` to `spender` using a signed approval.
+    /// @param owner Token owner.
+    /// @param spender Approved spender.
+    /// @param value Allowance amount.
+    /// @param deadline Signature expiration timestamp.
+    /// @param v Recovery identifier.
+    /// @param r Signature component.
+    /// @param s Signature component.
+    function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s)
+        external;
+
+    /// @notice Returns the current permit nonce for `owner`.
+    /// @param owner Token owner.
+    /// @return The current nonce.
+    function nonces(address owner) external view returns (uint256);
+
+    /// @notice Returns the EIP-712 domain separator used for permit signatures.
+    /// @return The domain separator.
+    function DOMAIN_SEPARATOR() external view returns (bytes32);
+}

--- a/src/interfaces/IERC20TokenBase.sol
+++ b/src/interfaces/IERC20TokenBase.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC20Metadata} from "./IERC20Metadata.sol";
+
+/// @title IERC20TokenBase
+/// @notice Interface for shared ERC-20 token foundation helpers.
+interface IERC20TokenBase is IERC20Metadata {
+    /// @notice Thrown when the ERC-20 initializer runs more than once.
+    error ERC20TokenAlreadyInitialized();
+    /// @notice Thrown when mutating helpers run before initialization.
+    error ERC20TokenNotInitialized();
+    /// @notice Thrown when a required account is the zero address.
+    error ERC20TokenZeroAddress();
+    /// @notice Thrown when an account balance is insufficient.
+    error ERC20TokenInsufficientBalance(address account, uint256 available, uint256 required);
+    /// @notice Thrown when allowance is insufficient.
+    error ERC20TokenInsufficientAllowance(address owner, address spender, uint256 available, uint256 required);
+
+    /// @notice Returns true when ERC-20 storage is initialized.
+    /// @return True if initialized.
+    function isErc20Initialized() external view returns (bool);
+}

--- a/src/interfaces/IERC20TokenFacet.sol
+++ b/src/interfaces/IERC20TokenFacet.sol
@@ -3,12 +3,18 @@ pragma solidity ^0.8.30;
 
 import {IAccessControl} from "./IAccessControl.sol";
 import {IERC20Metadata} from "./IERC20Metadata.sol";
+import {IERC20Permit} from "./IERC20Permit.sol";
 import {IERC20TokenBase} from "./IERC20TokenBase.sol";
 import {IPausable} from "./IPausable.sol";
 
 /// @title IERC20TokenFacet
 /// @notice Hosted ERC-20 facet surface for diamond deployments.
-interface IERC20TokenFacet is IERC20Metadata, IERC20TokenBase, IAccessControl, IPausable {
+interface IERC20TokenFacet is IERC20Metadata, IERC20TokenBase, IERC20Permit, IAccessControl, IPausable {
+    /// @notice Thrown when a Permit signature is expired.
+    error ERC20PermitExpired(uint256 deadline, uint256 currentTimestamp);
+    /// @notice Thrown when a Permit signature does not recover the expected signer.
+    error ERC20PermitInvalidSigner(address signer, address owner);
+
     /// @notice Returns the shared token admin role identifier.
     /// @return The role identifier.
     function TOKEN_ADMIN_ROLE() external view returns (bytes32);

--- a/src/interfaces/IERC20TokenFacet.sol
+++ b/src/interfaces/IERC20TokenFacet.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "./IAccessControl.sol";
+import {IERC20Metadata} from "./IERC20Metadata.sol";
+import {IERC20TokenBase} from "./IERC20TokenBase.sol";
+import {IPausable} from "./IPausable.sol";
+
+/// @title IERC20TokenFacet
+/// @notice Hosted ERC-20 facet surface for diamond deployments.
+interface IERC20TokenFacet is IERC20Metadata, IERC20TokenBase, IAccessControl, IPausable {
+    /// @notice Returns the shared token admin role identifier.
+    /// @return The role identifier.
+    function TOKEN_ADMIN_ROLE() external view returns (bytes32);
+
+    /// @notice Returns the ERC-20 minter role identifier.
+    /// @return The role identifier.
+    function ERC20_MINTER_ROLE() external view returns (bytes32);
+
+    /// @notice Returns the ERC-20 burner role identifier.
+    /// @return The role identifier.
+    function ERC20_BURNER_ROLE() external view returns (bytes32);
+
+    /// @notice Returns the ERC-20 transfer pause scope identifier.
+    /// @return The scope identifier.
+    function ERC20_TRANSFER_SCOPE() external view returns (bytes32);
+
+    /// @notice Returns the ERC-20 approval pause scope identifier.
+    /// @return The scope identifier.
+    function ERC20_APPROVAL_SCOPE() external view returns (bytes32);
+
+    /// @notice Initializes the hosted ERC-20 facet.
+    /// @param tokenName Token name.
+    /// @param tokenSymbol Token symbol.
+    /// @param tokenDecimals Token decimals.
+    /// @param admin Admin account seeded into the shared control plane.
+    function initializeErc20(
+        string calldata tokenName,
+        string calldata tokenSymbol,
+        uint8 tokenDecimals,
+        address admin
+    ) external;
+
+    /// @notice Mints `value` tokens to `to`.
+    /// @param to Recipient account.
+    /// @param value Amount to mint.
+    function mint(address to, uint256 value) external;
+
+    /// @notice Burns `value` tokens from `from`.
+    /// @param from Token holder.
+    /// @param value Amount to burn.
+    function burn(address from, uint256 value) external;
+}

--- a/src/interfaces/IERC721.sol
+++ b/src/interfaces/IERC721.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC165} from "./IERC165.sol";
+
+/// @title IERC721
+/// @notice ERC-721 non-fungible token standard interface.
+interface IERC721 is IERC165 {
+    /// @notice Emitted when `tokenId` transfers from `from` to `to`.
+    event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
+
+    /// @notice Emitted when `owner` approves `approved` for `tokenId`.
+    event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId);
+
+    /// @notice Emitted when `owner` enables or disables `operator`.
+    event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
+
+    /// @notice Returns the token count owned by `owner`.
+    /// @param owner The account to query.
+    /// @return The balance for `owner`.
+    function balanceOf(address owner) external view returns (uint256);
+
+    /// @notice Returns the owner of `tokenId`.
+    /// @param tokenId The token identifier.
+    /// @return The token owner.
+    function ownerOf(uint256 tokenId) external view returns (address);
+
+    /// @notice Safely transfers `tokenId` from `from` to `to`.
+    /// @param from The current owner.
+    /// @param to The receiver.
+    /// @param tokenId The token identifier.
+    function safeTransferFrom(address from, address to, uint256 tokenId) external;
+
+    /// @notice Transfers `tokenId` from `from` to `to`.
+    /// @param from The current owner.
+    /// @param to The receiver.
+    /// @param tokenId The token identifier.
+    function transferFrom(address from, address to, uint256 tokenId) external;
+
+    /// @notice Approves `to` to manage `tokenId`.
+    /// @param to Approved account.
+    /// @param tokenId The token identifier.
+    function approve(address to, uint256 tokenId) external;
+
+    /// @notice Enables or disables `operator` for caller-owned tokens.
+    /// @param operator The operator account.
+    /// @param approved True to approve, false to revoke.
+    function setApprovalForAll(address operator, bool approved) external;
+
+    /// @notice Returns the approved account for `tokenId`.
+    /// @param tokenId The token identifier.
+    /// @return The approved account, or zero if none.
+    function getApproved(uint256 tokenId) external view returns (address);
+
+    /// @notice Returns whether `operator` is approved for all of `owner`'s tokens.
+    /// @param owner Token owner.
+    /// @param operator Operator account.
+    /// @return True if approved.
+    function isApprovedForAll(address owner, address operator) external view returns (bool);
+
+    /// @notice Safely transfers `tokenId` from `from` to `to` with `data`.
+    /// @param from The current owner.
+    /// @param to The receiver.
+    /// @param tokenId The token identifier.
+    /// @param data Additional receiver data.
+    function safeTransferFrom(address from, address to, uint256 tokenId, bytes calldata data) external;
+}

--- a/src/interfaces/IERC721Metadata.sol
+++ b/src/interfaces/IERC721Metadata.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC721} from "./IERC721.sol";
+
+/// @title IERC721Metadata
+/// @notice ERC-721 metadata extension interface.
+interface IERC721Metadata is IERC721 {
+    /// @notice Returns token collection name.
+    /// @return The collection name.
+    function name() external view returns (string memory);
+
+    /// @notice Returns token collection symbol.
+    /// @return The collection symbol.
+    function symbol() external view returns (string memory);
+
+    /// @notice Returns the metadata URI for `tokenId`.
+    /// @param tokenId The token identifier.
+    /// @return The token metadata URI.
+    function tokenURI(uint256 tokenId) external view returns (string memory);
+}

--- a/src/interfaces/IERC721Receiver.sol
+++ b/src/interfaces/IERC721Receiver.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title IERC721Receiver
+/// @notice Interface for contracts that can receive safe ERC-721 transfers.
+interface IERC721Receiver {
+    /// @notice Handles receipt of an ERC-721 token.
+    /// @param operator The account that initiated the transfer.
+    /// @param from The previous owner.
+    /// @param tokenId The token identifier.
+    /// @param data Additional transfer data.
+    /// @return The selector to confirm receipt.
+    function onERC721Received(address operator, address from, uint256 tokenId, bytes calldata data)
+        external
+        returns (bytes4);
+}

--- a/src/interfaces/IERC721TokenBase.sol
+++ b/src/interfaces/IERC721TokenBase.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC721Metadata} from "./IERC721Metadata.sol";
+
+/// @title IERC721TokenBase
+/// @notice Interface for shared ERC-721 token foundation helpers.
+interface IERC721TokenBase is IERC721Metadata {
+    /// @notice Thrown when the ERC-721 initializer runs more than once.
+    error ERC721TokenAlreadyInitialized();
+    /// @notice Thrown when mutating helpers run before initialization.
+    error ERC721TokenNotInitialized();
+    /// @notice Thrown when a required account is the zero address.
+    error ERC721TokenZeroAddress();
+    /// @notice Thrown when `owner` is invalid for the requested operation.
+    error ERC721TokenInvalidOwner(address owner);
+    /// @notice Thrown when a token does not exist.
+    error ERC721TokenNonexistentToken(uint256 tokenId);
+    /// @notice Thrown when a mint targets an existing token.
+    error ERC721TokenAlreadyMinted(uint256 tokenId);
+    /// @notice Thrown when `from` is not the current owner of `tokenId`.
+    error ERC721TokenIncorrectOwner(address from, uint256 tokenId, address actualOwner);
+    /// @notice Thrown when a receiver does not implement `IERC721Receiver`.
+    error ERC721TokenUnsafeReceiver(address receiver);
+    /// @notice Thrown when `owner` tries to set themselves as operator.
+    error ERC721TokenInvalidOperator(address owner, address operator);
+
+    /// @notice Returns true when ERC-721 storage is initialized.
+    /// @return True if initialized.
+    function isErc721Initialized() external view returns (bool);
+}

--- a/src/interfaces/IERC721TokenFacet.sol
+++ b/src/interfaces/IERC721TokenFacet.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "./IAccessControl.sol";
+import {IERC721Metadata} from "./IERC721Metadata.sol";
+import {IERC721TokenBase} from "./IERC721TokenBase.sol";
+import {IPausable} from "./IPausable.sol";
+
+/// @title IERC721TokenFacet
+/// @notice Hosted ERC-721 facet surface for diamond deployments.
+interface IERC721TokenFacet is IERC721Metadata, IERC721TokenBase, IAccessControl, IPausable {
+    /// @notice Thrown when `operator` is not authorized to manage `tokenId`.
+    error ERC721TokenUnauthorizedOperator(address operator, uint256 tokenId);
+
+    /// @notice Returns the shared token admin role identifier.
+    /// @return The role identifier.
+    function TOKEN_ADMIN_ROLE() external view returns (bytes32);
+
+    /// @notice Returns the ERC-721 minter role identifier.
+    /// @return The role identifier.
+    function ERC721_MINTER_ROLE() external view returns (bytes32);
+
+    /// @notice Returns the ERC-721 burner role identifier.
+    /// @return The role identifier.
+    function ERC721_BURNER_ROLE() external view returns (bytes32);
+
+    /// @notice Returns the ERC-721 metadata manager role identifier.
+    /// @return The role identifier.
+    function ERC721_METADATA_ROLE() external view returns (bytes32);
+
+    /// @notice Returns the ERC-721 transfer pause scope identifier.
+    /// @return The scope identifier.
+    function ERC721_TRANSFER_SCOPE() external view returns (bytes32);
+
+    /// @notice Returns the ERC-721 approval pause scope identifier.
+    /// @return The scope identifier.
+    function ERC721_APPROVAL_SCOPE() external view returns (bytes32);
+
+    /// @notice Initializes the hosted ERC-721 facet.
+    /// @param tokenName Collection name.
+    /// @param tokenSymbol Collection symbol.
+    /// @param baseURI Default base URI for token metadata.
+    /// @param admin Admin account seeded into the shared control plane.
+    function initializeErc721(
+        string calldata tokenName,
+        string calldata tokenSymbol,
+        string calldata baseURI,
+        address admin
+    ) external;
+
+    /// @notice Returns the current live token count.
+    /// @return The current token count.
+    function totalSupply() external view returns (uint256);
+
+    /// @notice Mints `tokenId` to `to`.
+    /// @param to Recipient account.
+    /// @param tokenId Token identifier.
+    function mint(address to, uint256 tokenId) external;
+
+    /// @notice Safely mints `tokenId` to `to`.
+    /// @param to Recipient account.
+    /// @param tokenId Token identifier.
+    /// @param data Additional receiver data.
+    function safeMint(address to, uint256 tokenId, bytes calldata data) external;
+
+    /// @notice Burns `tokenId`.
+    /// @param tokenId Token identifier.
+    function burn(uint256 tokenId) external;
+
+    /// @notice Updates the collection base URI.
+    /// @param baseURI New base URI.
+    function setBaseURI(string calldata baseURI) external;
+
+    /// @notice Sets an explicit metadata URI for `tokenId`.
+    /// @param tokenId Token identifier.
+    /// @param uri Explicit metadata URI.
+    function setTokenURI(uint256 tokenId, string calldata uri) external;
+}

--- a/src/token/ERC20TokenBase.sol
+++ b/src/token/ERC20TokenBase.sol
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC20TokenBase} from "../interfaces/IERC20TokenBase.sol";
+import {LibERC20TokenStorage} from "./storage/LibERC20TokenStorage.sol";
+
+/// @title ERC20TokenBase
+/// @notice Diamond-ready ERC-20 token foundation with initializer and shared storage helpers.
+abstract contract ERC20TokenBase is IERC20TokenBase {
+    /// @notice Returns true when ERC-20 storage is initialized.
+    /// @return True if initialized.
+    function isErc20Initialized() public view returns (bool) {
+        return LibERC20TokenStorage.layout().initialized;
+    }
+
+    /// @notice Returns ERC-20 token name.
+    /// @return The token name.
+    function name() public view virtual returns (string memory) {
+        return LibERC20TokenStorage.layout().name;
+    }
+
+    /// @notice Returns ERC-20 token symbol.
+    /// @return The token symbol.
+    function symbol() public view virtual returns (string memory) {
+        return LibERC20TokenStorage.layout().symbol;
+    }
+
+    /// @notice Returns ERC-20 token decimals.
+    /// @return The token decimals.
+    function decimals() public view virtual returns (uint8) {
+        return LibERC20TokenStorage.layout().decimals;
+    }
+
+    /// @notice Returns total token supply.
+    /// @return The current total supply.
+    function totalSupply() public view virtual returns (uint256) {
+        return LibERC20TokenStorage.layout().totalSupply;
+    }
+
+    /// @notice Returns balance for `account`.
+    /// @param account The account to query.
+    /// @return The token balance.
+    function balanceOf(address account) public view virtual returns (uint256) {
+        return LibERC20TokenStorage.layout().balances[account];
+    }
+
+    /// @notice Returns allowance from `owner` to `spender`.
+    /// @param owner Token owner.
+    /// @param spender Approved spender.
+    /// @return Remaining allowance.
+    function allowance(address owner, address spender) public view virtual returns (uint256) {
+        return LibERC20TokenStorage.layout().allowances[owner][spender];
+    }
+
+    /// @dev Initializes ERC-20 metadata and shared storage.
+    /// @param tokenName The ERC-20 token name.
+    /// @param tokenSymbol The ERC-20 token symbol.
+    /// @param tokenDecimals The ERC-20 token decimals.
+    function _initializeErc20Token(string memory tokenName, string memory tokenSymbol, uint8 tokenDecimals) internal {
+        LibERC20TokenStorage.Layout storage layout = LibERC20TokenStorage.layout();
+        if (layout.initialized) {
+            revert ERC20TokenAlreadyInitialized();
+        }
+
+        layout.initialized = true;
+        layout.name = tokenName;
+        layout.symbol = tokenSymbol;
+        layout.decimals = tokenDecimals;
+    }
+
+    /// @dev Mints `value` tokens to `to`.
+    /// @param to Recipient account.
+    /// @param value Amount to mint.
+    function _mintTokens(address to, uint256 value) internal {
+        _requireInitialized();
+        _requireNonZeroAddress(to);
+
+        LibERC20TokenStorage.Layout storage layout = LibERC20TokenStorage.layout();
+        layout.totalSupply += value;
+        layout.balances[to] += value;
+
+        emit Transfer(address(0), to, value);
+    }
+
+    /// @dev Burns `value` tokens from `from`.
+    /// @param from Token owner.
+    /// @param value Amount to burn.
+    function _burnTokens(address from, uint256 value) internal {
+        _requireInitialized();
+        _requireNonZeroAddress(from);
+
+        LibERC20TokenStorage.Layout storage layout = LibERC20TokenStorage.layout();
+        uint256 fromBalance = layout.balances[from];
+        if (fromBalance < value) {
+            revert ERC20TokenInsufficientBalance(from, fromBalance, value);
+        }
+
+        unchecked {
+            layout.balances[from] = fromBalance - value;
+            layout.totalSupply -= value;
+        }
+
+        emit Transfer(from, address(0), value);
+    }
+
+    /// @dev Transfers `value` tokens from `from` to `to`.
+    /// @param from Token sender.
+    /// @param to Token receiver.
+    /// @param value Amount to transfer.
+    function _transferTokens(address from, address to, uint256 value) internal {
+        _requireInitialized();
+        _requireNonZeroAddress(from);
+        _requireNonZeroAddress(to);
+
+        LibERC20TokenStorage.Layout storage layout = LibERC20TokenStorage.layout();
+        uint256 fromBalance = layout.balances[from];
+        if (fromBalance < value) {
+            revert ERC20TokenInsufficientBalance(from, fromBalance, value);
+        }
+
+        unchecked {
+            layout.balances[from] = fromBalance - value;
+        }
+        layout.balances[to] += value;
+
+        emit Transfer(from, to, value);
+    }
+
+    /// @dev Sets allowance from `owner` to `spender`.
+    /// @param owner Token owner.
+    /// @param spender Approved spender.
+    /// @param value New allowance value.
+    function _setAllowance(address owner, address spender, uint256 value) internal {
+        _requireInitialized();
+        _requireNonZeroAddress(owner);
+
+        LibERC20TokenStorage.layout().allowances[owner][spender] = value;
+        emit Approval(owner, spender, value);
+    }
+
+    /// @dev Consumes allowance from `owner` to `spender`.
+    /// @dev Infinite allowance (`type(uint256).max`) is not decremented.
+    /// @param owner Token owner.
+    /// @param spender Approved spender.
+    /// @param value Amount to consume.
+    function _spendAllowance(address owner, address spender, uint256 value) internal {
+        _requireInitialized();
+        _requireNonZeroAddress(owner);
+
+        uint256 currentAllowance = allowance(owner, spender);
+        if (currentAllowance == type(uint256).max) {
+            return;
+        }
+        if (currentAllowance < value) {
+            revert ERC20TokenInsufficientAllowance(owner, spender, currentAllowance, value);
+        }
+
+        unchecked {
+            _setAllowance(owner, spender, currentAllowance - value);
+        }
+    }
+
+    /// @dev Reverts when ERC-20 storage has not been initialized.
+    function _requireInitialized() internal view {
+        if (!isErc20Initialized()) {
+            revert ERC20TokenNotInitialized();
+        }
+    }
+
+    /// @dev Reverts when `account` is zero.
+    /// @param account The account to validate.
+    function _requireNonZeroAddress(address account) internal pure {
+        if (account == address(0)) {
+            revert ERC20TokenZeroAddress();
+        }
+    }
+}

--- a/src/token/ERC721TokenBase.sol
+++ b/src/token/ERC721TokenBase.sol
@@ -89,7 +89,7 @@ abstract contract ERC721TokenBase is IERC721TokenBase {
 
     /// @notice Returns current live token count tracked by the foundation.
     /// @return The token count.
-    function totalSupply() public view returns (uint256) {
+    function totalSupply() public view virtual returns (uint256) {
         return LibERC721TokenStorage.layout().totalSupply;
     }
 

--- a/src/token/ERC721TokenBase.sol
+++ b/src/token/ERC721TokenBase.sol
@@ -1,0 +1,326 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC165} from "../interfaces/IERC165.sol";
+import {IERC721} from "../interfaces/IERC721.sol";
+import {IERC721Metadata} from "../interfaces/IERC721Metadata.sol";
+import {IERC721Receiver} from "../interfaces/IERC721Receiver.sol";
+import {IERC721TokenBase} from "../interfaces/IERC721TokenBase.sol";
+import {LibERC721TokenStorage} from "./storage/LibERC721TokenStorage.sol";
+
+/// @title ERC721TokenBase
+/// @notice Diamond-ready ERC-721 token foundation with initializer, metadata, and shared storage helpers.
+abstract contract ERC721TokenBase is IERC721TokenBase {
+    /// @notice Returns true when this contract implements `interfaceId`.
+    /// @param interfaceId The interface identifier.
+    /// @return True when supported.
+    function supportsInterface(bytes4 interfaceId) public view virtual returns (bool) {
+        return interfaceId == type(IERC165).interfaceId || interfaceId == type(IERC721).interfaceId
+            || interfaceId == type(IERC721Metadata).interfaceId;
+    }
+
+    /// @notice Returns true when ERC-721 storage is initialized.
+    /// @return True if initialized.
+    function isErc721Initialized() public view returns (bool) {
+        return LibERC721TokenStorage.layout().initialized;
+    }
+
+    /// @notice Returns ERC-721 collection name.
+    /// @return The collection name.
+    function name() public view virtual returns (string memory) {
+        return LibERC721TokenStorage.layout().name;
+    }
+
+    /// @notice Returns ERC-721 collection symbol.
+    /// @return The collection symbol.
+    function symbol() public view virtual returns (string memory) {
+        return LibERC721TokenStorage.layout().symbol;
+    }
+
+    /// @notice Returns the current token owner.
+    /// @param tokenId The token identifier.
+    /// @return The token owner.
+    function ownerOf(uint256 tokenId) public view virtual returns (address) {
+        return _requireOwned(tokenId);
+    }
+
+    /// @notice Returns token balance for `owner`.
+    /// @param owner The account to query.
+    /// @return The token balance.
+    function balanceOf(address owner) public view virtual returns (uint256) {
+        if (owner == address(0)) {
+            revert ERC721TokenInvalidOwner(owner);
+        }
+        return LibERC721TokenStorage.layout().balances[owner];
+    }
+
+    /// @notice Returns the approved account for `tokenId`.
+    /// @param tokenId The token identifier.
+    /// @return The approved account, or zero when unset.
+    function getApproved(uint256 tokenId) public view virtual returns (address) {
+        _requireOwned(tokenId);
+        return LibERC721TokenStorage.layout().tokenApprovals[tokenId];
+    }
+
+    /// @notice Returns whether `operator` is approved for all of `owner`'s tokens.
+    /// @param owner Token owner.
+    /// @param operator Operator account.
+    /// @return True when approved.
+    function isApprovedForAll(address owner, address operator) public view virtual returns (bool) {
+        return LibERC721TokenStorage.layout().operatorApprovals[owner][operator];
+    }
+
+    /// @notice Returns metadata URI for `tokenId`.
+    /// @param tokenId The token identifier.
+    /// @return The token metadata URI.
+    function tokenURI(uint256 tokenId) public view virtual returns (string memory) {
+        _requireOwned(tokenId);
+
+        LibERC721TokenStorage.Layout storage layout = LibERC721TokenStorage.layout();
+        string memory explicitTokenUri = layout.tokenURIs[tokenId];
+        if (bytes(explicitTokenUri).length != 0) {
+            return explicitTokenUri;
+        }
+        if (bytes(layout.baseURI).length == 0) {
+            return "";
+        }
+        return string.concat(layout.baseURI, _toString(tokenId));
+    }
+
+    /// @notice Returns current live token count tracked by the foundation.
+    /// @return The token count.
+    function totalSupply() public view returns (uint256) {
+        return LibERC721TokenStorage.layout().totalSupply;
+    }
+
+    /// @dev Initializes ERC-721 metadata and shared storage.
+    /// @param tokenName The collection name.
+    /// @param tokenSymbol The collection symbol.
+    /// @param defaultBaseURI Default base URI for tokens without explicit URI.
+    function _initializeErc721Token(string memory tokenName, string memory tokenSymbol, string memory defaultBaseURI)
+        internal
+    {
+        LibERC721TokenStorage.Layout storage layout = LibERC721TokenStorage.layout();
+        if (layout.initialized) {
+            revert ERC721TokenAlreadyInitialized();
+        }
+
+        layout.initialized = true;
+        layout.name = tokenName;
+        layout.symbol = tokenSymbol;
+        layout.baseURI = defaultBaseURI;
+    }
+
+    /// @dev Mints `tokenId` to `to`.
+    /// @param to Recipient account.
+    /// @param tokenId The token identifier.
+    function _mintToken(address to, uint256 tokenId) internal {
+        _requireInitialized();
+        if (to == address(0)) {
+            revert ERC721TokenZeroAddress();
+        }
+        if (_exists(tokenId)) {
+            revert ERC721TokenAlreadyMinted(tokenId);
+        }
+
+        LibERC721TokenStorage.Layout storage layout = LibERC721TokenStorage.layout();
+        layout.owners[tokenId] = to;
+        layout.balances[to] += 1;
+        layout.totalSupply += 1;
+
+        emit Transfer(address(0), to, tokenId);
+    }
+
+    /// @dev Safely mints `tokenId` to `to`.
+    /// @param to Recipient account.
+    /// @param tokenId The token identifier.
+    /// @param data Additional receiver data.
+    function _safeMintToken(address to, uint256 tokenId, bytes memory data) internal {
+        _mintToken(to, tokenId);
+        _checkOnErc721Received(address(0), to, tokenId, data);
+    }
+
+    /// @dev Burns `tokenId`.
+    /// @param tokenId The token identifier.
+    function _burnToken(uint256 tokenId) internal {
+        _requireInitialized();
+
+        LibERC721TokenStorage.Layout storage layout = LibERC721TokenStorage.layout();
+        address owner_ = _requireOwned(tokenId);
+
+        unchecked {
+            layout.balances[owner_] -= 1;
+            layout.totalSupply -= 1;
+        }
+
+        delete layout.owners[tokenId];
+        delete layout.tokenApprovals[tokenId];
+        delete layout.tokenURIs[tokenId];
+
+        emit Transfer(owner_, address(0), tokenId);
+    }
+
+    /// @dev Transfers `tokenId` from `from` to `to`.
+    /// @param from Current token owner.
+    /// @param to Token receiver.
+    /// @param tokenId The token identifier.
+    function _transferToken(address from, address to, uint256 tokenId) internal {
+        _requireInitialized();
+        if (to == address(0)) {
+            revert ERC721TokenZeroAddress();
+        }
+
+        address owner_ = _requireOwned(tokenId);
+        if (owner_ != from) {
+            revert ERC721TokenIncorrectOwner(from, tokenId, owner_);
+        }
+
+        LibERC721TokenStorage.Layout storage layout = LibERC721TokenStorage.layout();
+        delete layout.tokenApprovals[tokenId];
+
+        unchecked {
+            layout.balances[from] -= 1;
+        }
+        layout.balances[to] += 1;
+        layout.owners[tokenId] = to;
+
+        emit Transfer(from, to, tokenId);
+    }
+
+    /// @dev Safely transfers `tokenId` from `from` to `to`.
+    /// @param from Current token owner.
+    /// @param to Token receiver.
+    /// @param tokenId The token identifier.
+    /// @param data Additional receiver data.
+    function _safeTransferToken(address from, address to, uint256 tokenId, bytes memory data) internal {
+        _transferToken(from, to, tokenId);
+        _checkOnErc721Received(from, to, tokenId, data);
+    }
+
+    /// @dev Sets approved account for `tokenId`.
+    /// @param to Approved account, or zero to clear.
+    /// @param tokenId The token identifier.
+    function _approveToken(address to, uint256 tokenId) internal {
+        _requireInitialized();
+        _requireOwned(tokenId);
+
+        LibERC721TokenStorage.layout().tokenApprovals[tokenId] = to;
+        emit Approval(ownerOf(tokenId), to, tokenId);
+    }
+
+    /// @dev Enables or disables `operator` for all of `owner`'s tokens.
+    /// @param owner Token owner.
+    /// @param operator Operator account.
+    /// @param approved True to approve, false to revoke.
+    function _setApprovalForAll(address owner, address operator, bool approved) internal {
+        _requireInitialized();
+        if (owner == address(0) || operator == address(0)) {
+            revert ERC721TokenZeroAddress();
+        }
+        if (owner == operator) {
+            revert ERC721TokenInvalidOperator(owner, operator);
+        }
+
+        LibERC721TokenStorage.layout().operatorApprovals[owner][operator] = approved;
+        emit ApprovalForAll(owner, operator, approved);
+    }
+
+    /// @dev Sets the base URI used for tokens without explicit URI.
+    /// @param baseUri The new base URI.
+    function _setBaseURI(string memory baseUri) internal {
+        _requireInitialized();
+        LibERC721TokenStorage.layout().baseURI = baseUri;
+    }
+
+    /// @dev Sets explicit metadata URI for `tokenId`.
+    /// @param tokenId The token identifier.
+    /// @param uri The explicit metadata URI.
+    function _setTokenURI(uint256 tokenId, string memory uri) internal {
+        _requireInitialized();
+        _requireOwned(tokenId);
+        LibERC721TokenStorage.layout().tokenURIs[tokenId] = uri;
+    }
+
+    /// @dev Returns whether `tokenId` exists.
+    /// @param tokenId The token identifier.
+    /// @return True when the token exists.
+    function _exists(uint256 tokenId) internal view returns (bool) {
+        return _ownerOf(tokenId) != address(0);
+    }
+
+    /// @dev Returns the raw owner for `tokenId`, or zero when absent.
+    /// @param tokenId The token identifier.
+    /// @return The raw owner address.
+    function _ownerOf(uint256 tokenId) internal view returns (address) {
+        return LibERC721TokenStorage.layout().owners[tokenId];
+    }
+
+    /// @dev Returns whether `spender` can manage `tokenId`.
+    /// @param spender The account to check.
+    /// @param tokenId The token identifier.
+    /// @return True when `spender` is owner or approved.
+    function _isApprovedOrOwner(address spender, uint256 tokenId) internal view returns (bool) {
+        address owner_ = _requireOwned(tokenId);
+        return spender == owner_ || getApproved(tokenId) == spender || isApprovedForAll(owner_, spender);
+    }
+
+    /// @dev Returns token owner or reverts when token does not exist.
+    /// @param tokenId The token identifier.
+    /// @return owner_ The token owner.
+    function _requireOwned(uint256 tokenId) internal view returns (address owner_) {
+        owner_ = _ownerOf(tokenId);
+        if (owner_ == address(0)) {
+            revert ERC721TokenNonexistentToken(tokenId);
+        }
+    }
+
+    /// @dev Reverts when ERC-721 storage has not been initialized.
+    function _requireInitialized() internal view {
+        if (!isErc721Initialized()) {
+            revert ERC721TokenNotInitialized();
+        }
+    }
+
+    /// @dev Reverts when `to` cannot receive safe ERC-721 transfers.
+    /// @param from Previous token owner.
+    /// @param to Receiver account.
+    /// @param tokenId The token identifier.
+    /// @param data Additional receiver data.
+    function _checkOnErc721Received(address from, address to, uint256 tokenId, bytes memory data) internal {
+        if (to.code.length == 0) {
+            return;
+        }
+
+        try IERC721Receiver(to).onERC721Received(msg.sender, from, tokenId, data) returns (bytes4 retval) {
+            if (retval != IERC721Receiver.onERC721Received.selector) {
+                revert ERC721TokenUnsafeReceiver(to);
+            }
+        } catch {
+            revert ERC721TokenUnsafeReceiver(to);
+        }
+    }
+
+    /// @dev Converts `value` to its decimal string representation.
+    /// @param value The value to stringify.
+    /// @return The decimal string.
+    function _toString(uint256 value) private pure returns (string memory) {
+        if (value == 0) {
+            return "0";
+        }
+
+        uint256 temp = value;
+        uint256 digits;
+        while (temp != 0) {
+            digits++;
+            temp /= 10;
+        }
+
+        bytes memory buffer = new bytes(digits);
+        while (value != 0) {
+            digits -= 1;
+            buffer[digits] = bytes1(uint8(48 + uint256(value % 10)));
+            value /= 10;
+        }
+        return string(buffer);
+    }
+}

--- a/src/token/TokenFacetControl.sol
+++ b/src/token/TokenFacetControl.sol
@@ -1,0 +1,312 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "../interfaces/IAccessControl.sol";
+import {IERC165} from "../interfaces/IERC165.sol";
+import {IPausable} from "../interfaces/IPausable.sol";
+import {LibAccessControlStorage} from "../access/storage/LibAccessControlStorage.sol";
+import {LibPausableStorage} from "../access/storage/LibPausableStorage.sol";
+
+/// @title TokenFacetControl
+/// @notice Constructor-free access control and pausability layer for hosted token facets.
+abstract contract TokenFacetControl is IAccessControl, IPausable {
+    /// @notice Default admin for all roles unless overridden.
+    bytes32 public constant DEFAULT_ADMIN_ROLE = 0x00;
+
+    /// @notice Role required to call `pause` and `unpause`.
+    bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
+
+    /// @dev Reverts if the caller is missing `role`.
+    modifier onlyRole(bytes32 role) {
+        _checkRole(role, msg.sender);
+        _;
+    }
+
+    /// @dev Reverts when contract is paused.
+    modifier whenNotPaused() {
+        _requireNotPaused();
+        _;
+    }
+
+    /// @dev Reverts when the given pause `scope` is effectively paused.
+    modifier whenScopeNotPaused(bytes32 scope) {
+        _requireScopeNotPaused(scope);
+        _;
+    }
+
+    /// @notice Returns true if `account` has been granted `role`.
+    /// @param role The role to query.
+    /// @param account The account to query.
+    /// @return True if the account has the role.
+    function hasRole(bytes32 role, address account) public view returns (bool) {
+        return LibAccessControlStorage.layout().roles[role].members[account];
+    }
+
+    /// @notice Returns the admin role that controls `role`.
+    /// @param role The role to query.
+    /// @return The admin role for `role`.
+    function getRoleAdmin(bytes32 role) public view returns (bytes32) {
+        return LibAccessControlStorage.layout().roles[role].adminRole;
+    }
+
+    /// @notice Returns the role member at `index`.
+    /// @param role The role to enumerate.
+    /// @param index The index in the role member array.
+    /// @return The account at the given index.
+    function getRoleMember(bytes32 role, uint256 index) public view returns (address) {
+        return LibAccessControlStorage.layout().roles[role].memberList[index];
+    }
+
+    /// @notice Returns the number of members for `role`.
+    /// @param role The role to enumerate.
+    /// @return The number of accounts in the role.
+    function getRoleMemberCount(bytes32 role) public view returns (uint256) {
+        return LibAccessControlStorage.layout().roles[role].memberList.length;
+    }
+
+    /// @notice Grants `role` to `account`.
+    /// @dev Caller must have ``getRoleAdmin(role)``.
+    /// @param role The role to grant.
+    /// @param account The account to grant the role to.
+    function grantRole(bytes32 role, address account) public onlyRole(getRoleAdmin(role)) {
+        _grantRole(role, account);
+    }
+
+    /// @notice Revokes `role` from `account`.
+    /// @dev Caller must have ``getRoleAdmin(role)``.
+    /// @param role The role to revoke.
+    /// @param account The account to revoke the role from.
+    function revokeRole(bytes32 role, address account) public onlyRole(getRoleAdmin(role)) {
+        _revokeRole(role, account);
+    }
+
+    /// @notice Renounces `role` for `account`.
+    /// @dev Reverts unless `account == msg.sender`.
+    /// @param role The role to renounce.
+    /// @param account The account renouncing the role.
+    function renounceRole(bytes32 role, address account) public {
+        if (account != msg.sender) {
+            revert AccessControlRenounceSelfOnly();
+        }
+        _revokeRole(role, account);
+    }
+
+    /// @notice Returns true when the contract is paused.
+    /// @return True if paused.
+    function paused() public view returns (bool) {
+        return LibPausableStorage.layout().paused;
+    }
+
+    /// @notice Returns true when `scope` is effectively paused.
+    /// @dev Effective pause includes global pause override.
+    /// @param scope The scope identifier.
+    /// @return True if globally paused or scope paused.
+    function paused(bytes32 scope) public view returns (bool) {
+        return paused() || scopePaused(scope);
+    }
+
+    /// @notice Returns true when `scope` is locally paused.
+    /// @param scope The scope identifier.
+    /// @return True if the scope itself is paused.
+    function scopePaused(bytes32 scope) public view returns (bool) {
+        return LibPausableStorage.layout().pausedScopes[scope];
+    }
+
+    /// @notice Pauses the contract.
+    /// @dev Caller must have `PAUSER_ROLE`.
+    function pause() public onlyRole(PAUSER_ROLE) whenNotPaused {
+        LibPausableStorage.layout().paused = true;
+        emit Paused(msg.sender);
+    }
+
+    /// @notice Unpauses the contract.
+    /// @dev Caller must have `PAUSER_ROLE`.
+    function unpause() public onlyRole(PAUSER_ROLE) {
+        _requirePaused();
+        LibPausableStorage.layout().paused = false;
+        emit Unpaused(msg.sender);
+    }
+
+    /// @notice Pauses a specific scope.
+    /// @dev Caller must have `PAUSER_ROLE`.
+    /// @param scope The scope identifier.
+    function pauseScope(bytes32 scope) public onlyRole(PAUSER_ROLE) {
+        _requireValidScope(scope);
+        if (scopePaused(scope)) {
+            revert PausableScopeEnforcedPause(scope);
+        }
+        LibPausableStorage.layout().pausedScopes[scope] = true;
+        emit ScopePaused(scope, msg.sender);
+    }
+
+    /// @notice Unpauses a specific scope.
+    /// @dev Caller must have `PAUSER_ROLE`.
+    /// @param scope The scope identifier.
+    function unpauseScope(bytes32 scope) public onlyRole(PAUSER_ROLE) {
+        _requireValidScope(scope);
+        if (!scopePaused(scope)) {
+            revert PausableScopeExpectedPause(scope);
+        }
+        LibPausableStorage.layout().pausedScopes[scope] = false;
+        emit ScopeUnpaused(scope, msg.sender);
+    }
+
+    /// @notice Returns true if this contract implements `interfaceId`.
+    /// @param interfaceId The interface identifier.
+    /// @return True if the interface is supported.
+    function supportsInterface(bytes4 interfaceId) public view virtual returns (bool) {
+        return interfaceId == type(IERC165).interfaceId || interfaceId == type(IAccessControl).interfaceId
+            || interfaceId == type(IPausable).interfaceId;
+    }
+
+    /// @dev Initializes shared access control and pausability storage when needed.
+    /// @param initialAdmin The default admin and initial pauser.
+    function _initializeTokenFacetControl(address initialAdmin) internal {
+        if (!_isAccessControlInitialized()) {
+            _initializeAccessControl(initialAdmin);
+        }
+        if (!_isPausableInitialized()) {
+            _initializePausable(initialAdmin);
+        }
+    }
+
+    /// @dev Returns true if access control storage has already been initialized.
+    /// @return True if initialized.
+    function _isAccessControlInitialized() internal view returns (bool) {
+        return LibAccessControlStorage.layout().initialized;
+    }
+
+    /// @dev Returns true if pausability storage has already been initialized.
+    /// @return True if initialized.
+    function _isPausableInitialized() internal view returns (bool) {
+        return LibPausableStorage.layout().initialized;
+    }
+
+    /// @dev Initializes access control storage.
+    /// @param initialAdmin The account to receive DEFAULT_ADMIN_ROLE.
+    function _initializeAccessControl(address initialAdmin) internal {
+        LibAccessControlStorage.Layout storage layout = LibAccessControlStorage.layout();
+        if (layout.initialized) {
+            revert AccessControlAlreadyInitialized();
+        }
+        if (initialAdmin == address(0)) {
+            revert AccessControlZeroAdmin();
+        }
+
+        layout.initialized = true;
+        layout.roles[DEFAULT_ADMIN_ROLE].adminRole = DEFAULT_ADMIN_ROLE;
+        _grantRole(DEFAULT_ADMIN_ROLE, initialAdmin);
+    }
+
+    /// @dev Initializes pausable storage and grants `PAUSER_ROLE`.
+    /// @param initialPauser The account to receive `PAUSER_ROLE`.
+    function _initializePausable(address initialPauser) internal {
+        LibPausableStorage.Layout storage layout = LibPausableStorage.layout();
+        if (layout.initialized) {
+            revert PausableAlreadyInitialized();
+        }
+        _requireNonZeroAccount(initialPauser);
+
+        layout.initialized = true;
+        _grantRole(PAUSER_ROLE, initialPauser);
+    }
+
+    /// @dev Reverts with {AccessControlUnauthorized} if `account` lacks `role`.
+    /// @param role The required role.
+    /// @param account The account being checked.
+    function _checkRole(bytes32 role, address account) internal view {
+        if (!hasRole(role, account)) {
+            revert AccessControlUnauthorized(account, role);
+        }
+    }
+
+    /// @dev Updates the admin role for `role`.
+    /// @param role The role to update.
+    /// @param adminRole The new admin role.
+    function _setRoleAdmin(bytes32 role, bytes32 adminRole) internal {
+        LibAccessControlStorage.Layout storage layout = LibAccessControlStorage.layout();
+        bytes32 previousAdminRole = layout.roles[role].adminRole;
+        layout.roles[role].adminRole = adminRole;
+        emit RoleAdminChanged(role, previousAdminRole, adminRole);
+    }
+
+    /// @dev Grants `role` to `account` if not already granted.
+    /// @param role The role to grant.
+    /// @param account The account receiving the role.
+    function _grantRole(bytes32 role, address account) internal {
+        _requireNonZeroAccount(account);
+
+        LibAccessControlStorage.RoleData storage roleData = LibAccessControlStorage.layout().roles[role];
+        if (!roleData.members[account]) {
+            roleData.members[account] = true;
+            if (roleData.memberIndex[account] == 0) {
+                roleData.memberList.push(account);
+                roleData.memberIndex[account] = roleData.memberList.length;
+            }
+            emit RoleGranted(role, account, msg.sender);
+        }
+    }
+
+    /// @dev Revokes `role` from `account` if currently granted.
+    /// @param role The role to revoke.
+    /// @param account The account losing the role.
+    function _revokeRole(bytes32 role, address account) internal {
+        _requireNonZeroAccount(account);
+
+        LibAccessControlStorage.RoleData storage roleData = LibAccessControlStorage.layout().roles[role];
+        if (roleData.members[account]) {
+            roleData.members[account] = false;
+            uint256 index = roleData.memberIndex[account];
+            if (index != 0) {
+                uint256 lastIndex = roleData.memberList.length;
+                if (index != lastIndex) {
+                    address lastMember = roleData.memberList[lastIndex - 1];
+                    roleData.memberList[index - 1] = lastMember;
+                    roleData.memberIndex[lastMember] = index;
+                }
+                roleData.memberList.pop();
+                roleData.memberIndex[account] = 0;
+            }
+            emit RoleRevoked(role, account, msg.sender);
+        }
+    }
+
+    /// @dev Reverts when `account` is the zero address.
+    /// @param account The account to validate.
+    function _requireNonZeroAccount(address account) internal pure {
+        if (account == address(0)) {
+            revert AccessControlZeroAddressAccount();
+        }
+    }
+
+    /// @dev Reverts with {PausableEnforcedPause} when paused.
+    function _requireNotPaused() internal view {
+        if (paused()) {
+            revert PausableEnforcedPause();
+        }
+    }
+
+    /// @dev Reverts with {PausableExpectedPause} when unpaused.
+    function _requirePaused() internal view {
+        if (!paused()) {
+            revert PausableExpectedPause();
+        }
+    }
+
+    /// @dev Reverts with {PausableScopeEnforcedPause} when scope is effectively paused.
+    /// @param scope The scope identifier.
+    function _requireScopeNotPaused(bytes32 scope) internal view {
+        _requireValidScope(scope);
+        if (paused(scope)) {
+            revert PausableScopeEnforcedPause(scope);
+        }
+    }
+
+    /// @dev Reverts with {PausableZeroScope} when `scope` is zero.
+    /// @param scope The scope identifier.
+    function _requireValidScope(bytes32 scope) internal pure {
+        if (scope == bytes32(0)) {
+            revert PausableZeroScope();
+        }
+    }
+}

--- a/src/token/facets/ERC20TokenFacet.sol
+++ b/src/token/facets/ERC20TokenFacet.sol
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC20TokenFacet} from "../../interfaces/IERC20TokenFacet.sol";
+import {IERC165} from "../../interfaces/IERC165.sol";
+import {ERC20TokenBase} from "../ERC20TokenBase.sol";
+import {TokenFacetControl} from "../TokenFacetControl.sol";
+import {LibTokenFacetConstants} from "../libraries/LibTokenFacetConstants.sol";
+
+/// @title ERC20TokenFacet
+/// @notice Hosted ERC-20 + metadata facet with shared access control and pause integration.
+contract ERC20TokenFacet is ERC20TokenBase, TokenFacetControl, IERC20TokenFacet {
+    /// @notice Shared token admin role.
+    bytes32 public constant TOKEN_ADMIN_ROLE = LibTokenFacetConstants.TOKEN_ADMIN_ROLE;
+    /// @notice ERC-20 minter role.
+    bytes32 public constant ERC20_MINTER_ROLE = LibTokenFacetConstants.ERC20_MINTER_ROLE;
+    /// @notice ERC-20 burner role.
+    bytes32 public constant ERC20_BURNER_ROLE = LibTokenFacetConstants.ERC20_BURNER_ROLE;
+    /// @notice Pause scope for ERC-20 transfers.
+    bytes32 public constant ERC20_TRANSFER_SCOPE = LibTokenFacetConstants.ERC20_TRANSFER_SCOPE;
+    /// @notice Pause scope for ERC-20 approvals.
+    bytes32 public constant ERC20_APPROVAL_SCOPE = LibTokenFacetConstants.ERC20_APPROVAL_SCOPE;
+
+    /// @notice Initializes the hosted ERC-20 facet.
+    /// @param tokenName Token name.
+    /// @param tokenSymbol Token symbol.
+    /// @param tokenDecimals Token decimals.
+    /// @param admin Admin account seeded into the shared control plane.
+    function initializeErc20(
+        string calldata tokenName,
+        string calldata tokenSymbol,
+        uint8 tokenDecimals,
+        address admin
+    ) external {
+        if (isErc20Initialized()) {
+            revert ERC20TokenAlreadyInitialized();
+        }
+
+        if (_isAccessControlInitialized()) {
+            _checkRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        }
+
+        _initializeTokenFacetControl(admin);
+        _initializeErc20Token(tokenName, tokenSymbol, tokenDecimals);
+
+        _setRoleAdmin(TOKEN_ADMIN_ROLE, DEFAULT_ADMIN_ROLE);
+        _setRoleAdmin(ERC20_MINTER_ROLE, TOKEN_ADMIN_ROLE);
+        _setRoleAdmin(ERC20_BURNER_ROLE, TOKEN_ADMIN_ROLE);
+
+        _grantRole(TOKEN_ADMIN_ROLE, admin);
+        _grantRole(ERC20_MINTER_ROLE, admin);
+        _grantRole(ERC20_BURNER_ROLE, admin);
+        _grantRole(PAUSER_ROLE, admin);
+    }
+
+    /// @notice Transfers `value` tokens to `to`.
+    /// @param to Recipient account.
+    /// @param value Amount to transfer.
+    /// @return True if the transfer succeeded.
+    function transfer(address to, uint256 value) external whenScopeNotPaused(ERC20_TRANSFER_SCOPE) returns (bool) {
+        _transferTokens(msg.sender, to, value);
+        return true;
+    }
+
+    /// @notice Sets allowance from caller to `spender`.
+    /// @param spender Approved spender.
+    /// @param value New allowance amount.
+    /// @return True if the approval succeeded.
+    function approve(address spender, uint256 value) external whenScopeNotPaused(ERC20_APPROVAL_SCOPE) returns (bool) {
+        _setAllowance(msg.sender, spender, value);
+        return true;
+    }
+
+    /// @notice Transfers `value` tokens from `from` to `to` using allowance.
+    /// @param from Source account.
+    /// @param to Recipient account.
+    /// @param value Amount to transfer.
+    /// @return True if the transfer succeeded.
+    function transferFrom(address from, address to, uint256 value) external returns (bool) {
+        _requireScopeNotPaused(ERC20_APPROVAL_SCOPE);
+        _requireScopeNotPaused(ERC20_TRANSFER_SCOPE);
+        _spendAllowance(from, msg.sender, value);
+        _transferTokens(from, to, value);
+        return true;
+    }
+
+    /// @notice Mints `value` tokens to `to`.
+    /// @dev Caller must have `ERC20_MINTER_ROLE`.
+    /// @param to Recipient account.
+    /// @param value Amount to mint.
+    function mint(address to, uint256 value)
+        external
+        onlyRole(ERC20_MINTER_ROLE)
+        whenScopeNotPaused(ERC20_TRANSFER_SCOPE)
+    {
+        _mintTokens(to, value);
+    }
+
+    /// @notice Burns `value` tokens from `from`.
+    /// @dev Caller must have `ERC20_BURNER_ROLE`.
+    /// @param from Token holder.
+    /// @param value Amount to burn.
+    function burn(address from, uint256 value)
+        external
+        onlyRole(ERC20_BURNER_ROLE)
+        whenScopeNotPaused(ERC20_TRANSFER_SCOPE)
+    {
+        _burnTokens(from, value);
+    }
+
+    /// @notice Returns true if this contract implements `interfaceId`.
+    /// @param interfaceId The interface identifier.
+    /// @return True if supported.
+    function supportsInterface(bytes4 interfaceId) public view override(TokenFacetControl, IERC165) returns (bool) {
+        return interfaceId == type(IERC20TokenFacet).interfaceId || super.supportsInterface(interfaceId);
+    }
+}

--- a/src/token/facets/ERC20TokenFacet.sol
+++ b/src/token/facets/ERC20TokenFacet.sol
@@ -2,14 +2,23 @@
 pragma solidity ^0.8.30;
 
 import {IERC20TokenFacet} from "../../interfaces/IERC20TokenFacet.sol";
+import {IERC20Permit} from "../../interfaces/IERC20Permit.sol";
 import {IERC165} from "../../interfaces/IERC165.sol";
 import {ERC20TokenBase} from "../ERC20TokenBase.sol";
 import {TokenFacetControl} from "../TokenFacetControl.sol";
 import {LibTokenFacetConstants} from "../libraries/LibTokenFacetConstants.sol";
+import {LibERC20TokenStorage} from "../storage/LibERC20TokenStorage.sol";
 
 /// @title ERC20TokenFacet
 /// @notice Hosted ERC-20 + metadata facet with shared access control and pause integration.
 contract ERC20TokenFacet is ERC20TokenBase, TokenFacetControl, IERC20TokenFacet {
+    bytes32 internal constant EIP712_DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    bytes32 internal constant PERMIT_TYPEHASH =
+        keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+    bytes32 internal constant VERSION_HASH = keccak256("1");
+    uint256 internal constant SECP256K1N_DIV_2 = 0x7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0;
+
     /// @notice Shared token admin role.
     bytes32 public constant TOKEN_ADMIN_ROLE = LibTokenFacetConstants.TOKEN_ADMIN_ROLE;
     /// @notice ERC-20 minter role.
@@ -42,6 +51,7 @@ contract ERC20TokenFacet is ERC20TokenBase, TokenFacetControl, IERC20TokenFacet 
 
         _initializeTokenFacetControl(admin);
         _initializeErc20Token(tokenName, tokenSymbol, tokenDecimals);
+        _initializePermitDomain(tokenName);
 
         _setRoleAdmin(TOKEN_ADMIN_ROLE, DEFAULT_ADMIN_ROLE);
         _setRoleAdmin(ERC20_MINTER_ROLE, TOKEN_ADMIN_ROLE);
@@ -108,10 +118,79 @@ contract ERC20TokenFacet is ERC20TokenBase, TokenFacetControl, IERC20TokenFacet 
         _burnTokens(from, value);
     }
 
+    /// @notice Sets allowance with a signed Permit approval.
+    /// @param owner Token owner.
+    /// @param spender Approved spender.
+    /// @param value Allowance amount.
+    /// @param deadline Signature expiration timestamp.
+    /// @param v Recovery identifier.
+    /// @param r Signature component.
+    /// @param s Signature component.
+    function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s)
+        external
+        whenScopeNotPaused(ERC20_APPROVAL_SCOPE)
+    {
+        if (block.timestamp > deadline) {
+            revert ERC20PermitExpired(deadline, block.timestamp);
+        }
+
+        LibERC20TokenStorage.Layout storage layout = LibERC20TokenStorage.layout();
+        uint256 nonce = layout.nonces[owner];
+        bytes32 structHash = keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, nonce, deadline));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR(), structHash));
+        address signer = _recoverSigner(digest, v, r, s);
+        if (signer != owner) {
+            revert ERC20PermitInvalidSigner(signer, owner);
+        }
+
+        layout.nonces[owner] = nonce + 1;
+        _setAllowance(owner, spender, value);
+    }
+
+    /// @notice Returns the current Permit nonce for `owner`.
+    /// @param owner Token owner.
+    /// @return The current nonce.
+    function nonces(address owner) external view returns (uint256) {
+        return LibERC20TokenStorage.layout().nonces[owner];
+    }
+
+    /// @notice Returns the EIP-712 domain separator for Permit signatures.
+    /// @return The domain separator.
+    function DOMAIN_SEPARATOR() public view returns (bytes32) {
+        LibERC20TokenStorage.Layout storage layout = LibERC20TokenStorage.layout();
+        if (layout.cachedChainId == block.chainid) {
+            return layout.cachedDomainSeparator;
+        }
+        return _buildDomainSeparator(layout.hashedName, block.chainid);
+    }
+
     /// @notice Returns true if this contract implements `interfaceId`.
     /// @param interfaceId The interface identifier.
     /// @return True if supported.
     function supportsInterface(bytes4 interfaceId) public view override(TokenFacetControl, IERC165) returns (bool) {
-        return interfaceId == type(IERC20TokenFacet).interfaceId || super.supportsInterface(interfaceId);
+        return interfaceId == type(IERC20TokenFacet).interfaceId || interfaceId == type(IERC20Permit).interfaceId
+            || super.supportsInterface(interfaceId);
+    }
+
+    function _initializePermitDomain(string memory tokenName) internal {
+        LibERC20TokenStorage.Layout storage layout = LibERC20TokenStorage.layout();
+        layout.hashedName = keccak256(bytes(tokenName));
+        layout.cachedChainId = block.chainid;
+        layout.cachedDomainSeparator = _buildDomainSeparator(layout.hashedName, block.chainid);
+    }
+
+    function _buildDomainSeparator(bytes32 hashedName, uint256 chainId) internal view returns (bytes32) {
+        return keccak256(abi.encode(EIP712_DOMAIN_TYPEHASH, hashedName, VERSION_HASH, chainId, address(this)));
+    }
+
+    function _recoverSigner(bytes32 digest, uint8 v, bytes32 r, bytes32 s) internal pure returns (address) {
+        if (v != 27 && v != 28) {
+            return address(0);
+        }
+        if (uint256(s) > SECP256K1N_DIV_2) {
+            return address(0);
+        }
+
+        return ecrecover(digest, v, r, s);
     }
 }

--- a/src/token/facets/ERC721TokenFacet.sol
+++ b/src/token/facets/ERC721TokenFacet.sol
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "../../interfaces/IAccessControl.sol";
+import {IERC165} from "../../interfaces/IERC165.sol";
+import {IERC721TokenFacet} from "../../interfaces/IERC721TokenFacet.sol";
+import {ERC721TokenBase} from "../ERC721TokenBase.sol";
+import {TokenFacetControl} from "../TokenFacetControl.sol";
+import {LibTokenFacetConstants} from "../libraries/LibTokenFacetConstants.sol";
+
+/// @title ERC721TokenFacet
+/// @notice Hosted ERC-721 + metadata facet with shared access control and pause integration.
+contract ERC721TokenFacet is ERC721TokenBase, TokenFacetControl, IERC721TokenFacet {
+    /// @notice Shared token admin role.
+    bytes32 public constant TOKEN_ADMIN_ROLE = LibTokenFacetConstants.TOKEN_ADMIN_ROLE;
+    /// @notice ERC-721 minter role.
+    bytes32 public constant ERC721_MINTER_ROLE = LibTokenFacetConstants.ERC721_MINTER_ROLE;
+    /// @notice ERC-721 burner role.
+    bytes32 public constant ERC721_BURNER_ROLE = LibTokenFacetConstants.ERC721_BURNER_ROLE;
+    /// @notice ERC-721 metadata manager role.
+    bytes32 public constant ERC721_METADATA_ROLE = LibTokenFacetConstants.ERC721_METADATA_ROLE;
+    /// @notice Pause scope for ERC-721 transfers.
+    bytes32 public constant ERC721_TRANSFER_SCOPE = LibTokenFacetConstants.ERC721_TRANSFER_SCOPE;
+    /// @notice Pause scope for ERC-721 approvals.
+    bytes32 public constant ERC721_APPROVAL_SCOPE = LibTokenFacetConstants.ERC721_APPROVAL_SCOPE;
+
+    /// @notice Initializes the hosted ERC-721 facet.
+    /// @param tokenName Collection name.
+    /// @param tokenSymbol Collection symbol.
+    /// @param baseURI Default base URI for tokens without explicit metadata URI.
+    /// @param admin Admin account seeded into the shared control plane.
+    function initializeErc721(
+        string calldata tokenName,
+        string calldata tokenSymbol,
+        string calldata baseURI,
+        address admin
+    ) external {
+        if (isErc721Initialized()) {
+            revert ERC721TokenAlreadyInitialized();
+        }
+
+        if (_isAccessControlInitialized()) {
+            _checkRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        }
+
+        _initializeTokenFacetControl(admin);
+        _initializeErc721Token(tokenName, tokenSymbol, baseURI);
+
+        _setRoleAdmin(TOKEN_ADMIN_ROLE, DEFAULT_ADMIN_ROLE);
+        _setRoleAdmin(ERC721_MINTER_ROLE, TOKEN_ADMIN_ROLE);
+        _setRoleAdmin(ERC721_BURNER_ROLE, TOKEN_ADMIN_ROLE);
+        _setRoleAdmin(ERC721_METADATA_ROLE, TOKEN_ADMIN_ROLE);
+
+        _grantRole(TOKEN_ADMIN_ROLE, admin);
+        _grantRole(ERC721_MINTER_ROLE, admin);
+        _grantRole(ERC721_BURNER_ROLE, admin);
+        _grantRole(ERC721_METADATA_ROLE, admin);
+        _grantRole(PAUSER_ROLE, admin);
+    }
+
+    /// @notice Approves `to` to manage `tokenId`.
+    /// @param to Approved account, or zero to clear approval.
+    /// @param tokenId Token identifier.
+    function approve(address to, uint256 tokenId) external whenScopeNotPaused(ERC721_APPROVAL_SCOPE) {
+        address owner_ = ownerOf(tokenId);
+        if (msg.sender != owner_ && !isApprovedForAll(owner_, msg.sender)) {
+            revert ERC721TokenUnauthorizedOperator(msg.sender, tokenId);
+        }
+        _approveToken(to, tokenId);
+    }
+
+    /// @notice Enables or disables `operator` for all caller-owned tokens.
+    /// @param operator Operator account.
+    /// @param approved True to approve, false to revoke.
+    function setApprovalForAll(address operator, bool approved) external whenScopeNotPaused(ERC721_APPROVAL_SCOPE) {
+        _setApprovalForAll(msg.sender, operator, approved);
+    }
+
+    /// @notice Transfers `tokenId` from `from` to `to`.
+    /// @param from Current token owner.
+    /// @param to Receiver account.
+    /// @param tokenId Token identifier.
+    function transferFrom(address from, address to, uint256 tokenId)
+        external
+        whenScopeNotPaused(ERC721_TRANSFER_SCOPE)
+    {
+        if (!_isApprovedOrOwner(msg.sender, tokenId)) {
+            revert ERC721TokenUnauthorizedOperator(msg.sender, tokenId);
+        }
+        _transferToken(from, to, tokenId);
+    }
+
+    /// @notice Safely transfers `tokenId` from `from` to `to`.
+    /// @param from Current token owner.
+    /// @param to Receiver account.
+    /// @param tokenId Token identifier.
+    function safeTransferFrom(address from, address to, uint256 tokenId)
+        external
+        whenScopeNotPaused(ERC721_TRANSFER_SCOPE)
+    {
+        if (!_isApprovedOrOwner(msg.sender, tokenId)) {
+            revert ERC721TokenUnauthorizedOperator(msg.sender, tokenId);
+        }
+        _safeTransferToken(from, to, tokenId, "");
+    }
+
+    /// @notice Safely transfers `tokenId` from `from` to `to` with `data`.
+    /// @param from Current token owner.
+    /// @param to Receiver account.
+    /// @param tokenId Token identifier.
+    /// @param data Additional receiver data.
+    function safeTransferFrom(address from, address to, uint256 tokenId, bytes calldata data)
+        external
+        whenScopeNotPaused(ERC721_TRANSFER_SCOPE)
+    {
+        if (!_isApprovedOrOwner(msg.sender, tokenId)) {
+            revert ERC721TokenUnauthorizedOperator(msg.sender, tokenId);
+        }
+        _safeTransferToken(from, to, tokenId, data);
+    }
+
+    /// @notice Mints `tokenId` to `to`.
+    /// @param to Recipient account.
+    /// @param tokenId Token identifier.
+    function mint(address to, uint256 tokenId)
+        external
+        onlyRole(ERC721_MINTER_ROLE)
+        whenScopeNotPaused(ERC721_TRANSFER_SCOPE)
+    {
+        _mintToken(to, tokenId);
+    }
+
+    /// @notice Safely mints `tokenId` to `to`.
+    /// @param to Recipient account.
+    /// @param tokenId Token identifier.
+    /// @param data Additional receiver data.
+    function safeMint(address to, uint256 tokenId, bytes calldata data)
+        external
+        onlyRole(ERC721_MINTER_ROLE)
+        whenScopeNotPaused(ERC721_TRANSFER_SCOPE)
+    {
+        _safeMintToken(to, tokenId, data);
+    }
+
+    /// @notice Burns `tokenId`.
+    /// @param tokenId Token identifier.
+    function burn(uint256 tokenId) external onlyRole(ERC721_BURNER_ROLE) whenScopeNotPaused(ERC721_TRANSFER_SCOPE) {
+        _burnToken(tokenId);
+    }
+
+    /// @notice Updates the collection base URI.
+    /// @param baseURI New base URI.
+    function setBaseURI(string calldata baseURI) external onlyRole(ERC721_METADATA_ROLE) {
+        _setBaseURI(baseURI);
+    }
+
+    /// @notice Sets an explicit metadata URI for `tokenId`.
+    /// @param tokenId Token identifier.
+    /// @param uri Explicit metadata URI.
+    function setTokenURI(uint256 tokenId, string calldata uri) external onlyRole(ERC721_METADATA_ROLE) {
+        _setTokenURI(tokenId, uri);
+    }
+
+    /// @notice Returns the current live token count.
+    /// @return The current token count.
+    function totalSupply() public view override(ERC721TokenBase, IERC721TokenFacet) returns (uint256) {
+        return ERC721TokenBase.totalSupply();
+    }
+
+    /// @notice Returns true if this contract implements `interfaceId`.
+    /// @param interfaceId The interface identifier.
+    /// @return True if supported.
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        override(ERC721TokenBase, TokenFacetControl, IERC165)
+        returns (bool)
+    {
+        return interfaceId == type(IERC721TokenFacet).interfaceId || ERC721TokenBase.supportsInterface(interfaceId)
+            || TokenFacetControl.supportsInterface(interfaceId);
+    }
+}

--- a/src/token/libraries/LibTokenFacetConstants.sol
+++ b/src/token/libraries/LibTokenFacetConstants.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title LibTokenFacetConstants
+/// @notice Shared role and pause-scope identifiers for hosted token facets.
+library LibTokenFacetConstants {
+    /// @notice Role for token-level administrative configuration.
+    bytes32 internal constant TOKEN_ADMIN_ROLE = keccak256("TOKEN_ADMIN_ROLE");
+    /// @notice Role for ERC-20 mint operations.
+    bytes32 internal constant ERC20_MINTER_ROLE = keccak256("ERC20_MINTER_ROLE");
+    /// @notice Role for ERC-20 burn operations.
+    bytes32 internal constant ERC20_BURNER_ROLE = keccak256("ERC20_BURNER_ROLE");
+    /// @notice Role for ERC-721 mint operations.
+    bytes32 internal constant ERC721_MINTER_ROLE = keccak256("ERC721_MINTER_ROLE");
+    /// @notice Role for ERC-721 burn operations.
+    bytes32 internal constant ERC721_BURNER_ROLE = keccak256("ERC721_BURNER_ROLE");
+    /// @notice Role for ERC-721 metadata updates.
+    bytes32 internal constant ERC721_METADATA_ROLE = keccak256("ERC721_METADATA_ROLE");
+
+    /// @notice Pause scope for ERC-20 transfers.
+    bytes32 internal constant ERC20_TRANSFER_SCOPE = keccak256("ERC20_TRANSFER_SCOPE");
+    /// @notice Pause scope for ERC-20 approvals.
+    bytes32 internal constant ERC20_APPROVAL_SCOPE = keccak256("ERC20_APPROVAL_SCOPE");
+    /// @notice Pause scope for ERC-721 transfers.
+    bytes32 internal constant ERC721_TRANSFER_SCOPE = keccak256("ERC721_TRANSFER_SCOPE");
+    /// @notice Pause scope for ERC-721 approvals.
+    bytes32 internal constant ERC721_APPROVAL_SCOPE = keccak256("ERC721_APPROVAL_SCOPE");
+}

--- a/src/token/libraries/LibTokenFacetDeploymentSelectors.sol
+++ b/src/token/libraries/LibTokenFacetDeploymentSelectors.sol
@@ -14,7 +14,6 @@ import {IERC721TokenBase} from "../../interfaces/IERC721TokenBase.sol";
 import {IERC721TokenFacet} from "../../interfaces/IERC721TokenFacet.sol";
 import {IPausable} from "../../interfaces/IPausable.sol";
 import {DiamondLoupeFacet} from "../../diamond/facets/DiamondLoupeFacet.sol";
-import {DiamondCutFacet} from "../../diamond/facets/DiamondCutFacet.sol";
 
 /// @title LibTokenFacetDeploymentSelectors
 /// @notice Canonical selector sets for reference token-hosted diamond deployments.
@@ -31,10 +30,9 @@ library LibTokenFacetDeploymentSelectors {
         selectors[5] = DiamondLoupeFacet.transferOwnership.selector;
     }
 
-    /// @notice Returns the selector set used to install the ERC20 host facet.
-    /// @return selectors ERC20 + shared control selectors.
-    function erc20HostSelectors() internal pure returns (bytes4[] memory selectors) {
-        selectors = new bytes4[](30);
+    /// @notice Returns the ERC20 token selectors for hosted deployments.
+    function erc20TokenSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](16);
         selectors[0] = IERC20TokenFacet.initializeErc20.selector;
         selectors[1] = IERC20Metadata.name.selector;
         selectors[2] = IERC20Metadata.symbol.selector;
@@ -48,29 +46,39 @@ library LibTokenFacetDeploymentSelectors {
         selectors[10] = IERC20TokenFacet.mint.selector;
         selectors[11] = IERC20TokenFacet.burn.selector;
         selectors[12] = IERC20TokenBase.isErc20Initialized.selector;
-        selectors[13] = IAccessControl.DEFAULT_ADMIN_ROLE.selector;
-        selectors[14] = IPausable.PAUSER_ROLE.selector;
-        selectors[15] = IERC20TokenFacet.TOKEN_ADMIN_ROLE.selector;
-        selectors[16] = IERC20TokenFacet.ERC20_MINTER_ROLE.selector;
-        selectors[17] = IERC20TokenFacet.ERC20_BURNER_ROLE.selector;
-        selectors[18] = IERC20TokenFacet.ERC20_TRANSFER_SCOPE.selector;
-        selectors[19] = IERC20TokenFacet.ERC20_APPROVAL_SCOPE.selector;
-        selectors[20] = IAccessControl.hasRole.selector;
-        selectors[21] = IAccessControl.getRoleAdmin.selector;
-        selectors[22] = IAccessControl.grantRole.selector;
-        selectors[23] = IPausable.pauseScope.selector;
-        selectors[24] = IPausable.unpauseScope.selector;
-        selectors[25] = IPausable.scopePaused.selector;
-        selectors[26] = IERC20Permit.permit.selector;
-        selectors[27] = IERC20Permit.nonces.selector;
-        selectors[28] = IERC20Permit.DOMAIN_SEPARATOR.selector;
-        selectors[29] = IERC165.supportsInterface.selector;
+        selectors[13] = IERC20Permit.permit.selector;
+        selectors[14] = IERC20Permit.nonces.selector;
+        selectors[15] = IERC20Permit.DOMAIN_SEPARATOR.selector;
     }
 
-    /// @notice Returns the selector set used to install the ERC721 host facet.
-    /// @return selectors ERC721 + shared control selectors.
-    function erc721HostSelectors() internal pure returns (bytes4[] memory selectors) {
-        selectors = new bytes4[](35);
+    /// @notice Returns the ERC20 shared-control selectors for hosted deployments.
+    function erc20SharedControlSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](14);
+        selectors[0] = IAccessControl.DEFAULT_ADMIN_ROLE.selector;
+        selectors[1] = IPausable.PAUSER_ROLE.selector;
+        selectors[2] = IERC20TokenFacet.TOKEN_ADMIN_ROLE.selector;
+        selectors[3] = IERC20TokenFacet.ERC20_MINTER_ROLE.selector;
+        selectors[4] = IERC20TokenFacet.ERC20_BURNER_ROLE.selector;
+        selectors[5] = IERC20TokenFacet.ERC20_TRANSFER_SCOPE.selector;
+        selectors[6] = IERC20TokenFacet.ERC20_APPROVAL_SCOPE.selector;
+        selectors[7] = IAccessControl.hasRole.selector;
+        selectors[8] = IAccessControl.getRoleAdmin.selector;
+        selectors[9] = IAccessControl.grantRole.selector;
+        selectors[10] = IPausable.pauseScope.selector;
+        selectors[11] = IPausable.unpauseScope.selector;
+        selectors[12] = IPausable.scopePaused.selector;
+        selectors[13] = IERC165.supportsInterface.selector;
+    }
+
+    /// @notice Returns the selector set used to install the ERC20 host facet.
+    /// @return selectors ERC20 + shared control selectors.
+    function erc20HostSelectors() internal pure returns (bytes4[] memory selectors) {
+        return _concat(erc20TokenSelectors(), erc20SharedControlSelectors());
+    }
+
+    /// @notice Returns the ERC721 token selectors for hosted deployments.
+    function erc721TokenSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](20);
         selectors[0] = IERC721TokenFacet.initializeErc721.selector;
         selectors[1] = IERC721.balanceOf.selector;
         selectors[2] = IERC721.ownerOf.selector;
@@ -91,20 +99,44 @@ library LibTokenFacetDeploymentSelectors {
         selectors[17] = IERC721TokenFacet.burn.selector;
         selectors[18] = IERC721TokenFacet.setBaseURI.selector;
         selectors[19] = IERC721TokenFacet.setTokenURI.selector;
-        selectors[20] = IAccessControl.DEFAULT_ADMIN_ROLE.selector;
-        selectors[21] = IPausable.PAUSER_ROLE.selector;
-        selectors[22] = IERC721TokenFacet.TOKEN_ADMIN_ROLE.selector;
-        selectors[23] = IERC721TokenFacet.ERC721_MINTER_ROLE.selector;
-        selectors[24] = IERC721TokenFacet.ERC721_BURNER_ROLE.selector;
-        selectors[25] = IERC721TokenFacet.ERC721_METADATA_ROLE.selector;
-        selectors[26] = IERC721TokenFacet.ERC721_TRANSFER_SCOPE.selector;
-        selectors[27] = IERC721TokenFacet.ERC721_APPROVAL_SCOPE.selector;
-        selectors[28] = IAccessControl.hasRole.selector;
-        selectors[29] = IAccessControl.getRoleAdmin.selector;
-        selectors[30] = IAccessControl.grantRole.selector;
-        selectors[31] = IPausable.pauseScope.selector;
-        selectors[32] = IPausable.unpauseScope.selector;
-        selectors[33] = IPausable.scopePaused.selector;
-        selectors[34] = IERC165.supportsInterface.selector;
+    }
+
+    /// @notice Returns the ERC721 shared-control selectors for hosted deployments.
+    function erc721SharedControlSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](15);
+        selectors[0] = IAccessControl.DEFAULT_ADMIN_ROLE.selector;
+        selectors[1] = IPausable.PAUSER_ROLE.selector;
+        selectors[2] = IERC721TokenFacet.TOKEN_ADMIN_ROLE.selector;
+        selectors[3] = IERC721TokenFacet.ERC721_MINTER_ROLE.selector;
+        selectors[4] = IERC721TokenFacet.ERC721_BURNER_ROLE.selector;
+        selectors[5] = IERC721TokenFacet.ERC721_METADATA_ROLE.selector;
+        selectors[6] = IERC721TokenFacet.ERC721_TRANSFER_SCOPE.selector;
+        selectors[7] = IERC721TokenFacet.ERC721_APPROVAL_SCOPE.selector;
+        selectors[8] = IAccessControl.hasRole.selector;
+        selectors[9] = IAccessControl.getRoleAdmin.selector;
+        selectors[10] = IAccessControl.grantRole.selector;
+        selectors[11] = IPausable.pauseScope.selector;
+        selectors[12] = IPausable.unpauseScope.selector;
+        selectors[13] = IPausable.scopePaused.selector;
+        selectors[14] = IERC165.supportsInterface.selector;
+    }
+
+    /// @notice Returns the selector set used to install the ERC721 host facet.
+    /// @return selectors ERC721 + shared control selectors.
+    function erc721HostSelectors() internal pure returns (bytes4[] memory selectors) {
+        return _concat(erc721TokenSelectors(), erc721SharedControlSelectors());
+    }
+
+    function _concat(bytes4[] memory first, bytes4[] memory second) private pure returns (bytes4[] memory combined) {
+        combined = new bytes4[](first.length + second.length);
+
+        uint256 i;
+        for (; i < first.length; i++) {
+            combined[i] = first[i];
+        }
+
+        for (uint256 j = 0; j < second.length; j++) {
+            combined[i + j] = second[j];
+        }
     }
 }

--- a/src/token/libraries/LibTokenFacetDeploymentSelectors.sol
+++ b/src/token/libraries/LibTokenFacetDeploymentSelectors.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "../../interfaces/IAccessControl.sol";
+import {IERC165} from "../../interfaces/IERC165.sol";
+import {IERC20} from "../../interfaces/IERC20.sol";
+import {IERC20Metadata} from "../../interfaces/IERC20Metadata.sol";
+import {IERC20Permit} from "../../interfaces/IERC20Permit.sol";
+import {IERC20TokenBase} from "../../interfaces/IERC20TokenBase.sol";
+import {IERC20TokenFacet} from "../../interfaces/IERC20TokenFacet.sol";
+import {IERC721} from "../../interfaces/IERC721.sol";
+import {IERC721Metadata} from "../../interfaces/IERC721Metadata.sol";
+import {IERC721TokenBase} from "../../interfaces/IERC721TokenBase.sol";
+import {IERC721TokenFacet} from "../../interfaces/IERC721TokenFacet.sol";
+import {IPausable} from "../../interfaces/IPausable.sol";
+import {DiamondLoupeFacet} from "../../diamond/facets/DiamondLoupeFacet.sol";
+import {DiamondCutFacet} from "../../diamond/facets/DiamondCutFacet.sol";
+
+/// @title LibTokenFacetDeploymentSelectors
+/// @notice Canonical selector sets for reference token-hosted diamond deployments.
+library LibTokenFacetDeploymentSelectors {
+    /// @notice Returns the selector set used to install the loupe facet.
+    /// @return selectors Loupe + ownership selectors.
+    function loupeSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](6);
+        selectors[0] = DiamondLoupeFacet.facets.selector;
+        selectors[1] = DiamondLoupeFacet.facetFunctionSelectors.selector;
+        selectors[2] = DiamondLoupeFacet.facetAddresses.selector;
+        selectors[3] = DiamondLoupeFacet.facetAddress.selector;
+        selectors[4] = DiamondLoupeFacet.owner.selector;
+        selectors[5] = DiamondLoupeFacet.transferOwnership.selector;
+    }
+
+    /// @notice Returns the selector set used to install the ERC20 host facet.
+    /// @return selectors ERC20 + shared control selectors.
+    function erc20HostSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](30);
+        selectors[0] = IERC20TokenFacet.initializeErc20.selector;
+        selectors[1] = IERC20Metadata.name.selector;
+        selectors[2] = IERC20Metadata.symbol.selector;
+        selectors[3] = IERC20Metadata.decimals.selector;
+        selectors[4] = IERC20.totalSupply.selector;
+        selectors[5] = IERC20.balanceOf.selector;
+        selectors[6] = IERC20.allowance.selector;
+        selectors[7] = IERC20.transfer.selector;
+        selectors[8] = IERC20.approve.selector;
+        selectors[9] = IERC20.transferFrom.selector;
+        selectors[10] = IERC20TokenFacet.mint.selector;
+        selectors[11] = IERC20TokenFacet.burn.selector;
+        selectors[12] = IERC20TokenBase.isErc20Initialized.selector;
+        selectors[13] = IAccessControl.DEFAULT_ADMIN_ROLE.selector;
+        selectors[14] = IPausable.PAUSER_ROLE.selector;
+        selectors[15] = IERC20TokenFacet.TOKEN_ADMIN_ROLE.selector;
+        selectors[16] = IERC20TokenFacet.ERC20_MINTER_ROLE.selector;
+        selectors[17] = IERC20TokenFacet.ERC20_BURNER_ROLE.selector;
+        selectors[18] = IERC20TokenFacet.ERC20_TRANSFER_SCOPE.selector;
+        selectors[19] = IERC20TokenFacet.ERC20_APPROVAL_SCOPE.selector;
+        selectors[20] = IAccessControl.hasRole.selector;
+        selectors[21] = IAccessControl.getRoleAdmin.selector;
+        selectors[22] = IAccessControl.grantRole.selector;
+        selectors[23] = IPausable.pauseScope.selector;
+        selectors[24] = IPausable.unpauseScope.selector;
+        selectors[25] = IPausable.scopePaused.selector;
+        selectors[26] = IERC20Permit.permit.selector;
+        selectors[27] = IERC20Permit.nonces.selector;
+        selectors[28] = IERC20Permit.DOMAIN_SEPARATOR.selector;
+        selectors[29] = IERC165.supportsInterface.selector;
+    }
+
+    /// @notice Returns the selector set used to install the ERC721 host facet.
+    /// @return selectors ERC721 + shared control selectors.
+    function erc721HostSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](35);
+        selectors[0] = IERC721TokenFacet.initializeErc721.selector;
+        selectors[1] = IERC721.balanceOf.selector;
+        selectors[2] = IERC721.ownerOf.selector;
+        selectors[3] = IERC721.approve.selector;
+        selectors[4] = IERC721.getApproved.selector;
+        selectors[5] = IERC721.setApprovalForAll.selector;
+        selectors[6] = IERC721.isApprovedForAll.selector;
+        selectors[7] = IERC721.transferFrom.selector;
+        selectors[8] = bytes4(keccak256("safeTransferFrom(address,address,uint256)"));
+        selectors[9] = bytes4(keccak256("safeTransferFrom(address,address,uint256,bytes)"));
+        selectors[10] = IERC721Metadata.tokenURI.selector;
+        selectors[11] = IERC721Metadata.name.selector;
+        selectors[12] = IERC721Metadata.symbol.selector;
+        selectors[13] = IERC721TokenFacet.totalSupply.selector;
+        selectors[14] = IERC721TokenBase.isErc721Initialized.selector;
+        selectors[15] = IERC721TokenFacet.mint.selector;
+        selectors[16] = IERC721TokenFacet.safeMint.selector;
+        selectors[17] = IERC721TokenFacet.burn.selector;
+        selectors[18] = IERC721TokenFacet.setBaseURI.selector;
+        selectors[19] = IERC721TokenFacet.setTokenURI.selector;
+        selectors[20] = IAccessControl.DEFAULT_ADMIN_ROLE.selector;
+        selectors[21] = IPausable.PAUSER_ROLE.selector;
+        selectors[22] = IERC721TokenFacet.TOKEN_ADMIN_ROLE.selector;
+        selectors[23] = IERC721TokenFacet.ERC721_MINTER_ROLE.selector;
+        selectors[24] = IERC721TokenFacet.ERC721_BURNER_ROLE.selector;
+        selectors[25] = IERC721TokenFacet.ERC721_METADATA_ROLE.selector;
+        selectors[26] = IERC721TokenFacet.ERC721_TRANSFER_SCOPE.selector;
+        selectors[27] = IERC721TokenFacet.ERC721_APPROVAL_SCOPE.selector;
+        selectors[28] = IAccessControl.hasRole.selector;
+        selectors[29] = IAccessControl.getRoleAdmin.selector;
+        selectors[30] = IAccessControl.grantRole.selector;
+        selectors[31] = IPausable.pauseScope.selector;
+        selectors[32] = IPausable.unpauseScope.selector;
+        selectors[33] = IPausable.scopePaused.selector;
+        selectors[34] = IERC165.supportsInterface.selector;
+    }
+}

--- a/src/token/storage/LibERC20TokenStorage.sol
+++ b/src/token/storage/LibERC20TokenStorage.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title LibERC20TokenStorage
+/// @notice Diamond-safe storage layout for hosted ERC-20 facets.
+library LibERC20TokenStorage {
+    /// @dev Storage slot for ERC-20 token layout.
+    bytes32 internal constant STORAGE_SLOT = keccak256("smart-contracts.token.erc20.storage");
+
+    /// @notice ERC-20 token storage layout.
+    struct Layout {
+        bool initialized;
+        uint8 decimals;
+        string name;
+        string symbol;
+        uint256 totalSupply;
+        mapping(address => uint256) balances;
+        mapping(address => mapping(address => uint256)) allowances;
+    }
+
+    /// @notice Returns the ERC-20 storage layout.
+    /// @return l The storage layout pointer.
+    function layout() internal pure returns (Layout storage l) {
+        bytes32 slot = STORAGE_SLOT;
+        assembly {
+            l.slot := slot
+        }
+    }
+}

--- a/src/token/storage/LibERC20TokenStorage.sol
+++ b/src/token/storage/LibERC20TokenStorage.sol
@@ -13,9 +13,13 @@ library LibERC20TokenStorage {
         uint8 decimals;
         string name;
         string symbol;
+        bytes32 hashedName;
         uint256 totalSupply;
+        uint256 cachedChainId;
+        bytes32 cachedDomainSeparator;
         mapping(address => uint256) balances;
         mapping(address => mapping(address => uint256)) allowances;
+        mapping(address => uint256) nonces;
     }
 
     /// @notice Returns the ERC-20 storage layout.

--- a/src/token/storage/LibERC721TokenStorage.sol
+++ b/src/token/storage/LibERC721TokenStorage.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title LibERC721TokenStorage
+/// @notice Diamond-safe storage layout for hosted ERC-721 facets.
+library LibERC721TokenStorage {
+    /// @dev Storage slot for ERC-721 token layout.
+    bytes32 internal constant STORAGE_SLOT = keccak256("smart-contracts.token.erc721.storage");
+
+    /// @notice ERC-721 token storage layout.
+    struct Layout {
+        bool initialized;
+        string name;
+        string symbol;
+        string baseURI;
+        uint256 totalSupply;
+        mapping(uint256 => address) owners;
+        mapping(address => uint256) balances;
+        mapping(uint256 => address) tokenApprovals;
+        mapping(address => mapping(address => bool)) operatorApprovals;
+        mapping(uint256 => string) tokenURIs;
+    }
+
+    /// @notice Returns the ERC-721 storage layout.
+    /// @return l The storage layout pointer.
+    function layout() internal pure returns (Layout storage l) {
+        bytes32 slot = STORAGE_SLOT;
+        assembly {
+            l.slot := slot
+        }
+    }
+}

--- a/test/DiamondErc20HostInvariant.t.sol
+++ b/test/DiamondErc20HostInvariant.t.sol
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC20TokenFacet} from "../src/interfaces/IERC20TokenFacet.sol";
+import {IPausable} from "../src/interfaces/IPausable.sol";
+import {DiamondTokenHostHardeningFixture} from "./helpers/DiamondTokenHostHardeningTestHarness.sol";
+
+contract DiamondErc20HostInvariantTest is DiamondTokenHostHardeningFixture {
+    struct AccountingSnapshot {
+        uint256 totalSupply;
+        uint256 totalTrackedBalances;
+    }
+
+    uint256 internal constant ACTOR_COUNT = 5;
+    uint256 internal constant INITIAL_BALANCE = 1_000_000;
+
+    address[ACTOR_COUNT] internal actors;
+    mapping(address => uint256) internal trackedPermitSuccesses;
+
+    function setUp() public override {
+        super.setUp();
+        _installErc20HostFacet(address(erc20Facet));
+        _erc20InitDiamond();
+
+        actors[0] = admin;
+        actors[1] = bob;
+        actors[2] = eve;
+        actors[3] = carol;
+        actors[4] = dave;
+
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            VM.prank(admin);
+            IERC20TokenFacet(address(diamond)).mint(actors[i], INITIAL_BALANCE);
+        }
+    }
+
+    function targetContracts() external view returns (address[] memory contracts) {
+        contracts = new address[](1);
+        contracts[0] = address(this);
+    }
+
+    function actionApprove(uint8 ownerSeed, uint8 spenderSeed, uint96 valueRaw) external {
+        IERC20TokenFacet token = IERC20TokenFacet(address(diamond));
+        address owner = _actor(ownerSeed);
+        address spender = _actorExcluding(owner, spenderSeed);
+        bytes32 approvalScope = token.ERC20_APPROVAL_SCOPE();
+        uint256 value = uint256(valueRaw);
+
+        if (token.scopePaused(approvalScope)) {
+            AccountingSnapshot memory snapshot = _snapshotAccounting();
+            VM.startPrank(owner);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, approvalScope));
+            token.approve(spender, value);
+            VM.stopPrank();
+            _assertAccountingUnchanged(snapshot, "paused approve should not mutate accounting");
+            return;
+        }
+
+        VM.prank(owner);
+        token.approve(spender, value);
+    }
+
+    function actionPermit(uint8 ownerSeed, uint8 spenderSeed, uint96 valueRaw, uint32 deadlineOffsetRaw) external {
+        IERC20TokenFacet token = IERC20TokenFacet(address(diamond));
+        address owner = _actor(ownerSeed);
+        address spender = _actorExcluding(owner, spenderSeed);
+        bytes32 approvalScope = token.ERC20_APPROVAL_SCOPE();
+        uint256 value = uint256(valueRaw);
+        uint256 deadline = block.timestamp + uint256(deadlineOffsetRaw) + 1;
+        uint256 nonce = token.nonces(owner);
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(address(diamond), owner, spender, value, nonce, deadline);
+
+        if (token.scopePaused(approvalScope)) {
+            AccountingSnapshot memory snapshot = _snapshotAccounting();
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, approvalScope));
+            token.permit(owner, spender, value, deadline, v, r, s);
+            _assertAccountingUnchanged(snapshot, "paused permit should not mutate accounting");
+            return;
+        }
+
+        token.permit(owner, spender, value, deadline, v, r, s);
+        trackedPermitSuccesses[owner] += 1;
+    }
+
+    function actionTransfer(uint8 fromSeed, uint8 toSeed, uint96 valueRaw) external {
+        IERC20TokenFacet token = IERC20TokenFacet(address(diamond));
+        address from = _actor(fromSeed);
+        address to = _actorExcluding(from, toSeed);
+        bytes32 transferScope = token.ERC20_TRANSFER_SCOPE();
+        uint256 value = _boundAmount(valueRaw, token.balanceOf(from));
+        if (value == 0) return;
+
+        if (token.scopePaused(transferScope)) {
+            AccountingSnapshot memory snapshot = _snapshotAccounting();
+            VM.startPrank(from);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+            token.transfer(to, value);
+            VM.stopPrank();
+            _assertAccountingUnchanged(snapshot, "paused transfer should not mutate accounting");
+            return;
+        }
+
+        VM.prank(from);
+        token.transfer(to, value);
+    }
+
+    function actionTransferFrom(uint8 spenderSeed, uint8 ownerSeed, uint8 toSeed, uint96 valueRaw) external {
+        IERC20TokenFacet token = IERC20TokenFacet(address(diamond));
+        address spender = _actor(spenderSeed);
+        address owner = _actor(ownerSeed);
+        address to = _actorExcluding(owner, toSeed);
+        if (spender == owner) return;
+
+        uint256 allowance = token.allowance(owner, spender);
+        uint256 balance = token.balanceOf(owner);
+        uint256 value = _boundAmount(valueRaw, allowance < balance ? allowance : balance);
+        if (value == 0) return;
+
+        bytes32 transferScope = token.ERC20_TRANSFER_SCOPE();
+        bytes32 approvalScope = token.ERC20_APPROVAL_SCOPE();
+        if (token.scopePaused(transferScope) || token.scopePaused(approvalScope)) {
+            bytes32 expectedScope = token.scopePaused(approvalScope) ? approvalScope : transferScope;
+            AccountingSnapshot memory snapshot = _snapshotAccounting();
+            VM.startPrank(spender);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, expectedScope));
+            token.transferFrom(owner, to, value);
+            VM.stopPrank();
+            _assertAccountingUnchanged(snapshot, "paused transferFrom should not mutate accounting");
+            return;
+        }
+
+        VM.prank(spender);
+        token.transferFrom(owner, to, value);
+    }
+
+    function actionMint(uint8 actorSeed, uint96 valueRaw) external {
+        IERC20TokenFacet token = IERC20TokenFacet(address(diamond));
+        bytes32 transferScope = token.ERC20_TRANSFER_SCOPE();
+        uint256 value = uint256(valueRaw);
+        if (value == 0) return;
+
+        if (token.scopePaused(transferScope)) {
+            AccountingSnapshot memory snapshot = _snapshotAccounting();
+            VM.prank(admin);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+            token.mint(_actor(actorSeed), value);
+            _assertAccountingUnchanged(snapshot, "paused mint should not mutate accounting");
+            return;
+        }
+
+        VM.prank(admin);
+        token.mint(_actor(actorSeed), value);
+    }
+
+    function actionBurn(uint8 actorSeed, uint96 valueRaw) external {
+        IERC20TokenFacet token = IERC20TokenFacet(address(diamond));
+        address actor = _actor(actorSeed);
+        bytes32 transferScope = token.ERC20_TRANSFER_SCOPE();
+        uint256 value = _boundAmount(valueRaw, token.balanceOf(actor));
+        if (value == 0) return;
+
+        if (token.scopePaused(transferScope)) {
+            AccountingSnapshot memory snapshot = _snapshotAccounting();
+            VM.prank(admin);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+            token.burn(actor, value);
+            _assertAccountingUnchanged(snapshot, "paused burn should not mutate accounting");
+            return;
+        }
+
+        VM.prank(admin);
+        token.burn(actor, value);
+    }
+
+    function actionSetApprovalScopePaused(bool paused_) external {
+        IERC20TokenFacet token = IERC20TokenFacet(address(diamond));
+        bytes32 approvalScope = token.ERC20_APPROVAL_SCOPE();
+        bool isPaused = token.scopePaused(approvalScope);
+        if (paused_ && !isPaused) {
+            VM.prank(admin);
+            token.pauseScope(approvalScope);
+        } else if (!paused_ && isPaused) {
+            VM.prank(admin);
+            token.unpauseScope(approvalScope);
+        }
+    }
+
+    function actionSetTransferScopePaused(bool paused_) external {
+        IERC20TokenFacet token = IERC20TokenFacet(address(diamond));
+        bytes32 transferScope = token.ERC20_TRANSFER_SCOPE();
+        bool isPaused = token.scopePaused(transferScope);
+        if (paused_ && !isPaused) {
+            VM.prank(admin);
+            token.pauseScope(transferScope);
+        } else if (!paused_ && isPaused) {
+            VM.prank(admin);
+            token.unpauseScope(transferScope);
+        }
+    }
+
+    function invariantTotalSupplyEqualsTrackedBalances() public view {
+        assertTrue(
+            IERC20TokenFacet(address(diamond)).totalSupply() == _sumTrackedBalances(),
+            "host total supply must equal tracked balances"
+        );
+    }
+
+    function invariantTrackedPermitNoncesMatchSuccessfulCalls() public view {
+        IERC20TokenFacet token = IERC20TokenFacet(address(diamond));
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            address actor = actors[i];
+            assertTrue(
+                token.nonces(actor) == trackedPermitSuccesses[actor],
+                "host permit nonces must match successful permit calls"
+            );
+        }
+    }
+
+    function _boundAmount(uint256 raw, uint256 max) internal pure returns (uint256) {
+        if (max == 0) return 0;
+        return (raw % max) + 1;
+    }
+
+    function _sumTrackedBalances() internal view returns (uint256 sum) {
+        IERC20TokenFacet token = IERC20TokenFacet(address(diamond));
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            sum += token.balanceOf(actors[i]);
+        }
+    }
+
+    function _snapshotAccounting() internal view returns (AccountingSnapshot memory snapshot) {
+        IERC20TokenFacet token = IERC20TokenFacet(address(diamond));
+        snapshot.totalSupply = token.totalSupply();
+        snapshot.totalTrackedBalances = _sumTrackedBalances();
+    }
+
+    function _assertAccountingUnchanged(AccountingSnapshot memory snapshot, string memory reason) internal view {
+        IERC20TokenFacet token = IERC20TokenFacet(address(diamond));
+        assertTrue(token.totalSupply() == snapshot.totalSupply, reason);
+        assertTrue(_sumTrackedBalances() == snapshot.totalTrackedBalances, reason);
+    }
+}

--- a/test/DiamondErc721HostInvariant.t.sol
+++ b/test/DiamondErc721HostInvariant.t.sol
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC721TokenBase} from "../src/interfaces/IERC721TokenBase.sol";
+import {IERC721TokenFacet} from "../src/interfaces/IERC721TokenFacet.sol";
+import {IPausable} from "../src/interfaces/IPausable.sol";
+import {DiamondTokenHostHardeningFixture} from "./helpers/DiamondTokenHostHardeningTestHarness.sol";
+
+contract DiamondErc721HostInvariantTest is DiamondTokenHostHardeningFixture {
+    uint256 internal constant TOKEN_POOL = 8;
+    uint256 internal constant ACTOR_COUNT = 5;
+
+    address[ACTOR_COUNT] internal actors;
+
+    function setUp() public override {
+        super.setUp();
+        _installErc721HostFacet(address(erc721Facet));
+        _erc721InitDiamond();
+
+        actors[0] = admin;
+        actors[1] = bob;
+        actors[2] = eve;
+        actors[3] = carol;
+        actors[4] = dave;
+    }
+
+    function targetContracts() external view returns (address[] memory contracts) {
+        contracts = new address[](1);
+        contracts[0] = address(this);
+    }
+
+    function actionMint(uint8 toSeed, uint8 tokenSeed) external {
+        IERC721TokenFacet token = IERC721TokenFacet(address(diamond));
+        uint256 tokenId = _tokenId(tokenSeed);
+        bytes32 transferScope = token.ERC721_TRANSFER_SCOPE();
+        if (_erc721Exists(tokenId)) return;
+
+        if (token.scopePaused(transferScope)) {
+            VM.prank(admin);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+            token.mint(_actor(toSeed), tokenId);
+            return;
+        }
+
+        VM.prank(admin);
+        token.mint(_actor(toSeed), tokenId);
+    }
+
+    function actionSafeMint(uint8 toSeed, uint8 tokenSeed, bytes4 dataSeed) external {
+        IERC721TokenFacet token = IERC721TokenFacet(address(diamond));
+        uint256 tokenId = _tokenId(tokenSeed);
+        bytes32 transferScope = token.ERC721_TRANSFER_SCOPE();
+        if (_erc721Exists(tokenId)) return;
+
+        if (token.scopePaused(transferScope)) {
+            VM.prank(admin);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+            token.safeMint(_actor(toSeed), tokenId, abi.encodePacked(dataSeed));
+            return;
+        }
+
+        VM.prank(admin);
+        token.safeMint(_actor(toSeed), tokenId, abi.encodePacked(dataSeed));
+    }
+
+    function actionApprove(uint8 operatorSeed, uint8 tokenSeed) external {
+        IERC721TokenFacet token = IERC721TokenFacet(address(diamond));
+        uint256 tokenId = _tokenId(tokenSeed);
+        if (!_erc721Exists(tokenId)) return;
+
+        address owner = token.ownerOf(tokenId);
+        address operator = _actorExcluding(owner, operatorSeed);
+        bytes32 approvalScope = token.ERC721_APPROVAL_SCOPE();
+
+        if (token.scopePaused(approvalScope)) {
+            VM.prank(owner);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, approvalScope));
+            token.approve(operator, tokenId);
+            return;
+        }
+
+        VM.prank(owner);
+        token.approve(operator, tokenId);
+        assertTrue(token.getApproved(tokenId) == operator, "host erc721 approval should update");
+    }
+
+    function actionSetApprovalForAll(uint8 ownerSeed, uint8 operatorSeed, bool approved) external {
+        IERC721TokenFacet token = IERC721TokenFacet(address(diamond));
+        address owner = _actor(ownerSeed);
+        address operator = _actorExcluding(owner, operatorSeed);
+        bytes32 approvalScope = token.ERC721_APPROVAL_SCOPE();
+
+        if (token.scopePaused(approvalScope)) {
+            VM.prank(owner);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, approvalScope));
+            token.setApprovalForAll(operator, approved);
+            return;
+        }
+
+        VM.prank(owner);
+        token.setApprovalForAll(operator, approved);
+        assertTrue(token.isApprovedForAll(owner, operator) == approved, "host erc721 operator approval mismatch");
+    }
+
+    function actionTransferFrom(uint8 toSeed, uint8 tokenSeed, uint8 approvalSeed) external {
+        IERC721TokenFacet token = IERC721TokenFacet(address(diamond));
+        uint256 tokenId = _tokenId(tokenSeed);
+        if (!_erc721Exists(tokenId)) return;
+
+        address owner = token.ownerOf(tokenId);
+        address to = _actorExcluding(owner, toSeed);
+        bytes32 transferScope = token.ERC721_TRANSFER_SCOPE();
+        bytes32 approvalScope = token.ERC721_APPROVAL_SCOPE();
+
+        if (!token.scopePaused(approvalScope)) {
+            VM.prank(owner);
+            token.approve(_actorExcluding(owner, approvalSeed), tokenId);
+        }
+
+        if (token.scopePaused(transferScope)) {
+            VM.prank(owner);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+            token.transferFrom(owner, to, tokenId);
+            return;
+        }
+
+        VM.prank(owner);
+        token.transferFrom(owner, to, tokenId);
+        assertTrue(token.ownerOf(tokenId) == to, "host erc721 transfer owner mismatch");
+        assertTrue(token.getApproved(tokenId) == address(0), "host erc721 transfer should clear approval");
+    }
+
+    function actionSafeTransferFrom(uint8 toSeed, uint8 tokenSeed, uint8 approvalSeed, bool withData) external {
+        IERC721TokenFacet token = IERC721TokenFacet(address(diamond));
+        uint256 tokenId = _tokenId(tokenSeed);
+        if (!_erc721Exists(tokenId)) return;
+
+        address owner = token.ownerOf(tokenId);
+        address to = _actorExcluding(owner, toSeed);
+        bytes32 transferScope = token.ERC721_TRANSFER_SCOPE();
+        bytes32 approvalScope = token.ERC721_APPROVAL_SCOPE();
+
+        if (!token.scopePaused(approvalScope)) {
+            VM.prank(owner);
+            token.approve(_actorExcluding(owner, approvalSeed), tokenId);
+        }
+
+        if (token.scopePaused(transferScope)) {
+            VM.prank(owner);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+            if (withData) {
+                token.safeTransferFrom(owner, to, tokenId, hex"cafe");
+            } else {
+                token.safeTransferFrom(owner, to, tokenId);
+            }
+            return;
+        }
+
+        VM.prank(owner);
+        if (withData) {
+            token.safeTransferFrom(owner, to, tokenId, hex"cafe");
+        } else {
+            token.safeTransferFrom(owner, to, tokenId);
+        }
+        assertTrue(token.ownerOf(tokenId) == to, "host erc721 safe transfer owner mismatch");
+        assertTrue(token.getApproved(tokenId) == address(0), "host erc721 safe transfer should clear approval");
+    }
+
+    function actionBurn(uint8 tokenSeed, uint8 approvalSeed) external {
+        IERC721TokenFacet token = IERC721TokenFacet(address(diamond));
+        uint256 tokenId = _tokenId(tokenSeed);
+        if (!_erc721Exists(tokenId)) return;
+
+        bytes32 transferScope = token.ERC721_TRANSFER_SCOPE();
+        bytes32 approvalScope = token.ERC721_APPROVAL_SCOPE();
+        address owner = token.ownerOf(tokenId);
+        if (!token.scopePaused(approvalScope)) {
+            VM.prank(owner);
+            token.approve(_actorExcluding(owner, approvalSeed), tokenId);
+        }
+
+        if (token.scopePaused(transferScope)) {
+            VM.prank(admin);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+            token.burn(tokenId);
+            return;
+        }
+
+        VM.prank(admin);
+        token.burn(tokenId);
+        _expectNonexistentToken(tokenId);
+        assertTrue(_erc721ApprovalOrZero(tokenId) == address(0), "host erc721 burn should clear approval");
+    }
+
+    function actionSetBaseURI(bool alternate) external {
+        IERC721TokenFacet token = IERC721TokenFacet(address(diamond));
+        string memory baseUri = alternate ? "ipfs://updated-a/" : "ipfs://updated-b/";
+        VM.prank(admin);
+        token.setBaseURI(baseUri);
+    }
+
+    function actionSetTokenURI(uint8 tokenSeed, bool alternate) external {
+        IERC721TokenFacet token = IERC721TokenFacet(address(diamond));
+        uint256 tokenId = _tokenId(tokenSeed);
+        if (!_erc721Exists(tokenId)) return;
+
+        string memory customUri = alternate ? "ipfs://custom-a" : "ipfs://custom-b";
+        VM.prank(admin);
+        token.setTokenURI(tokenId, customUri);
+        assertTrue(
+            keccak256(bytes(token.tokenURI(tokenId))) == keccak256(bytes(customUri)),
+            "host erc721 token uri update mismatch"
+        );
+    }
+
+    function actionSetApprovalScopePaused(bool paused_) external {
+        IERC721TokenFacet token = IERC721TokenFacet(address(diamond));
+        bytes32 approvalScope = token.ERC721_APPROVAL_SCOPE();
+        bool isPaused = token.scopePaused(approvalScope);
+        if (paused_ && !isPaused) {
+            VM.prank(admin);
+            token.pauseScope(approvalScope);
+        } else if (!paused_ && isPaused) {
+            VM.prank(admin);
+            token.unpauseScope(approvalScope);
+        }
+    }
+
+    function actionSetTransferScopePaused(bool paused_) external {
+        IERC721TokenFacet token = IERC721TokenFacet(address(diamond));
+        bytes32 transferScope = token.ERC721_TRANSFER_SCOPE();
+        bool isPaused = token.scopePaused(transferScope);
+        if (paused_ && !isPaused) {
+            VM.prank(admin);
+            token.pauseScope(transferScope);
+        } else if (!paused_ && isPaused) {
+            VM.prank(admin);
+            token.unpauseScope(transferScope);
+        }
+    }
+
+    function invariantTotalSupplyMatchesLiveTokenCount() public view {
+        IERC721TokenFacet token = IERC721TokenFacet(address(diamond));
+        uint256 liveCount;
+        for (uint256 tokenId = 1; tokenId <= TOKEN_POOL; tokenId++) {
+            if (_erc721Exists(tokenId)) {
+                liveCount++;
+            }
+        }
+
+        assertTrue(token.totalSupply() == liveCount, "host erc721 total supply should match live tokens");
+    }
+
+    function invariantBalancesMatchTrackedOwnershipCounts() public view {
+        IERC721TokenFacet token = IERC721TokenFacet(address(diamond));
+        uint256[ACTOR_COUNT] memory counts;
+
+        for (uint256 tokenId = 1; tokenId <= TOKEN_POOL; tokenId++) {
+            address owner = _erc721OwnerOrZero(tokenId);
+            for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+                if (owner == actors[i]) {
+                    counts[i] += 1;
+                    break;
+                }
+            }
+        }
+
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            assertTrue(token.balanceOf(actors[i]) == counts[i], "host erc721 balances should match ownership counts");
+        }
+    }
+
+    function invariantApprovalsOnlyExistForLiveTokens() public view {
+        for (uint256 tokenId = 1; tokenId <= TOKEN_POOL; tokenId++) {
+            if (!_erc721Exists(tokenId)) {
+                assertTrue(_erc721ApprovalOrZero(tokenId) == address(0), "burned tokens must not retain approval");
+            }
+        }
+    }
+
+    function _tokenId(uint8 seed) internal pure returns (uint256) {
+        return (uint256(seed) % TOKEN_POOL) + 1;
+    }
+}

--- a/test/DiamondTokenDeploymentIntegration.t.sol
+++ b/test/DiamondTokenDeploymentIntegration.t.sol
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {DiamondCutFacet} from "../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../src/diamond/facets/DiamondLoupeFacet.sol";
+import {IDiamondCut} from "../src/interfaces/IDiamondCut.sol";
+import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
+import {IERC165} from "../src/interfaces/IERC165.sol";
+import {IERC20Metadata} from "../src/interfaces/IERC20Metadata.sol";
+import {IERC20TokenBase} from "../src/interfaces/IERC20TokenBase.sol";
+import {IERC20TokenFacet} from "../src/interfaces/IERC20TokenFacet.sol";
+import {IERC721} from "../src/interfaces/IERC721.sol";
+import {IERC721Metadata} from "../src/interfaces/IERC721Metadata.sol";
+import {IERC721TokenBase} from "../src/interfaces/IERC721TokenBase.sol";
+import {IERC721TokenFacet} from "../src/interfaces/IERC721TokenFacet.sol";
+import {LibDiamond} from "../src/diamond/libraries/LibDiamond.sol";
+import {DiamondTokenDeploymentFixture} from "./helpers/DiamondTokenDeploymentTestHarness.sol";
+
+contract DiamondTokenDeploymentIntegrationTest is DiamondTokenDeploymentFixture {
+    function testErc20HostDeployInstallInitAndLoupeChecks() public {
+        _installErc20HostFacet();
+
+        VM.prank(admin);
+        IERC20TokenFacet(address(diamond)).initializeErc20("Facet Token", "FTKN", 18, admin);
+
+        IDiamondLoupe loupe = IDiamondLoupe(address(diamond));
+        address[] memory facetAddresses = loupe.facetAddresses();
+
+        assertTrue(facetAddresses.length == 3, "erc20 host facet count mismatch");
+        assertTrue(_containsAddress(facetAddresses, address(cutFacet)), "erc20 host missing cut facet");
+        assertTrue(_containsAddress(facetAddresses, address(loupeFacet)), "erc20 host missing loupe facet");
+        assertTrue(_containsAddress(facetAddresses, address(erc20Facet)), "erc20 host missing erc20 facet");
+        assertTrue(loupe.facetFunctionSelectors(address(erc20Facet)).length == 30, "erc20 host selector count mismatch");
+        assertTrue(
+            loupe.facetAddress(DiamondCutFacet.diamondCut.selector) == address(cutFacet), "erc20 cut owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(DiamondLoupeFacet.facets.selector) == address(loupeFacet), "erc20 loupe owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC20TokenFacet.initializeErc20.selector) == address(erc20Facet),
+            "erc20 init owner mismatch"
+        );
+        assertTrue(loupe.facetAddress(IERC20Metadata.name.selector) == address(erc20Facet), "erc20 name owner mismatch");
+        assertTrue(
+            loupe.facetAddress(IERC165.supportsInterface.selector) == address(erc20Facet),
+            "erc20 supportsInterface owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC20TokenFacet.TOKEN_ADMIN_ROLE.selector) == address(erc20Facet),
+            "erc20 token admin owner mismatch"
+        );
+        assertTrue(IERC20TokenFacet(address(diamond)).isErc20Initialized(), "erc20 host not initialized");
+        assertTrue(
+            keccak256(bytes(IERC20TokenFacet(address(diamond)).name())) == keccak256(bytes("Facet Token")),
+            "erc20 host name mismatch"
+        );
+        assertTrue(
+            keccak256(bytes(IERC20TokenFacet(address(diamond)).symbol())) == keccak256(bytes("FTKN")),
+            "erc20 host symbol mismatch"
+        );
+        assertTrue(IERC20TokenFacet(address(diamond)).decimals() == 18, "erc20 host decimals mismatch");
+        assertTrue(
+            IERC20TokenFacet(address(diamond)).hasRole(IERC20TokenFacet(address(diamond)).TOKEN_ADMIN_ROLE(), admin),
+            "erc20 host token admin missing"
+        );
+        assertTrue(
+            IERC20TokenFacet(address(diamond)).supportsInterface(type(IERC20TokenFacet).interfaceId),
+            "erc20 host interface missing"
+        );
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IERC20TokenBase.ERC20TokenAlreadyInitialized.selector));
+        IERC20TokenFacet(address(diamond)).initializeErc20("Facet Token", "FTKN", 18, admin);
+    }
+
+    function testErc721HostDeployInstallInitAndLoupeChecks() public {
+        _installErc721HostFacet();
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(diamond)).initializeErc721("Facet NFT", "FNFT", "ipfs://facet/", admin);
+
+        IDiamondLoupe loupe = IDiamondLoupe(address(diamond));
+        address[] memory facetAddresses = loupe.facetAddresses();
+
+        assertTrue(facetAddresses.length == 3, "erc721 host facet count mismatch");
+        assertTrue(_containsAddress(facetAddresses, address(cutFacet)), "erc721 host missing cut facet");
+        assertTrue(_containsAddress(facetAddresses, address(loupeFacet)), "erc721 host missing loupe facet");
+        assertTrue(_containsAddress(facetAddresses, address(erc721Facet)), "erc721 host missing erc721 facet");
+        assertTrue(
+            loupe.facetFunctionSelectors(address(erc721Facet)).length == 35, "erc721 host selector count mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(DiamondCutFacet.diamondCut.selector) == address(cutFacet), "erc721 cut owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(DiamondLoupeFacet.facets.selector) == address(loupeFacet), "erc721 loupe owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC721TokenFacet.initializeErc721.selector) == address(erc721Facet),
+            "erc721 init owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC721Metadata.name.selector) == address(erc721Facet), "erc721 name owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC165.supportsInterface.selector) == address(erc721Facet),
+            "erc721 supportsInterface owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC721TokenFacet.ERC721_METADATA_ROLE.selector) == address(erc721Facet),
+            "erc721 metadata owner mismatch"
+        );
+        assertTrue(IERC721TokenFacet(address(diamond)).isErc721Initialized(), "erc721 host not initialized");
+        assertTrue(
+            keccak256(bytes(IERC721TokenFacet(address(diamond)).name())) == keccak256(bytes("Facet NFT")),
+            "erc721 host name mismatch"
+        );
+        assertTrue(
+            keccak256(bytes(IERC721TokenFacet(address(diamond)).symbol())) == keccak256(bytes("FNFT")),
+            "erc721 host symbol mismatch"
+        );
+        assertTrue(IERC721TokenFacet(address(diamond)).totalSupply() == 0, "erc721 host supply mismatch");
+        assertTrue(
+            IERC721TokenFacet(address(diamond))
+                .hasRole(IERC721TokenFacet(address(diamond)).ERC721_METADATA_ROLE(), admin),
+            "erc721 metadata role missing"
+        );
+        assertTrue(
+            IERC721TokenFacet(address(diamond)).supportsInterface(type(IERC721TokenFacet).interfaceId),
+            "erc721 host interface missing"
+        );
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IERC721TokenBase.ERC721TokenAlreadyInitialized.selector));
+        IERC721TokenFacet(address(diamond)).initializeErc721("Facet NFT", "FNFT", "ipfs://facet/", admin);
+    }
+
+    function testErc20AndErc721SelectorsCannotCoexistUnchanged() public {
+        _installErc20HostFacet();
+
+        IDiamondLoupe loupe = IDiamondLoupe(address(diamond));
+        IDiamondCut.FacetCut[] memory collisionCut = new IDiamondCut.FacetCut[](1);
+        bytes4[] memory selectors = new bytes4[](2);
+        selectors[0] = IERC721.ownerOf.selector;
+        selectors[1] = IERC721Metadata.name.selector;
+        collisionCut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(erc721Facet), action: IDiamondCut.FacetCutAction.Add, functionSelectors: selectors
+        });
+
+        VM.prank(admin);
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                LibDiamond.DiamondSelectorAlreadyExists.selector, IERC721Metadata.name.selector, address(erc20Facet)
+            )
+        );
+        IDiamondCut(address(diamond)).diamondCut(collisionCut, address(0), "");
+
+        assertTrue(
+            loupe.facetAddress(IERC721.ownerOf.selector) == address(0), "erc721 ownerOf should not be partially routed"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC20Metadata.name.selector) == address(erc20Facet),
+            "erc20 name owner should remain unchanged"
+        );
+        assertTrue(loupe.facetAddresses().length == 3, "collision revert should preserve facet count");
+    }
+}

--- a/test/DiamondTokenHostHardening.t.sol
+++ b/test/DiamondTokenHostHardening.t.sol
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
+import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
+import {IERC165} from "../src/interfaces/IERC165.sol";
+import {IERC20Metadata} from "../src/interfaces/IERC20Metadata.sol";
+import {IERC721} from "../src/interfaces/IERC721.sol";
+import {IERC721Metadata} from "../src/interfaces/IERC721Metadata.sol";
+import {IERC20TokenFacet} from "../src/interfaces/IERC20TokenFacet.sol";
+import {IERC721TokenFacet} from "../src/interfaces/IERC721TokenFacet.sol";
+import {IPausable} from "../src/interfaces/IPausable.sol";
+import {
+    DiamondTokenHostHardeningFixture,
+    IFacetVersionMarker
+} from "./helpers/DiamondTokenHostHardeningTestHarness.sol";
+
+contract DiamondTokenHostHardeningTest is DiamondTokenHostHardeningFixture {
+    function testErc20HostReplaceRemoveAndReAddPreservesState() public {
+        _installErc20HostFacet(address(erc20Facet));
+        _erc20InitDiamond();
+        _seedErc20HostState();
+
+        bytes32 tokenAdminRole = IERC20TokenFacet(address(diamond)).TOKEN_ADMIN_ROLE();
+        bytes32 approvalScope = IERC20TokenFacet(address(diamond)).ERC20_APPROVAL_SCOPE();
+
+        _replaceErc20HostFacet(address(erc20Replacement));
+        _addErc20ReplacementMarker(address(erc20Replacement));
+
+        IDiamondLoupe loupe = IDiamondLoupe(address(diamond));
+        assertTrue(loupe.facetAddresses().length == 3, "erc20 replace facet count mismatch");
+        assertTrue(
+            loupe.facetFunctionSelectors(address(erc20Replacement)).length == 31,
+            "erc20 replacement selector count mismatch"
+        );
+        assertTrue(loupe.facetFunctionSelectors(address(erc20Facet)).length == 0, "erc20 old facet should be empty");
+        assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "erc20 marker routing mismatch");
+
+        _assertErc20State(address(erc20Replacement));
+
+        _removeErc20HostFacetWithMarker();
+
+        assertTrue(loupe.facetAddresses().length == 2, "erc20 removal should leave core facets only");
+        _assertMissingSelector(abi.encodeCall(IERC20Metadata.name, ()), "erc20 name should be missing after removal");
+        _assertMissingSelector(
+            abi.encodeCall(IAccessControl.hasRole, (tokenAdminRole, eve)),
+            "erc20 hasRole should be missing after removal"
+        );
+        _assertMissingSelector(
+            abi.encodeCall(IPausable.scopePaused, (approvalScope)), "erc20 scopePaused should be missing after removal"
+        );
+        _assertMissingSelector(
+            abi.encodeWithSelector(IFacetVersionMarker.facetVersion.selector),
+            "erc20 marker should be missing after removal"
+        );
+
+        _reAddErc20HostFacetWithMarker(address(erc20Replacement));
+
+        assertTrue(loupe.facetAddresses().length == 3, "erc20 re-add facet count mismatch");
+        assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "erc20 marker should survive re-add");
+        _assertErc20State(address(erc20Replacement));
+    }
+
+    function testErc721HostReplaceRemoveAndReAddPreservesState() public {
+        _installErc721HostFacet(address(erc721Facet));
+        _erc721InitDiamond();
+        _seedErc721HostState();
+
+        bytes32 metadataRole = IERC721TokenFacet(address(diamond)).ERC721_METADATA_ROLE();
+        bytes32 approvalScope = IERC721TokenFacet(address(diamond)).ERC721_APPROVAL_SCOPE();
+
+        _replaceErc721HostFacet(address(erc721Replacement));
+        _addErc721ReplacementMarker(address(erc721Replacement));
+
+        IDiamondLoupe loupe = IDiamondLoupe(address(diamond));
+        assertTrue(loupe.facetAddresses().length == 3, "erc721 replace facet count mismatch");
+        assertTrue(
+            loupe.facetFunctionSelectors(address(erc721Replacement)).length == 36,
+            "erc721 replacement selector count mismatch"
+        );
+        assertTrue(loupe.facetFunctionSelectors(address(erc721Facet)).length == 0, "erc721 old facet should be empty");
+        assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "erc721 marker routing mismatch");
+
+        _assertErc721State(address(erc721Replacement));
+
+        _removeErc721HostFacetWithMarker();
+
+        assertTrue(loupe.facetAddresses().length == 2, "erc721 removal should leave core facets only");
+        _assertMissingSelector(abi.encodeCall(IERC721Metadata.name, ()), "erc721 name should be missing after removal");
+        _assertMissingSelector(abi.encodeCall(IERC721.ownerOf, (1)), "erc721 ownerOf should be missing after removal");
+        _assertMissingSelector(
+            abi.encodeCall(IAccessControl.hasRole, (metadataRole, eve)),
+            "erc721 hasRole should be missing after removal"
+        );
+        _assertMissingSelector(
+            abi.encodeCall(IPausable.scopePaused, (approvalScope)), "erc721 scopePaused should be missing after removal"
+        );
+        _assertMissingSelector(
+            abi.encodeWithSelector(IFacetVersionMarker.facetVersion.selector),
+            "erc721 marker should be missing after removal"
+        );
+
+        _reAddErc721HostFacetWithMarker(address(erc721Replacement));
+
+        assertTrue(loupe.facetAddresses().length == 3, "erc721 re-add facet count mismatch");
+        assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "erc721 marker should survive re-add");
+        _assertErc721State(address(erc721Replacement));
+    }
+
+    function _assertErc20State(address expectedFacetOwner) internal view {
+        IERC20TokenFacet token = IERC20TokenFacet(address(diamond));
+        IDiamondLoupe loupe = IDiamondLoupe(address(diamond));
+
+        assertTrue(keccak256(bytes(token.name())) == keccak256(bytes("Facet Token")), "erc20 name mismatch");
+        assertTrue(keccak256(bytes(token.symbol())) == keccak256(bytes("FTKN")), "erc20 symbol mismatch");
+        assertTrue(token.decimals() == 18, "erc20 decimals mismatch");
+        assertTrue(token.totalSupply() == 150, "erc20 total supply mismatch");
+        assertTrue(token.balanceOf(bob) == 100, "erc20 bob balance mismatch");
+        assertTrue(token.balanceOf(carol) == 50, "erc20 carol balance mismatch");
+        assertTrue(token.allowance(bob, eve) == 25, "erc20 approval allowance mismatch");
+        assertTrue(token.allowance(bob, dave) == 40, "erc20 permit allowance mismatch");
+        assertTrue(token.nonces(bob) == 1, "erc20 nonce mismatch");
+        assertTrue(token.hasRole(token.TOKEN_ADMIN_ROLE(), eve), "erc20 role state mismatch");
+        assertTrue(token.scopePaused(token.ERC20_APPROVAL_SCOPE()), "erc20 approval scope pause mismatch");
+        assertTrue(!token.scopePaused(token.ERC20_TRANSFER_SCOPE()), "erc20 transfer scope should remain live");
+        assertTrue(token.supportsInterface(type(IERC20TokenFacet).interfaceId), "erc20 interface support mismatch");
+        assertTrue(
+            loupe.facetAddress(IERC20Metadata.name.selector) == expectedFacetOwner, "erc20 name selector owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC165.supportsInterface.selector) == expectedFacetOwner,
+            "erc20 supportsInterface owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IAccessControl.hasRole.selector) == expectedFacetOwner, "erc20 hasRole owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IPausable.pauseScope.selector) == expectedFacetOwner, "erc20 pauseScope owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC20TokenFacet.TOKEN_ADMIN_ROLE.selector) == expectedFacetOwner,
+            "erc20 token admin selector owner mismatch"
+        );
+    }
+
+    function _assertErc721State(address expectedFacetOwner) internal view {
+        IERC721TokenFacet token = IERC721TokenFacet(address(diamond));
+        IDiamondLoupe loupe = IDiamondLoupe(address(diamond));
+
+        assertTrue(keccak256(bytes(token.name())) == keccak256(bytes("Facet NFT")), "erc721 name mismatch");
+        assertTrue(keccak256(bytes(token.symbol())) == keccak256(bytes("FNFT")), "erc721 symbol mismatch");
+        assertTrue(token.totalSupply() == 2, "erc721 total supply mismatch");
+        assertTrue(token.ownerOf(1) == bob, "erc721 token 1 owner mismatch");
+        assertTrue(token.ownerOf(2) == carol, "erc721 token 2 owner mismatch");
+        assertTrue(token.balanceOf(bob) == 1, "erc721 bob balance mismatch");
+        assertTrue(token.balanceOf(carol) == 1, "erc721 carol balance mismatch");
+        assertTrue(token.getApproved(1) == eve, "erc721 approval mismatch");
+        assertTrue(token.isApprovedForAll(bob, dave), "erc721 operator approval mismatch");
+        assertTrue(
+            keccak256(bytes(token.tokenURI(1))) == keccak256(bytes("ipfs://facet/custom-1")),
+            "erc721 explicit uri mismatch"
+        );
+        assertTrue(
+            keccak256(bytes(token.tokenURI(2))) == keccak256(bytes("ipfs://facet/2")), "erc721 base uri mismatch"
+        );
+        assertTrue(token.hasRole(token.ERC721_METADATA_ROLE(), eve), "erc721 metadata role mismatch");
+        assertTrue(token.scopePaused(token.ERC721_APPROVAL_SCOPE()), "erc721 approval scope pause mismatch");
+        assertTrue(token.scopePaused(token.ERC721_TRANSFER_SCOPE()), "erc721 transfer scope pause mismatch");
+        assertTrue(token.supportsInterface(type(IERC721TokenFacet).interfaceId), "erc721 interface support mismatch");
+        assertTrue(
+            loupe.facetAddress(IERC721Metadata.name.selector) == expectedFacetOwner,
+            "erc721 name selector owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC165.supportsInterface.selector) == expectedFacetOwner,
+            "erc721 supportsInterface owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IAccessControl.hasRole.selector) == expectedFacetOwner, "erc721 hasRole owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IPausable.pauseScope.selector) == expectedFacetOwner, "erc721 pauseScope owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC721TokenFacet.ERC721_METADATA_ROLE.selector) == expectedFacetOwner,
+            "erc721 metadata selector owner mismatch"
+        );
+    }
+}

--- a/test/ERC20TokenFacetCore.t.sol
+++ b/test/ERC20TokenFacetCore.t.sol
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
+import {IERC20TokenBase} from "../src/interfaces/IERC20TokenBase.sol";
+import {IERC20TokenFacet} from "../src/interfaces/IERC20TokenFacet.sol";
+import {IPausable} from "../src/interfaces/IPausable.sol";
+import {IERC165} from "../src/interfaces/IERC165.sol";
+import {ERC20TokenFacetFixture} from "./helpers/ERC20TokenFacetTestHarness.sol";
+
+contract ERC20TokenFacetCoreTest is ERC20TokenFacetFixture {
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    function testInitializeSeedsMetadataAndSharedRoles() public {
+        _erc20Init(address(facet));
+
+        assertTrue(IERC20TokenFacet(address(facet)).isErc20Initialized(), "facet should initialize");
+        assertTrue(
+            keccak256(bytes(IERC20TokenFacet(address(facet)).name())) == keccak256(bytes("Facet Token")),
+            "name mismatch"
+        );
+        assertTrue(
+            keccak256(bytes(IERC20TokenFacet(address(facet)).symbol())) == keccak256(bytes("FTKN")), "symbol mismatch"
+        );
+        assertTrue(IERC20TokenFacet(address(facet)).decimals() == 18, "decimals mismatch");
+        assertTrue(
+            IERC20TokenFacet(address(facet)).hasRole(IERC20TokenFacet(address(facet)).DEFAULT_ADMIN_ROLE(), admin),
+            "admin should have default admin role"
+        );
+        assertTrue(
+            IERC20TokenFacet(address(facet)).hasRole(IERC20TokenFacet(address(facet)).TOKEN_ADMIN_ROLE(), admin),
+            "admin should have token admin role"
+        );
+        assertTrue(
+            IERC20TokenFacet(address(facet)).hasRole(IERC20TokenFacet(address(facet)).ERC20_MINTER_ROLE(), admin),
+            "admin should have minter role"
+        );
+        assertTrue(
+            IERC20TokenFacet(address(facet)).hasRole(IERC20TokenFacet(address(facet)).ERC20_BURNER_ROLE(), admin),
+            "admin should have burner role"
+        );
+        assertTrue(
+            IERC20TokenFacet(address(facet)).hasRole(IERC20TokenFacet(address(facet)).PAUSER_ROLE(), admin),
+            "admin should have pauser role"
+        );
+        assertTrue(
+            IERC20TokenFacet(address(facet)).getRoleAdmin(IERC20TokenFacet(address(facet)).ERC20_MINTER_ROLE())
+                == IERC20TokenFacet(address(facet)).TOKEN_ADMIN_ROLE(),
+            "minter admin mismatch"
+        );
+        assertTrue(
+            IERC20TokenFacet(address(facet)).getRoleAdmin(IERC20TokenFacet(address(facet)).ERC20_BURNER_ROLE())
+                == IERC20TokenFacet(address(facet)).TOKEN_ADMIN_ROLE(),
+            "burner admin mismatch"
+        );
+    }
+
+    function testInitializeRevertsWhenCalledTwice() public {
+        _erc20Init(address(facet));
+
+        VM.expectRevert(abi.encodeWithSelector(IERC20TokenBase.ERC20TokenAlreadyInitialized.selector));
+        _erc20Init(address(facet));
+    }
+
+    function testMintBurnTransferAndApprovalFlows() public {
+        _erc20Init(address(facet));
+
+        VM.expectEmit(true, true, false, true, address(facet));
+        emit Transfer(address(0), bob, 100);
+        VM.prank(admin);
+        IERC20TokenFacet(address(facet)).mint(bob, 100);
+
+        VM.expectEmit(true, true, false, true, address(facet));
+        emit Approval(bob, eve, 45);
+        VM.prank(bob);
+        IERC20TokenFacet(address(facet)).approve(eve, 45);
+
+        VM.expectEmit(true, true, false, true, address(facet));
+        emit Transfer(bob, admin, 10);
+        VM.prank(bob);
+        IERC20TokenFacet(address(facet)).transfer(admin, 10);
+
+        VM.expectEmit(true, true, false, true, address(facet));
+        emit Approval(bob, eve, 20);
+        VM.prank(eve);
+        IERC20TokenFacet(address(facet)).transferFrom(bob, admin, 25);
+
+        VM.prank(admin);
+        IERC20TokenFacet(address(facet)).burn(bob, 20);
+
+        assertTrue(IERC20TokenFacet(address(facet)).totalSupply() == 80, "total supply mismatch");
+        assertTrue(IERC20TokenFacet(address(facet)).balanceOf(bob) == 45, "bob balance mismatch");
+        assertTrue(IERC20TokenFacet(address(facet)).balanceOf(admin) == 35, "admin balance mismatch");
+        assertTrue(IERC20TokenFacet(address(facet)).allowance(bob, eve) == 20, "allowance mismatch");
+    }
+
+    function testUnauthorizedMintAndBurnRevert() public {
+        _erc20Init(address(facet));
+
+        VM.startPrank(bob);
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorized.selector,
+                bob,
+                IERC20TokenFacet(address(facet)).ERC20_MINTER_ROLE()
+            )
+        );
+        IERC20TokenFacet(address(facet)).mint(bob, 1);
+        VM.stopPrank();
+
+        VM.startPrank(bob);
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorized.selector,
+                bob,
+                IERC20TokenFacet(address(facet)).ERC20_BURNER_ROLE()
+            )
+        );
+        IERC20TokenFacet(address(facet)).burn(admin, 1);
+        VM.stopPrank();
+    }
+
+    function testTransferScopePauseBlocksTransferAndMintBurn() public {
+        _erc20Init(address(facet));
+        bytes32 transferScope = IERC20TokenFacet(address(facet)).ERC20_TRANSFER_SCOPE();
+
+        VM.prank(admin);
+        IERC20TokenFacet(address(facet)).mint(bob, 50);
+        VM.startPrank(admin);
+        IERC20TokenFacet(address(facet)).pauseScope(transferScope);
+        VM.stopPrank();
+
+        VM.startPrank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+        IERC20TokenFacet(address(facet)).transfer(admin, 1);
+        VM.stopPrank();
+
+        VM.startPrank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+        IERC20TokenFacet(address(facet)).mint(bob, 1);
+        VM.stopPrank();
+
+        VM.startPrank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+        IERC20TokenFacet(address(facet)).burn(bob, 1);
+        VM.stopPrank();
+    }
+
+    function testApprovalScopePauseBlocksApproveAndTransferFrom() public {
+        _erc20Init(address(facet));
+        bytes32 approvalScope = IERC20TokenFacet(address(facet)).ERC20_APPROVAL_SCOPE();
+
+        VM.prank(admin);
+        IERC20TokenFacet(address(facet)).mint(bob, 50);
+        VM.startPrank(admin);
+        IERC20TokenFacet(address(facet)).pauseScope(approvalScope);
+        VM.stopPrank();
+
+        VM.startPrank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, approvalScope));
+        IERC20TokenFacet(address(facet)).approve(eve, 1);
+        VM.stopPrank();
+
+        VM.startPrank(admin);
+        IERC20TokenFacet(address(facet)).unpauseScope(approvalScope);
+        VM.stopPrank();
+
+        VM.prank(bob);
+        IERC20TokenFacet(address(facet)).approve(eve, 10);
+
+        VM.startPrank(admin);
+        IERC20TokenFacet(address(facet)).pauseScope(approvalScope);
+        VM.stopPrank();
+
+        VM.startPrank(eve);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, approvalScope));
+        IERC20TokenFacet(address(facet)).transferFrom(bob, admin, 1);
+        VM.stopPrank();
+    }
+
+    function testSupportsFacetAndControlInterfaces() public {
+        _erc20Init(address(facet));
+
+        assertTrue(IERC20TokenFacet(address(facet)).supportsInterface(type(IERC165).interfaceId), "erc165 unsupported");
+        assertTrue(
+            IERC20TokenFacet(address(facet)).supportsInterface(type(IAccessControl).interfaceId),
+            "access control unsupported"
+        );
+        assertTrue(
+            IERC20TokenFacet(address(facet)).supportsInterface(type(IPausable).interfaceId), "pausable unsupported"
+        );
+        assertTrue(
+            IERC20TokenFacet(address(facet)).supportsInterface(type(IERC20TokenFacet).interfaceId),
+            "facet interface unsupported"
+        );
+    }
+
+    function testDiamondRoutingAndInitWorkThroughFallback() public {
+        _addErc20FacetToDiamond();
+        bytes32 transferScope = IERC20TokenFacet(address(diamond)).ERC20_TRANSFER_SCOPE();
+
+        VM.prank(admin);
+        IERC20TokenFacet(address(diamond)).initializeErc20("Facet Token", "FTKN", 18, admin);
+
+        assertTrue(IERC20TokenFacet(address(diamond)).isErc20Initialized(), "diamond erc20 should initialize");
+        assertTrue(
+            keccak256(bytes(IERC20TokenFacet(address(diamond)).name())) == keccak256(bytes("Facet Token")),
+            "diamond name mismatch"
+        );
+
+        VM.prank(admin);
+        IERC20TokenFacet(address(diamond)).mint(bob, 120);
+
+        VM.prank(bob);
+        IERC20TokenFacet(address(diamond)).approve(eve, 50);
+
+        VM.prank(eve);
+        IERC20TokenFacet(address(diamond)).transferFrom(bob, admin, 20);
+
+        assertTrue(IERC20TokenFacet(address(diamond)).balanceOf(bob) == 100, "diamond bob balance mismatch");
+        assertTrue(IERC20TokenFacet(address(diamond)).balanceOf(admin) == 20, "diamond admin balance mismatch");
+        assertTrue(IERC20TokenFacet(address(diamond)).allowance(bob, eve) == 30, "diamond allowance mismatch");
+        assertTrue(
+            IERC20TokenFacet(address(diamond)).hasRole(IERC20TokenFacet(address(diamond)).ERC20_MINTER_ROLE(), admin),
+            "diamond admin should have minter role"
+        );
+
+        VM.startPrank(admin);
+        IERC20TokenFacet(address(diamond)).pauseScope(transferScope);
+        VM.stopPrank();
+
+        VM.startPrank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+        IERC20TokenFacet(address(diamond)).transfer(admin, 1);
+        VM.stopPrank();
+    }
+
+    function testDiamondReinitializeReverts() public {
+        _addErc20FacetToDiamond();
+
+        VM.prank(admin);
+        IERC20TokenFacet(address(diamond)).initializeErc20("Facet Token", "FTKN", 18, admin);
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IERC20TokenBase.ERC20TokenAlreadyInitialized.selector));
+        IERC20TokenFacet(address(diamond)).initializeErc20("Facet Token", "FTKN", 18, admin);
+    }
+}

--- a/test/ERC20TokenFacetCore.t.sol
+++ b/test/ERC20TokenFacetCore.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.30;
 
 import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
+import {IERC20Permit} from "../src/interfaces/IERC20Permit.sol";
 import {IERC20TokenBase} from "../src/interfaces/IERC20TokenBase.sol";
 import {IERC20TokenFacet} from "../src/interfaces/IERC20TokenFacet.sol";
 import {IPausable} from "../src/interfaces/IPausable.sol";
@@ -11,6 +12,8 @@ import {ERC20TokenFacetFixture} from "./helpers/ERC20TokenFacetTestHarness.sol";
 contract ERC20TokenFacetCoreTest is ERC20TokenFacetFixture {
     event Transfer(address indexed from, address indexed to, uint256 value);
     event Approval(address indexed owner, address indexed spender, uint256 value);
+    bytes32 internal constant EIP712_DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
 
     function testInitializeSeedsMetadataAndSharedRoles() public {
         _erc20Init(address(facet));
@@ -191,6 +194,9 @@ contract ERC20TokenFacetCoreTest is ERC20TokenFacetFixture {
             IERC20TokenFacet(address(facet)).supportsInterface(type(IPausable).interfaceId), "pausable unsupported"
         );
         assertTrue(
+            IERC20TokenFacet(address(facet)).supportsInterface(type(IERC20Permit).interfaceId), "permit unsupported"
+        );
+        assertTrue(
             IERC20TokenFacet(address(facet)).supportsInterface(type(IERC20TokenFacet).interfaceId),
             "facet interface unsupported"
         );
@@ -245,5 +251,111 @@ contract ERC20TokenFacetCoreTest is ERC20TokenFacetFixture {
         VM.prank(admin);
         VM.expectRevert(abi.encodeWithSelector(IERC20TokenBase.ERC20TokenAlreadyInitialized.selector));
         IERC20TokenFacet(address(diamond)).initializeErc20("Facet Token", "FTKN", 18, admin);
+    }
+
+    function testPermitSetsAllowanceEmitsApprovalAndIncrementsNonce() public {
+        _erc20Init(address(facet));
+        uint256 deadline = block.timestamp + 1 days;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(BOB_PK, address(facet), bob, eve, 55, 0, deadline);
+
+        VM.expectEmit(true, true, false, true, address(facet));
+        emit Approval(bob, eve, 55);
+        IERC20TokenFacet(address(facet)).permit(bob, eve, 55, deadline, v, r, s);
+
+        assertTrue(IERC20TokenFacet(address(facet)).allowance(bob, eve) == 55, "permit allowance mismatch");
+        assertTrue(IERC20TokenFacet(address(facet)).nonces(bob) == 1, "permit nonce mismatch");
+    }
+
+    function testPermitRevertsOnReplay() public {
+        _erc20Init(address(facet));
+        uint256 deadline = block.timestamp + 1 days;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(BOB_PK, address(facet), bob, eve, 55, 0, deadline);
+
+        IERC20TokenFacet(address(facet)).permit(bob, eve, 55, deadline, v, r, s);
+
+        address replaySigner = _recoverPermitSigner(address(facet), bob, eve, 55, 1, deadline, v, r, s);
+        VM.expectRevert(abi.encodeWithSelector(IERC20TokenFacet.ERC20PermitInvalidSigner.selector, replaySigner, bob));
+        IERC20TokenFacet(address(facet)).permit(bob, eve, 55, deadline, v, r, s);
+    }
+
+    function testPermitRevertsOnExpiredDeadline() public {
+        _erc20Init(address(facet));
+        uint256 deadline = block.timestamp;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(BOB_PK, address(facet), bob, eve, 55, 0, deadline);
+
+        VM.warp(block.timestamp + 1);
+        VM.expectRevert(abi.encodeWithSelector(IERC20TokenFacet.ERC20PermitExpired.selector, deadline, block.timestamp));
+        IERC20TokenFacet(address(facet)).permit(bob, eve, 55, deadline, v, r, s);
+    }
+
+    function testPermitRevertsOnWrongPayload() public {
+        _erc20Init(address(facet));
+        uint256 deadline = block.timestamp + 1 days;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(BOB_PK, address(facet), bob, eve, 55, 0, deadline);
+
+        address wrongSpenderSigner = _recoverPermitSigner(address(facet), bob, admin, 55, 0, deadline, v, r, s);
+        VM.expectRevert(
+            abi.encodeWithSelector(IERC20TokenFacet.ERC20PermitInvalidSigner.selector, wrongSpenderSigner, bob)
+        );
+        IERC20TokenFacet(address(facet)).permit(bob, admin, 55, deadline, v, r, s);
+
+        address wrongValueSigner = _recoverPermitSigner(address(facet), bob, eve, 54, 0, deadline, v, r, s);
+        VM.expectRevert(
+            abi.encodeWithSelector(IERC20TokenFacet.ERC20PermitInvalidSigner.selector, wrongValueSigner, bob)
+        );
+        IERC20TokenFacet(address(facet)).permit(bob, eve, 54, deadline, v, r, s);
+
+        address wrongDeadlineSigner = _recoverPermitSigner(address(facet), bob, eve, 55, 0, deadline + 1, v, r, s);
+        VM.expectRevert(
+            abi.encodeWithSelector(IERC20TokenFacet.ERC20PermitInvalidSigner.selector, wrongDeadlineSigner, bob)
+        );
+        IERC20TokenFacet(address(facet)).permit(bob, eve, 55, deadline + 1, v, r, s);
+    }
+
+    function testDomainSeparatorMatchesInitializedContext() public {
+        _erc20Init(address(facet));
+
+        bytes32 expectedSeparator = keccak256(
+            abi.encode(
+                EIP712_DOMAIN_TYPEHASH,
+                keccak256(bytes("Facet Token")),
+                keccak256(bytes("1")),
+                block.chainid,
+                address(facet)
+            )
+        );
+
+        assertTrue(
+            IERC20TokenFacet(address(facet)).DOMAIN_SEPARATOR() == expectedSeparator, "domain separator mismatch"
+        );
+    }
+
+    function testPermitRespectsApprovalPauseScope() public {
+        _erc20Init(address(facet));
+        bytes32 approvalScope = IERC20TokenFacet(address(facet)).ERC20_APPROVAL_SCOPE();
+        uint256 deadline = block.timestamp + 1 days;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(BOB_PK, address(facet), bob, eve, 55, 0, deadline);
+
+        VM.startPrank(admin);
+        IERC20TokenFacet(address(facet)).pauseScope(approvalScope);
+        VM.stopPrank();
+
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, approvalScope));
+        IERC20TokenFacet(address(facet)).permit(bob, eve, 55, deadline, v, r, s);
+    }
+
+    function testDiamondPermitWorksThroughFallback() public {
+        _addErc20FacetToDiamond();
+
+        VM.prank(admin);
+        IERC20TokenFacet(address(diamond)).initializeErc20("Facet Token", "FTKN", 18, admin);
+
+        uint256 deadline = block.timestamp + 1 days;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(BOB_PK, address(diamond), bob, eve, 77, 0, deadline);
+
+        IERC20TokenFacet(address(diamond)).permit(bob, eve, 77, deadline, v, r, s);
+
+        assertTrue(IERC20TokenFacet(address(diamond)).allowance(bob, eve) == 77, "diamond permit allowance mismatch");
+        assertTrue(IERC20TokenFacet(address(diamond)).nonces(bob) == 1, "diamond permit nonce mismatch");
     }
 }

--- a/test/ERC20TokenFacetFuzz.t.sol
+++ b/test/ERC20TokenFacetFuzz.t.sol
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
+import {IERC20TokenFacet} from "../src/interfaces/IERC20TokenFacet.sol";
+import {IPausable} from "../src/interfaces/IPausable.sol";
+import {ERC20TokenFacetFixture} from "./helpers/ERC20TokenFacetTestHarness.sol";
+
+contract ERC20TokenFacetFuzzTest is ERC20TokenFacetFixture {
+    function testFuzzPermitSetsAllowanceAndIncrementsNonce(uint96 valueRaw, uint40 deadlineOffsetRaw) public {
+        _erc20Init(address(facet));
+
+        uint256 value = uint256(valueRaw);
+        uint256 deadline = block.timestamp + uint256(deadlineOffsetRaw) + 1;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(BOB_PK, address(facet), bob, eve, value, 0, deadline);
+
+        IERC20TokenFacet(address(facet)).permit(bob, eve, value, deadline, v, r, s);
+
+        assertTrue(IERC20TokenFacet(address(facet)).allowance(bob, eve) == value, "permit allowance mismatch");
+        assertTrue(IERC20TokenFacet(address(facet)).nonces(bob) == 1, "permit nonce mismatch");
+    }
+
+    function testFuzzPermitReplayReverts(uint96 valueRaw, uint40 deadlineOffsetRaw) public {
+        _erc20Init(address(facet));
+
+        uint256 value = uint256(valueRaw);
+        uint256 deadline = block.timestamp + uint256(deadlineOffsetRaw) + 1;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(BOB_PK, address(facet), bob, eve, value, 0, deadline);
+
+        IERC20TokenFacet(address(facet)).permit(bob, eve, value, deadline, v, r, s);
+
+        address replaySigner = _recoverPermitSigner(address(facet), bob, eve, value, 1, deadline, v, r, s);
+        VM.expectRevert(abi.encodeWithSelector(IERC20TokenFacet.ERC20PermitInvalidSigner.selector, replaySigner, bob));
+        IERC20TokenFacet(address(facet)).permit(bob, eve, value, deadline, v, r, s);
+    }
+
+    function testFuzzTransferFromConsumesAllowanceAfterPermit(uint96 allowanceRaw, uint96 spendRaw) public {
+        _erc20Init(address(facet));
+
+        uint256 allowance = uint256(allowanceRaw) + 1;
+        uint256 spend = _boundAmount(spendRaw, allowance);
+        uint256 mintAmount = allowance + 100;
+
+        VM.prank(admin);
+        IERC20TokenFacet(address(facet)).mint(bob, mintAmount);
+
+        uint256 deadline = block.timestamp + 1 days;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(BOB_PK, address(facet), bob, eve, allowance, 0, deadline);
+        IERC20TokenFacet(address(facet)).permit(bob, eve, allowance, deadline, v, r, s);
+
+        VM.prank(eve);
+        IERC20TokenFacet(address(facet)).transferFrom(bob, admin, spend);
+
+        assertTrue(
+            IERC20TokenFacet(address(facet)).allowance(bob, eve) == allowance - spend,
+            "permit allowance should decrement"
+        );
+    }
+
+    function testFuzzPausedApprovalScopeBlocksPermit(uint96 valueRaw) public {
+        _erc20Init(address(facet));
+        bytes32 approvalScope = IERC20TokenFacet(address(facet)).ERC20_APPROVAL_SCOPE();
+        uint256 value = uint256(valueRaw);
+        uint256 deadline = block.timestamp + 1 days;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(BOB_PK, address(facet), bob, eve, value, 0, deadline);
+
+        VM.prank(admin);
+        IERC20TokenFacet(address(facet)).pauseScope(approvalScope);
+
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, approvalScope));
+        IERC20TokenFacet(address(facet)).permit(bob, eve, value, deadline, v, r, s);
+    }
+
+    function testFuzzMintBurnSupplyAccounting(uint96 mintRaw, uint96 burnRaw) public {
+        _erc20Init(address(facet));
+
+        uint256 mintAmount = uint256(mintRaw) + 1;
+        VM.prank(admin);
+        IERC20TokenFacet(address(facet)).mint(bob, mintAmount);
+
+        uint256 burnAmount = _boundAmount(burnRaw, mintAmount);
+        VM.prank(admin);
+        IERC20TokenFacet(address(facet)).burn(bob, burnAmount);
+
+        assertTrue(IERC20TokenFacet(address(facet)).totalSupply() == mintAmount - burnAmount, "total supply mismatch");
+        assertTrue(IERC20TokenFacet(address(facet)).balanceOf(bob) == mintAmount - burnAmount, "balance mismatch");
+    }
+
+    function testFuzzPausedTransferScopeBlocksMutations(uint96 mintRaw, uint96 burnRaw, uint96 transferRaw) public {
+        _erc20Init(address(facet));
+        bytes32 transferScope = IERC20TokenFacet(address(facet)).ERC20_TRANSFER_SCOPE();
+        uint256 initialMint = uint256(mintRaw) + 1;
+
+        VM.prank(admin);
+        IERC20TokenFacet(address(facet)).mint(bob, initialMint);
+        VM.prank(admin);
+        IERC20TokenFacet(address(facet)).pauseScope(transferScope);
+
+        uint256 transferAmount = _boundAmount(transferRaw, initialMint);
+        VM.startPrank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+        IERC20TokenFacet(address(facet)).transfer(eve, transferAmount);
+        VM.stopPrank();
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+        IERC20TokenFacet(address(facet)).mint(eve, 1);
+
+        uint256 burnAmount = _boundAmount(burnRaw, initialMint);
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+        IERC20TokenFacet(address(facet)).burn(bob, burnAmount);
+    }
+
+    function _boundAmount(uint256 raw, uint256 max) internal pure returns (uint256) {
+        if (max == 0) {
+            return 0;
+        }
+        return (raw % max) + 1;
+    }
+}

--- a/test/ERC20TokenFacetInvariant.t.sol
+++ b/test/ERC20TokenFacetInvariant.t.sol
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC20TokenFacet} from "../src/interfaces/IERC20TokenFacet.sol";
+import {IPausable} from "../src/interfaces/IPausable.sol";
+import {ERC20TokenFacetInvariantFixture} from "./helpers/ERC20TokenFacetInvariantTestHarness.sol";
+
+contract ERC20TokenFacetInvariantTest is ERC20TokenFacetInvariantFixture {
+    function targetContracts() external view returns (address[] memory contracts) {
+        contracts = new address[](1);
+        contracts[0] = address(this);
+    }
+
+    function actionApprove(uint8 ownerSeed, uint8 spenderSeed, uint96 valueRaw) external {
+        address owner = _actor(ownerSeed);
+        address spender = _actor(spenderSeed);
+        if (owner == spender) {
+            return;
+        }
+
+        bytes32 approvalScope = IERC20TokenFacet(address(facet)).ERC20_APPROVAL_SCOPE();
+        uint256 value = uint256(valueRaw);
+        if (IERC20TokenFacet(address(facet)).scopePaused(approvalScope)) {
+            AccountingSnapshot memory snapshot = _snapshotAccounting();
+            VM.startPrank(owner);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, approvalScope));
+            IERC20TokenFacet(address(facet)).approve(spender, value);
+            VM.stopPrank();
+            _assertAccountingUnchanged(snapshot, "paused approval should not mutate accounting");
+            return;
+        }
+
+        VM.prank(owner);
+        IERC20TokenFacet(address(facet)).approve(spender, value);
+    }
+
+    function actionPermit(uint8 ownerSeed, uint8 spenderSeed, uint96 valueRaw, uint32 deadlineOffsetRaw) external {
+        address owner = _actor(ownerSeed);
+        address spender = _actor(spenderSeed);
+        if (owner == spender) {
+            return;
+        }
+
+        bytes32 approvalScope = IERC20TokenFacet(address(facet)).ERC20_APPROVAL_SCOPE();
+        uint256 value = uint256(valueRaw);
+        uint256 deadline = block.timestamp + uint256(deadlineOffsetRaw) + 1;
+        uint256 nonce = IERC20TokenFacet(address(facet)).nonces(owner);
+        (uint8 v, bytes32 r, bytes32 s) =
+            _signPermit(_actorKey(ownerSeed), address(facet), owner, spender, value, nonce, deadline);
+
+        if (IERC20TokenFacet(address(facet)).scopePaused(approvalScope)) {
+            AccountingSnapshot memory snapshot = _snapshotAccounting();
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, approvalScope));
+            IERC20TokenFacet(address(facet)).permit(owner, spender, value, deadline, v, r, s);
+            _assertAccountingUnchanged(snapshot, "paused permit should not mutate accounting");
+            return;
+        }
+
+        IERC20TokenFacet(address(facet)).permit(owner, spender, value, deadline, v, r, s);
+        trackedPermitSuccesses[owner] += 1;
+    }
+
+    function actionTransfer(uint8 fromSeed, uint8 toSeed, uint96 valueRaw) external {
+        address from = _actor(fromSeed);
+        address to = _actor(toSeed);
+        if (from == to) {
+            return;
+        }
+
+        bytes32 transferScope = IERC20TokenFacet(address(facet)).ERC20_TRANSFER_SCOPE();
+        uint256 value = _boundAmount(valueRaw, IERC20TokenFacet(address(facet)).balanceOf(from));
+        if (value == 0) {
+            return;
+        }
+
+        if (IERC20TokenFacet(address(facet)).scopePaused(transferScope)) {
+            AccountingSnapshot memory snapshot = _snapshotAccounting();
+            VM.startPrank(from);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+            IERC20TokenFacet(address(facet)).transfer(to, value);
+            VM.stopPrank();
+            _assertAccountingUnchanged(snapshot, "paused transfer should not mutate accounting");
+            return;
+        }
+
+        VM.prank(from);
+        IERC20TokenFacet(address(facet)).transfer(to, value);
+    }
+
+    function actionTransferFrom(uint8 spenderSeed, uint8 ownerSeed, uint8 toSeed, uint96 valueRaw) external {
+        address spender = _actor(spenderSeed);
+        address owner = _actor(ownerSeed);
+        address to = _actor(toSeed);
+        if (owner == to || spender == owner) {
+            return;
+        }
+
+        uint256 allowance = IERC20TokenFacet(address(facet)).allowance(owner, spender);
+        uint256 balance = IERC20TokenFacet(address(facet)).balanceOf(owner);
+        uint256 value = _boundAmount(valueRaw, allowance < balance ? allowance : balance);
+        if (value == 0) {
+            return;
+        }
+
+        bytes32 transferScope = IERC20TokenFacet(address(facet)).ERC20_TRANSFER_SCOPE();
+        bytes32 approvalScope = IERC20TokenFacet(address(facet)).ERC20_APPROVAL_SCOPE();
+        if (
+            IERC20TokenFacet(address(facet)).scopePaused(transferScope)
+                || IERC20TokenFacet(address(facet)).scopePaused(approvalScope)
+        ) {
+            bytes32 expectedScope =
+                IERC20TokenFacet(address(facet)).scopePaused(approvalScope) ? approvalScope : transferScope;
+            AccountingSnapshot memory snapshot = _snapshotAccounting();
+            VM.startPrank(spender);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, expectedScope));
+            IERC20TokenFacet(address(facet)).transferFrom(owner, to, value);
+            VM.stopPrank();
+            _assertAccountingUnchanged(snapshot, "paused transferFrom should not mutate accounting");
+            return;
+        }
+
+        VM.prank(spender);
+        IERC20TokenFacet(address(facet)).transferFrom(owner, to, value);
+    }
+
+    function actionMint(uint8 actorSeed, uint96 valueRaw) external {
+        bytes32 transferScope = IERC20TokenFacet(address(facet)).ERC20_TRANSFER_SCOPE();
+        uint256 value = uint256(valueRaw);
+        if (value == 0) {
+            return;
+        }
+
+        if (IERC20TokenFacet(address(facet)).scopePaused(transferScope)) {
+            AccountingSnapshot memory snapshot = _snapshotAccounting();
+            VM.prank(admin);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+            IERC20TokenFacet(address(facet)).mint(_actor(actorSeed), value);
+            _assertAccountingUnchanged(snapshot, "paused mint should not mutate accounting");
+            return;
+        }
+
+        VM.prank(admin);
+        IERC20TokenFacet(address(facet)).mint(_actor(actorSeed), value);
+    }
+
+    function actionBurn(uint8 actorSeed, uint96 valueRaw) external {
+        address actor = _actor(actorSeed);
+        bytes32 transferScope = IERC20TokenFacet(address(facet)).ERC20_TRANSFER_SCOPE();
+        uint256 value = _boundAmount(valueRaw, IERC20TokenFacet(address(facet)).balanceOf(actor));
+        if (value == 0) {
+            return;
+        }
+
+        if (IERC20TokenFacet(address(facet)).scopePaused(transferScope)) {
+            AccountingSnapshot memory snapshot = _snapshotAccounting();
+            VM.prank(admin);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+            IERC20TokenFacet(address(facet)).burn(actor, value);
+            _assertAccountingUnchanged(snapshot, "paused burn should not mutate accounting");
+            return;
+        }
+
+        VM.prank(admin);
+        IERC20TokenFacet(address(facet)).burn(actor, value);
+    }
+
+    function actionSetApprovalScopePaused(bool paused_) external {
+        bytes32 approvalScope = IERC20TokenFacet(address(facet)).ERC20_APPROVAL_SCOPE();
+        bool isPaused = IERC20TokenFacet(address(facet)).scopePaused(approvalScope);
+        if (paused_ && !isPaused) {
+            VM.prank(admin);
+            IERC20TokenFacet(address(facet)).pauseScope(approvalScope);
+        } else if (!paused_ && isPaused) {
+            VM.prank(admin);
+            IERC20TokenFacet(address(facet)).unpauseScope(approvalScope);
+        }
+    }
+
+    function actionSetTransferScopePaused(bool paused_) external {
+        bytes32 transferScope = IERC20TokenFacet(address(facet)).ERC20_TRANSFER_SCOPE();
+        bool isPaused = IERC20TokenFacet(address(facet)).scopePaused(transferScope);
+        if (paused_ && !isPaused) {
+            VM.prank(admin);
+            IERC20TokenFacet(address(facet)).pauseScope(transferScope);
+        } else if (!paused_ && isPaused) {
+            VM.prank(admin);
+            IERC20TokenFacet(address(facet)).unpauseScope(transferScope);
+        }
+    }
+
+    function invariantTotalSupplyEqualsTrackedBalances() public view {
+        assertTrue(
+            IERC20TokenFacet(address(facet)).totalSupply() == _sumTrackedBalances(),
+            "total supply must equal tracked balances"
+        );
+    }
+
+    function invariantTrackedPermitNoncesMatchSuccessfulCalls() public view {
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            address actor = actors[i];
+            assertTrue(
+                IERC20TokenFacet(address(facet)).nonces(actor) == trackedPermitSuccesses[actor],
+                "tracked permit nonces must match successful permit calls"
+            );
+        }
+    }
+}

--- a/test/ERC721TokenFacetCore.t.sol
+++ b/test/ERC721TokenFacetCore.t.sol
@@ -1,0 +1,389 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
+import {IERC165} from "../src/interfaces/IERC165.sol";
+import {IERC721} from "../src/interfaces/IERC721.sol";
+import {IERC721Metadata} from "../src/interfaces/IERC721Metadata.sol";
+import {IERC721TokenBase} from "../src/interfaces/IERC721TokenBase.sol";
+import {IERC721TokenFacet} from "../src/interfaces/IERC721TokenFacet.sol";
+import {IPausable} from "../src/interfaces/IPausable.sol";
+import {ERC721TokenFacetFixture} from "./helpers/ERC721TokenFacetTestHarness.sol";
+
+contract ERC721TokenFacetCoreTest is ERC721TokenFacetFixture {
+    event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
+    event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId);
+    event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
+
+    function testInitializeSeedsMetadataAndSharedRoles() public {
+        _erc721Init(address(facet));
+
+        assertTrue(IERC721TokenFacet(address(facet)).isErc721Initialized(), "facet should initialize");
+        assertTrue(
+            keccak256(bytes(IERC721TokenFacet(address(facet)).name())) == keccak256(bytes("Facet NFT")), "name mismatch"
+        );
+        assertTrue(
+            keccak256(bytes(IERC721TokenFacet(address(facet)).symbol())) == keccak256(bytes("FNFT")), "symbol mismatch"
+        );
+        assertTrue(IERC721TokenFacet(address(facet)).totalSupply() == 0, "initial supply mismatch");
+    }
+
+    function testInitializeSeedsRoleHierarchyAndBaseUri() public {
+        _erc721Init(address(facet));
+        VM.prank(admin);
+        IERC721TokenFacet(address(facet)).mint(admin, 1);
+
+        assertTrue(
+            keccak256(bytes(IERC721TokenFacet(address(facet)).tokenURI(1))) == keccak256(bytes("ipfs://facet/1")),
+            "base uri mismatch"
+        );
+        assertTrue(
+            IERC721TokenFacet(address(facet)).hasRole(IERC721TokenFacet(address(facet)).DEFAULT_ADMIN_ROLE(), admin),
+            "admin should have default admin role"
+        );
+        assertTrue(
+            IERC721TokenFacet(address(facet)).hasRole(IERC721TokenFacet(address(facet)).TOKEN_ADMIN_ROLE(), admin),
+            "admin should have token admin role"
+        );
+        assertTrue(
+            IERC721TokenFacet(address(facet)).hasRole(IERC721TokenFacet(address(facet)).ERC721_MINTER_ROLE(), admin),
+            "admin should have minter role"
+        );
+        assertTrue(
+            IERC721TokenFacet(address(facet)).hasRole(IERC721TokenFacet(address(facet)).ERC721_BURNER_ROLE(), admin),
+            "admin should have burner role"
+        );
+        assertTrue(
+            IERC721TokenFacet(address(facet)).hasRole(IERC721TokenFacet(address(facet)).ERC721_METADATA_ROLE(), admin),
+            "admin should have metadata role"
+        );
+        assertTrue(
+            IERC721TokenFacet(address(facet)).hasRole(IERC721TokenFacet(address(facet)).PAUSER_ROLE(), admin),
+            "admin should have pauser role"
+        );
+        assertTrue(
+            IERC721TokenFacet(address(facet)).getRoleAdmin(IERC721TokenFacet(address(facet)).TOKEN_ADMIN_ROLE())
+                == IERC721TokenFacet(address(facet)).DEFAULT_ADMIN_ROLE(),
+            "token admin admin mismatch"
+        );
+        assertTrue(
+            IERC721TokenFacet(address(facet)).getRoleAdmin(IERC721TokenFacet(address(facet)).ERC721_MINTER_ROLE())
+                == IERC721TokenFacet(address(facet)).TOKEN_ADMIN_ROLE(),
+            "minter admin mismatch"
+        );
+        assertTrue(
+            IERC721TokenFacet(address(facet)).getRoleAdmin(IERC721TokenFacet(address(facet)).ERC721_BURNER_ROLE())
+                == IERC721TokenFacet(address(facet)).TOKEN_ADMIN_ROLE(),
+            "burner admin mismatch"
+        );
+        assertTrue(
+            IERC721TokenFacet(address(facet)).getRoleAdmin(IERC721TokenFacet(address(facet)).ERC721_METADATA_ROLE())
+                == IERC721TokenFacet(address(facet)).TOKEN_ADMIN_ROLE(),
+            "metadata admin mismatch"
+        );
+    }
+
+    function testInitializeRevertsWhenCalledTwice() public {
+        _erc721Init(address(facet));
+
+        VM.expectRevert(abi.encodeWithSelector(IERC721TokenBase.ERC721TokenAlreadyInitialized.selector));
+        _erc721Init(address(facet));
+    }
+
+    function testMintBurnTransferAndMetadataFlows() public {
+        _erc721Init(address(facet));
+
+        VM.expectEmit(true, true, true, true, address(facet));
+        emit Transfer(address(0), bob, 1);
+        VM.prank(admin);
+        IERC721TokenFacet(address(facet)).mint(bob, 1);
+
+        VM.expectEmit(true, true, true, true, address(facet));
+        emit Approval(bob, eve, 1);
+        VM.prank(bob);
+        IERC721TokenFacet(address(facet)).approve(eve, 1);
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(facet)).setTokenURI(1, "ipfs://facet/custom-1");
+
+        VM.expectEmit(true, true, true, true, address(facet));
+        emit Transfer(bob, admin, 1);
+        VM.prank(eve);
+        IERC721TokenFacet(address(facet)).transferFrom(bob, admin, 1);
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(facet)).setBaseURI("https://example.com/meta/");
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(facet)).burn(1);
+
+        assertTrue(IERC721TokenFacet(address(facet)).totalSupply() == 0, "total supply mismatch");
+        assertTrue(IERC721TokenFacet(address(facet)).balanceOf(bob) == 0, "bob balance mismatch");
+        assertTrue(IERC721TokenFacet(address(facet)).balanceOf(admin) == 0, "admin balance mismatch");
+        VM.expectRevert(abi.encodeWithSelector(IERC721TokenBase.ERC721TokenNonexistentToken.selector, 1));
+        IERC721TokenFacet(address(facet)).ownerOf(1);
+    }
+
+    function testTokenUriPrefersExplicitUriAndClearsApprovalOnTransfer() public {
+        _erc721Init(address(facet));
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(facet)).mint(bob, 7);
+        VM.prank(admin);
+        IERC721TokenFacet(address(facet)).setTokenURI(7, "ipfs://facet/custom-7");
+
+        assertTrue(
+            keccak256(bytes(IERC721TokenFacet(address(facet)).tokenURI(7)))
+                == keccak256(bytes("ipfs://facet/custom-7")),
+            "explicit token uri mismatch"
+        );
+
+        VM.prank(bob);
+        IERC721TokenFacet(address(facet)).approve(eve, 7);
+
+        VM.prank(eve);
+        IERC721TokenFacet(address(facet)).transferFrom(bob, admin, 7);
+
+        assertTrue(IERC721TokenFacet(address(facet)).getApproved(7) == address(0), "approval should clear");
+    }
+
+    function testSafeTransferAndSafeMintHandleReceivers() public {
+        _erc721Init(address(facet));
+        bytes memory payload = hex"1234";
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(facet)).safeMint(address(receiver), 1, payload);
+
+        assertTrue(IERC721TokenFacet(address(facet)).ownerOf(1) == address(receiver), "receiver should own token");
+        assertTrue(receiver.lastOperator() == admin, "safe mint operator mismatch");
+        assertTrue(receiver.lastFrom() == address(0), "safe mint from mismatch");
+        assertTrue(receiver.lastTokenId() == 1, "safe mint token id mismatch");
+        assertTrue(keccak256(receiver.lastData()) == keccak256(payload), "safe mint data mismatch");
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(facet)).mint(admin, 2);
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(facet)).safeTransferFrom(admin, address(receiver), 2, payload);
+
+        assertTrue(IERC721TokenFacet(address(facet)).ownerOf(2) == address(receiver), "safe transfer owner mismatch");
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(facet)).mint(admin, 3);
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IERC721TokenBase.ERC721TokenUnsafeReceiver.selector, address(rejector)));
+        IERC721TokenFacet(address(facet)).safeTransferFrom(admin, address(rejector), 3);
+    }
+
+    function testApproveAndTransferRequireAuthorizedOperator() public {
+        _erc721Init(address(facet));
+        VM.prank(admin);
+        IERC721TokenFacet(address(facet)).mint(bob, 1);
+
+        VM.prank(eve);
+        VM.expectRevert(abi.encodeWithSelector(IERC721TokenFacet.ERC721TokenUnauthorizedOperator.selector, eve, 1));
+        IERC721TokenFacet(address(facet)).approve(admin, 1);
+
+        VM.prank(eve);
+        VM.expectRevert(abi.encodeWithSelector(IERC721TokenFacet.ERC721TokenUnauthorizedOperator.selector, eve, 1));
+        IERC721TokenFacet(address(facet)).transferFrom(bob, admin, 1);
+
+        VM.prank(bob);
+        IERC721TokenFacet(address(facet)).setApprovalForAll(eve, true);
+        VM.prank(eve);
+        IERC721TokenFacet(address(facet)).transferFrom(bob, admin, 1);
+
+        assertTrue(IERC721TokenFacet(address(facet)).ownerOf(1) == admin, "operator transfer should succeed");
+    }
+
+    function testUnauthorizedMintBurnAndMetadataUpdatesRevert() public {
+        _erc721Init(address(facet));
+        VM.prank(admin);
+        IERC721TokenFacet(address(facet)).mint(admin, 1);
+
+        VM.startPrank(bob);
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorized.selector,
+                bob,
+                IERC721TokenFacet(address(facet)).ERC721_MINTER_ROLE()
+            )
+        );
+        IERC721TokenFacet(address(facet)).mint(bob, 2);
+        VM.stopPrank();
+
+        VM.startPrank(bob);
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorized.selector,
+                bob,
+                IERC721TokenFacet(address(facet)).ERC721_BURNER_ROLE()
+            )
+        );
+        IERC721TokenFacet(address(facet)).burn(1);
+        VM.stopPrank();
+
+        VM.startPrank(bob);
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorized.selector,
+                bob,
+                IERC721TokenFacet(address(facet)).ERC721_METADATA_ROLE()
+            )
+        );
+        IERC721TokenFacet(address(facet)).setBaseURI("ipfs://other/");
+        VM.stopPrank();
+
+        VM.startPrank(bob);
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorized.selector,
+                bob,
+                IERC721TokenFacet(address(facet)).ERC721_METADATA_ROLE()
+            )
+        );
+        IERC721TokenFacet(address(facet)).setTokenURI(1, "ipfs://other/1");
+        VM.stopPrank();
+    }
+
+    function testPauseScopesBlockOnlyTheirIntendedPaths() public {
+        _erc721Init(address(facet));
+        bytes32 approvalScope = IERC721TokenFacet(address(facet)).ERC721_APPROVAL_SCOPE();
+        bytes32 transferScope = IERC721TokenFacet(address(facet)).ERC721_TRANSFER_SCOPE();
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(facet)).mint(bob, 1);
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(facet)).pauseScope(approvalScope);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, approvalScope));
+        IERC721TokenFacet(address(facet)).approve(eve, 1);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, approvalScope));
+        IERC721TokenFacet(address(facet)).setApprovalForAll(eve, true);
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(facet)).pauseScope(transferScope);
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(facet)).setBaseURI("https://example.com/meta/");
+        VM.prank(admin);
+        IERC721TokenFacet(address(facet)).setTokenURI(1, "https://example.com/meta/custom-1");
+
+        assertTrue(
+            keccak256(bytes(IERC721TokenFacet(address(facet)).tokenURI(1)))
+                == keccak256(bytes("https://example.com/meta/custom-1")),
+            "metadata updates should remain available"
+        );
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+        IERC721TokenFacet(address(facet)).transferFrom(bob, admin, 1);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+        IERC721TokenFacet(address(facet)).safeTransferFrom(bob, admin, 1);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+        IERC721TokenFacet(address(facet)).safeTransferFrom(bob, admin, 1, "");
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+        IERC721TokenFacet(address(facet)).mint(bob, 2);
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+        IERC721TokenFacet(address(facet)).safeMint(bob, 2, "");
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+        IERC721TokenFacet(address(facet)).burn(1);
+    }
+
+    function testSupportsFacetAndControlInterfaces() public {
+        _erc721Init(address(facet));
+
+        assertTrue(IERC721TokenFacet(address(facet)).supportsInterface(type(IERC165).interfaceId), "erc165 unsupported");
+        assertTrue(IERC721TokenFacet(address(facet)).supportsInterface(type(IERC721).interfaceId), "erc721 unsupported");
+        assertTrue(
+            IERC721TokenFacet(address(facet)).supportsInterface(type(IERC721Metadata).interfaceId),
+            "erc721 metadata unsupported"
+        );
+        assertTrue(
+            IERC721TokenFacet(address(facet)).supportsInterface(type(IAccessControl).interfaceId),
+            "access control unsupported"
+        );
+        assertTrue(
+            IERC721TokenFacet(address(facet)).supportsInterface(type(IPausable).interfaceId), "pausable unsupported"
+        );
+        assertTrue(
+            IERC721TokenFacet(address(facet)).supportsInterface(type(IERC721TokenFacet).interfaceId),
+            "facet interface unsupported"
+        );
+    }
+
+    function testDiamondRoutingAndInitWorkThroughFallback() public {
+        _addErc721FacetToDiamond();
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(diamond)).initializeErc721("Facet NFT", "FNFT", "ipfs://facet/", admin);
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(diamond)).mint(bob, 1);
+
+        VM.prank(bob);
+        IERC721TokenFacet(address(diamond)).approve(eve, 1);
+
+        VM.prank(eve);
+        IERC721TokenFacet(address(diamond)).transferFrom(bob, admin, 1);
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(diamond)).setApprovalForAll(eve, true);
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(diamond)).safeMint(address(receiver), 2, hex"cafe");
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(diamond)).mint(admin, 3);
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(diamond)).safeTransferFrom(admin, address(receiver), 3);
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(diamond)).setTokenURI(1, "ipfs://facet/custom-1");
+
+        assertTrue(IERC721TokenFacet(address(diamond)).isErc721Initialized(), "diamond erc721 should initialize");
+        assertTrue(IERC721TokenFacet(address(diamond)).ownerOf(1) == admin, "diamond owner mismatch");
+        assertTrue(IERC721TokenFacet(address(diamond)).ownerOf(2) == address(receiver), "diamond safe mint mismatch");
+        assertTrue(
+            IERC721TokenFacet(address(diamond)).ownerOf(3) == address(receiver), "diamond safe transfer mismatch"
+        );
+        assertTrue(IERC721TokenFacet(address(diamond)).balanceOf(admin) == 1, "diamond admin balance mismatch");
+        assertTrue(IERC721TokenFacet(address(diamond)).totalSupply() == 3, "diamond total supply mismatch");
+        assertTrue(
+            keccak256(bytes(IERC721TokenFacet(address(diamond)).tokenURI(1)))
+                == keccak256(bytes("ipfs://facet/custom-1")),
+            "diamond token uri mismatch"
+        );
+        assertTrue(
+            IERC721TokenFacet(address(diamond))
+                .hasRole(IERC721TokenFacet(address(diamond)).ERC721_METADATA_ROLE(), admin),
+            "diamond metadata role missing"
+        );
+    }
+
+    function testDiamondReinitializeReverts() public {
+        _addErc721FacetToDiamond();
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(diamond)).initializeErc721("Facet NFT", "FNFT", "ipfs://facet/", admin);
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IERC721TokenBase.ERC721TokenAlreadyInitialized.selector));
+        IERC721TokenFacet(address(diamond)).initializeErc721("Facet NFT", "FNFT", "ipfs://facet/", admin);
+    }
+}

--- a/test/TokenFacetFoundationCore.t.sol
+++ b/test/TokenFacetFoundationCore.t.sol
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC165} from "../src/interfaces/IERC165.sol";
+import {IERC20TokenBase} from "../src/interfaces/IERC20TokenBase.sol";
+import {IERC721} from "../src/interfaces/IERC721.sol";
+import {IERC721Metadata} from "../src/interfaces/IERC721Metadata.sol";
+import {IERC721Receiver} from "../src/interfaces/IERC721Receiver.sol";
+import {IERC721TokenBase} from "../src/interfaces/IERC721TokenBase.sol";
+import {TokenFacetFoundationFixture} from "./helpers/TokenFacetFoundationTestHarness.sol";
+
+contract TokenFacetFoundationCoreTest is TokenFacetFoundationFixture {
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+    event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
+
+    function testStorageSlotsAndConstantsAreDistinct() public pure {
+        assertTrue(erc20StorageSlot() != erc721StorageSlot(), "token storage slots should differ");
+        assertTrue(tokenAdminRole() != erc20MinterRole(), "token roles should differ");
+        assertTrue(erc20TransferScope() != erc721ApprovalScope(), "token pause scopes should differ");
+    }
+
+    function testErc20InitializerSetsMetadata() public {
+        erc20.initialize("Facet Token", "FTKN", 18);
+
+        assertTrue(erc20.isErc20Initialized(), "erc20 should initialize");
+        assertTrue(keccak256(bytes(erc20.name())) == keccak256(bytes("Facet Token")), "erc20 name should initialize");
+        assertTrue(keccak256(bytes(erc20.symbol())) == keccak256(bytes("FTKN")), "erc20 symbol should initialize");
+        assertTrue(erc20.decimals() == 18, "erc20 decimals should initialize");
+    }
+
+    function testErc20InitializerRevertsWhenCalledTwice() public {
+        erc20.initialize("Facet Token", "FTKN", 18);
+
+        VM.expectRevert(abi.encodeWithSelector(IERC20TokenBase.ERC20TokenAlreadyInitialized.selector));
+        erc20.initialize("Facet Token", "FTKN", 18);
+    }
+
+    function testErc20HelpersUpdateSupplyBalancesAndAllowance() public {
+        erc20.initialize("Facet Token", "FTKN", 18);
+
+        VM.expectEmit(true, true, false, true, address(erc20));
+        emit Transfer(address(0), admin, 100);
+        erc20.mint(admin, 100);
+
+        VM.expectEmit(true, true, false, true, address(erc20));
+        emit Approval(admin, bob, 40);
+        erc20.approveTokens(admin, bob, 40);
+
+        VM.expectEmit(true, true, false, true, address(erc20));
+        emit Approval(admin, bob, 15);
+        erc20.spendAllowance(admin, bob, 25);
+
+        VM.expectEmit(true, true, false, true, address(erc20));
+        emit Transfer(admin, eve, 55);
+        erc20.transferTokens(admin, eve, 55);
+
+        VM.expectEmit(true, true, false, true, address(erc20));
+        emit Transfer(admin, address(0), 15);
+        erc20.burn(admin, 15);
+
+        assertTrue(erc20.totalSupply() == 85, "erc20 total supply mismatch");
+        assertTrue(erc20.balanceOf(admin) == 30, "admin balance mismatch");
+        assertTrue(erc20.balanceOf(eve) == 55, "eve balance mismatch");
+        assertTrue(erc20.allowance(admin, bob) == 15, "allowance should decrement");
+    }
+
+    function testErc20InfiniteAllowanceDoesNotDecrement() public {
+        erc20.initialize("Facet Token", "FTKN", 18);
+        erc20.approveTokens(admin, bob, type(uint256).max);
+        erc20.spendAllowance(admin, bob, 50);
+
+        assertTrue(erc20.allowance(admin, bob) == type(uint256).max, "infinite allowance should remain unchanged");
+    }
+
+    function testErc20GuardsForUninitializedAndZeroAddress() public {
+        VM.expectRevert(abi.encodeWithSelector(IERC20TokenBase.ERC20TokenNotInitialized.selector));
+        erc20.mint(admin, 1);
+
+        erc20.initialize("Facet Token", "FTKN", 18);
+
+        VM.expectRevert(abi.encodeWithSelector(IERC20TokenBase.ERC20TokenZeroAddress.selector));
+        erc20.mint(address(0), 1);
+
+        erc20.mint(admin, 10);
+        VM.expectRevert(abi.encodeWithSelector(IERC20TokenBase.ERC20TokenInsufficientBalance.selector, admin, 10, 11));
+        erc20.burn(admin, 11);
+    }
+
+    function testErc721InitializerSetsMetadataAndSupportsInterfaces() public {
+        erc721.initialize("Facet NFT", "FNFT", "ipfs://facet/");
+
+        assertTrue(erc721.isErc721Initialized(), "erc721 should initialize");
+        assertTrue(keccak256(bytes(erc721.name())) == keccak256(bytes("Facet NFT")), "erc721 name should initialize");
+        assertTrue(keccak256(bytes(erc721.symbol())) == keccak256(bytes("FNFT")), "erc721 symbol should initialize");
+        assertTrue(erc721.supportsInterface(type(IERC165).interfaceId), "erc165 should be supported");
+        assertTrue(erc721.supportsInterface(type(IERC721).interfaceId), "erc721 should be supported");
+        assertTrue(erc721.supportsInterface(type(IERC721Metadata).interfaceId), "erc721 metadata should be supported");
+        assertFalse(erc721.supportsInterface(0xffffffff), "unexpected interface support");
+    }
+
+    function testErc721InitializerRevertsWhenCalledTwice() public {
+        erc721.initialize("Facet NFT", "FNFT", "ipfs://facet/");
+
+        VM.expectRevert(abi.encodeWithSelector(IERC721TokenBase.ERC721TokenAlreadyInitialized.selector));
+        erc721.initialize("Facet NFT", "FNFT", "ipfs://facet/");
+    }
+
+    function testErc721HelpersUpdateOwnershipApprovalsAndMetadata() public {
+        erc721.initialize("Facet NFT", "FNFT", "ipfs://facet/");
+
+        erc721.mint(admin, 1);
+
+        erc721.approveToken(bob, 1);
+
+        VM.expectEmit(true, true, false, true, address(erc721));
+        emit ApprovalForAll(admin, eve, true);
+        erc721.setApprovalForAll(admin, eve, true);
+
+        erc721.setTokenURI(1, "ipfs://facet/custom-1");
+        assertTrue(
+            keccak256(bytes(erc721.tokenURI(1))) == keccak256(bytes("ipfs://facet/custom-1")),
+            "explicit token uri mismatch"
+        );
+
+        erc721.transferTokens(admin, eve, 1);
+
+        assertTrue(erc721.ownerOf(1) == eve, "owner should update");
+        assertTrue(erc721.balanceOf(admin) == 0, "admin nft balance should decrement");
+        assertTrue(erc721.balanceOf(eve) == 1, "eve nft balance should increment");
+        assertTrue(erc721.getApproved(1) == address(0), "approval should clear on transfer");
+        assertTrue(erc721.isApprovedOrOwner(eve, 1), "new owner should be approved or owner");
+    }
+
+    function testErc721TokenUriFallsBackToBaseUriPlusTokenId() public {
+        erc721.initialize("Facet NFT", "FNFT", "ipfs://facet/");
+        erc721.mint(admin, 7);
+
+        assertTrue(
+            keccak256(bytes(erc721.tokenURI(7))) == keccak256(bytes("ipfs://facet/7")),
+            "base uri fallback should append token id"
+        );
+
+        erc721.setBaseURI("https://example.com/meta/");
+        assertTrue(
+            keccak256(bytes(erc721.tokenURI(7))) == keccak256(bytes("https://example.com/meta/7")),
+            "updated base uri should be reflected"
+        );
+    }
+
+    function testErc721SafeTransferCallsReceiver() public {
+        bytes memory payload = hex"1234";
+
+        erc721.initialize("Facet NFT", "FNFT", "ipfs://facet/");
+        erc721.mint(admin, 1);
+        erc721.safeTransferTokens(admin, address(receiver), 1, payload);
+
+        assertTrue(erc721.ownerOf(1) == address(receiver), "receiver should own token");
+        assertTrue(receiver.lastOperator() == address(this), "receiver should record operator");
+        assertTrue(receiver.lastFrom() == admin, "receiver should record sender");
+        assertTrue(receiver.lastTokenId() == 1, "receiver should record token id");
+        assertTrue(keccak256(receiver.lastData()) == keccak256(payload), "receiver should record data");
+    }
+
+    function testErc721SafeTransferRejectorReverts() public {
+        erc721.initialize("Facet NFT", "FNFT", "ipfs://facet/");
+        erc721.mint(admin, 1);
+
+        VM.expectRevert(abi.encodeWithSelector(IERC721TokenBase.ERC721TokenUnsafeReceiver.selector, address(rejector)));
+        erc721.safeTransferTokens(admin, address(rejector), 1, "");
+    }
+
+    function testErc721BurnClearsOwnershipAndSupply() public {
+        erc721.initialize("Facet NFT", "FNFT", "ipfs://facet/");
+        erc721.mint(admin, 1);
+
+        erc721.burn(1);
+
+        assertTrue(erc721.totalSupply() == 0, "erc721 total supply should decrement");
+        assertTrue(erc721.balanceOf(admin) == 0, "erc721 owner balance should decrement");
+
+        VM.expectRevert(abi.encodeWithSelector(IERC721TokenBase.ERC721TokenNonexistentToken.selector, 1));
+        erc721.ownerOf(1);
+    }
+
+    function testErc721GuardsForZeroAddressAndInvalidOperator() public {
+        VM.expectRevert(abi.encodeWithSelector(IERC721TokenBase.ERC721TokenNotInitialized.selector));
+        erc721.mint(admin, 1);
+
+        erc721.initialize("Facet NFT", "FNFT", "ipfs://facet/");
+
+        VM.expectRevert(abi.encodeWithSelector(IERC721TokenBase.ERC721TokenZeroAddress.selector));
+        erc721.mint(address(0), 1);
+
+        VM.expectRevert(abi.encodeWithSelector(IERC721TokenBase.ERC721TokenInvalidOwner.selector, address(0)));
+        erc721.balanceOf(address(0));
+
+        VM.expectRevert(abi.encodeWithSelector(IERC721TokenBase.ERC721TokenInvalidOperator.selector, admin, admin));
+        erc721.setApprovalForAll(admin, admin, true);
+    }
+}

--- a/test/helpers/AccessControlTestHarness.sol
+++ b/test/helpers/AccessControlTestHarness.sol
@@ -8,6 +8,9 @@ interface Vm {
     function startPrank(address) external;
     function stopPrank() external;
     function assume(bool) external;
+    function addr(uint256) external returns (address);
+    function sign(uint256, bytes32) external returns (uint8, bytes32, bytes32);
+    function expectRevert(bytes4) external;
     function expectRevert(bytes calldata) external;
     function expectEmit(bool, bool, bool, bool) external;
     function expectEmit(bool, bool, bool, bool, address) external;

--- a/test/helpers/DiamondTokenDeploymentTestHarness.sol
+++ b/test/helpers/DiamondTokenDeploymentTestHarness.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
+import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
+import {IDiamondLoupe} from "../../src/interfaces/IDiamondLoupe.sol";
+import {IERC165} from "../../src/interfaces/IERC165.sol";
+import {IERC20Metadata} from "../../src/interfaces/IERC20Metadata.sol";
+import {IERC20TokenFacet} from "../../src/interfaces/IERC20TokenFacet.sol";
+import {IERC721} from "../../src/interfaces/IERC721.sol";
+import {IERC721Metadata} from "../../src/interfaces/IERC721Metadata.sol";
+import {IERC721TokenBase} from "../../src/interfaces/IERC721TokenBase.sol";
+import {IERC721TokenFacet} from "../../src/interfaces/IERC721TokenFacet.sol";
+import {ERC20TokenFacet} from "../../src/token/facets/ERC20TokenFacet.sol";
+import {ERC721TokenFacet} from "../../src/token/facets/ERC721TokenFacet.sol";
+import {LibDiamond} from "../../src/diamond/libraries/LibDiamond.sol";
+import {LibTokenFacetDeploymentSelectors} from "../../src/token/libraries/LibTokenFacetDeploymentSelectors.sol";
+import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+
+abstract contract DiamondTokenDeploymentFixture is TestBase {
+    address internal admin = address(0xA11CE);
+
+    DiamondCutFacet internal cutFacet;
+    DiamondLoupeFacet internal loupeFacet;
+    ERC20TokenFacet internal erc20Facet;
+    ERC721TokenFacet internal erc721Facet;
+    DiamondProxyHarness internal diamond;
+
+    function setUp() public virtual {
+        cutFacet = new DiamondCutFacet();
+        loupeFacet = new DiamondLoupeFacet();
+        erc20Facet = new ERC20TokenFacet();
+        erc721Facet = new ERC721TokenFacet();
+        diamond = new DiamondProxyHarness(admin, address(cutFacet));
+
+        _installLoupeFacet();
+    }
+
+    function _installLoupeFacet() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(loupeFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibTokenFacetDeploymentSelectors.loupeSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installErc20HostFacet() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(erc20Facet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibTokenFacetDeploymentSelectors.erc20HostSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installErc721HostFacet() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(erc721Facet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibTokenFacetDeploymentSelectors.erc721HostSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _containsAddress(address[] memory addresses, address expected) internal pure returns (bool) {
+        for (uint256 i = 0; i < addresses.length; i++) {
+            if (addresses[i] == expected) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/test/helpers/DiamondTokenHostHardeningTestHarness.sol
+++ b/test/helpers/DiamondTokenHostHardeningTestHarness.sol
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
+import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
+import {IERC20Metadata} from "../../src/interfaces/IERC20Metadata.sol";
+import {IERC20Permit} from "../../src/interfaces/IERC20Permit.sol";
+import {IERC20TokenFacet} from "../../src/interfaces/IERC20TokenFacet.sol";
+import {IERC721TokenBase} from "../../src/interfaces/IERC721TokenBase.sol";
+import {IERC721TokenFacet} from "../../src/interfaces/IERC721TokenFacet.sol";
+import {ERC20TokenFacet} from "../../src/token/facets/ERC20TokenFacet.sol";
+import {ERC721TokenFacet} from "../../src/token/facets/ERC721TokenFacet.sol";
+import {LibTokenFacetDeploymentSelectors} from "../../src/token/libraries/LibTokenFacetDeploymentSelectors.sol";
+import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+
+interface IFacetVersionMarker {
+    function facetVersion() external view returns (uint256);
+}
+
+contract ERC20TokenFacetReplacement is ERC20TokenFacet {
+    function facetVersion() external pure returns (uint256) {
+        return 2;
+    }
+}
+
+contract ERC721TokenFacetReplacement is ERC721TokenFacet {
+    function facetVersion() external pure returns (uint256) {
+        return 2;
+    }
+}
+
+abstract contract DiamondTokenHostHardeningFixture is TestBase {
+    bytes32 internal constant PERMIT_TYPEHASH =
+        keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+    uint256 internal constant ADMIN_PK = uint256(keccak256("erc20-facet-admin"));
+    uint256 internal constant BOB_PK = uint256(keccak256("erc20-facet-bob"));
+    uint256 internal constant EVE_PK = uint256(keccak256("erc20-facet-eve"));
+    uint256 internal constant CAROL_PK = uint256(keccak256("erc20-facet-carol"));
+    uint256 internal constant DAVE_PK = uint256(keccak256("erc20-facet-dave"));
+
+    address internal admin;
+    address internal bob;
+    address internal eve;
+    address internal carol;
+    address internal dave;
+
+    DiamondCutFacet internal cutFacet;
+    DiamondLoupeFacet internal loupeFacet;
+    ERC20TokenFacet internal erc20Facet;
+    ERC20TokenFacetReplacement internal erc20Replacement;
+    ERC721TokenFacet internal erc721Facet;
+    ERC721TokenFacetReplacement internal erc721Replacement;
+    DiamondProxyHarness internal diamond;
+
+    function setUp() public virtual {
+        admin = VM.addr(ADMIN_PK);
+        bob = VM.addr(BOB_PK);
+        eve = VM.addr(EVE_PK);
+        carol = VM.addr(CAROL_PK);
+        dave = VM.addr(DAVE_PK);
+
+        cutFacet = new DiamondCutFacet();
+        loupeFacet = new DiamondLoupeFacet();
+        erc20Facet = new ERC20TokenFacet();
+        erc20Replacement = new ERC20TokenFacetReplacement();
+        erc721Facet = new ERC721TokenFacet();
+        erc721Replacement = new ERC721TokenFacetReplacement();
+        diamond = new DiamondProxyHarness(admin, address(cutFacet));
+
+        _installLoupeFacet();
+    }
+
+    function _installLoupeFacet() internal {
+        _addFacet(address(loupeFacet), LibTokenFacetDeploymentSelectors.loupeSelectors());
+    }
+
+    function _installErc20HostFacet(address facetAddress_) internal {
+        _addFacet(facetAddress_, LibTokenFacetDeploymentSelectors.erc20HostSelectors());
+    }
+
+    function _installErc721HostFacet(address facetAddress_) internal {
+        _addFacet(facetAddress_, LibTokenFacetDeploymentSelectors.erc721HostSelectors());
+    }
+
+    function _replaceErc20HostFacet(address facetAddress_) internal {
+        _replaceFacet(facetAddress_, LibTokenFacetDeploymentSelectors.erc20HostSelectors());
+    }
+
+    function _replaceErc721HostFacet(address facetAddress_) internal {
+        _replaceFacet(facetAddress_, LibTokenFacetDeploymentSelectors.erc721HostSelectors());
+    }
+
+    function _addErc20ReplacementMarker(address facetAddress_) internal {
+        _addFacet(facetAddress_, _markerSelectors());
+    }
+
+    function _addErc721ReplacementMarker(address facetAddress_) internal {
+        _addFacet(facetAddress_, _markerSelectors());
+    }
+
+    function _removeErc20HostFacetWithMarker() internal {
+        _removeSelectors(_concat(LibTokenFacetDeploymentSelectors.erc20HostSelectors(), _markerSelectors()));
+    }
+
+    function _removeErc721HostFacetWithMarker() internal {
+        _removeSelectors(_concat(LibTokenFacetDeploymentSelectors.erc721HostSelectors(), _markerSelectors()));
+    }
+
+    function _reAddErc20HostFacetWithMarker(address facetAddress_) internal {
+        _addFacet(facetAddress_, _concat(LibTokenFacetDeploymentSelectors.erc20HostSelectors(), _markerSelectors()));
+    }
+
+    function _reAddErc721HostFacetWithMarker(address facetAddress_) internal {
+        _addFacet(facetAddress_, _concat(LibTokenFacetDeploymentSelectors.erc721HostSelectors(), _markerSelectors()));
+    }
+
+    function _erc20InitDiamond() internal {
+        IERC20TokenFacet(address(diamond)).initializeErc20("Facet Token", "FTKN", 18, admin);
+    }
+
+    function _erc721InitDiamond() internal {
+        IERC721TokenFacet(address(diamond)).initializeErc721("Facet NFT", "FNFT", "ipfs://facet/", admin);
+    }
+
+    function _seedErc20HostState() internal {
+        IERC20TokenFacet token = IERC20TokenFacet(address(diamond));
+        bytes32 tokenAdminRole = token.TOKEN_ADMIN_ROLE();
+        bytes32 approvalScope = token.ERC20_APPROVAL_SCOPE();
+
+        VM.prank(admin);
+        token.mint(bob, 100);
+        VM.prank(admin);
+        token.mint(carol, 50);
+
+        VM.prank(bob);
+        token.approve(eve, 25);
+
+        uint256 deadline = block.timestamp + 1 days;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(address(diamond), bob, dave, 40, token.nonces(bob), deadline);
+        token.permit(bob, dave, 40, deadline, v, r, s);
+
+        VM.prank(admin);
+        token.grantRole(tokenAdminRole, eve);
+
+        VM.prank(admin);
+        token.pauseScope(approvalScope);
+    }
+
+    function _seedErc721HostState() internal {
+        IERC721TokenFacet token = IERC721TokenFacet(address(diamond));
+        bytes32 metadataRole = token.ERC721_METADATA_ROLE();
+        bytes32 approvalScope = token.ERC721_APPROVAL_SCOPE();
+        bytes32 transferScope = token.ERC721_TRANSFER_SCOPE();
+
+        VM.prank(admin);
+        token.mint(bob, 1);
+        VM.prank(admin);
+        token.mint(carol, 2);
+
+        VM.prank(bob);
+        token.approve(eve, 1);
+        VM.prank(bob);
+        token.setApprovalForAll(dave, true);
+
+        VM.prank(admin);
+        token.setTokenURI(1, "ipfs://facet/custom-1");
+
+        VM.prank(admin);
+        token.grantRole(metadataRole, eve);
+
+        VM.prank(admin);
+        token.pauseScope(approvalScope);
+        VM.prank(admin);
+        token.pauseScope(transferScope);
+    }
+
+    function _permitDigest(
+        address target,
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 nonce,
+        uint256 deadline
+    ) internal view returns (bytes32) {
+        bytes32 structHash = keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, nonce, deadline));
+        return keccak256(abi.encodePacked("\x19\x01", IERC20Permit(target).DOMAIN_SEPARATOR(), structHash));
+    }
+
+    function _signPermit(
+        address target,
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 nonce,
+        uint256 deadline
+    ) internal returns (uint8 v, bytes32 r, bytes32 s) {
+        return VM.sign(_privateKeyFor(owner), _permitDigest(target, owner, spender, value, nonce, deadline));
+    }
+
+    function _privateKeyFor(address actor) internal view returns (uint256) {
+        if (actor == admin) return ADMIN_PK;
+        if (actor == bob) return BOB_PK;
+        if (actor == eve) return EVE_PK;
+        if (actor == carol) return CAROL_PK;
+        if (actor == dave) return DAVE_PK;
+        revert("unknown actor");
+    }
+
+    function _actor(uint8 seed) internal view returns (address) {
+        uint256 normalized = uint256(seed) % 5;
+        if (normalized == 0) return admin;
+        if (normalized == 1) return bob;
+        if (normalized == 2) return eve;
+        if (normalized == 3) return carol;
+        return dave;
+    }
+
+    function _actorExcluding(address excluded, uint8 seed) internal view returns (address actor) {
+        actor = _actor(seed);
+        if (actor == excluded) {
+            actor = _actor(seed + 1);
+        }
+    }
+
+    function _markerSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](1);
+        selectors[0] = IFacetVersionMarker.facetVersion.selector;
+    }
+
+    function _addFacet(address facetAddress_, bytes4[] memory selectors) internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: facetAddress_, action: IDiamondCut.FacetCutAction.Add, functionSelectors: selectors
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _replaceFacet(address facetAddress_, bytes4[] memory selectors) internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: facetAddress_, action: IDiamondCut.FacetCutAction.Replace, functionSelectors: selectors
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _removeSelectors(bytes4[] memory selectors) internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(0), action: IDiamondCut.FacetCutAction.Remove, functionSelectors: selectors
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _assertMissingSelector(bytes memory callData, string memory reason) internal {
+        (bool success,) = address(diamond).call(callData);
+        assertTrue(!success, reason);
+    }
+
+    function _concat(bytes4[] memory first, bytes4[] memory second) internal pure returns (bytes4[] memory combined) {
+        combined = new bytes4[](first.length + second.length);
+
+        uint256 i;
+        for (; i < first.length; i++) {
+            combined[i] = first[i];
+        }
+
+        for (uint256 j = 0; j < second.length; j++) {
+            combined[i + j] = second[j];
+        }
+    }
+
+    function _erc721Exists(uint256 tokenId) internal view returns (bool) {
+        try IERC721TokenFacet(address(diamond)).ownerOf(tokenId) returns (address) {
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    function _erc721OwnerOrZero(uint256 tokenId) internal view returns (address owner) {
+        try IERC721TokenFacet(address(diamond)).ownerOf(tokenId) returns (address owner_) {
+            return owner_;
+        } catch {
+            return address(0);
+        }
+    }
+
+    function _erc721ApprovalOrZero(uint256 tokenId) internal view returns (address approved) {
+        try IERC721TokenFacet(address(diamond)).getApproved(tokenId) returns (address approved_) {
+            return approved_;
+        } catch {
+            return address(0);
+        }
+    }
+
+    function _expectNonexistentToken(uint256 tokenId) internal {
+        VM.expectRevert(abi.encodeWithSelector(IERC721TokenBase.ERC721TokenNonexistentToken.selector, tokenId));
+        IERC721TokenFacet(address(diamond)).ownerOf(tokenId);
+    }
+}

--- a/test/helpers/ERC20TokenFacetInvariantTestHarness.sol
+++ b/test/helpers/ERC20TokenFacetInvariantTestHarness.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC20TokenFacet} from "../../src/interfaces/IERC20TokenFacet.sol";
+import {ERC20TokenFacetFixture} from "./ERC20TokenFacetTestHarness.sol";
+
+abstract contract ERC20TokenFacetInvariantFixture is ERC20TokenFacetFixture {
+    struct AccountingSnapshot {
+        uint256 totalSupply;
+        uint256 totalTrackedBalances;
+    }
+
+    uint256 internal constant ACTOR_COUNT = 4;
+    uint256 internal constant INITIAL_BALANCE = 1_000_000;
+
+    address[ACTOR_COUNT] internal actors;
+    uint256[ACTOR_COUNT] internal actorKeys;
+    mapping(address => uint256) internal trackedPermitSuccesses;
+
+    function setUp() public virtual override {
+        super.setUp();
+        _erc20Init(address(facet));
+
+        actors[0] = bob;
+        actors[1] = eve;
+        actors[2] = carol;
+        actors[3] = dave;
+
+        actorKeys[0] = BOB_PK;
+        actorKeys[1] = EVE_PK;
+        actorKeys[2] = CAROL_PK;
+        actorKeys[3] = DAVE_PK;
+
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            VM.prank(admin);
+            IERC20TokenFacet(address(facet)).mint(actors[i], INITIAL_BALANCE);
+        }
+    }
+
+    function _actor(uint8 seed) internal view returns (address) {
+        return actors[uint256(seed) % ACTOR_COUNT];
+    }
+
+    function _actorKey(uint8 seed) internal view returns (uint256) {
+        return actorKeys[uint256(seed) % ACTOR_COUNT];
+    }
+
+    function _boundAmount(uint256 raw, uint256 max) internal pure returns (uint256) {
+        if (max == 0) {
+            return 0;
+        }
+        return (raw % max) + 1;
+    }
+
+    function _sumTrackedBalances() internal view returns (uint256 sum) {
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            sum += IERC20TokenFacet(address(facet)).balanceOf(actors[i]);
+        }
+    }
+
+    function _snapshotAccounting() internal view returns (AccountingSnapshot memory snapshot) {
+        snapshot.totalSupply = IERC20TokenFacet(address(facet)).totalSupply();
+        snapshot.totalTrackedBalances = _sumTrackedBalances();
+    }
+
+    function _assertAccountingUnchanged(AccountingSnapshot memory snapshot, string memory reason) internal view {
+        assertTrue(IERC20TokenFacet(address(facet)).totalSupply() == snapshot.totalSupply, reason);
+        assertTrue(_sumTrackedBalances() == snapshot.totalTrackedBalances, reason);
+    }
+}

--- a/test/helpers/ERC20TokenFacetTestHarness.sol
+++ b/test/helpers/ERC20TokenFacetTestHarness.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
+import {IAccessControl} from "../../src/interfaces/IAccessControl.sol";
+import {IERC20} from "../../src/interfaces/IERC20.sol";
+import {IERC20Metadata} from "../../src/interfaces/IERC20Metadata.sol";
+import {IERC20TokenBase} from "../../src/interfaces/IERC20TokenBase.sol";
+import {IERC20TokenFacet} from "../../src/interfaces/IERC20TokenFacet.sol";
+import {IPausable} from "../../src/interfaces/IPausable.sol";
+import {ERC20TokenFacet} from "../../src/token/facets/ERC20TokenFacet.sol";
+import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+
+abstract contract ERC20TokenFacetFixture is TestBase {
+    address internal admin = address(0xA11CE);
+    address internal bob = address(0xB0B);
+    address internal eve = address(0xE11E);
+
+    ERC20TokenFacet internal facet;
+    DiamondCutFacet internal cutFacet;
+    DiamondProxyHarness internal diamond;
+
+    function setUp() public virtual {
+        facet = new ERC20TokenFacet();
+        cutFacet = new DiamondCutFacet();
+        diamond = new DiamondProxyHarness(admin, address(cutFacet));
+    }
+
+    function _erc20Init(address target) internal {
+        IERC20TokenFacet(target).initializeErc20("Facet Token", "FTKN", 18, admin);
+    }
+
+    function _addErc20FacetToDiamond() internal {
+        bytes4[] memory selectors = new bytes4[](26);
+        selectors[0] = IERC20TokenFacet.initializeErc20.selector;
+        selectors[1] = IERC20Metadata.name.selector;
+        selectors[2] = IERC20Metadata.symbol.selector;
+        selectors[3] = IERC20Metadata.decimals.selector;
+        selectors[4] = IERC20.totalSupply.selector;
+        selectors[5] = IERC20.balanceOf.selector;
+        selectors[6] = IERC20.allowance.selector;
+        selectors[7] = IERC20.transfer.selector;
+        selectors[8] = IERC20.approve.selector;
+        selectors[9] = IERC20.transferFrom.selector;
+        selectors[10] = IERC20TokenFacet.mint.selector;
+        selectors[11] = IERC20TokenFacet.burn.selector;
+        selectors[12] = IERC20TokenBase.isErc20Initialized.selector;
+        selectors[13] = IAccessControl.DEFAULT_ADMIN_ROLE.selector;
+        selectors[14] = IPausable.PAUSER_ROLE.selector;
+        selectors[15] = IERC20TokenFacet.TOKEN_ADMIN_ROLE.selector;
+        selectors[16] = IERC20TokenFacet.ERC20_MINTER_ROLE.selector;
+        selectors[17] = IERC20TokenFacet.ERC20_BURNER_ROLE.selector;
+        selectors[18] = IERC20TokenFacet.ERC20_TRANSFER_SCOPE.selector;
+        selectors[19] = IERC20TokenFacet.ERC20_APPROVAL_SCOPE.selector;
+        selectors[20] = IAccessControl.hasRole.selector;
+        selectors[21] = IAccessControl.getRoleAdmin.selector;
+        selectors[22] = IAccessControl.grantRole.selector;
+        selectors[23] = IPausable.pauseScope.selector;
+        selectors[24] = IPausable.unpauseScope.selector;
+        selectors[25] = IPausable.scopePaused.selector;
+
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(facet), action: IDiamondCut.FacetCutAction.Add, functionSelectors: selectors
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+}

--- a/test/helpers/ERC20TokenFacetTestHarness.sol
+++ b/test/helpers/ERC20TokenFacetTestHarness.sol
@@ -5,6 +5,7 @@ import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
 import {IAccessControl} from "../../src/interfaces/IAccessControl.sol";
 import {IERC20} from "../../src/interfaces/IERC20.sol";
 import {IERC20Metadata} from "../../src/interfaces/IERC20Metadata.sol";
+import {IERC20Permit} from "../../src/interfaces/IERC20Permit.sol";
 import {IERC20TokenBase} from "../../src/interfaces/IERC20TokenBase.sol";
 import {IERC20TokenFacet} from "../../src/interfaces/IERC20TokenFacet.sol";
 import {IPausable} from "../../src/interfaces/IPausable.sol";
@@ -14,15 +15,31 @@ import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
 import {TestBase} from "./AccessControlTestHarness.sol";
 
 abstract contract ERC20TokenFacetFixture is TestBase {
-    address internal admin = address(0xA11CE);
-    address internal bob = address(0xB0B);
-    address internal eve = address(0xE11E);
+    bytes32 internal constant PERMIT_TYPEHASH =
+        keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+    uint256 internal constant ADMIN_PK = uint256(keccak256("erc20-facet-admin"));
+    uint256 internal constant BOB_PK = uint256(keccak256("erc20-facet-bob"));
+    uint256 internal constant EVE_PK = uint256(keccak256("erc20-facet-eve"));
+    uint256 internal constant CAROL_PK = uint256(keccak256("erc20-facet-carol"));
+    uint256 internal constant DAVE_PK = uint256(keccak256("erc20-facet-dave"));
+
+    address internal admin;
+    address internal bob;
+    address internal eve;
+    address internal carol;
+    address internal dave;
 
     ERC20TokenFacet internal facet;
     DiamondCutFacet internal cutFacet;
     DiamondProxyHarness internal diamond;
 
     function setUp() public virtual {
+        admin = VM.addr(ADMIN_PK);
+        bob = VM.addr(BOB_PK);
+        eve = VM.addr(EVE_PK);
+        carol = VM.addr(CAROL_PK);
+        dave = VM.addr(DAVE_PK);
+
         facet = new ERC20TokenFacet();
         cutFacet = new DiamondCutFacet();
         diamond = new DiamondProxyHarness(admin, address(cutFacet));
@@ -33,7 +50,7 @@ abstract contract ERC20TokenFacetFixture is TestBase {
     }
 
     function _addErc20FacetToDiamond() internal {
-        bytes4[] memory selectors = new bytes4[](26);
+        bytes4[] memory selectors = new bytes4[](29);
         selectors[0] = IERC20TokenFacet.initializeErc20.selector;
         selectors[1] = IERC20Metadata.name.selector;
         selectors[2] = IERC20Metadata.symbol.selector;
@@ -60,6 +77,9 @@ abstract contract ERC20TokenFacetFixture is TestBase {
         selectors[23] = IPausable.pauseScope.selector;
         selectors[24] = IPausable.unpauseScope.selector;
         selectors[25] = IPausable.scopePaused.selector;
+        selectors[26] = IERC20Permit.permit.selector;
+        selectors[27] = IERC20Permit.nonces.selector;
+        selectors[28] = IERC20Permit.DOMAIN_SEPARATOR.selector;
 
         IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
         cut[0] = IDiamondCut.FacetCut({
@@ -68,5 +88,43 @@ abstract contract ERC20TokenFacetFixture is TestBase {
 
         VM.prank(admin);
         IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _permitDigest(
+        address target,
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 nonce,
+        uint256 deadline
+    ) internal view returns (bytes32) {
+        bytes32 structHash = keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, nonce, deadline));
+        return keccak256(abi.encodePacked("\x19\x01", IERC20Permit(target).DOMAIN_SEPARATOR(), structHash));
+    }
+
+    function _signPermit(
+        uint256 ownerKey,
+        address target,
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 nonce,
+        uint256 deadline
+    ) internal returns (uint8 v, bytes32 r, bytes32 s) {
+        return VM.sign(ownerKey, _permitDigest(target, owner, spender, value, nonce, deadline));
+    }
+
+    function _recoverPermitSigner(
+        address target,
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 nonce,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) internal view returns (address) {
+        return ecrecover(_permitDigest(target, owner, spender, value, nonce, deadline), v, r, s);
     }
 }

--- a/test/helpers/ERC20TokenFacetTestHarness.sol
+++ b/test/helpers/ERC20TokenFacetTestHarness.sol
@@ -2,15 +2,11 @@
 pragma solidity ^0.8.30;
 
 import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
-import {IAccessControl} from "../../src/interfaces/IAccessControl.sol";
-import {IERC20} from "../../src/interfaces/IERC20.sol";
-import {IERC20Metadata} from "../../src/interfaces/IERC20Metadata.sol";
 import {IERC20Permit} from "../../src/interfaces/IERC20Permit.sol";
-import {IERC20TokenBase} from "../../src/interfaces/IERC20TokenBase.sol";
 import {IERC20TokenFacet} from "../../src/interfaces/IERC20TokenFacet.sol";
-import {IPausable} from "../../src/interfaces/IPausable.sol";
 import {ERC20TokenFacet} from "../../src/token/facets/ERC20TokenFacet.sol";
 import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
+import {LibTokenFacetDeploymentSelectors} from "../../src/token/libraries/LibTokenFacetDeploymentSelectors.sol";
 import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
 import {TestBase} from "./AccessControlTestHarness.sol";
 
@@ -50,40 +46,11 @@ abstract contract ERC20TokenFacetFixture is TestBase {
     }
 
     function _addErc20FacetToDiamond() internal {
-        bytes4[] memory selectors = new bytes4[](29);
-        selectors[0] = IERC20TokenFacet.initializeErc20.selector;
-        selectors[1] = IERC20Metadata.name.selector;
-        selectors[2] = IERC20Metadata.symbol.selector;
-        selectors[3] = IERC20Metadata.decimals.selector;
-        selectors[4] = IERC20.totalSupply.selector;
-        selectors[5] = IERC20.balanceOf.selector;
-        selectors[6] = IERC20.allowance.selector;
-        selectors[7] = IERC20.transfer.selector;
-        selectors[8] = IERC20.approve.selector;
-        selectors[9] = IERC20.transferFrom.selector;
-        selectors[10] = IERC20TokenFacet.mint.selector;
-        selectors[11] = IERC20TokenFacet.burn.selector;
-        selectors[12] = IERC20TokenBase.isErc20Initialized.selector;
-        selectors[13] = IAccessControl.DEFAULT_ADMIN_ROLE.selector;
-        selectors[14] = IPausable.PAUSER_ROLE.selector;
-        selectors[15] = IERC20TokenFacet.TOKEN_ADMIN_ROLE.selector;
-        selectors[16] = IERC20TokenFacet.ERC20_MINTER_ROLE.selector;
-        selectors[17] = IERC20TokenFacet.ERC20_BURNER_ROLE.selector;
-        selectors[18] = IERC20TokenFacet.ERC20_TRANSFER_SCOPE.selector;
-        selectors[19] = IERC20TokenFacet.ERC20_APPROVAL_SCOPE.selector;
-        selectors[20] = IAccessControl.hasRole.selector;
-        selectors[21] = IAccessControl.getRoleAdmin.selector;
-        selectors[22] = IAccessControl.grantRole.selector;
-        selectors[23] = IPausable.pauseScope.selector;
-        selectors[24] = IPausable.unpauseScope.selector;
-        selectors[25] = IPausable.scopePaused.selector;
-        selectors[26] = IERC20Permit.permit.selector;
-        selectors[27] = IERC20Permit.nonces.selector;
-        selectors[28] = IERC20Permit.DOMAIN_SEPARATOR.selector;
-
         IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
         cut[0] = IDiamondCut.FacetCut({
-            facetAddress: address(facet), action: IDiamondCut.FacetCutAction.Add, functionSelectors: selectors
+            facetAddress: address(facet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibTokenFacetDeploymentSelectors.erc20HostSelectors()
         });
 
         VM.prank(admin);

--- a/test/helpers/ERC721TokenFacetTestHarness.sol
+++ b/test/helpers/ERC721TokenFacetTestHarness.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "../../src/interfaces/IAccessControl.sol";
+import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
+import {IERC165} from "../../src/interfaces/IERC165.sol";
+import {IERC721} from "../../src/interfaces/IERC721.sol";
+import {IERC721Metadata} from "../../src/interfaces/IERC721Metadata.sol";
+import {IERC721Receiver} from "../../src/interfaces/IERC721Receiver.sol";
+import {IERC721TokenBase} from "../../src/interfaces/IERC721TokenBase.sol";
+import {IERC721TokenFacet} from "../../src/interfaces/IERC721TokenFacet.sol";
+import {IPausable} from "../../src/interfaces/IPausable.sol";
+import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
+import {ERC721TokenFacet} from "../../src/token/facets/ERC721TokenFacet.sol";
+import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+import {ERC721ReceiverMock, ERC721ReceiverRejector} from "./TokenFacetFoundationTestHarness.sol";
+
+abstract contract ERC721TokenFacetFixture is TestBase {
+    address internal admin = address(0xA11CE);
+    address internal bob = address(0xB0B);
+    address internal eve = address(0xE11E);
+    address internal carol = address(0xCA401);
+
+    ERC721TokenFacet internal facet;
+    DiamondCutFacet internal cutFacet;
+    DiamondProxyHarness internal diamond;
+    ERC721ReceiverMock internal receiver;
+    ERC721ReceiverRejector internal rejector;
+
+    function setUp() public virtual {
+        facet = new ERC721TokenFacet();
+        cutFacet = new DiamondCutFacet();
+        diamond = new DiamondProxyHarness(admin, address(cutFacet));
+        receiver = new ERC721ReceiverMock(IERC721Receiver.onERC721Received.selector);
+        rejector = new ERC721ReceiverRejector();
+    }
+
+    function _erc721Init(address target) internal {
+        IERC721TokenFacet(target).initializeErc721("Facet NFT", "FNFT", "ipfs://facet/", admin);
+    }
+
+    function _addErc721FacetToDiamond() internal {
+        bytes4[] memory selectors = new bytes4[](35);
+        selectors[0] = IERC721TokenFacet.initializeErc721.selector;
+        selectors[1] = IERC721.balanceOf.selector;
+        selectors[2] = IERC721.ownerOf.selector;
+        selectors[3] = IERC721.approve.selector;
+        selectors[4] = IERC721.getApproved.selector;
+        selectors[5] = IERC721.setApprovalForAll.selector;
+        selectors[6] = IERC721.isApprovedForAll.selector;
+        selectors[7] = IERC721.transferFrom.selector;
+        selectors[8] = bytes4(keccak256("safeTransferFrom(address,address,uint256)"));
+        selectors[9] = bytes4(keccak256("safeTransferFrom(address,address,uint256,bytes)"));
+        selectors[10] = IERC721Metadata.tokenURI.selector;
+        selectors[11] = IERC721Metadata.name.selector;
+        selectors[12] = IERC721Metadata.symbol.selector;
+        selectors[13] = IERC721TokenFacet.totalSupply.selector;
+        selectors[14] = IERC721TokenBase.isErc721Initialized.selector;
+        selectors[15] = IERC721TokenFacet.mint.selector;
+        selectors[16] = IERC721TokenFacet.safeMint.selector;
+        selectors[17] = IERC721TokenFacet.burn.selector;
+        selectors[18] = IERC721TokenFacet.setBaseURI.selector;
+        selectors[19] = IERC721TokenFacet.setTokenURI.selector;
+        selectors[20] = IAccessControl.DEFAULT_ADMIN_ROLE.selector;
+        selectors[21] = IPausable.PAUSER_ROLE.selector;
+        selectors[22] = IERC721TokenFacet.TOKEN_ADMIN_ROLE.selector;
+        selectors[23] = IERC721TokenFacet.ERC721_MINTER_ROLE.selector;
+        selectors[24] = IERC721TokenFacet.ERC721_BURNER_ROLE.selector;
+        selectors[25] = IERC721TokenFacet.ERC721_METADATA_ROLE.selector;
+        selectors[26] = IERC721TokenFacet.ERC721_TRANSFER_SCOPE.selector;
+        selectors[27] = IERC721TokenFacet.ERC721_APPROVAL_SCOPE.selector;
+        selectors[28] = IAccessControl.hasRole.selector;
+        selectors[29] = IAccessControl.getRoleAdmin.selector;
+        selectors[30] = IAccessControl.grantRole.selector;
+        selectors[31] = IPausable.pauseScope.selector;
+        selectors[32] = IPausable.unpauseScope.selector;
+        selectors[33] = IPausable.scopePaused.selector;
+        selectors[34] = IERC165.supportsInterface.selector;
+
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(facet), action: IDiamondCut.FacetCutAction.Add, functionSelectors: selectors
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+}

--- a/test/helpers/ERC721TokenFacetTestHarness.sol
+++ b/test/helpers/ERC721TokenFacetTestHarness.sol
@@ -1,17 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
-import {IAccessControl} from "../../src/interfaces/IAccessControl.sol";
 import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
-import {IERC165} from "../../src/interfaces/IERC165.sol";
-import {IERC721} from "../../src/interfaces/IERC721.sol";
-import {IERC721Metadata} from "../../src/interfaces/IERC721Metadata.sol";
 import {IERC721Receiver} from "../../src/interfaces/IERC721Receiver.sol";
-import {IERC721TokenBase} from "../../src/interfaces/IERC721TokenBase.sol";
 import {IERC721TokenFacet} from "../../src/interfaces/IERC721TokenFacet.sol";
-import {IPausable} from "../../src/interfaces/IPausable.sol";
 import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
 import {ERC721TokenFacet} from "../../src/token/facets/ERC721TokenFacet.sol";
+import {LibTokenFacetDeploymentSelectors} from "../../src/token/libraries/LibTokenFacetDeploymentSelectors.sol";
 import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
 import {TestBase} from "./AccessControlTestHarness.sol";
 import {ERC721ReceiverMock, ERC721ReceiverRejector} from "./TokenFacetFoundationTestHarness.sol";
@@ -41,46 +36,11 @@ abstract contract ERC721TokenFacetFixture is TestBase {
     }
 
     function _addErc721FacetToDiamond() internal {
-        bytes4[] memory selectors = new bytes4[](35);
-        selectors[0] = IERC721TokenFacet.initializeErc721.selector;
-        selectors[1] = IERC721.balanceOf.selector;
-        selectors[2] = IERC721.ownerOf.selector;
-        selectors[3] = IERC721.approve.selector;
-        selectors[4] = IERC721.getApproved.selector;
-        selectors[5] = IERC721.setApprovalForAll.selector;
-        selectors[6] = IERC721.isApprovedForAll.selector;
-        selectors[7] = IERC721.transferFrom.selector;
-        selectors[8] = bytes4(keccak256("safeTransferFrom(address,address,uint256)"));
-        selectors[9] = bytes4(keccak256("safeTransferFrom(address,address,uint256,bytes)"));
-        selectors[10] = IERC721Metadata.tokenURI.selector;
-        selectors[11] = IERC721Metadata.name.selector;
-        selectors[12] = IERC721Metadata.symbol.selector;
-        selectors[13] = IERC721TokenFacet.totalSupply.selector;
-        selectors[14] = IERC721TokenBase.isErc721Initialized.selector;
-        selectors[15] = IERC721TokenFacet.mint.selector;
-        selectors[16] = IERC721TokenFacet.safeMint.selector;
-        selectors[17] = IERC721TokenFacet.burn.selector;
-        selectors[18] = IERC721TokenFacet.setBaseURI.selector;
-        selectors[19] = IERC721TokenFacet.setTokenURI.selector;
-        selectors[20] = IAccessControl.DEFAULT_ADMIN_ROLE.selector;
-        selectors[21] = IPausable.PAUSER_ROLE.selector;
-        selectors[22] = IERC721TokenFacet.TOKEN_ADMIN_ROLE.selector;
-        selectors[23] = IERC721TokenFacet.ERC721_MINTER_ROLE.selector;
-        selectors[24] = IERC721TokenFacet.ERC721_BURNER_ROLE.selector;
-        selectors[25] = IERC721TokenFacet.ERC721_METADATA_ROLE.selector;
-        selectors[26] = IERC721TokenFacet.ERC721_TRANSFER_SCOPE.selector;
-        selectors[27] = IERC721TokenFacet.ERC721_APPROVAL_SCOPE.selector;
-        selectors[28] = IAccessControl.hasRole.selector;
-        selectors[29] = IAccessControl.getRoleAdmin.selector;
-        selectors[30] = IAccessControl.grantRole.selector;
-        selectors[31] = IPausable.pauseScope.selector;
-        selectors[32] = IPausable.unpauseScope.selector;
-        selectors[33] = IPausable.scopePaused.selector;
-        selectors[34] = IERC165.supportsInterface.selector;
-
         IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
         cut[0] = IDiamondCut.FacetCut({
-            facetAddress: address(facet), action: IDiamondCut.FacetCutAction.Add, functionSelectors: selectors
+            facetAddress: address(facet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibTokenFacetDeploymentSelectors.erc721HostSelectors()
         });
 
         VM.prank(admin);

--- a/test/helpers/TokenFacetFoundationTestHarness.sol
+++ b/test/helpers/TokenFacetFoundationTestHarness.sol
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC165} from "../../src/interfaces/IERC165.sol";
+import {IERC721Receiver} from "../../src/interfaces/IERC721Receiver.sol";
+import {ERC20TokenBase} from "../../src/token/ERC20TokenBase.sol";
+import {ERC721TokenBase} from "../../src/token/ERC721TokenBase.sol";
+import {LibERC20TokenStorage} from "../../src/token/storage/LibERC20TokenStorage.sol";
+import {LibERC721TokenStorage} from "../../src/token/storage/LibERC721TokenStorage.sol";
+import {LibTokenFacetConstants} from "../../src/token/libraries/LibTokenFacetConstants.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+
+contract ERC20TokenBaseHarness is ERC20TokenBase {
+    function initialize(string calldata tokenName, string calldata tokenSymbol, uint8 tokenDecimals) external {
+        _initializeErc20Token(tokenName, tokenSymbol, tokenDecimals);
+    }
+
+    function transfer(address to, uint256 value) external returns (bool) {
+        _transferTokens(msg.sender, to, value);
+        return true;
+    }
+
+    function approve(address spender, uint256 value) external returns (bool) {
+        _setAllowance(msg.sender, spender, value);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 value) external returns (bool) {
+        _spendAllowance(from, msg.sender, value);
+        _transferTokens(from, to, value);
+        return true;
+    }
+
+    function mint(address to, uint256 value) external {
+        _mintTokens(to, value);
+    }
+
+    function burn(address from, uint256 value) external {
+        _burnTokens(from, value);
+    }
+
+    function transferTokens(address from, address to, uint256 value) external {
+        _transferTokens(from, to, value);
+    }
+
+    function approveTokens(address owner, address spender, uint256 value) external {
+        _setAllowance(owner, spender, value);
+    }
+
+    function spendAllowance(address owner, address spender, uint256 value) external {
+        _spendAllowance(owner, spender, value);
+    }
+}
+
+contract ERC721TokenBaseHarness is ERC721TokenBase {
+    function initialize(string calldata tokenName, string calldata tokenSymbol, string calldata baseUri) external {
+        _initializeErc721Token(tokenName, tokenSymbol, baseUri);
+    }
+
+    function safeTransferFrom(address from, address to, uint256 tokenId) external {
+        _safeTransferToken(from, to, tokenId, "");
+    }
+
+    function transferFrom(address from, address to, uint256 tokenId) external {
+        _transferToken(from, to, tokenId);
+    }
+
+    function approve(address to, uint256 tokenId) external {
+        _approveToken(to, tokenId);
+    }
+
+    function setApprovalForAll(address operator, bool approved) external {
+        _setApprovalForAll(msg.sender, operator, approved);
+    }
+
+    function safeTransferFrom(address from, address to, uint256 tokenId, bytes calldata data) external {
+        _safeTransferToken(from, to, tokenId, data);
+    }
+
+    function mint(address to, uint256 tokenId) external {
+        _mintToken(to, tokenId);
+    }
+
+    function safeMint(address to, uint256 tokenId, bytes calldata data) external {
+        _safeMintToken(to, tokenId, data);
+    }
+
+    function burn(uint256 tokenId) external {
+        _burnToken(tokenId);
+    }
+
+    function transferTokens(address from, address to, uint256 tokenId) external {
+        _transferToken(from, to, tokenId);
+    }
+
+    function safeTransferTokens(address from, address to, uint256 tokenId, bytes calldata data) external {
+        _safeTransferToken(from, to, tokenId, data);
+    }
+
+    function approveToken(address to, uint256 tokenId) external {
+        _approveToken(to, tokenId);
+    }
+
+    function setApprovalForAll(address owner, address operator, bool approved) external {
+        _setApprovalForAll(owner, operator, approved);
+    }
+
+    function setBaseURI(string calldata baseUri) external {
+        _setBaseURI(baseUri);
+    }
+
+    function setTokenURI(uint256 tokenId, string calldata uri) external {
+        _setTokenURI(tokenId, uri);
+    }
+
+    function isApprovedOrOwner(address spender, uint256 tokenId) external view returns (bool) {
+        return _isApprovedOrOwner(spender, tokenId);
+    }
+
+    function supportsInterface(bytes4 interfaceId) public view override returns (bool) {
+        return super.supportsInterface(interfaceId);
+    }
+}
+
+contract ERC721ReceiverMock is IERC721Receiver {
+    bytes4 internal _response;
+    address internal _lastOperator;
+    address internal _lastFrom;
+    uint256 internal _lastTokenId;
+    bytes internal _lastData;
+
+    constructor(bytes4 response_) {
+        _response = response_;
+    }
+
+    function onERC721Received(address operator, address from, uint256 tokenId, bytes calldata data)
+        external
+        returns (bytes4)
+    {
+        _lastOperator = operator;
+        _lastFrom = from;
+        _lastTokenId = tokenId;
+        _lastData = data;
+        return _response;
+    }
+
+    function lastOperator() external view returns (address) {
+        return _lastOperator;
+    }
+
+    function lastFrom() external view returns (address) {
+        return _lastFrom;
+    }
+
+    function lastTokenId() external view returns (uint256) {
+        return _lastTokenId;
+    }
+
+    function lastData() external view returns (bytes memory) {
+        return _lastData;
+    }
+}
+
+contract ERC721ReceiverRejector {}
+
+abstract contract TokenFacetFoundationFixture is TestBase {
+    address internal admin = address(0xA11CE);
+    address internal bob = address(0xB0B);
+    address internal eve = address(0xE11E);
+
+    ERC20TokenBaseHarness internal erc20;
+    ERC721TokenBaseHarness internal erc721;
+    ERC721ReceiverMock internal receiver;
+    ERC721ReceiverRejector internal rejector;
+
+    function setUp() public virtual {
+        erc20 = new ERC20TokenBaseHarness();
+        erc721 = new ERC721TokenBaseHarness();
+        receiver = new ERC721ReceiverMock(IERC721Receiver.onERC721Received.selector);
+        rejector = new ERC721ReceiverRejector();
+    }
+
+    function erc20StorageSlot() public pure returns (bytes32) {
+        return LibERC20TokenStorage.STORAGE_SLOT;
+    }
+
+    function erc721StorageSlot() public pure returns (bytes32) {
+        return LibERC721TokenStorage.STORAGE_SLOT;
+    }
+
+    function tokenAdminRole() public pure returns (bytes32) {
+        return LibTokenFacetConstants.TOKEN_ADMIN_ROLE;
+    }
+
+    function erc20MinterRole() public pure returns (bytes32) {
+        return LibTokenFacetConstants.ERC20_MINTER_ROLE;
+    }
+
+    function erc721MetadataRole() public pure returns (bytes32) {
+        return LibTokenFacetConstants.ERC721_METADATA_ROLE;
+    }
+
+    function erc20TransferScope() public pure returns (bytes32) {
+        return LibTokenFacetConstants.ERC20_TRANSFER_SCOPE;
+    }
+
+    function erc721ApprovalScope() public pure returns (bytes32) {
+        return LibTokenFacetConstants.ERC721_APPROVAL_SCOPE;
+    }
+
+    function supportsErc721(bytes4 interfaceId) public view returns (bool) {
+        return erc721.supportsInterface(interfaceId);
+    }
+
+    function supportsErc165(bytes4 interfaceId) public pure returns (bool) {
+        return interfaceId == type(IERC165).interfaceId;
+    }
+}


### PR DESCRIPTION
## Summary
- add a shared token facet foundation for hosted ERC20 and ERC721 modules, including diamond-safe storage, initializer/idempotency patterns, and shared token roles/scopes
- implement hosted ERC20 and ERC721 token facets with the required metadata, initialization, and control-plane integration for diamond deployments
- add deployment/integration coverage for installing token facets into the diamond and validating selector ownership, storage isolation, and ERC165 surface expectations
- harden the hosted token system with cross-facet routing, storage, and invariant coverage, then document token facet usage and safety assumptions

## Included Work
- closes #80 Shared token facet foundation
- closes #81 Implement ERC20 facet core
- closes #82 Add ERC20 Permit and ERC20 compliance coverage
- closes #83 Implement ERC721 facet core + metadata
- closes #84 Add diamond token deployment and init integration
- closes #85 Add cross-facet routing, storage, and token invariant coverage
- closes #86 Document diamond token usage and safety assumptions

## Validation
- `forge test --offline`
- token facet targeted and integration suites added in this milestone
- diamond routing, init, and storage isolation checks pass for hosted token facets

## Outcome
- ERC20 and ERC721 token standards can be hosted behind the diamond with dedicated storage layouts and controlled initialization
- token facets compose with the existing diamond, access control, pausability, and hardening foundations
- docs explain token facet init flow, selector/storage assumptions, and upgrade safety expectations

## Milestone
- Diamond Token Facets (#48)