### PR TITLE
Implement ERC20 token facet core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: stable
+          version: 1.4.3
 
       - name: Cache Foundry Artifacts
         uses: actions/cache@v4

--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: stable
+          version: 1.4.3
 
       - name: Run Slither (fail on high)
         uses: crytic/slither-action@v0.4.1

--- a/.github/workflows/system-hardening.yml
+++ b/.github/workflows/system-hardening.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: stable
+          version: 1.4.3
 
       - name: Cache Foundry Artifacts
         uses: actions/cache@v4
@@ -64,7 +64,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: stable
+          version: 1.4.3
 
       - name: Cache Foundry Artifacts
         uses: actions/cache@v4

--- a/src/interfaces/IERC20TokenFacet.sol
+++ b/src/interfaces/IERC20TokenFacet.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "./IAccessControl.sol";
+import {IERC20Metadata} from "./IERC20Metadata.sol";
+import {IERC20TokenBase} from "./IERC20TokenBase.sol";
+import {IPausable} from "./IPausable.sol";
+
+/// @title IERC20TokenFacet
+/// @notice Hosted ERC-20 facet surface for diamond deployments.
+interface IERC20TokenFacet is IERC20Metadata, IERC20TokenBase, IAccessControl, IPausable {
+    /// @notice Returns the shared token admin role identifier.
+    /// @return The role identifier.
+    function TOKEN_ADMIN_ROLE() external view returns (bytes32);
+
+    /// @notice Returns the ERC-20 minter role identifier.
+    /// @return The role identifier.
+    function ERC20_MINTER_ROLE() external view returns (bytes32);
+
+    /// @notice Returns the ERC-20 burner role identifier.
+    /// @return The role identifier.
+    function ERC20_BURNER_ROLE() external view returns (bytes32);
+
+    /// @notice Returns the ERC-20 transfer pause scope identifier.
+    /// @return The scope identifier.
+    function ERC20_TRANSFER_SCOPE() external view returns (bytes32);
+
+    /// @notice Returns the ERC-20 approval pause scope identifier.
+    /// @return The scope identifier.
+    function ERC20_APPROVAL_SCOPE() external view returns (bytes32);
+
+    /// @notice Initializes the hosted ERC-20 facet.
+    /// @param tokenName Token name.
+    /// @param tokenSymbol Token symbol.
+    /// @param tokenDecimals Token decimals.
+    /// @param admin Admin account seeded into the shared control plane.
+    function initializeErc20(
+        string calldata tokenName,
+        string calldata tokenSymbol,
+        uint8 tokenDecimals,
+        address admin
+    ) external;
+
+    /// @notice Mints `value` tokens to `to`.
+    /// @param to Recipient account.
+    /// @param value Amount to mint.
+    function mint(address to, uint256 value) external;
+
+    /// @notice Burns `value` tokens from `from`.
+    /// @param from Token holder.
+    /// @param value Amount to burn.
+    function burn(address from, uint256 value) external;
+}

--- a/src/token/TokenFacetControl.sol
+++ b/src/token/TokenFacetControl.sol
@@ -1,0 +1,312 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "../interfaces/IAccessControl.sol";
+import {IERC165} from "../interfaces/IERC165.sol";
+import {IPausable} from "../interfaces/IPausable.sol";
+import {LibAccessControlStorage} from "../access/storage/LibAccessControlStorage.sol";
+import {LibPausableStorage} from "../access/storage/LibPausableStorage.sol";
+
+/// @title TokenFacetControl
+/// @notice Constructor-free access control and pausability layer for hosted token facets.
+abstract contract TokenFacetControl is IAccessControl, IPausable {
+    /// @notice Default admin for all roles unless overridden.
+    bytes32 public constant DEFAULT_ADMIN_ROLE = 0x00;
+
+    /// @notice Role required to call `pause` and `unpause`.
+    bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
+
+    /// @dev Reverts if the caller is missing `role`.
+    modifier onlyRole(bytes32 role) {
+        _checkRole(role, msg.sender);
+        _;
+    }
+
+    /// @dev Reverts when contract is paused.
+    modifier whenNotPaused() {
+        _requireNotPaused();
+        _;
+    }
+
+    /// @dev Reverts when the given pause `scope` is effectively paused.
+    modifier whenScopeNotPaused(bytes32 scope) {
+        _requireScopeNotPaused(scope);
+        _;
+    }
+
+    /// @notice Returns true if `account` has been granted `role`.
+    /// @param role The role to query.
+    /// @param account The account to query.
+    /// @return True if the account has the role.
+    function hasRole(bytes32 role, address account) public view returns (bool) {
+        return LibAccessControlStorage.layout().roles[role].members[account];
+    }
+
+    /// @notice Returns the admin role that controls `role`.
+    /// @param role The role to query.
+    /// @return The admin role for `role`.
+    function getRoleAdmin(bytes32 role) public view returns (bytes32) {
+        return LibAccessControlStorage.layout().roles[role].adminRole;
+    }
+
+    /// @notice Returns the role member at `index`.
+    /// @param role The role to enumerate.
+    /// @param index The index in the role member array.
+    /// @return The account at the given index.
+    function getRoleMember(bytes32 role, uint256 index) public view returns (address) {
+        return LibAccessControlStorage.layout().roles[role].memberList[index];
+    }
+
+    /// @notice Returns the number of members for `role`.
+    /// @param role The role to enumerate.
+    /// @return The number of accounts in the role.
+    function getRoleMemberCount(bytes32 role) public view returns (uint256) {
+        return LibAccessControlStorage.layout().roles[role].memberList.length;
+    }
+
+    /// @notice Grants `role` to `account`.
+    /// @dev Caller must have ``getRoleAdmin(role)``.
+    /// @param role The role to grant.
+    /// @param account The account to grant the role to.
+    function grantRole(bytes32 role, address account) public onlyRole(getRoleAdmin(role)) {
+        _grantRole(role, account);
+    }
+
+    /// @notice Revokes `role` from `account`.
+    /// @dev Caller must have ``getRoleAdmin(role)``.
+    /// @param role The role to revoke.
+    /// @param account The account to revoke the role from.
+    function revokeRole(bytes32 role, address account) public onlyRole(getRoleAdmin(role)) {
+        _revokeRole(role, account);
+    }
+
+    /// @notice Renounces `role` for `account`.
+    /// @dev Reverts unless `account == msg.sender`.
+    /// @param role The role to renounce.
+    /// @param account The account renouncing the role.
+    function renounceRole(bytes32 role, address account) public {
+        if (account != msg.sender) {
+            revert AccessControlRenounceSelfOnly();
+        }
+        _revokeRole(role, account);
+    }
+
+    /// @notice Returns true when the contract is paused.
+    /// @return True if paused.
+    function paused() public view returns (bool) {
+        return LibPausableStorage.layout().paused;
+    }
+
+    /// @notice Returns true when `scope` is effectively paused.
+    /// @dev Effective pause includes global pause override.
+    /// @param scope The scope identifier.
+    /// @return True if globally paused or scope paused.
+    function paused(bytes32 scope) public view returns (bool) {
+        return paused() || scopePaused(scope);
+    }
+
+    /// @notice Returns true when `scope` is locally paused.
+    /// @param scope The scope identifier.
+    /// @return True if the scope itself is paused.
+    function scopePaused(bytes32 scope) public view returns (bool) {
+        return LibPausableStorage.layout().pausedScopes[scope];
+    }
+
+    /// @notice Pauses the contract.
+    /// @dev Caller must have `PAUSER_ROLE`.
+    function pause() public onlyRole(PAUSER_ROLE) whenNotPaused {
+        LibPausableStorage.layout().paused = true;
+        emit Paused(msg.sender);
+    }
+
+    /// @notice Unpauses the contract.
+    /// @dev Caller must have `PAUSER_ROLE`.
+    function unpause() public onlyRole(PAUSER_ROLE) {
+        _requirePaused();
+        LibPausableStorage.layout().paused = false;
+        emit Unpaused(msg.sender);
+    }
+
+    /// @notice Pauses a specific scope.
+    /// @dev Caller must have `PAUSER_ROLE`.
+    /// @param scope The scope identifier.
+    function pauseScope(bytes32 scope) public onlyRole(PAUSER_ROLE) {
+        _requireValidScope(scope);
+        if (scopePaused(scope)) {
+            revert PausableScopeEnforcedPause(scope);
+        }
+        LibPausableStorage.layout().pausedScopes[scope] = true;
+        emit ScopePaused(scope, msg.sender);
+    }
+
+    /// @notice Unpauses a specific scope.
+    /// @dev Caller must have `PAUSER_ROLE`.
+    /// @param scope The scope identifier.
+    function unpauseScope(bytes32 scope) public onlyRole(PAUSER_ROLE) {
+        _requireValidScope(scope);
+        if (!scopePaused(scope)) {
+            revert PausableScopeExpectedPause(scope);
+        }
+        LibPausableStorage.layout().pausedScopes[scope] = false;
+        emit ScopeUnpaused(scope, msg.sender);
+    }
+
+    /// @notice Returns true if this contract implements `interfaceId`.
+    /// @param interfaceId The interface identifier.
+    /// @return True if the interface is supported.
+    function supportsInterface(bytes4 interfaceId) public view virtual returns (bool) {
+        return interfaceId == type(IERC165).interfaceId || interfaceId == type(IAccessControl).interfaceId
+            || interfaceId == type(IPausable).interfaceId;
+    }
+
+    /// @dev Initializes shared access control and pausability storage when needed.
+    /// @param initialAdmin The default admin and initial pauser.
+    function _initializeTokenFacetControl(address initialAdmin) internal {
+        if (!_isAccessControlInitialized()) {
+            _initializeAccessControl(initialAdmin);
+        }
+        if (!_isPausableInitialized()) {
+            _initializePausable(initialAdmin);
+        }
+    }
+
+    /// @dev Returns true if access control storage has already been initialized.
+    /// @return True if initialized.
+    function _isAccessControlInitialized() internal view returns (bool) {
+        return LibAccessControlStorage.layout().initialized;
+    }
+
+    /// @dev Returns true if pausability storage has already been initialized.
+    /// @return True if initialized.
+    function _isPausableInitialized() internal view returns (bool) {
+        return LibPausableStorage.layout().initialized;
+    }
+
+    /// @dev Initializes access control storage.
+    /// @param initialAdmin The account to receive DEFAULT_ADMIN_ROLE.
+    function _initializeAccessControl(address initialAdmin) internal {
+        LibAccessControlStorage.Layout storage layout = LibAccessControlStorage.layout();
+        if (layout.initialized) {
+            revert AccessControlAlreadyInitialized();
+        }
+        if (initialAdmin == address(0)) {
+            revert AccessControlZeroAdmin();
+        }
+
+        layout.initialized = true;
+        layout.roles[DEFAULT_ADMIN_ROLE].adminRole = DEFAULT_ADMIN_ROLE;
+        _grantRole(DEFAULT_ADMIN_ROLE, initialAdmin);
+    }
+
+    /// @dev Initializes pausable storage and grants `PAUSER_ROLE`.
+    /// @param initialPauser The account to receive `PAUSER_ROLE`.
+    function _initializePausable(address initialPauser) internal {
+        LibPausableStorage.Layout storage layout = LibPausableStorage.layout();
+        if (layout.initialized) {
+            revert PausableAlreadyInitialized();
+        }
+        _requireNonZeroAccount(initialPauser);
+
+        layout.initialized = true;
+        _grantRole(PAUSER_ROLE, initialPauser);
+    }
+
+    /// @dev Reverts with {AccessControlUnauthorized} if `account` lacks `role`.
+    /// @param role The required role.
+    /// @param account The account being checked.
+    function _checkRole(bytes32 role, address account) internal view {
+        if (!hasRole(role, account)) {
+            revert AccessControlUnauthorized(account, role);
+        }
+    }
+
+    /// @dev Updates the admin role for `role`.
+    /// @param role The role to update.
+    /// @param adminRole The new admin role.
+    function _setRoleAdmin(bytes32 role, bytes32 adminRole) internal {
+        LibAccessControlStorage.Layout storage layout = LibAccessControlStorage.layout();
+        bytes32 previousAdminRole = layout.roles[role].adminRole;
+        layout.roles[role].adminRole = adminRole;
+        emit RoleAdminChanged(role, previousAdminRole, adminRole);
+    }
+
+    /// @dev Grants `role` to `account` if not already granted.
+    /// @param role The role to grant.
+    /// @param account The account receiving the role.
+    function _grantRole(bytes32 role, address account) internal {
+        _requireNonZeroAccount(account);
+
+        LibAccessControlStorage.RoleData storage roleData = LibAccessControlStorage.layout().roles[role];
+        if (!roleData.members[account]) {
+            roleData.members[account] = true;
+            if (roleData.memberIndex[account] == 0) {
+                roleData.memberList.push(account);
+                roleData.memberIndex[account] = roleData.memberList.length;
+            }
+            emit RoleGranted(role, account, msg.sender);
+        }
+    }
+
+    /// @dev Revokes `role` from `account` if currently granted.
+    /// @param role The role to revoke.
+    /// @param account The account losing the role.
+    function _revokeRole(bytes32 role, address account) internal {
+        _requireNonZeroAccount(account);
+
+        LibAccessControlStorage.RoleData storage roleData = LibAccessControlStorage.layout().roles[role];
+        if (roleData.members[account]) {
+            roleData.members[account] = false;
+            uint256 index = roleData.memberIndex[account];
+            if (index != 0) {
+                uint256 lastIndex = roleData.memberList.length;
+                if (index != lastIndex) {
+                    address lastMember = roleData.memberList[lastIndex - 1];
+                    roleData.memberList[index - 1] = lastMember;
+                    roleData.memberIndex[lastMember] = index;
+                }
+                roleData.memberList.pop();
+                roleData.memberIndex[account] = 0;
+            }
+            emit RoleRevoked(role, account, msg.sender);
+        }
+    }
+
+    /// @dev Reverts when `account` is the zero address.
+    /// @param account The account to validate.
+    function _requireNonZeroAccount(address account) internal pure {
+        if (account == address(0)) {
+            revert AccessControlZeroAddressAccount();
+        }
+    }
+
+    /// @dev Reverts with {PausableEnforcedPause} when paused.
+    function _requireNotPaused() internal view {
+        if (paused()) {
+            revert PausableEnforcedPause();
+        }
+    }
+
+    /// @dev Reverts with {PausableExpectedPause} when unpaused.
+    function _requirePaused() internal view {
+        if (!paused()) {
+            revert PausableExpectedPause();
+        }
+    }
+
+    /// @dev Reverts with {PausableScopeEnforcedPause} when scope is effectively paused.
+    /// @param scope The scope identifier.
+    function _requireScopeNotPaused(bytes32 scope) internal view {
+        _requireValidScope(scope);
+        if (paused(scope)) {
+            revert PausableScopeEnforcedPause(scope);
+        }
+    }
+
+    /// @dev Reverts with {PausableZeroScope} when `scope` is zero.
+    /// @param scope The scope identifier.
+    function _requireValidScope(bytes32 scope) internal pure {
+        if (scope == bytes32(0)) {
+            revert PausableZeroScope();
+        }
+    }
+}

--- a/src/token/facets/ERC20TokenFacet.sol
+++ b/src/token/facets/ERC20TokenFacet.sol
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC20TokenFacet} from "../../interfaces/IERC20TokenFacet.sol";
+import {IERC165} from "../../interfaces/IERC165.sol";
+import {ERC20TokenBase} from "../ERC20TokenBase.sol";
+import {TokenFacetControl} from "../TokenFacetControl.sol";
+import {LibTokenFacetConstants} from "../libraries/LibTokenFacetConstants.sol";
+
+/// @title ERC20TokenFacet
+/// @notice Hosted ERC-20 + metadata facet with shared access control and pause integration.
+contract ERC20TokenFacet is ERC20TokenBase, TokenFacetControl, IERC20TokenFacet {
+    /// @notice Shared token admin role.
+    bytes32 public constant TOKEN_ADMIN_ROLE = LibTokenFacetConstants.TOKEN_ADMIN_ROLE;
+    /// @notice ERC-20 minter role.
+    bytes32 public constant ERC20_MINTER_ROLE = LibTokenFacetConstants.ERC20_MINTER_ROLE;
+    /// @notice ERC-20 burner role.
+    bytes32 public constant ERC20_BURNER_ROLE = LibTokenFacetConstants.ERC20_BURNER_ROLE;
+    /// @notice Pause scope for ERC-20 transfers.
+    bytes32 public constant ERC20_TRANSFER_SCOPE = LibTokenFacetConstants.ERC20_TRANSFER_SCOPE;
+    /// @notice Pause scope for ERC-20 approvals.
+    bytes32 public constant ERC20_APPROVAL_SCOPE = LibTokenFacetConstants.ERC20_APPROVAL_SCOPE;
+
+    /// @notice Initializes the hosted ERC-20 facet.
+    /// @param tokenName Token name.
+    /// @param tokenSymbol Token symbol.
+    /// @param tokenDecimals Token decimals.
+    /// @param admin Admin account seeded into the shared control plane.
+    function initializeErc20(
+        string calldata tokenName,
+        string calldata tokenSymbol,
+        uint8 tokenDecimals,
+        address admin
+    ) external {
+        if (isErc20Initialized()) {
+            revert ERC20TokenAlreadyInitialized();
+        }
+
+        if (_isAccessControlInitialized()) {
+            _checkRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        }
+
+        _initializeTokenFacetControl(admin);
+        _initializeErc20Token(tokenName, tokenSymbol, tokenDecimals);
+
+        _setRoleAdmin(TOKEN_ADMIN_ROLE, DEFAULT_ADMIN_ROLE);
+        _setRoleAdmin(ERC20_MINTER_ROLE, TOKEN_ADMIN_ROLE);
+        _setRoleAdmin(ERC20_BURNER_ROLE, TOKEN_ADMIN_ROLE);
+
+        _grantRole(TOKEN_ADMIN_ROLE, admin);
+        _grantRole(ERC20_MINTER_ROLE, admin);
+        _grantRole(ERC20_BURNER_ROLE, admin);
+        _grantRole(PAUSER_ROLE, admin);
+    }
+
+    /// @notice Transfers `value` tokens to `to`.
+    /// @param to Recipient account.
+    /// @param value Amount to transfer.
+    /// @return True if the transfer succeeded.
+    function transfer(address to, uint256 value) external whenScopeNotPaused(ERC20_TRANSFER_SCOPE) returns (bool) {
+        _transferTokens(msg.sender, to, value);
+        return true;
+    }
+
+    /// @notice Sets allowance from caller to `spender`.
+    /// @param spender Approved spender.
+    /// @param value New allowance amount.
+    /// @return True if the approval succeeded.
+    function approve(address spender, uint256 value) external whenScopeNotPaused(ERC20_APPROVAL_SCOPE) returns (bool) {
+        _setAllowance(msg.sender, spender, value);
+        return true;
+    }
+
+    /// @notice Transfers `value` tokens from `from` to `to` using allowance.
+    /// @param from Source account.
+    /// @param to Recipient account.
+    /// @param value Amount to transfer.
+    /// @return True if the transfer succeeded.
+    function transferFrom(address from, address to, uint256 value) external returns (bool) {
+        _requireScopeNotPaused(ERC20_APPROVAL_SCOPE);
+        _requireScopeNotPaused(ERC20_TRANSFER_SCOPE);
+        _spendAllowance(from, msg.sender, value);
+        _transferTokens(from, to, value);
+        return true;
+    }
+
+    /// @notice Mints `value` tokens to `to`.
+    /// @dev Caller must have `ERC20_MINTER_ROLE`.
+    /// @param to Recipient account.
+    /// @param value Amount to mint.
+    function mint(address to, uint256 value)
+        external
+        onlyRole(ERC20_MINTER_ROLE)
+        whenScopeNotPaused(ERC20_TRANSFER_SCOPE)
+    {
+        _mintTokens(to, value);
+    }
+
+    /// @notice Burns `value` tokens from `from`.
+    /// @dev Caller must have `ERC20_BURNER_ROLE`.
+    /// @param from Token holder.
+    /// @param value Amount to burn.
+    function burn(address from, uint256 value)
+        external
+        onlyRole(ERC20_BURNER_ROLE)
+        whenScopeNotPaused(ERC20_TRANSFER_SCOPE)
+    {
+        _burnTokens(from, value);
+    }
+
+    /// @notice Returns true if this contract implements `interfaceId`.
+    /// @param interfaceId The interface identifier.
+    /// @return True if supported.
+    function supportsInterface(bytes4 interfaceId) public view override(TokenFacetControl, IERC165) returns (bool) {
+        return interfaceId == type(IERC20TokenFacet).interfaceId || super.supportsInterface(interfaceId);
+    }
+}

--- a/test/ERC20TokenFacetCore.t.sol
+++ b/test/ERC20TokenFacetCore.t.sol
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
+import {IERC20TokenBase} from "../src/interfaces/IERC20TokenBase.sol";
+import {IERC20TokenFacet} from "../src/interfaces/IERC20TokenFacet.sol";
+import {IPausable} from "../src/interfaces/IPausable.sol";
+import {IERC165} from "../src/interfaces/IERC165.sol";
+import {ERC20TokenFacetFixture} from "./helpers/ERC20TokenFacetTestHarness.sol";
+
+contract ERC20TokenFacetCoreTest is ERC20TokenFacetFixture {
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    function testInitializeSeedsMetadataAndSharedRoles() public {
+        _erc20Init(address(facet));
+
+        assertTrue(IERC20TokenFacet(address(facet)).isErc20Initialized(), "facet should initialize");
+        assertTrue(
+            keccak256(bytes(IERC20TokenFacet(address(facet)).name())) == keccak256(bytes("Facet Token")),
+            "name mismatch"
+        );
+        assertTrue(
+            keccak256(bytes(IERC20TokenFacet(address(facet)).symbol())) == keccak256(bytes("FTKN")), "symbol mismatch"
+        );
+        assertTrue(IERC20TokenFacet(address(facet)).decimals() == 18, "decimals mismatch");
+        assertTrue(
+            IERC20TokenFacet(address(facet)).hasRole(IERC20TokenFacet(address(facet)).DEFAULT_ADMIN_ROLE(), admin),
+            "admin should have default admin role"
+        );
+        assertTrue(
+            IERC20TokenFacet(address(facet)).hasRole(IERC20TokenFacet(address(facet)).TOKEN_ADMIN_ROLE(), admin),
+            "admin should have token admin role"
+        );
+        assertTrue(
+            IERC20TokenFacet(address(facet)).hasRole(IERC20TokenFacet(address(facet)).ERC20_MINTER_ROLE(), admin),
+            "admin should have minter role"
+        );
+        assertTrue(
+            IERC20TokenFacet(address(facet)).hasRole(IERC20TokenFacet(address(facet)).ERC20_BURNER_ROLE(), admin),
+            "admin should have burner role"
+        );
+        assertTrue(
+            IERC20TokenFacet(address(facet)).hasRole(IERC20TokenFacet(address(facet)).PAUSER_ROLE(), admin),
+            "admin should have pauser role"
+        );
+        assertTrue(
+            IERC20TokenFacet(address(facet)).getRoleAdmin(IERC20TokenFacet(address(facet)).ERC20_MINTER_ROLE())
+                == IERC20TokenFacet(address(facet)).TOKEN_ADMIN_ROLE(),
+            "minter admin mismatch"
+        );
+        assertTrue(
+            IERC20TokenFacet(address(facet)).getRoleAdmin(IERC20TokenFacet(address(facet)).ERC20_BURNER_ROLE())
+                == IERC20TokenFacet(address(facet)).TOKEN_ADMIN_ROLE(),
+            "burner admin mismatch"
+        );
+    }
+
+    function testInitializeRevertsWhenCalledTwice() public {
+        _erc20Init(address(facet));
+
+        VM.expectRevert(abi.encodeWithSelector(IERC20TokenBase.ERC20TokenAlreadyInitialized.selector));
+        _erc20Init(address(facet));
+    }
+
+    function testMintBurnTransferAndApprovalFlows() public {
+        _erc20Init(address(facet));
+
+        VM.expectEmit(true, true, false, true, address(facet));
+        emit Transfer(address(0), bob, 100);
+        VM.prank(admin);
+        IERC20TokenFacet(address(facet)).mint(bob, 100);
+
+        VM.expectEmit(true, true, false, true, address(facet));
+        emit Approval(bob, eve, 45);
+        VM.prank(bob);
+        IERC20TokenFacet(address(facet)).approve(eve, 45);
+
+        VM.expectEmit(true, true, false, true, address(facet));
+        emit Transfer(bob, admin, 10);
+        VM.prank(bob);
+        IERC20TokenFacet(address(facet)).transfer(admin, 10);
+
+        VM.expectEmit(true, true, false, true, address(facet));
+        emit Approval(bob, eve, 20);
+        VM.prank(eve);
+        IERC20TokenFacet(address(facet)).transferFrom(bob, admin, 25);
+
+        VM.prank(admin);
+        IERC20TokenFacet(address(facet)).burn(bob, 20);
+
+        assertTrue(IERC20TokenFacet(address(facet)).totalSupply() == 80, "total supply mismatch");
+        assertTrue(IERC20TokenFacet(address(facet)).balanceOf(bob) == 45, "bob balance mismatch");
+        assertTrue(IERC20TokenFacet(address(facet)).balanceOf(admin) == 35, "admin balance mismatch");
+        assertTrue(IERC20TokenFacet(address(facet)).allowance(bob, eve) == 20, "allowance mismatch");
+    }
+
+    function testUnauthorizedMintAndBurnRevert() public {
+        _erc20Init(address(facet));
+
+        VM.startPrank(bob);
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorized.selector,
+                bob,
+                IERC20TokenFacet(address(facet)).ERC20_MINTER_ROLE()
+            )
+        );
+        IERC20TokenFacet(address(facet)).mint(bob, 1);
+        VM.stopPrank();
+
+        VM.startPrank(bob);
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorized.selector,
+                bob,
+                IERC20TokenFacet(address(facet)).ERC20_BURNER_ROLE()
+            )
+        );
+        IERC20TokenFacet(address(facet)).burn(admin, 1);
+        VM.stopPrank();
+    }
+
+    function testTransferScopePauseBlocksTransferAndMintBurn() public {
+        _erc20Init(address(facet));
+        bytes32 transferScope = IERC20TokenFacet(address(facet)).ERC20_TRANSFER_SCOPE();
+
+        VM.prank(admin);
+        IERC20TokenFacet(address(facet)).mint(bob, 50);
+        VM.startPrank(admin);
+        IERC20TokenFacet(address(facet)).pauseScope(transferScope);
+        VM.stopPrank();
+
+        VM.startPrank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+        IERC20TokenFacet(address(facet)).transfer(admin, 1);
+        VM.stopPrank();
+
+        VM.startPrank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+        IERC20TokenFacet(address(facet)).mint(bob, 1);
+        VM.stopPrank();
+
+        VM.startPrank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+        IERC20TokenFacet(address(facet)).burn(bob, 1);
+        VM.stopPrank();
+    }
+
+    function testApprovalScopePauseBlocksApproveAndTransferFrom() public {
+        _erc20Init(address(facet));
+        bytes32 approvalScope = IERC20TokenFacet(address(facet)).ERC20_APPROVAL_SCOPE();
+
+        VM.prank(admin);
+        IERC20TokenFacet(address(facet)).mint(bob, 50);
+        VM.startPrank(admin);
+        IERC20TokenFacet(address(facet)).pauseScope(approvalScope);
+        VM.stopPrank();
+
+        VM.startPrank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, approvalScope));
+        IERC20TokenFacet(address(facet)).approve(eve, 1);
+        VM.stopPrank();
+
+        VM.startPrank(admin);
+        IERC20TokenFacet(address(facet)).unpauseScope(approvalScope);
+        VM.stopPrank();
+
+        VM.prank(bob);
+        IERC20TokenFacet(address(facet)).approve(eve, 10);
+
+        VM.startPrank(admin);
+        IERC20TokenFacet(address(facet)).pauseScope(approvalScope);
+        VM.stopPrank();
+
+        VM.startPrank(eve);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, approvalScope));
+        IERC20TokenFacet(address(facet)).transferFrom(bob, admin, 1);
+        VM.stopPrank();
+    }
+
+    function testSupportsFacetAndControlInterfaces() public {
+        _erc20Init(address(facet));
+
+        assertTrue(IERC20TokenFacet(address(facet)).supportsInterface(type(IERC165).interfaceId), "erc165 unsupported");
+        assertTrue(
+            IERC20TokenFacet(address(facet)).supportsInterface(type(IAccessControl).interfaceId),
+            "access control unsupported"
+        );
+        assertTrue(
+            IERC20TokenFacet(address(facet)).supportsInterface(type(IPausable).interfaceId), "pausable unsupported"
+        );
+        assertTrue(
+            IERC20TokenFacet(address(facet)).supportsInterface(type(IERC20TokenFacet).interfaceId),
+            "facet interface unsupported"
+        );
+    }
+
+    function testDiamondRoutingAndInitWorkThroughFallback() public {
+        _addErc20FacetToDiamond();
+        bytes32 transferScope = IERC20TokenFacet(address(diamond)).ERC20_TRANSFER_SCOPE();
+
+        VM.prank(admin);
+        IERC20TokenFacet(address(diamond)).initializeErc20("Facet Token", "FTKN", 18, admin);
+
+        assertTrue(IERC20TokenFacet(address(diamond)).isErc20Initialized(), "diamond erc20 should initialize");
+        assertTrue(
+            keccak256(bytes(IERC20TokenFacet(address(diamond)).name())) == keccak256(bytes("Facet Token")),
+            "diamond name mismatch"
+        );
+
+        VM.prank(admin);
+        IERC20TokenFacet(address(diamond)).mint(bob, 120);
+
+        VM.prank(bob);
+        IERC20TokenFacet(address(diamond)).approve(eve, 50);
+
+        VM.prank(eve);
+        IERC20TokenFacet(address(diamond)).transferFrom(bob, admin, 20);
+
+        assertTrue(IERC20TokenFacet(address(diamond)).balanceOf(bob) == 100, "diamond bob balance mismatch");
+        assertTrue(IERC20TokenFacet(address(diamond)).balanceOf(admin) == 20, "diamond admin balance mismatch");
+        assertTrue(IERC20TokenFacet(address(diamond)).allowance(bob, eve) == 30, "diamond allowance mismatch");
+        assertTrue(
+            IERC20TokenFacet(address(diamond)).hasRole(IERC20TokenFacet(address(diamond)).ERC20_MINTER_ROLE(), admin),
+            "diamond admin should have minter role"
+        );
+
+        VM.startPrank(admin);
+        IERC20TokenFacet(address(diamond)).pauseScope(transferScope);
+        VM.stopPrank();
+
+        VM.startPrank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+        IERC20TokenFacet(address(diamond)).transfer(admin, 1);
+        VM.stopPrank();
+    }
+
+    function testDiamondReinitializeReverts() public {
+        _addErc20FacetToDiamond();
+
+        VM.prank(admin);
+        IERC20TokenFacet(address(diamond)).initializeErc20("Facet Token", "FTKN", 18, admin);
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IERC20TokenBase.ERC20TokenAlreadyInitialized.selector));
+        IERC20TokenFacet(address(diamond)).initializeErc20("Facet Token", "FTKN", 18, admin);
+    }
+}

--- a/test/helpers/ERC20TokenFacetTestHarness.sol
+++ b/test/helpers/ERC20TokenFacetTestHarness.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
+import {IAccessControl} from "../../src/interfaces/IAccessControl.sol";
+import {IERC20} from "../../src/interfaces/IERC20.sol";
+import {IERC20Metadata} from "../../src/interfaces/IERC20Metadata.sol";
+import {IERC20TokenBase} from "../../src/interfaces/IERC20TokenBase.sol";
+import {IERC20TokenFacet} from "../../src/interfaces/IERC20TokenFacet.sol";
+import {IPausable} from "../../src/interfaces/IPausable.sol";
+import {ERC20TokenFacet} from "../../src/token/facets/ERC20TokenFacet.sol";
+import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+
+abstract contract ERC20TokenFacetFixture is TestBase {
+    address internal admin = address(0xA11CE);
+    address internal bob = address(0xB0B);
+    address internal eve = address(0xE11E);
+
+    ERC20TokenFacet internal facet;
+    DiamondCutFacet internal cutFacet;
+    DiamondProxyHarness internal diamond;
+
+    function setUp() public virtual {
+        facet = new ERC20TokenFacet();
+        cutFacet = new DiamondCutFacet();
+        diamond = new DiamondProxyHarness(admin, address(cutFacet));
+    }
+
+    function _erc20Init(address target) internal {
+        IERC20TokenFacet(target).initializeErc20("Facet Token", "FTKN", 18, admin);
+    }
+
+    function _addErc20FacetToDiamond() internal {
+        bytes4[] memory selectors = new bytes4[](26);
+        selectors[0] = IERC20TokenFacet.initializeErc20.selector;
+        selectors[1] = IERC20Metadata.name.selector;
+        selectors[2] = IERC20Metadata.symbol.selector;
+        selectors[3] = IERC20Metadata.decimals.selector;
+        selectors[4] = IERC20.totalSupply.selector;
+        selectors[5] = IERC20.balanceOf.selector;
+        selectors[6] = IERC20.allowance.selector;
+        selectors[7] = IERC20.transfer.selector;
+        selectors[8] = IERC20.approve.selector;
+        selectors[9] = IERC20.transferFrom.selector;
+        selectors[10] = IERC20TokenFacet.mint.selector;
+        selectors[11] = IERC20TokenFacet.burn.selector;
+        selectors[12] = IERC20TokenBase.isErc20Initialized.selector;
+        selectors[13] = IAccessControl.DEFAULT_ADMIN_ROLE.selector;
+        selectors[14] = IPausable.PAUSER_ROLE.selector;
+        selectors[15] = IERC20TokenFacet.TOKEN_ADMIN_ROLE.selector;
+        selectors[16] = IERC20TokenFacet.ERC20_MINTER_ROLE.selector;
+        selectors[17] = IERC20TokenFacet.ERC20_BURNER_ROLE.selector;
+        selectors[18] = IERC20TokenFacet.ERC20_TRANSFER_SCOPE.selector;
+        selectors[19] = IERC20TokenFacet.ERC20_APPROVAL_SCOPE.selector;
+        selectors[20] = IAccessControl.hasRole.selector;
+        selectors[21] = IAccessControl.getRoleAdmin.selector;
+        selectors[22] = IAccessControl.grantRole.selector;
+        selectors[23] = IPausable.pauseScope.selector;
+        selectors[24] = IPausable.unpauseScope.selector;
+        selectors[25] = IPausable.scopePaused.selector;
+
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(facet), action: IDiamondCut.FacetCutAction.Add, functionSelectors: selectors
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+}


### PR DESCRIPTION
## Summary
- add the hosted ERC20 facet surface and shared token control layer
- integrate ERC20 core flows with shared access control and scoped pausability
- add direct and diamond-routed tests for init, routing, mint/burn, transfer, and pause behavior

## Included Work
- add `IERC20TokenFacet` for the hosted ERC20 facet API
- add `TokenFacetControl` to reuse shared ACL and pausability storage without constructor-based initialization
- add `ERC20TokenFacet` with `initializeErc20`, metadata views, transfer/approval flows, and role-gated mint/burn
- add focused fixture and core tests covering direct facet usage and fallback routing through the diamond

## Validation
- `forge test --offline --match-path test/ERC20TokenFacetCore.t.sol`
- `forge test --offline`

## Issue
- Closes #81