### PR TITLE
Add ERC20 Permit and compliance coverage

### DIFF
--- a/src/interfaces/IERC20TokenFacet.sol
+++ b/src/interfaces/IERC20TokenFacet.sol
@@ -3,12 +3,18 @@ pragma solidity ^0.8.30;
 
 import {IAccessControl} from "./IAccessControl.sol";
 import {IERC20Metadata} from "./IERC20Metadata.sol";
+import {IERC20Permit} from "./IERC20Permit.sol";
 import {IERC20TokenBase} from "./IERC20TokenBase.sol";
 import {IPausable} from "./IPausable.sol";
 
 /// @title IERC20TokenFacet
 /// @notice Hosted ERC-20 facet surface for diamond deployments.
-interface IERC20TokenFacet is IERC20Metadata, IERC20TokenBase, IAccessControl, IPausable {
+interface IERC20TokenFacet is IERC20Metadata, IERC20TokenBase, IERC20Permit, IAccessControl, IPausable {
+    /// @notice Thrown when a Permit signature is expired.
+    error ERC20PermitExpired(uint256 deadline, uint256 currentTimestamp);
+    /// @notice Thrown when a Permit signature does not recover the expected signer.
+    error ERC20PermitInvalidSigner(address signer, address owner);
+
     /// @notice Returns the shared token admin role identifier.
     /// @return The role identifier.
     function TOKEN_ADMIN_ROLE() external view returns (bytes32);

--- a/src/token/facets/ERC20TokenFacet.sol
+++ b/src/token/facets/ERC20TokenFacet.sol
@@ -2,14 +2,23 @@
 pragma solidity ^0.8.30;
 
 import {IERC20TokenFacet} from "../../interfaces/IERC20TokenFacet.sol";
+import {IERC20Permit} from "../../interfaces/IERC20Permit.sol";
 import {IERC165} from "../../interfaces/IERC165.sol";
 import {ERC20TokenBase} from "../ERC20TokenBase.sol";
 import {TokenFacetControl} from "../TokenFacetControl.sol";
 import {LibTokenFacetConstants} from "../libraries/LibTokenFacetConstants.sol";
+import {LibERC20TokenStorage} from "../storage/LibERC20TokenStorage.sol";
 
 /// @title ERC20TokenFacet
 /// @notice Hosted ERC-20 + metadata facet with shared access control and pause integration.
 contract ERC20TokenFacet is ERC20TokenBase, TokenFacetControl, IERC20TokenFacet {
+    bytes32 internal constant EIP712_DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    bytes32 internal constant PERMIT_TYPEHASH =
+        keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+    bytes32 internal constant VERSION_HASH = keccak256("1");
+    uint256 internal constant SECP256K1N_DIV_2 = 0x7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0;
+
     /// @notice Shared token admin role.
     bytes32 public constant TOKEN_ADMIN_ROLE = LibTokenFacetConstants.TOKEN_ADMIN_ROLE;
     /// @notice ERC-20 minter role.
@@ -42,6 +51,7 @@ contract ERC20TokenFacet is ERC20TokenBase, TokenFacetControl, IERC20TokenFacet 
 
         _initializeTokenFacetControl(admin);
         _initializeErc20Token(tokenName, tokenSymbol, tokenDecimals);
+        _initializePermitDomain(tokenName);
 
         _setRoleAdmin(TOKEN_ADMIN_ROLE, DEFAULT_ADMIN_ROLE);
         _setRoleAdmin(ERC20_MINTER_ROLE, TOKEN_ADMIN_ROLE);
@@ -108,10 +118,79 @@ contract ERC20TokenFacet is ERC20TokenBase, TokenFacetControl, IERC20TokenFacet 
         _burnTokens(from, value);
     }
 
+    /// @notice Sets allowance with a signed Permit approval.
+    /// @param owner Token owner.
+    /// @param spender Approved spender.
+    /// @param value Allowance amount.
+    /// @param deadline Signature expiration timestamp.
+    /// @param v Recovery identifier.
+    /// @param r Signature component.
+    /// @param s Signature component.
+    function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s)
+        external
+        whenScopeNotPaused(ERC20_APPROVAL_SCOPE)
+    {
+        if (block.timestamp > deadline) {
+            revert ERC20PermitExpired(deadline, block.timestamp);
+        }
+
+        LibERC20TokenStorage.Layout storage layout = LibERC20TokenStorage.layout();
+        uint256 nonce = layout.nonces[owner];
+        bytes32 structHash = keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, nonce, deadline));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR(), structHash));
+        address signer = _recoverSigner(digest, v, r, s);
+        if (signer != owner) {
+            revert ERC20PermitInvalidSigner(signer, owner);
+        }
+
+        layout.nonces[owner] = nonce + 1;
+        _setAllowance(owner, spender, value);
+    }
+
+    /// @notice Returns the current Permit nonce for `owner`.
+    /// @param owner Token owner.
+    /// @return The current nonce.
+    function nonces(address owner) external view returns (uint256) {
+        return LibERC20TokenStorage.layout().nonces[owner];
+    }
+
+    /// @notice Returns the EIP-712 domain separator for Permit signatures.
+    /// @return The domain separator.
+    function DOMAIN_SEPARATOR() public view returns (bytes32) {
+        LibERC20TokenStorage.Layout storage layout = LibERC20TokenStorage.layout();
+        if (layout.cachedChainId == block.chainid) {
+            return layout.cachedDomainSeparator;
+        }
+        return _buildDomainSeparator(layout.hashedName, block.chainid);
+    }
+
     /// @notice Returns true if this contract implements `interfaceId`.
     /// @param interfaceId The interface identifier.
     /// @return True if supported.
     function supportsInterface(bytes4 interfaceId) public view override(TokenFacetControl, IERC165) returns (bool) {
-        return interfaceId == type(IERC20TokenFacet).interfaceId || super.supportsInterface(interfaceId);
+        return interfaceId == type(IERC20TokenFacet).interfaceId || interfaceId == type(IERC20Permit).interfaceId
+            || super.supportsInterface(interfaceId);
+    }
+
+    function _initializePermitDomain(string memory tokenName) internal {
+        LibERC20TokenStorage.Layout storage layout = LibERC20TokenStorage.layout();
+        layout.hashedName = keccak256(bytes(tokenName));
+        layout.cachedChainId = block.chainid;
+        layout.cachedDomainSeparator = _buildDomainSeparator(layout.hashedName, block.chainid);
+    }
+
+    function _buildDomainSeparator(bytes32 hashedName, uint256 chainId) internal view returns (bytes32) {
+        return keccak256(abi.encode(EIP712_DOMAIN_TYPEHASH, hashedName, VERSION_HASH, chainId, address(this)));
+    }
+
+    function _recoverSigner(bytes32 digest, uint8 v, bytes32 r, bytes32 s) internal pure returns (address) {
+        if (v != 27 && v != 28) {
+            return address(0);
+        }
+        if (uint256(s) > SECP256K1N_DIV_2) {
+            return address(0);
+        }
+
+        return ecrecover(digest, v, r, s);
     }
 }

--- a/src/token/storage/LibERC20TokenStorage.sol
+++ b/src/token/storage/LibERC20TokenStorage.sol
@@ -13,9 +13,13 @@ library LibERC20TokenStorage {
         uint8 decimals;
         string name;
         string symbol;
+        bytes32 hashedName;
         uint256 totalSupply;
+        uint256 cachedChainId;
+        bytes32 cachedDomainSeparator;
         mapping(address => uint256) balances;
         mapping(address => mapping(address => uint256)) allowances;
+        mapping(address => uint256) nonces;
     }
 
     /// @notice Returns the ERC-20 storage layout.

--- a/test/ERC20TokenFacetCore.t.sol
+++ b/test/ERC20TokenFacetCore.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.30;
 
 import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
+import {IERC20Permit} from "../src/interfaces/IERC20Permit.sol";
 import {IERC20TokenBase} from "../src/interfaces/IERC20TokenBase.sol";
 import {IERC20TokenFacet} from "../src/interfaces/IERC20TokenFacet.sol";
 import {IPausable} from "../src/interfaces/IPausable.sol";
@@ -11,6 +12,8 @@ import {ERC20TokenFacetFixture} from "./helpers/ERC20TokenFacetTestHarness.sol";
 contract ERC20TokenFacetCoreTest is ERC20TokenFacetFixture {
     event Transfer(address indexed from, address indexed to, uint256 value);
     event Approval(address indexed owner, address indexed spender, uint256 value);
+    bytes32 internal constant EIP712_DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
 
     function testInitializeSeedsMetadataAndSharedRoles() public {
         _erc20Init(address(facet));
@@ -191,6 +194,9 @@ contract ERC20TokenFacetCoreTest is ERC20TokenFacetFixture {
             IERC20TokenFacet(address(facet)).supportsInterface(type(IPausable).interfaceId), "pausable unsupported"
         );
         assertTrue(
+            IERC20TokenFacet(address(facet)).supportsInterface(type(IERC20Permit).interfaceId), "permit unsupported"
+        );
+        assertTrue(
             IERC20TokenFacet(address(facet)).supportsInterface(type(IERC20TokenFacet).interfaceId),
             "facet interface unsupported"
         );
@@ -245,5 +251,111 @@ contract ERC20TokenFacetCoreTest is ERC20TokenFacetFixture {
         VM.prank(admin);
         VM.expectRevert(abi.encodeWithSelector(IERC20TokenBase.ERC20TokenAlreadyInitialized.selector));
         IERC20TokenFacet(address(diamond)).initializeErc20("Facet Token", "FTKN", 18, admin);
+    }
+
+    function testPermitSetsAllowanceEmitsApprovalAndIncrementsNonce() public {
+        _erc20Init(address(facet));
+        uint256 deadline = block.timestamp + 1 days;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(BOB_PK, address(facet), bob, eve, 55, 0, deadline);
+
+        VM.expectEmit(true, true, false, true, address(facet));
+        emit Approval(bob, eve, 55);
+        IERC20TokenFacet(address(facet)).permit(bob, eve, 55, deadline, v, r, s);
+
+        assertTrue(IERC20TokenFacet(address(facet)).allowance(bob, eve) == 55, "permit allowance mismatch");
+        assertTrue(IERC20TokenFacet(address(facet)).nonces(bob) == 1, "permit nonce mismatch");
+    }
+
+    function testPermitRevertsOnReplay() public {
+        _erc20Init(address(facet));
+        uint256 deadline = block.timestamp + 1 days;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(BOB_PK, address(facet), bob, eve, 55, 0, deadline);
+
+        IERC20TokenFacet(address(facet)).permit(bob, eve, 55, deadline, v, r, s);
+
+        address replaySigner = _recoverPermitSigner(address(facet), bob, eve, 55, 1, deadline, v, r, s);
+        VM.expectRevert(abi.encodeWithSelector(IERC20TokenFacet.ERC20PermitInvalidSigner.selector, replaySigner, bob));
+        IERC20TokenFacet(address(facet)).permit(bob, eve, 55, deadline, v, r, s);
+    }
+
+    function testPermitRevertsOnExpiredDeadline() public {
+        _erc20Init(address(facet));
+        uint256 deadline = block.timestamp;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(BOB_PK, address(facet), bob, eve, 55, 0, deadline);
+
+        VM.warp(block.timestamp + 1);
+        VM.expectRevert(abi.encodeWithSelector(IERC20TokenFacet.ERC20PermitExpired.selector, deadline, block.timestamp));
+        IERC20TokenFacet(address(facet)).permit(bob, eve, 55, deadline, v, r, s);
+    }
+
+    function testPermitRevertsOnWrongPayload() public {
+        _erc20Init(address(facet));
+        uint256 deadline = block.timestamp + 1 days;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(BOB_PK, address(facet), bob, eve, 55, 0, deadline);
+
+        address wrongSpenderSigner = _recoverPermitSigner(address(facet), bob, admin, 55, 0, deadline, v, r, s);
+        VM.expectRevert(
+            abi.encodeWithSelector(IERC20TokenFacet.ERC20PermitInvalidSigner.selector, wrongSpenderSigner, bob)
+        );
+        IERC20TokenFacet(address(facet)).permit(bob, admin, 55, deadline, v, r, s);
+
+        address wrongValueSigner = _recoverPermitSigner(address(facet), bob, eve, 54, 0, deadline, v, r, s);
+        VM.expectRevert(
+            abi.encodeWithSelector(IERC20TokenFacet.ERC20PermitInvalidSigner.selector, wrongValueSigner, bob)
+        );
+        IERC20TokenFacet(address(facet)).permit(bob, eve, 54, deadline, v, r, s);
+
+        address wrongDeadlineSigner = _recoverPermitSigner(address(facet), bob, eve, 55, 0, deadline + 1, v, r, s);
+        VM.expectRevert(
+            abi.encodeWithSelector(IERC20TokenFacet.ERC20PermitInvalidSigner.selector, wrongDeadlineSigner, bob)
+        );
+        IERC20TokenFacet(address(facet)).permit(bob, eve, 55, deadline + 1, v, r, s);
+    }
+
+    function testDomainSeparatorMatchesInitializedContext() public {
+        _erc20Init(address(facet));
+
+        bytes32 expectedSeparator = keccak256(
+            abi.encode(
+                EIP712_DOMAIN_TYPEHASH,
+                keccak256(bytes("Facet Token")),
+                keccak256(bytes("1")),
+                block.chainid,
+                address(facet)
+            )
+        );
+
+        assertTrue(
+            IERC20TokenFacet(address(facet)).DOMAIN_SEPARATOR() == expectedSeparator, "domain separator mismatch"
+        );
+    }
+
+    function testPermitRespectsApprovalPauseScope() public {
+        _erc20Init(address(facet));
+        bytes32 approvalScope = IERC20TokenFacet(address(facet)).ERC20_APPROVAL_SCOPE();
+        uint256 deadline = block.timestamp + 1 days;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(BOB_PK, address(facet), bob, eve, 55, 0, deadline);
+
+        VM.startPrank(admin);
+        IERC20TokenFacet(address(facet)).pauseScope(approvalScope);
+        VM.stopPrank();
+
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, approvalScope));
+        IERC20TokenFacet(address(facet)).permit(bob, eve, 55, deadline, v, r, s);
+    }
+
+    function testDiamondPermitWorksThroughFallback() public {
+        _addErc20FacetToDiamond();
+
+        VM.prank(admin);
+        IERC20TokenFacet(address(diamond)).initializeErc20("Facet Token", "FTKN", 18, admin);
+
+        uint256 deadline = block.timestamp + 1 days;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(BOB_PK, address(diamond), bob, eve, 77, 0, deadline);
+
+        IERC20TokenFacet(address(diamond)).permit(bob, eve, 77, deadline, v, r, s);
+
+        assertTrue(IERC20TokenFacet(address(diamond)).allowance(bob, eve) == 77, "diamond permit allowance mismatch");
+        assertTrue(IERC20TokenFacet(address(diamond)).nonces(bob) == 1, "diamond permit nonce mismatch");
     }
 }

--- a/test/ERC20TokenFacetFuzz.t.sol
+++ b/test/ERC20TokenFacetFuzz.t.sol
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
+import {IERC20TokenFacet} from "../src/interfaces/IERC20TokenFacet.sol";
+import {IPausable} from "../src/interfaces/IPausable.sol";
+import {ERC20TokenFacetFixture} from "./helpers/ERC20TokenFacetTestHarness.sol";
+
+contract ERC20TokenFacetFuzzTest is ERC20TokenFacetFixture {
+    function testFuzzPermitSetsAllowanceAndIncrementsNonce(uint96 valueRaw, uint40 deadlineOffsetRaw) public {
+        _erc20Init(address(facet));
+
+        uint256 value = uint256(valueRaw);
+        uint256 deadline = block.timestamp + uint256(deadlineOffsetRaw) + 1;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(BOB_PK, address(facet), bob, eve, value, 0, deadline);
+
+        IERC20TokenFacet(address(facet)).permit(bob, eve, value, deadline, v, r, s);
+
+        assertTrue(IERC20TokenFacet(address(facet)).allowance(bob, eve) == value, "permit allowance mismatch");
+        assertTrue(IERC20TokenFacet(address(facet)).nonces(bob) == 1, "permit nonce mismatch");
+    }
+
+    function testFuzzPermitReplayReverts(uint96 valueRaw, uint40 deadlineOffsetRaw) public {
+        _erc20Init(address(facet));
+
+        uint256 value = uint256(valueRaw);
+        uint256 deadline = block.timestamp + uint256(deadlineOffsetRaw) + 1;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(BOB_PK, address(facet), bob, eve, value, 0, deadline);
+
+        IERC20TokenFacet(address(facet)).permit(bob, eve, value, deadline, v, r, s);
+
+        address replaySigner = _recoverPermitSigner(address(facet), bob, eve, value, 1, deadline, v, r, s);
+        VM.expectRevert(abi.encodeWithSelector(IERC20TokenFacet.ERC20PermitInvalidSigner.selector, replaySigner, bob));
+        IERC20TokenFacet(address(facet)).permit(bob, eve, value, deadline, v, r, s);
+    }
+
+    function testFuzzTransferFromConsumesAllowanceAfterPermit(uint96 allowanceRaw, uint96 spendRaw) public {
+        _erc20Init(address(facet));
+
+        uint256 allowance = uint256(allowanceRaw) + 1;
+        uint256 spend = _boundAmount(spendRaw, allowance);
+        uint256 mintAmount = allowance + 100;
+
+        VM.prank(admin);
+        IERC20TokenFacet(address(facet)).mint(bob, mintAmount);
+
+        uint256 deadline = block.timestamp + 1 days;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(BOB_PK, address(facet), bob, eve, allowance, 0, deadline);
+        IERC20TokenFacet(address(facet)).permit(bob, eve, allowance, deadline, v, r, s);
+
+        VM.prank(eve);
+        IERC20TokenFacet(address(facet)).transferFrom(bob, admin, spend);
+
+        assertTrue(
+            IERC20TokenFacet(address(facet)).allowance(bob, eve) == allowance - spend,
+            "permit allowance should decrement"
+        );
+    }
+
+    function testFuzzPausedApprovalScopeBlocksPermit(uint96 valueRaw) public {
+        _erc20Init(address(facet));
+        bytes32 approvalScope = IERC20TokenFacet(address(facet)).ERC20_APPROVAL_SCOPE();
+        uint256 value = uint256(valueRaw);
+        uint256 deadline = block.timestamp + 1 days;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(BOB_PK, address(facet), bob, eve, value, 0, deadline);
+
+        VM.prank(admin);
+        IERC20TokenFacet(address(facet)).pauseScope(approvalScope);
+
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, approvalScope));
+        IERC20TokenFacet(address(facet)).permit(bob, eve, value, deadline, v, r, s);
+    }
+
+    function testFuzzMintBurnSupplyAccounting(uint96 mintRaw, uint96 burnRaw) public {
+        _erc20Init(address(facet));
+
+        uint256 mintAmount = uint256(mintRaw) + 1;
+        VM.prank(admin);
+        IERC20TokenFacet(address(facet)).mint(bob, mintAmount);
+
+        uint256 burnAmount = _boundAmount(burnRaw, mintAmount);
+        VM.prank(admin);
+        IERC20TokenFacet(address(facet)).burn(bob, burnAmount);
+
+        assertTrue(IERC20TokenFacet(address(facet)).totalSupply() == mintAmount - burnAmount, "total supply mismatch");
+        assertTrue(IERC20TokenFacet(address(facet)).balanceOf(bob) == mintAmount - burnAmount, "balance mismatch");
+    }
+
+    function testFuzzPausedTransferScopeBlocksMutations(uint96 mintRaw, uint96 burnRaw, uint96 transferRaw) public {
+        _erc20Init(address(facet));
+        bytes32 transferScope = IERC20TokenFacet(address(facet)).ERC20_TRANSFER_SCOPE();
+        uint256 initialMint = uint256(mintRaw) + 1;
+
+        VM.prank(admin);
+        IERC20TokenFacet(address(facet)).mint(bob, initialMint);
+        VM.prank(admin);
+        IERC20TokenFacet(address(facet)).pauseScope(transferScope);
+
+        uint256 transferAmount = _boundAmount(transferRaw, initialMint);
+        VM.startPrank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+        IERC20TokenFacet(address(facet)).transfer(eve, transferAmount);
+        VM.stopPrank();
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+        IERC20TokenFacet(address(facet)).mint(eve, 1);
+
+        uint256 burnAmount = _boundAmount(burnRaw, initialMint);
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+        IERC20TokenFacet(address(facet)).burn(bob, burnAmount);
+    }
+
+    function _boundAmount(uint256 raw, uint256 max) internal pure returns (uint256) {
+        if (max == 0) {
+            return 0;
+        }
+        return (raw % max) + 1;
+    }
+}

--- a/test/ERC20TokenFacetInvariant.t.sol
+++ b/test/ERC20TokenFacetInvariant.t.sol
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC20TokenFacet} from "../src/interfaces/IERC20TokenFacet.sol";
+import {IPausable} from "../src/interfaces/IPausable.sol";
+import {ERC20TokenFacetInvariantFixture} from "./helpers/ERC20TokenFacetInvariantTestHarness.sol";
+
+contract ERC20TokenFacetInvariantTest is ERC20TokenFacetInvariantFixture {
+    function targetContracts() external view returns (address[] memory contracts) {
+        contracts = new address[](1);
+        contracts[0] = address(this);
+    }
+
+    function actionApprove(uint8 ownerSeed, uint8 spenderSeed, uint96 valueRaw) external {
+        address owner = _actor(ownerSeed);
+        address spender = _actor(spenderSeed);
+        if (owner == spender) {
+            return;
+        }
+
+        bytes32 approvalScope = IERC20TokenFacet(address(facet)).ERC20_APPROVAL_SCOPE();
+        uint256 value = uint256(valueRaw);
+        if (IERC20TokenFacet(address(facet)).scopePaused(approvalScope)) {
+            AccountingSnapshot memory snapshot = _snapshotAccounting();
+            VM.startPrank(owner);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, approvalScope));
+            IERC20TokenFacet(address(facet)).approve(spender, value);
+            VM.stopPrank();
+            _assertAccountingUnchanged(snapshot, "paused approval should not mutate accounting");
+            return;
+        }
+
+        VM.prank(owner);
+        IERC20TokenFacet(address(facet)).approve(spender, value);
+    }
+
+    function actionPermit(uint8 ownerSeed, uint8 spenderSeed, uint96 valueRaw, uint32 deadlineOffsetRaw) external {
+        address owner = _actor(ownerSeed);
+        address spender = _actor(spenderSeed);
+        if (owner == spender) {
+            return;
+        }
+
+        bytes32 approvalScope = IERC20TokenFacet(address(facet)).ERC20_APPROVAL_SCOPE();
+        uint256 value = uint256(valueRaw);
+        uint256 deadline = block.timestamp + uint256(deadlineOffsetRaw) + 1;
+        uint256 nonce = IERC20TokenFacet(address(facet)).nonces(owner);
+        (uint8 v, bytes32 r, bytes32 s) =
+            _signPermit(_actorKey(ownerSeed), address(facet), owner, spender, value, nonce, deadline);
+
+        if (IERC20TokenFacet(address(facet)).scopePaused(approvalScope)) {
+            AccountingSnapshot memory snapshot = _snapshotAccounting();
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, approvalScope));
+            IERC20TokenFacet(address(facet)).permit(owner, spender, value, deadline, v, r, s);
+            _assertAccountingUnchanged(snapshot, "paused permit should not mutate accounting");
+            return;
+        }
+
+        IERC20TokenFacet(address(facet)).permit(owner, spender, value, deadline, v, r, s);
+        trackedPermitSuccesses[owner] += 1;
+    }
+
+    function actionTransfer(uint8 fromSeed, uint8 toSeed, uint96 valueRaw) external {
+        address from = _actor(fromSeed);
+        address to = _actor(toSeed);
+        if (from == to) {
+            return;
+        }
+
+        bytes32 transferScope = IERC20TokenFacet(address(facet)).ERC20_TRANSFER_SCOPE();
+        uint256 value = _boundAmount(valueRaw, IERC20TokenFacet(address(facet)).balanceOf(from));
+        if (value == 0) {
+            return;
+        }
+
+        if (IERC20TokenFacet(address(facet)).scopePaused(transferScope)) {
+            AccountingSnapshot memory snapshot = _snapshotAccounting();
+            VM.startPrank(from);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+            IERC20TokenFacet(address(facet)).transfer(to, value);
+            VM.stopPrank();
+            _assertAccountingUnchanged(snapshot, "paused transfer should not mutate accounting");
+            return;
+        }
+
+        VM.prank(from);
+        IERC20TokenFacet(address(facet)).transfer(to, value);
+    }
+
+    function actionTransferFrom(uint8 spenderSeed, uint8 ownerSeed, uint8 toSeed, uint96 valueRaw) external {
+        address spender = _actor(spenderSeed);
+        address owner = _actor(ownerSeed);
+        address to = _actor(toSeed);
+        if (owner == to || spender == owner) {
+            return;
+        }
+
+        uint256 allowance = IERC20TokenFacet(address(facet)).allowance(owner, spender);
+        uint256 balance = IERC20TokenFacet(address(facet)).balanceOf(owner);
+        uint256 value = _boundAmount(valueRaw, allowance < balance ? allowance : balance);
+        if (value == 0) {
+            return;
+        }
+
+        bytes32 transferScope = IERC20TokenFacet(address(facet)).ERC20_TRANSFER_SCOPE();
+        bytes32 approvalScope = IERC20TokenFacet(address(facet)).ERC20_APPROVAL_SCOPE();
+        if (
+            IERC20TokenFacet(address(facet)).scopePaused(transferScope)
+                || IERC20TokenFacet(address(facet)).scopePaused(approvalScope)
+        ) {
+            bytes32 expectedScope =
+                IERC20TokenFacet(address(facet)).scopePaused(approvalScope) ? approvalScope : transferScope;
+            AccountingSnapshot memory snapshot = _snapshotAccounting();
+            VM.startPrank(spender);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, expectedScope));
+            IERC20TokenFacet(address(facet)).transferFrom(owner, to, value);
+            VM.stopPrank();
+            _assertAccountingUnchanged(snapshot, "paused transferFrom should not mutate accounting");
+            return;
+        }
+
+        VM.prank(spender);
+        IERC20TokenFacet(address(facet)).transferFrom(owner, to, value);
+    }
+
+    function actionMint(uint8 actorSeed, uint96 valueRaw) external {
+        bytes32 transferScope = IERC20TokenFacet(address(facet)).ERC20_TRANSFER_SCOPE();
+        uint256 value = uint256(valueRaw);
+        if (value == 0) {
+            return;
+        }
+
+        if (IERC20TokenFacet(address(facet)).scopePaused(transferScope)) {
+            AccountingSnapshot memory snapshot = _snapshotAccounting();
+            VM.prank(admin);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+            IERC20TokenFacet(address(facet)).mint(_actor(actorSeed), value);
+            _assertAccountingUnchanged(snapshot, "paused mint should not mutate accounting");
+            return;
+        }
+
+        VM.prank(admin);
+        IERC20TokenFacet(address(facet)).mint(_actor(actorSeed), value);
+    }
+
+    function actionBurn(uint8 actorSeed, uint96 valueRaw) external {
+        address actor = _actor(actorSeed);
+        bytes32 transferScope = IERC20TokenFacet(address(facet)).ERC20_TRANSFER_SCOPE();
+        uint256 value = _boundAmount(valueRaw, IERC20TokenFacet(address(facet)).balanceOf(actor));
+        if (value == 0) {
+            return;
+        }
+
+        if (IERC20TokenFacet(address(facet)).scopePaused(transferScope)) {
+            AccountingSnapshot memory snapshot = _snapshotAccounting();
+            VM.prank(admin);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+            IERC20TokenFacet(address(facet)).burn(actor, value);
+            _assertAccountingUnchanged(snapshot, "paused burn should not mutate accounting");
+            return;
+        }
+
+        VM.prank(admin);
+        IERC20TokenFacet(address(facet)).burn(actor, value);
+    }
+
+    function actionSetApprovalScopePaused(bool paused_) external {
+        bytes32 approvalScope = IERC20TokenFacet(address(facet)).ERC20_APPROVAL_SCOPE();
+        bool isPaused = IERC20TokenFacet(address(facet)).scopePaused(approvalScope);
+        if (paused_ && !isPaused) {
+            VM.prank(admin);
+            IERC20TokenFacet(address(facet)).pauseScope(approvalScope);
+        } else if (!paused_ && isPaused) {
+            VM.prank(admin);
+            IERC20TokenFacet(address(facet)).unpauseScope(approvalScope);
+        }
+    }
+
+    function actionSetTransferScopePaused(bool paused_) external {
+        bytes32 transferScope = IERC20TokenFacet(address(facet)).ERC20_TRANSFER_SCOPE();
+        bool isPaused = IERC20TokenFacet(address(facet)).scopePaused(transferScope);
+        if (paused_ && !isPaused) {
+            VM.prank(admin);
+            IERC20TokenFacet(address(facet)).pauseScope(transferScope);
+        } else if (!paused_ && isPaused) {
+            VM.prank(admin);
+            IERC20TokenFacet(address(facet)).unpauseScope(transferScope);
+        }
+    }
+
+    function invariantTotalSupplyEqualsTrackedBalances() public view {
+        assertTrue(
+            IERC20TokenFacet(address(facet)).totalSupply() == _sumTrackedBalances(),
+            "total supply must equal tracked balances"
+        );
+    }
+
+    function invariantTrackedPermitNoncesMatchSuccessfulCalls() public view {
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            address actor = actors[i];
+            assertTrue(
+                IERC20TokenFacet(address(facet)).nonces(actor) == trackedPermitSuccesses[actor],
+                "tracked permit nonces must match successful permit calls"
+            );
+        }
+    }
+}

--- a/test/helpers/AccessControlTestHarness.sol
+++ b/test/helpers/AccessControlTestHarness.sol
@@ -8,6 +8,9 @@ interface Vm {
     function startPrank(address) external;
     function stopPrank() external;
     function assume(bool) external;
+    function addr(uint256) external returns (address);
+    function sign(uint256, bytes32) external returns (uint8, bytes32, bytes32);
+    function expectRevert(bytes4) external;
     function expectRevert(bytes calldata) external;
     function expectEmit(bool, bool, bool, bool) external;
     function expectEmit(bool, bool, bool, bool, address) external;

--- a/test/helpers/ERC20TokenFacetInvariantTestHarness.sol
+++ b/test/helpers/ERC20TokenFacetInvariantTestHarness.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC20TokenFacet} from "../../src/interfaces/IERC20TokenFacet.sol";
+import {ERC20TokenFacetFixture} from "./ERC20TokenFacetTestHarness.sol";
+
+abstract contract ERC20TokenFacetInvariantFixture is ERC20TokenFacetFixture {
+    struct AccountingSnapshot {
+        uint256 totalSupply;
+        uint256 totalTrackedBalances;
+    }
+
+    uint256 internal constant ACTOR_COUNT = 4;
+    uint256 internal constant INITIAL_BALANCE = 1_000_000;
+
+    address[ACTOR_COUNT] internal actors;
+    uint256[ACTOR_COUNT] internal actorKeys;
+    mapping(address => uint256) internal trackedPermitSuccesses;
+
+    function setUp() public virtual override {
+        super.setUp();
+        _erc20Init(address(facet));
+
+        actors[0] = bob;
+        actors[1] = eve;
+        actors[2] = carol;
+        actors[3] = dave;
+
+        actorKeys[0] = BOB_PK;
+        actorKeys[1] = EVE_PK;
+        actorKeys[2] = CAROL_PK;
+        actorKeys[3] = DAVE_PK;
+
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            VM.prank(admin);
+            IERC20TokenFacet(address(facet)).mint(actors[i], INITIAL_BALANCE);
+        }
+    }
+
+    function _actor(uint8 seed) internal view returns (address) {
+        return actors[uint256(seed) % ACTOR_COUNT];
+    }
+
+    function _actorKey(uint8 seed) internal view returns (uint256) {
+        return actorKeys[uint256(seed) % ACTOR_COUNT];
+    }
+
+    function _boundAmount(uint256 raw, uint256 max) internal pure returns (uint256) {
+        if (max == 0) {
+            return 0;
+        }
+        return (raw % max) + 1;
+    }
+
+    function _sumTrackedBalances() internal view returns (uint256 sum) {
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            sum += IERC20TokenFacet(address(facet)).balanceOf(actors[i]);
+        }
+    }
+
+    function _snapshotAccounting() internal view returns (AccountingSnapshot memory snapshot) {
+        snapshot.totalSupply = IERC20TokenFacet(address(facet)).totalSupply();
+        snapshot.totalTrackedBalances = _sumTrackedBalances();
+    }
+
+    function _assertAccountingUnchanged(AccountingSnapshot memory snapshot, string memory reason) internal view {
+        assertTrue(IERC20TokenFacet(address(facet)).totalSupply() == snapshot.totalSupply, reason);
+        assertTrue(_sumTrackedBalances() == snapshot.totalTrackedBalances, reason);
+    }
+}

--- a/test/helpers/ERC20TokenFacetTestHarness.sol
+++ b/test/helpers/ERC20TokenFacetTestHarness.sol
@@ -5,6 +5,7 @@ import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
 import {IAccessControl} from "../../src/interfaces/IAccessControl.sol";
 import {IERC20} from "../../src/interfaces/IERC20.sol";
 import {IERC20Metadata} from "../../src/interfaces/IERC20Metadata.sol";
+import {IERC20Permit} from "../../src/interfaces/IERC20Permit.sol";
 import {IERC20TokenBase} from "../../src/interfaces/IERC20TokenBase.sol";
 import {IERC20TokenFacet} from "../../src/interfaces/IERC20TokenFacet.sol";
 import {IPausable} from "../../src/interfaces/IPausable.sol";
@@ -14,15 +15,31 @@ import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
 import {TestBase} from "./AccessControlTestHarness.sol";
 
 abstract contract ERC20TokenFacetFixture is TestBase {
-    address internal admin = address(0xA11CE);
-    address internal bob = address(0xB0B);
-    address internal eve = address(0xE11E);
+    bytes32 internal constant PERMIT_TYPEHASH =
+        keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+    uint256 internal constant ADMIN_PK = uint256(keccak256("erc20-facet-admin"));
+    uint256 internal constant BOB_PK = uint256(keccak256("erc20-facet-bob"));
+    uint256 internal constant EVE_PK = uint256(keccak256("erc20-facet-eve"));
+    uint256 internal constant CAROL_PK = uint256(keccak256("erc20-facet-carol"));
+    uint256 internal constant DAVE_PK = uint256(keccak256("erc20-facet-dave"));
+
+    address internal admin;
+    address internal bob;
+    address internal eve;
+    address internal carol;
+    address internal dave;
 
     ERC20TokenFacet internal facet;
     DiamondCutFacet internal cutFacet;
     DiamondProxyHarness internal diamond;
 
     function setUp() public virtual {
+        admin = VM.addr(ADMIN_PK);
+        bob = VM.addr(BOB_PK);
+        eve = VM.addr(EVE_PK);
+        carol = VM.addr(CAROL_PK);
+        dave = VM.addr(DAVE_PK);
+
         facet = new ERC20TokenFacet();
         cutFacet = new DiamondCutFacet();
         diamond = new DiamondProxyHarness(admin, address(cutFacet));
@@ -33,7 +50,7 @@ abstract contract ERC20TokenFacetFixture is TestBase {
     }
 
     function _addErc20FacetToDiamond() internal {
-        bytes4[] memory selectors = new bytes4[](26);
+        bytes4[] memory selectors = new bytes4[](29);
         selectors[0] = IERC20TokenFacet.initializeErc20.selector;
         selectors[1] = IERC20Metadata.name.selector;
         selectors[2] = IERC20Metadata.symbol.selector;
@@ -60,6 +77,9 @@ abstract contract ERC20TokenFacetFixture is TestBase {
         selectors[23] = IPausable.pauseScope.selector;
         selectors[24] = IPausable.unpauseScope.selector;
         selectors[25] = IPausable.scopePaused.selector;
+        selectors[26] = IERC20Permit.permit.selector;
+        selectors[27] = IERC20Permit.nonces.selector;
+        selectors[28] = IERC20Permit.DOMAIN_SEPARATOR.selector;
 
         IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
         cut[0] = IDiamondCut.FacetCut({
@@ -68,5 +88,43 @@ abstract contract ERC20TokenFacetFixture is TestBase {
 
         VM.prank(admin);
         IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _permitDigest(
+        address target,
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 nonce,
+        uint256 deadline
+    ) internal view returns (bytes32) {
+        bytes32 structHash = keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, nonce, deadline));
+        return keccak256(abi.encodePacked("\x19\x01", IERC20Permit(target).DOMAIN_SEPARATOR(), structHash));
+    }
+
+    function _signPermit(
+        uint256 ownerKey,
+        address target,
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 nonce,
+        uint256 deadline
+    ) internal returns (uint8 v, bytes32 r, bytes32 s) {
+        return VM.sign(ownerKey, _permitDigest(target, owner, spender, value, nonce, deadline));
+    }
+
+    function _recoverPermitSigner(
+        address target,
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 nonce,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) internal view returns (address) {
+        return ecrecover(_permitDigest(target, owner, spender, value, nonce, deadline), v, r, s);
     }
 }


### PR DESCRIPTION
## Summary
- add EIP-2612 Permit support to the hosted ERC20 facet
- extend ERC20 storage with nonce and domain-separator state for Permit
- add core, fuzz, and invariant coverage for Permit, allowance, pause, and accounting behavior

## Included Work
- extend `IERC20TokenFacet` with the Permit surface and custom Permit errors
- implement `permit`, `nonces`, and `DOMAIN_SEPARATOR` in the hosted ERC20 facet
- update the diamond ERC20 harness to route Permit selectors through fallback
- add direct and diamond-routed Permit tests
- add ERC20 fuzz and invariant suites for replay, allowance consumption, pause enforcement, supply accounting, and nonce tracking

## Validation
- `forge test --offline --match-path test/ERC20TokenFacetCore.t.sol`
- `forge test --offline --match-path test/ERC20TokenFacetFuzz.t.sol`
- `forge test --offline --match-path test/ERC20TokenFacetInvariant.t.sol`
- `forge test --offline`

## Issue
- Closes #82