### PR TITLE
Implement ERC721 token facet core

### DIFF
--- a/src/interfaces/IERC721TokenFacet.sol
+++ b/src/interfaces/IERC721TokenFacet.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "./IAccessControl.sol";
+import {IERC721Metadata} from "./IERC721Metadata.sol";
+import {IERC721TokenBase} from "./IERC721TokenBase.sol";
+import {IPausable} from "./IPausable.sol";
+
+/// @title IERC721TokenFacet
+/// @notice Hosted ERC-721 facet surface for diamond deployments.
+interface IERC721TokenFacet is IERC721Metadata, IERC721TokenBase, IAccessControl, IPausable {
+    /// @notice Thrown when `operator` is not authorized to manage `tokenId`.
+    error ERC721TokenUnauthorizedOperator(address operator, uint256 tokenId);
+
+    /// @notice Returns the shared token admin role identifier.
+    /// @return The role identifier.
+    function TOKEN_ADMIN_ROLE() external view returns (bytes32);
+
+    /// @notice Returns the ERC-721 minter role identifier.
+    /// @return The role identifier.
+    function ERC721_MINTER_ROLE() external view returns (bytes32);
+
+    /// @notice Returns the ERC-721 burner role identifier.
+    /// @return The role identifier.
+    function ERC721_BURNER_ROLE() external view returns (bytes32);
+
+    /// @notice Returns the ERC-721 metadata manager role identifier.
+    /// @return The role identifier.
+    function ERC721_METADATA_ROLE() external view returns (bytes32);
+
+    /// @notice Returns the ERC-721 transfer pause scope identifier.
+    /// @return The scope identifier.
+    function ERC721_TRANSFER_SCOPE() external view returns (bytes32);
+
+    /// @notice Returns the ERC-721 approval pause scope identifier.
+    /// @return The scope identifier.
+    function ERC721_APPROVAL_SCOPE() external view returns (bytes32);
+
+    /// @notice Initializes the hosted ERC-721 facet.
+    /// @param tokenName Collection name.
+    /// @param tokenSymbol Collection symbol.
+    /// @param baseURI Default base URI for token metadata.
+    /// @param admin Admin account seeded into the shared control plane.
+    function initializeErc721(
+        string calldata tokenName,
+        string calldata tokenSymbol,
+        string calldata baseURI,
+        address admin
+    ) external;
+
+    /// @notice Returns the current live token count.
+    /// @return The current token count.
+    function totalSupply() external view returns (uint256);
+
+    /// @notice Mints `tokenId` to `to`.
+    /// @param to Recipient account.
+    /// @param tokenId Token identifier.
+    function mint(address to, uint256 tokenId) external;
+
+    /// @notice Safely mints `tokenId` to `to`.
+    /// @param to Recipient account.
+    /// @param tokenId Token identifier.
+    /// @param data Additional receiver data.
+    function safeMint(address to, uint256 tokenId, bytes calldata data) external;
+
+    /// @notice Burns `tokenId`.
+    /// @param tokenId Token identifier.
+    function burn(uint256 tokenId) external;
+
+    /// @notice Updates the collection base URI.
+    /// @param baseURI New base URI.
+    function setBaseURI(string calldata baseURI) external;
+
+    /// @notice Sets an explicit metadata URI for `tokenId`.
+    /// @param tokenId Token identifier.
+    /// @param uri Explicit metadata URI.
+    function setTokenURI(uint256 tokenId, string calldata uri) external;
+}

--- a/src/token/ERC721TokenBase.sol
+++ b/src/token/ERC721TokenBase.sol
@@ -89,7 +89,7 @@ abstract contract ERC721TokenBase is IERC721TokenBase {
 
     /// @notice Returns current live token count tracked by the foundation.
     /// @return The token count.
-    function totalSupply() public view returns (uint256) {
+    function totalSupply() public view virtual returns (uint256) {
         return LibERC721TokenStorage.layout().totalSupply;
     }
 

--- a/src/token/facets/ERC721TokenFacet.sol
+++ b/src/token/facets/ERC721TokenFacet.sol
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "../../interfaces/IAccessControl.sol";
+import {IERC165} from "../../interfaces/IERC165.sol";
+import {IERC721TokenFacet} from "../../interfaces/IERC721TokenFacet.sol";
+import {ERC721TokenBase} from "../ERC721TokenBase.sol";
+import {TokenFacetControl} from "../TokenFacetControl.sol";
+import {LibTokenFacetConstants} from "../libraries/LibTokenFacetConstants.sol";
+
+/// @title ERC721TokenFacet
+/// @notice Hosted ERC-721 + metadata facet with shared access control and pause integration.
+contract ERC721TokenFacet is ERC721TokenBase, TokenFacetControl, IERC721TokenFacet {
+    /// @notice Shared token admin role.
+    bytes32 public constant TOKEN_ADMIN_ROLE = LibTokenFacetConstants.TOKEN_ADMIN_ROLE;
+    /// @notice ERC-721 minter role.
+    bytes32 public constant ERC721_MINTER_ROLE = LibTokenFacetConstants.ERC721_MINTER_ROLE;
+    /// @notice ERC-721 burner role.
+    bytes32 public constant ERC721_BURNER_ROLE = LibTokenFacetConstants.ERC721_BURNER_ROLE;
+    /// @notice ERC-721 metadata manager role.
+    bytes32 public constant ERC721_METADATA_ROLE = LibTokenFacetConstants.ERC721_METADATA_ROLE;
+    /// @notice Pause scope for ERC-721 transfers.
+    bytes32 public constant ERC721_TRANSFER_SCOPE = LibTokenFacetConstants.ERC721_TRANSFER_SCOPE;
+    /// @notice Pause scope for ERC-721 approvals.
+    bytes32 public constant ERC721_APPROVAL_SCOPE = LibTokenFacetConstants.ERC721_APPROVAL_SCOPE;
+
+    /// @notice Initializes the hosted ERC-721 facet.
+    /// @param tokenName Collection name.
+    /// @param tokenSymbol Collection symbol.
+    /// @param baseURI Default base URI for tokens without explicit metadata URI.
+    /// @param admin Admin account seeded into the shared control plane.
+    function initializeErc721(
+        string calldata tokenName,
+        string calldata tokenSymbol,
+        string calldata baseURI,
+        address admin
+    ) external {
+        if (isErc721Initialized()) {
+            revert ERC721TokenAlreadyInitialized();
+        }
+
+        if (_isAccessControlInitialized()) {
+            _checkRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        }
+
+        _initializeTokenFacetControl(admin);
+        _initializeErc721Token(tokenName, tokenSymbol, baseURI);
+
+        _setRoleAdmin(TOKEN_ADMIN_ROLE, DEFAULT_ADMIN_ROLE);
+        _setRoleAdmin(ERC721_MINTER_ROLE, TOKEN_ADMIN_ROLE);
+        _setRoleAdmin(ERC721_BURNER_ROLE, TOKEN_ADMIN_ROLE);
+        _setRoleAdmin(ERC721_METADATA_ROLE, TOKEN_ADMIN_ROLE);
+
+        _grantRole(TOKEN_ADMIN_ROLE, admin);
+        _grantRole(ERC721_MINTER_ROLE, admin);
+        _grantRole(ERC721_BURNER_ROLE, admin);
+        _grantRole(ERC721_METADATA_ROLE, admin);
+        _grantRole(PAUSER_ROLE, admin);
+    }
+
+    /// @notice Approves `to` to manage `tokenId`.
+    /// @param to Approved account, or zero to clear approval.
+    /// @param tokenId Token identifier.
+    function approve(address to, uint256 tokenId) external whenScopeNotPaused(ERC721_APPROVAL_SCOPE) {
+        address owner_ = ownerOf(tokenId);
+        if (msg.sender != owner_ && !isApprovedForAll(owner_, msg.sender)) {
+            revert ERC721TokenUnauthorizedOperator(msg.sender, tokenId);
+        }
+        _approveToken(to, tokenId);
+    }
+
+    /// @notice Enables or disables `operator` for all caller-owned tokens.
+    /// @param operator Operator account.
+    /// @param approved True to approve, false to revoke.
+    function setApprovalForAll(address operator, bool approved) external whenScopeNotPaused(ERC721_APPROVAL_SCOPE) {
+        _setApprovalForAll(msg.sender, operator, approved);
+    }
+
+    /// @notice Transfers `tokenId` from `from` to `to`.
+    /// @param from Current token owner.
+    /// @param to Receiver account.
+    /// @param tokenId Token identifier.
+    function transferFrom(address from, address to, uint256 tokenId)
+        external
+        whenScopeNotPaused(ERC721_TRANSFER_SCOPE)
+    {
+        if (!_isApprovedOrOwner(msg.sender, tokenId)) {
+            revert ERC721TokenUnauthorizedOperator(msg.sender, tokenId);
+        }
+        _transferToken(from, to, tokenId);
+    }
+
+    /// @notice Safely transfers `tokenId` from `from` to `to`.
+    /// @param from Current token owner.
+    /// @param to Receiver account.
+    /// @param tokenId Token identifier.
+    function safeTransferFrom(address from, address to, uint256 tokenId)
+        external
+        whenScopeNotPaused(ERC721_TRANSFER_SCOPE)
+    {
+        if (!_isApprovedOrOwner(msg.sender, tokenId)) {
+            revert ERC721TokenUnauthorizedOperator(msg.sender, tokenId);
+        }
+        _safeTransferToken(from, to, tokenId, "");
+    }
+
+    /// @notice Safely transfers `tokenId` from `from` to `to` with `data`.
+    /// @param from Current token owner.
+    /// @param to Receiver account.
+    /// @param tokenId Token identifier.
+    /// @param data Additional receiver data.
+    function safeTransferFrom(address from, address to, uint256 tokenId, bytes calldata data)
+        external
+        whenScopeNotPaused(ERC721_TRANSFER_SCOPE)
+    {
+        if (!_isApprovedOrOwner(msg.sender, tokenId)) {
+            revert ERC721TokenUnauthorizedOperator(msg.sender, tokenId);
+        }
+        _safeTransferToken(from, to, tokenId, data);
+    }
+
+    /// @notice Mints `tokenId` to `to`.
+    /// @param to Recipient account.
+    /// @param tokenId Token identifier.
+    function mint(address to, uint256 tokenId)
+        external
+        onlyRole(ERC721_MINTER_ROLE)
+        whenScopeNotPaused(ERC721_TRANSFER_SCOPE)
+    {
+        _mintToken(to, tokenId);
+    }
+
+    /// @notice Safely mints `tokenId` to `to`.
+    /// @param to Recipient account.
+    /// @param tokenId Token identifier.
+    /// @param data Additional receiver data.
+    function safeMint(address to, uint256 tokenId, bytes calldata data)
+        external
+        onlyRole(ERC721_MINTER_ROLE)
+        whenScopeNotPaused(ERC721_TRANSFER_SCOPE)
+    {
+        _safeMintToken(to, tokenId, data);
+    }
+
+    /// @notice Burns `tokenId`.
+    /// @param tokenId Token identifier.
+    function burn(uint256 tokenId) external onlyRole(ERC721_BURNER_ROLE) whenScopeNotPaused(ERC721_TRANSFER_SCOPE) {
+        _burnToken(tokenId);
+    }
+
+    /// @notice Updates the collection base URI.
+    /// @param baseURI New base URI.
+    function setBaseURI(string calldata baseURI) external onlyRole(ERC721_METADATA_ROLE) {
+        _setBaseURI(baseURI);
+    }
+
+    /// @notice Sets an explicit metadata URI for `tokenId`.
+    /// @param tokenId Token identifier.
+    /// @param uri Explicit metadata URI.
+    function setTokenURI(uint256 tokenId, string calldata uri) external onlyRole(ERC721_METADATA_ROLE) {
+        _setTokenURI(tokenId, uri);
+    }
+
+    /// @notice Returns the current live token count.
+    /// @return The current token count.
+    function totalSupply() public view override(ERC721TokenBase, IERC721TokenFacet) returns (uint256) {
+        return ERC721TokenBase.totalSupply();
+    }
+
+    /// @notice Returns true if this contract implements `interfaceId`.
+    /// @param interfaceId The interface identifier.
+    /// @return True if supported.
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        override(ERC721TokenBase, TokenFacetControl, IERC165)
+        returns (bool)
+    {
+        return interfaceId == type(IERC721TokenFacet).interfaceId || ERC721TokenBase.supportsInterface(interfaceId)
+            || TokenFacetControl.supportsInterface(interfaceId);
+    }
+}

--- a/test/ERC721TokenFacetCore.t.sol
+++ b/test/ERC721TokenFacetCore.t.sol
@@ -1,0 +1,389 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
+import {IERC165} from "../src/interfaces/IERC165.sol";
+import {IERC721} from "../src/interfaces/IERC721.sol";
+import {IERC721Metadata} from "../src/interfaces/IERC721Metadata.sol";
+import {IERC721TokenBase} from "../src/interfaces/IERC721TokenBase.sol";
+import {IERC721TokenFacet} from "../src/interfaces/IERC721TokenFacet.sol";
+import {IPausable} from "../src/interfaces/IPausable.sol";
+import {ERC721TokenFacetFixture} from "./helpers/ERC721TokenFacetTestHarness.sol";
+
+contract ERC721TokenFacetCoreTest is ERC721TokenFacetFixture {
+    event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
+    event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId);
+    event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
+
+    function testInitializeSeedsMetadataAndSharedRoles() public {
+        _erc721Init(address(facet));
+
+        assertTrue(IERC721TokenFacet(address(facet)).isErc721Initialized(), "facet should initialize");
+        assertTrue(
+            keccak256(bytes(IERC721TokenFacet(address(facet)).name())) == keccak256(bytes("Facet NFT")), "name mismatch"
+        );
+        assertTrue(
+            keccak256(bytes(IERC721TokenFacet(address(facet)).symbol())) == keccak256(bytes("FNFT")), "symbol mismatch"
+        );
+        assertTrue(IERC721TokenFacet(address(facet)).totalSupply() == 0, "initial supply mismatch");
+    }
+
+    function testInitializeSeedsRoleHierarchyAndBaseUri() public {
+        _erc721Init(address(facet));
+        VM.prank(admin);
+        IERC721TokenFacet(address(facet)).mint(admin, 1);
+
+        assertTrue(
+            keccak256(bytes(IERC721TokenFacet(address(facet)).tokenURI(1))) == keccak256(bytes("ipfs://facet/1")),
+            "base uri mismatch"
+        );
+        assertTrue(
+            IERC721TokenFacet(address(facet)).hasRole(IERC721TokenFacet(address(facet)).DEFAULT_ADMIN_ROLE(), admin),
+            "admin should have default admin role"
+        );
+        assertTrue(
+            IERC721TokenFacet(address(facet)).hasRole(IERC721TokenFacet(address(facet)).TOKEN_ADMIN_ROLE(), admin),
+            "admin should have token admin role"
+        );
+        assertTrue(
+            IERC721TokenFacet(address(facet)).hasRole(IERC721TokenFacet(address(facet)).ERC721_MINTER_ROLE(), admin),
+            "admin should have minter role"
+        );
+        assertTrue(
+            IERC721TokenFacet(address(facet)).hasRole(IERC721TokenFacet(address(facet)).ERC721_BURNER_ROLE(), admin),
+            "admin should have burner role"
+        );
+        assertTrue(
+            IERC721TokenFacet(address(facet)).hasRole(IERC721TokenFacet(address(facet)).ERC721_METADATA_ROLE(), admin),
+            "admin should have metadata role"
+        );
+        assertTrue(
+            IERC721TokenFacet(address(facet)).hasRole(IERC721TokenFacet(address(facet)).PAUSER_ROLE(), admin),
+            "admin should have pauser role"
+        );
+        assertTrue(
+            IERC721TokenFacet(address(facet)).getRoleAdmin(IERC721TokenFacet(address(facet)).TOKEN_ADMIN_ROLE())
+                == IERC721TokenFacet(address(facet)).DEFAULT_ADMIN_ROLE(),
+            "token admin admin mismatch"
+        );
+        assertTrue(
+            IERC721TokenFacet(address(facet)).getRoleAdmin(IERC721TokenFacet(address(facet)).ERC721_MINTER_ROLE())
+                == IERC721TokenFacet(address(facet)).TOKEN_ADMIN_ROLE(),
+            "minter admin mismatch"
+        );
+        assertTrue(
+            IERC721TokenFacet(address(facet)).getRoleAdmin(IERC721TokenFacet(address(facet)).ERC721_BURNER_ROLE())
+                == IERC721TokenFacet(address(facet)).TOKEN_ADMIN_ROLE(),
+            "burner admin mismatch"
+        );
+        assertTrue(
+            IERC721TokenFacet(address(facet)).getRoleAdmin(IERC721TokenFacet(address(facet)).ERC721_METADATA_ROLE())
+                == IERC721TokenFacet(address(facet)).TOKEN_ADMIN_ROLE(),
+            "metadata admin mismatch"
+        );
+    }
+
+    function testInitializeRevertsWhenCalledTwice() public {
+        _erc721Init(address(facet));
+
+        VM.expectRevert(abi.encodeWithSelector(IERC721TokenBase.ERC721TokenAlreadyInitialized.selector));
+        _erc721Init(address(facet));
+    }
+
+    function testMintBurnTransferAndMetadataFlows() public {
+        _erc721Init(address(facet));
+
+        VM.expectEmit(true, true, true, true, address(facet));
+        emit Transfer(address(0), bob, 1);
+        VM.prank(admin);
+        IERC721TokenFacet(address(facet)).mint(bob, 1);
+
+        VM.expectEmit(true, true, true, true, address(facet));
+        emit Approval(bob, eve, 1);
+        VM.prank(bob);
+        IERC721TokenFacet(address(facet)).approve(eve, 1);
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(facet)).setTokenURI(1, "ipfs://facet/custom-1");
+
+        VM.expectEmit(true, true, true, true, address(facet));
+        emit Transfer(bob, admin, 1);
+        VM.prank(eve);
+        IERC721TokenFacet(address(facet)).transferFrom(bob, admin, 1);
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(facet)).setBaseURI("https://example.com/meta/");
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(facet)).burn(1);
+
+        assertTrue(IERC721TokenFacet(address(facet)).totalSupply() == 0, "total supply mismatch");
+        assertTrue(IERC721TokenFacet(address(facet)).balanceOf(bob) == 0, "bob balance mismatch");
+        assertTrue(IERC721TokenFacet(address(facet)).balanceOf(admin) == 0, "admin balance mismatch");
+        VM.expectRevert(abi.encodeWithSelector(IERC721TokenBase.ERC721TokenNonexistentToken.selector, 1));
+        IERC721TokenFacet(address(facet)).ownerOf(1);
+    }
+
+    function testTokenUriPrefersExplicitUriAndClearsApprovalOnTransfer() public {
+        _erc721Init(address(facet));
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(facet)).mint(bob, 7);
+        VM.prank(admin);
+        IERC721TokenFacet(address(facet)).setTokenURI(7, "ipfs://facet/custom-7");
+
+        assertTrue(
+            keccak256(bytes(IERC721TokenFacet(address(facet)).tokenURI(7)))
+                == keccak256(bytes("ipfs://facet/custom-7")),
+            "explicit token uri mismatch"
+        );
+
+        VM.prank(bob);
+        IERC721TokenFacet(address(facet)).approve(eve, 7);
+
+        VM.prank(eve);
+        IERC721TokenFacet(address(facet)).transferFrom(bob, admin, 7);
+
+        assertTrue(IERC721TokenFacet(address(facet)).getApproved(7) == address(0), "approval should clear");
+    }
+
+    function testSafeTransferAndSafeMintHandleReceivers() public {
+        _erc721Init(address(facet));
+        bytes memory payload = hex"1234";
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(facet)).safeMint(address(receiver), 1, payload);
+
+        assertTrue(IERC721TokenFacet(address(facet)).ownerOf(1) == address(receiver), "receiver should own token");
+        assertTrue(receiver.lastOperator() == admin, "safe mint operator mismatch");
+        assertTrue(receiver.lastFrom() == address(0), "safe mint from mismatch");
+        assertTrue(receiver.lastTokenId() == 1, "safe mint token id mismatch");
+        assertTrue(keccak256(receiver.lastData()) == keccak256(payload), "safe mint data mismatch");
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(facet)).mint(admin, 2);
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(facet)).safeTransferFrom(admin, address(receiver), 2, payload);
+
+        assertTrue(IERC721TokenFacet(address(facet)).ownerOf(2) == address(receiver), "safe transfer owner mismatch");
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(facet)).mint(admin, 3);
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IERC721TokenBase.ERC721TokenUnsafeReceiver.selector, address(rejector)));
+        IERC721TokenFacet(address(facet)).safeTransferFrom(admin, address(rejector), 3);
+    }
+
+    function testApproveAndTransferRequireAuthorizedOperator() public {
+        _erc721Init(address(facet));
+        VM.prank(admin);
+        IERC721TokenFacet(address(facet)).mint(bob, 1);
+
+        VM.prank(eve);
+        VM.expectRevert(abi.encodeWithSelector(IERC721TokenFacet.ERC721TokenUnauthorizedOperator.selector, eve, 1));
+        IERC721TokenFacet(address(facet)).approve(admin, 1);
+
+        VM.prank(eve);
+        VM.expectRevert(abi.encodeWithSelector(IERC721TokenFacet.ERC721TokenUnauthorizedOperator.selector, eve, 1));
+        IERC721TokenFacet(address(facet)).transferFrom(bob, admin, 1);
+
+        VM.prank(bob);
+        IERC721TokenFacet(address(facet)).setApprovalForAll(eve, true);
+        VM.prank(eve);
+        IERC721TokenFacet(address(facet)).transferFrom(bob, admin, 1);
+
+        assertTrue(IERC721TokenFacet(address(facet)).ownerOf(1) == admin, "operator transfer should succeed");
+    }
+
+    function testUnauthorizedMintBurnAndMetadataUpdatesRevert() public {
+        _erc721Init(address(facet));
+        VM.prank(admin);
+        IERC721TokenFacet(address(facet)).mint(admin, 1);
+
+        VM.startPrank(bob);
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorized.selector,
+                bob,
+                IERC721TokenFacet(address(facet)).ERC721_MINTER_ROLE()
+            )
+        );
+        IERC721TokenFacet(address(facet)).mint(bob, 2);
+        VM.stopPrank();
+
+        VM.startPrank(bob);
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorized.selector,
+                bob,
+                IERC721TokenFacet(address(facet)).ERC721_BURNER_ROLE()
+            )
+        );
+        IERC721TokenFacet(address(facet)).burn(1);
+        VM.stopPrank();
+
+        VM.startPrank(bob);
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorized.selector,
+                bob,
+                IERC721TokenFacet(address(facet)).ERC721_METADATA_ROLE()
+            )
+        );
+        IERC721TokenFacet(address(facet)).setBaseURI("ipfs://other/");
+        VM.stopPrank();
+
+        VM.startPrank(bob);
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorized.selector,
+                bob,
+                IERC721TokenFacet(address(facet)).ERC721_METADATA_ROLE()
+            )
+        );
+        IERC721TokenFacet(address(facet)).setTokenURI(1, "ipfs://other/1");
+        VM.stopPrank();
+    }
+
+    function testPauseScopesBlockOnlyTheirIntendedPaths() public {
+        _erc721Init(address(facet));
+        bytes32 approvalScope = IERC721TokenFacet(address(facet)).ERC721_APPROVAL_SCOPE();
+        bytes32 transferScope = IERC721TokenFacet(address(facet)).ERC721_TRANSFER_SCOPE();
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(facet)).mint(bob, 1);
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(facet)).pauseScope(approvalScope);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, approvalScope));
+        IERC721TokenFacet(address(facet)).approve(eve, 1);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, approvalScope));
+        IERC721TokenFacet(address(facet)).setApprovalForAll(eve, true);
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(facet)).pauseScope(transferScope);
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(facet)).setBaseURI("https://example.com/meta/");
+        VM.prank(admin);
+        IERC721TokenFacet(address(facet)).setTokenURI(1, "https://example.com/meta/custom-1");
+
+        assertTrue(
+            keccak256(bytes(IERC721TokenFacet(address(facet)).tokenURI(1)))
+                == keccak256(bytes("https://example.com/meta/custom-1")),
+            "metadata updates should remain available"
+        );
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+        IERC721TokenFacet(address(facet)).transferFrom(bob, admin, 1);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+        IERC721TokenFacet(address(facet)).safeTransferFrom(bob, admin, 1);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+        IERC721TokenFacet(address(facet)).safeTransferFrom(bob, admin, 1, "");
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+        IERC721TokenFacet(address(facet)).mint(bob, 2);
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+        IERC721TokenFacet(address(facet)).safeMint(bob, 2, "");
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+        IERC721TokenFacet(address(facet)).burn(1);
+    }
+
+    function testSupportsFacetAndControlInterfaces() public {
+        _erc721Init(address(facet));
+
+        assertTrue(IERC721TokenFacet(address(facet)).supportsInterface(type(IERC165).interfaceId), "erc165 unsupported");
+        assertTrue(IERC721TokenFacet(address(facet)).supportsInterface(type(IERC721).interfaceId), "erc721 unsupported");
+        assertTrue(
+            IERC721TokenFacet(address(facet)).supportsInterface(type(IERC721Metadata).interfaceId),
+            "erc721 metadata unsupported"
+        );
+        assertTrue(
+            IERC721TokenFacet(address(facet)).supportsInterface(type(IAccessControl).interfaceId),
+            "access control unsupported"
+        );
+        assertTrue(
+            IERC721TokenFacet(address(facet)).supportsInterface(type(IPausable).interfaceId), "pausable unsupported"
+        );
+        assertTrue(
+            IERC721TokenFacet(address(facet)).supportsInterface(type(IERC721TokenFacet).interfaceId),
+            "facet interface unsupported"
+        );
+    }
+
+    function testDiamondRoutingAndInitWorkThroughFallback() public {
+        _addErc721FacetToDiamond();
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(diamond)).initializeErc721("Facet NFT", "FNFT", "ipfs://facet/", admin);
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(diamond)).mint(bob, 1);
+
+        VM.prank(bob);
+        IERC721TokenFacet(address(diamond)).approve(eve, 1);
+
+        VM.prank(eve);
+        IERC721TokenFacet(address(diamond)).transferFrom(bob, admin, 1);
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(diamond)).setApprovalForAll(eve, true);
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(diamond)).safeMint(address(receiver), 2, hex"cafe");
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(diamond)).mint(admin, 3);
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(diamond)).safeTransferFrom(admin, address(receiver), 3);
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(diamond)).setTokenURI(1, "ipfs://facet/custom-1");
+
+        assertTrue(IERC721TokenFacet(address(diamond)).isErc721Initialized(), "diamond erc721 should initialize");
+        assertTrue(IERC721TokenFacet(address(diamond)).ownerOf(1) == admin, "diamond owner mismatch");
+        assertTrue(IERC721TokenFacet(address(diamond)).ownerOf(2) == address(receiver), "diamond safe mint mismatch");
+        assertTrue(
+            IERC721TokenFacet(address(diamond)).ownerOf(3) == address(receiver), "diamond safe transfer mismatch"
+        );
+        assertTrue(IERC721TokenFacet(address(diamond)).balanceOf(admin) == 1, "diamond admin balance mismatch");
+        assertTrue(IERC721TokenFacet(address(diamond)).totalSupply() == 3, "diamond total supply mismatch");
+        assertTrue(
+            keccak256(bytes(IERC721TokenFacet(address(diamond)).tokenURI(1)))
+                == keccak256(bytes("ipfs://facet/custom-1")),
+            "diamond token uri mismatch"
+        );
+        assertTrue(
+            IERC721TokenFacet(address(diamond))
+                .hasRole(IERC721TokenFacet(address(diamond)).ERC721_METADATA_ROLE(), admin),
+            "diamond metadata role missing"
+        );
+    }
+
+    function testDiamondReinitializeReverts() public {
+        _addErc721FacetToDiamond();
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(diamond)).initializeErc721("Facet NFT", "FNFT", "ipfs://facet/", admin);
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IERC721TokenBase.ERC721TokenAlreadyInitialized.selector));
+        IERC721TokenFacet(address(diamond)).initializeErc721("Facet NFT", "FNFT", "ipfs://facet/", admin);
+    }
+}

--- a/test/helpers/ERC721TokenFacetTestHarness.sol
+++ b/test/helpers/ERC721TokenFacetTestHarness.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "../../src/interfaces/IAccessControl.sol";
+import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
+import {IERC165} from "../../src/interfaces/IERC165.sol";
+import {IERC721} from "../../src/interfaces/IERC721.sol";
+import {IERC721Metadata} from "../../src/interfaces/IERC721Metadata.sol";
+import {IERC721Receiver} from "../../src/interfaces/IERC721Receiver.sol";
+import {IERC721TokenBase} from "../../src/interfaces/IERC721TokenBase.sol";
+import {IERC721TokenFacet} from "../../src/interfaces/IERC721TokenFacet.sol";
+import {IPausable} from "../../src/interfaces/IPausable.sol";
+import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
+import {ERC721TokenFacet} from "../../src/token/facets/ERC721TokenFacet.sol";
+import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+import {ERC721ReceiverMock, ERC721ReceiverRejector} from "./TokenFacetFoundationTestHarness.sol";
+
+abstract contract ERC721TokenFacetFixture is TestBase {
+    address internal admin = address(0xA11CE);
+    address internal bob = address(0xB0B);
+    address internal eve = address(0xE11E);
+    address internal carol = address(0xCA401);
+
+    ERC721TokenFacet internal facet;
+    DiamondCutFacet internal cutFacet;
+    DiamondProxyHarness internal diamond;
+    ERC721ReceiverMock internal receiver;
+    ERC721ReceiverRejector internal rejector;
+
+    function setUp() public virtual {
+        facet = new ERC721TokenFacet();
+        cutFacet = new DiamondCutFacet();
+        diamond = new DiamondProxyHarness(admin, address(cutFacet));
+        receiver = new ERC721ReceiverMock(IERC721Receiver.onERC721Received.selector);
+        rejector = new ERC721ReceiverRejector();
+    }
+
+    function _erc721Init(address target) internal {
+        IERC721TokenFacet(target).initializeErc721("Facet NFT", "FNFT", "ipfs://facet/", admin);
+    }
+
+    function _addErc721FacetToDiamond() internal {
+        bytes4[] memory selectors = new bytes4[](35);
+        selectors[0] = IERC721TokenFacet.initializeErc721.selector;
+        selectors[1] = IERC721.balanceOf.selector;
+        selectors[2] = IERC721.ownerOf.selector;
+        selectors[3] = IERC721.approve.selector;
+        selectors[4] = IERC721.getApproved.selector;
+        selectors[5] = IERC721.setApprovalForAll.selector;
+        selectors[6] = IERC721.isApprovedForAll.selector;
+        selectors[7] = IERC721.transferFrom.selector;
+        selectors[8] = bytes4(keccak256("safeTransferFrom(address,address,uint256)"));
+        selectors[9] = bytes4(keccak256("safeTransferFrom(address,address,uint256,bytes)"));
+        selectors[10] = IERC721Metadata.tokenURI.selector;
+        selectors[11] = IERC721Metadata.name.selector;
+        selectors[12] = IERC721Metadata.symbol.selector;
+        selectors[13] = IERC721TokenFacet.totalSupply.selector;
+        selectors[14] = IERC721TokenBase.isErc721Initialized.selector;
+        selectors[15] = IERC721TokenFacet.mint.selector;
+        selectors[16] = IERC721TokenFacet.safeMint.selector;
+        selectors[17] = IERC721TokenFacet.burn.selector;
+        selectors[18] = IERC721TokenFacet.setBaseURI.selector;
+        selectors[19] = IERC721TokenFacet.setTokenURI.selector;
+        selectors[20] = IAccessControl.DEFAULT_ADMIN_ROLE.selector;
+        selectors[21] = IPausable.PAUSER_ROLE.selector;
+        selectors[22] = IERC721TokenFacet.TOKEN_ADMIN_ROLE.selector;
+        selectors[23] = IERC721TokenFacet.ERC721_MINTER_ROLE.selector;
+        selectors[24] = IERC721TokenFacet.ERC721_BURNER_ROLE.selector;
+        selectors[25] = IERC721TokenFacet.ERC721_METADATA_ROLE.selector;
+        selectors[26] = IERC721TokenFacet.ERC721_TRANSFER_SCOPE.selector;
+        selectors[27] = IERC721TokenFacet.ERC721_APPROVAL_SCOPE.selector;
+        selectors[28] = IAccessControl.hasRole.selector;
+        selectors[29] = IAccessControl.getRoleAdmin.selector;
+        selectors[30] = IAccessControl.grantRole.selector;
+        selectors[31] = IPausable.pauseScope.selector;
+        selectors[32] = IPausable.unpauseScope.selector;
+        selectors[33] = IPausable.scopePaused.selector;
+        selectors[34] = IERC165.supportsInterface.selector;
+
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(facet), action: IDiamondCut.FacetCutAction.Add, functionSelectors: selectors
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+}


### PR DESCRIPTION
## Summary
- add a hosted `ERC721TokenFacet` with shared ACL and scoped pausability integration
- add mutable metadata administration with role-gated `setBaseURI` and `setTokenURI`
- add direct and diamond-routed ERC721 facet coverage for init, roles, transfers, safe transfers, metadata, and pause enforcement

## Validation
- `forge fmt --check`
- `forge test --offline --match-path test/ERC721TokenFacetCore.t.sol`
- `forge test --offline`

## Issue
- Closes #83