### PR TITLE
Add diamond token host deployment integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         run: forge fmt --check
 
       - name: Build With Sizes
-        run: forge build --sizes
+        run: forge build --sizes --skip script
 
       - name: Run Offline Tests
         run: forge test --offline

--- a/.github/workflows/system-hardening.yml
+++ b/.github/workflows/system-hardening.yml
@@ -38,7 +38,7 @@ jobs:
             ${{ runner.os }}-foundry-cache-
 
       - name: Build With Sizes
-        run: forge build --sizes
+        run: forge build --sizes --skip script
 
       - name: Run System Vault Stress Invariants
         run: forge test --offline --match-path test/SystemVaultStressInvariant.t.sol
@@ -75,7 +75,7 @@ jobs:
             ${{ runner.os }}-foundry-cache-
 
       - name: Build With Sizes
-        run: forge build --sizes
+        run: forge build --sizes --skip script
 
       - name: Run Full Local Hardening Flow
         run: bash script/run-local-system-hardening.sh

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ execution order collected in `docs/ops/runbook-system-hardening.md`.
 
 CI and local validation parity are documented in `docs/security-checks.md`.
 
+Token facet deployment notes live in `docs/token-facets.md`, including the
+current reference rule that standard ERC20 and ERC721 surfaces are deployed as
+separate diamond hosts because their selectors collide.
+
 ## Tooling
 
 Built with Foundry. CI workflows live under `.github/workflows/`.

--- a/docs/token-facets.md
+++ b/docs/token-facets.md
@@ -67,3 +67,47 @@ advertises:
 When ERC-721 is installed behind a diamond, the init or deployment flow should
 ensure the diamond-level interface surface remains consistent with the facet
 selectors that are actually installed.
+
+### Selector Collision Constraint
+
+ERC20 and ERC721 storage layouts are intentionally separate and can coexist
+without storage collision. Their raw external selector surfaces cannot.
+
+The standard interfaces collide on shared selectors such as:
+
+- `name()`
+- `symbol()`
+- `totalSupply()`
+- `balanceOf(address)`
+- `supportsInterface(bytes4)` once shared control and ERC165 surfaces are
+  included
+
+That means one diamond cannot expose both standards unchanged at the same
+address. The reference deployment model in this repo is therefore:
+
+- one diamond hosting ERC20
+- one diamond hosting ERC721
+
+If both standards ever need to coexist in one host, that future design will
+need namespaced selectors or a different routing surface.
+
+### Reference Host Deployment Model
+
+The current reference deployment scripts install and initialize token facets as
+separate host flows:
+
+- `script/DeployDiamondErc20Host.s.sol`
+- `script/DeployDiamondErc721Host.s.sol`
+
+Each flow:
+
+- deploys a fresh diamond core
+- installs loupe selectors
+- installs one token facet selector set
+- immediately calls the token initializer through the diamond
+- validates selector ownership and initialized token metadata
+
+Deployment artifacts are written separately for replayable local validation:
+
+- `deployments/diamond-erc20.local.json`
+- `deployments/diamond-erc721.local.json`

--- a/script/DeployDiamondErc20Host.s.sol
+++ b/script/DeployDiamondErc20Host.s.sol
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {DiamondCutFacet} from "../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../src/diamond/facets/DiamondLoupeFacet.sol";
+import {IDiamondCut} from "../src/interfaces/IDiamondCut.sol";
+import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
+import {IERC165} from "../src/interfaces/IERC165.sol";
+import {IERC20Metadata} from "../src/interfaces/IERC20Metadata.sol";
+import {IERC20Permit} from "../src/interfaces/IERC20Permit.sol";
+import {IERC20TokenFacet} from "../src/interfaces/IERC20TokenFacet.sol";
+import {ERC20TokenFacet} from "../src/token/facets/ERC20TokenFacet.sol";
+import {LibTokenFacetDeploymentSelectors} from "../src/token/libraries/LibTokenFacetDeploymentSelectors.sol";
+import {DiamondTokenHostScriptBase} from "./common/DiamondTokenHostScriptBase.sol";
+
+/// @title DeployDiamondErc20HostScript
+/// @notice Reference local deployment flow for an ERC20-hosted diamond.
+contract DeployDiamondErc20HostScript is DiamondTokenHostScriptBase {
+    string internal constant TOKEN_OBJECT = "diamondErc20Host";
+    string internal constant TOKEN_OUTPUT_RELATIVE_PATH = "/deployments/diamond-erc20.local.json";
+
+    /// @notice Deploys and initializes a reference ERC20-hosted diamond.
+    /// @dev Requires `PRIVATE_KEY` to be set in the environment.
+    function run() external returns (address diamondAddress, address tokenFacetAddress) {
+        uint256 deployerPrivateKey = VM.envUint("PRIVATE_KEY");
+        address owner = VM.addr(deployerPrivateKey);
+        address cutFacetAddress;
+        address loupeFacetAddress;
+
+        VM.startBroadcast(deployerPrivateKey);
+
+        (diamondAddress, cutFacetAddress, loupeFacetAddress) = _deployDiamondCore(owner);
+        ERC20TokenFacet tokenFacet = new ERC20TokenFacet();
+        tokenFacetAddress = address(tokenFacet);
+
+        IDiamondCut.FacetCut[] memory tokenCut = new IDiamondCut.FacetCut[](1);
+        tokenCut[0] = IDiamondCut.FacetCut({
+            facetAddress: tokenFacetAddress,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibTokenFacetDeploymentSelectors.erc20HostSelectors()
+        });
+        IDiamondCut(diamondAddress).diamondCut(tokenCut, address(0), "");
+        IERC20TokenFacet(diamondAddress).initializeErc20("Facet Token", "FTKN", 18, owner);
+
+        VM.stopBroadcast();
+
+        _validateErc20Host(diamondAddress, owner, cutFacetAddress, loupeFacetAddress, tokenFacetAddress);
+        _writeTokenDeploymentArtifact(
+            TOKEN_OBJECT,
+            TOKEN_OUTPUT_RELATIVE_PATH,
+            "erc20",
+            owner,
+            diamondAddress,
+            cutFacetAddress,
+            loupeFacetAddress,
+            tokenFacetAddress
+        );
+    }
+
+    function _validateErc20Host(
+        address diamondAddress,
+        address owner,
+        address cutFacetAddress,
+        address loupeFacetAddress,
+        address tokenFacetAddress
+    ) internal view {
+        _validateDiamondCore(diamondAddress, owner, cutFacetAddress, loupeFacetAddress);
+
+        IDiamondLoupe loupe = IDiamondLoupe(diamondAddress);
+        IERC20TokenFacet token = IERC20TokenFacet(diamondAddress);
+        address[] memory facetAddresses = loupe.facetAddresses();
+        bytes4[] memory tokenSelectors = loupe.facetFunctionSelectors(tokenFacetAddress);
+
+        require(facetAddresses.length == 3, "erc20 host facet count mismatch");
+        require(_containsAddress(facetAddresses, cutFacetAddress), "erc20 host missing cut facet");
+        require(_containsAddress(facetAddresses, loupeFacetAddress), "erc20 host missing loupe facet");
+        require(_containsAddress(facetAddresses, tokenFacetAddress), "erc20 host missing token facet");
+        require(
+            tokenSelectors.length == LibTokenFacetDeploymentSelectors.erc20HostSelectors().length,
+            "erc20 host selector count mismatch"
+        );
+        require(token.isErc20Initialized(), "erc20 host not initialized");
+        require(keccak256(bytes(token.name())) == keccak256(bytes("Facet Token")), "erc20 host name mismatch");
+        require(keccak256(bytes(token.symbol())) == keccak256(bytes("FTKN")), "erc20 host symbol mismatch");
+        require(token.decimals() == 18, "erc20 host decimals mismatch");
+        require(token.hasRole(token.DEFAULT_ADMIN_ROLE(), owner), "erc20 host default admin missing");
+        require(token.hasRole(token.TOKEN_ADMIN_ROLE(), owner), "erc20 host token admin missing");
+        require(token.hasRole(token.ERC20_MINTER_ROLE(), owner), "erc20 host minter missing");
+        require(token.hasRole(token.ERC20_BURNER_ROLE(), owner), "erc20 host burner missing");
+        require(token.hasRole(token.PAUSER_ROLE(), owner), "erc20 host pauser missing");
+        require(token.supportsInterface(type(IERC165).interfaceId), "erc20 host missing erc165");
+        require(token.supportsInterface(type(IERC20Permit).interfaceId), "erc20 host missing permit");
+        require(token.supportsInterface(type(IERC20TokenFacet).interfaceId), "erc20 host missing facet interface");
+
+        _requireSelectorOwner(loupe, DiamondCutFacet.diamondCut.selector, cutFacetAddress, "erc20 host cut owner");
+        _requireSelectorOwner(loupe, DiamondLoupeFacet.facets.selector, loupeFacetAddress, "erc20 host loupe owner");
+        _requireSelectorOwner(
+            loupe, IERC20TokenFacet.initializeErc20.selector, tokenFacetAddress, "erc20 host init owner"
+        );
+        _requireSelectorOwner(loupe, IERC20Metadata.name.selector, tokenFacetAddress, "erc20 host name owner");
+        _requireSelectorOwner(
+            loupe, IERC20TokenFacet.TOKEN_ADMIN_ROLE.selector, tokenFacetAddress, "erc20 host token admin owner"
+        );
+        _requireSelectorOwner(loupe, IERC20Permit.permit.selector, tokenFacetAddress, "erc20 host permit owner");
+        _requireSelectorOwner(loupe, IERC165.supportsInterface.selector, tokenFacetAddress, "erc20 host erc165 owner");
+    }
+
+    function _requireSelectorOwner(IDiamondLoupe loupe, bytes4 selector, address expected, string memory message)
+        internal
+        view
+    {
+        require(loupe.facetAddress(selector) == expected, message);
+    }
+}

--- a/script/DeployDiamondErc721Host.s.sol
+++ b/script/DeployDiamondErc721Host.s.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {DiamondCutFacet} from "../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../src/diamond/facets/DiamondLoupeFacet.sol";
+import {IDiamondCut} from "../src/interfaces/IDiamondCut.sol";
+import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
+import {IERC165} from "../src/interfaces/IERC165.sol";
+import {IERC721} from "../src/interfaces/IERC721.sol";
+import {IERC721Metadata} from "../src/interfaces/IERC721Metadata.sol";
+import {IERC721TokenFacet} from "../src/interfaces/IERC721TokenFacet.sol";
+import {ERC721TokenFacet} from "../src/token/facets/ERC721TokenFacet.sol";
+import {LibTokenFacetDeploymentSelectors} from "../src/token/libraries/LibTokenFacetDeploymentSelectors.sol";
+import {DiamondTokenHostScriptBase} from "./common/DiamondTokenHostScriptBase.sol";
+
+/// @title DeployDiamondErc721HostScript
+/// @notice Reference local deployment flow for an ERC721-hosted diamond.
+contract DeployDiamondErc721HostScript is DiamondTokenHostScriptBase {
+    string internal constant TOKEN_OBJECT = "diamondErc721Host";
+    string internal constant TOKEN_OUTPUT_RELATIVE_PATH = "/deployments/diamond-erc721.local.json";
+
+    /// @notice Deploys and initializes a reference ERC721-hosted diamond.
+    /// @dev Requires `PRIVATE_KEY` to be set in the environment.
+    function run() external returns (address diamondAddress, address tokenFacetAddress) {
+        uint256 deployerPrivateKey = VM.envUint("PRIVATE_KEY");
+        address owner = VM.addr(deployerPrivateKey);
+        address cutFacetAddress;
+        address loupeFacetAddress;
+
+        VM.startBroadcast(deployerPrivateKey);
+
+        (diamondAddress, cutFacetAddress, loupeFacetAddress) = _deployDiamondCore(owner);
+        ERC721TokenFacet tokenFacet = new ERC721TokenFacet();
+        tokenFacetAddress = address(tokenFacet);
+
+        IDiamondCut.FacetCut[] memory tokenCut = new IDiamondCut.FacetCut[](1);
+        tokenCut[0] = IDiamondCut.FacetCut({
+            facetAddress: tokenFacetAddress,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibTokenFacetDeploymentSelectors.erc721HostSelectors()
+        });
+        IDiamondCut(diamondAddress).diamondCut(tokenCut, address(0), "");
+        IERC721TokenFacet(diamondAddress).initializeErc721("Facet NFT", "FNFT", "ipfs://facet/", owner);
+
+        VM.stopBroadcast();
+
+        _validateErc721Host(diamondAddress, owner, cutFacetAddress, loupeFacetAddress, tokenFacetAddress);
+        _writeTokenDeploymentArtifact(
+            TOKEN_OBJECT,
+            TOKEN_OUTPUT_RELATIVE_PATH,
+            "erc721",
+            owner,
+            diamondAddress,
+            cutFacetAddress,
+            loupeFacetAddress,
+            tokenFacetAddress
+        );
+    }
+
+    function _validateErc721Host(
+        address diamondAddress,
+        address owner,
+        address cutFacetAddress,
+        address loupeFacetAddress,
+        address tokenFacetAddress
+    ) internal view {
+        _validateDiamondCore(diamondAddress, owner, cutFacetAddress, loupeFacetAddress);
+
+        IDiamondLoupe loupe = IDiamondLoupe(diamondAddress);
+        IERC721TokenFacet token = IERC721TokenFacet(diamondAddress);
+        address[] memory facetAddresses = loupe.facetAddresses();
+        bytes4[] memory tokenSelectors = loupe.facetFunctionSelectors(tokenFacetAddress);
+
+        require(facetAddresses.length == 3, "erc721 host facet count mismatch");
+        require(_containsAddress(facetAddresses, cutFacetAddress), "erc721 host missing cut facet");
+        require(_containsAddress(facetAddresses, loupeFacetAddress), "erc721 host missing loupe facet");
+        require(_containsAddress(facetAddresses, tokenFacetAddress), "erc721 host missing token facet");
+        require(
+            tokenSelectors.length == LibTokenFacetDeploymentSelectors.erc721HostSelectors().length,
+            "erc721 host selector count mismatch"
+        );
+        require(token.isErc721Initialized(), "erc721 host not initialized");
+        require(keccak256(bytes(token.name())) == keccak256(bytes("Facet NFT")), "erc721 host name mismatch");
+        require(keccak256(bytes(token.symbol())) == keccak256(bytes("FNFT")), "erc721 host symbol mismatch");
+        require(token.totalSupply() == 0, "erc721 host initial supply mismatch");
+        require(token.hasRole(token.DEFAULT_ADMIN_ROLE(), owner), "erc721 host default admin missing");
+        require(token.hasRole(token.TOKEN_ADMIN_ROLE(), owner), "erc721 host token admin missing");
+        require(token.hasRole(token.ERC721_MINTER_ROLE(), owner), "erc721 host minter missing");
+        require(token.hasRole(token.ERC721_BURNER_ROLE(), owner), "erc721 host burner missing");
+        require(token.hasRole(token.ERC721_METADATA_ROLE(), owner), "erc721 host metadata missing");
+        require(token.hasRole(token.PAUSER_ROLE(), owner), "erc721 host pauser missing");
+        require(token.supportsInterface(type(IERC165).interfaceId), "erc721 host missing erc165");
+        require(token.supportsInterface(type(IERC721).interfaceId), "erc721 host missing erc721");
+        require(token.supportsInterface(type(IERC721Metadata).interfaceId), "erc721 host missing metadata");
+        require(token.supportsInterface(type(IERC721TokenFacet).interfaceId), "erc721 host missing facet interface");
+
+        _requireSelectorOwner(loupe, DiamondCutFacet.diamondCut.selector, cutFacetAddress, "erc721 host cut owner");
+        _requireSelectorOwner(loupe, DiamondLoupeFacet.facets.selector, loupeFacetAddress, "erc721 host loupe owner");
+        _requireSelectorOwner(
+            loupe, IERC721TokenFacet.initializeErc721.selector, tokenFacetAddress, "erc721 host init owner"
+        );
+        _requireSelectorOwner(loupe, IERC721Metadata.name.selector, tokenFacetAddress, "erc721 host name owner");
+        _requireSelectorOwner(
+            loupe, IERC721TokenFacet.ERC721_METADATA_ROLE.selector, tokenFacetAddress, "erc721 host metadata owner"
+        );
+        _requireSelectorOwner(loupe, IERC721.ownerOf.selector, tokenFacetAddress, "erc721 host ownerOf owner");
+        _requireSelectorOwner(loupe, IERC165.supportsInterface.selector, tokenFacetAddress, "erc721 host erc165 owner");
+    }
+
+    function _requireSelectorOwner(IDiamondLoupe loupe, bytes4 selector, address expected, string memory message)
+        internal
+        view
+    {
+        require(loupe.facetAddress(selector) == expected, message);
+    }
+}

--- a/script/common/DiamondTokenHostScriptBase.sol
+++ b/script/common/DiamondTokenHostScriptBase.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Diamond} from "../../src/diamond/Diamond.sol";
+import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
+import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
+import {IDiamondLoupe} from "../../src/interfaces/IDiamondLoupe.sol";
+import {IERC173} from "../../src/interfaces/IERC173.sol";
+import {LibTokenFacetDeploymentSelectors} from "../../src/token/libraries/LibTokenFacetDeploymentSelectors.sol";
+import {DiamondCoreScriptBase} from "./DiamondCoreScriptBase.sol";
+
+/// @title DiamondTokenHostScriptBase
+/// @notice Shared deployment helpers for reference token-hosted diamonds.
+abstract contract DiamondTokenHostScriptBase is DiamondCoreScriptBase {
+    /// @notice Parsed addresses from a token host deployment artifact.
+    struct TokenHostDeploymentArtifact {
+        address diamond;
+        address diamondCutFacet;
+        address diamondLoupeFacet;
+        address tokenFacet;
+        address owner;
+        uint256 chainId;
+        string tokenStandard;
+    }
+
+    function _deployDiamondCore(address owner)
+        internal
+        returns (address diamondAddress, address cutFacetAddress, address loupeFacetAddress)
+    {
+        DiamondCutFacet cutFacet = new DiamondCutFacet();
+        Diamond diamond = new Diamond(owner, address(cutFacet));
+        DiamondLoupeFacet loupeFacet = new DiamondLoupeFacet();
+
+        IDiamondCut.FacetCut[] memory initialCut = new IDiamondCut.FacetCut[](1);
+        initialCut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(loupeFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibTokenFacetDeploymentSelectors.loupeSelectors()
+        });
+        IDiamondCut(address(diamond)).diamondCut(initialCut, address(0), "");
+
+        diamondAddress = address(diamond);
+        cutFacetAddress = address(cutFacet);
+        loupeFacetAddress = address(loupeFacet);
+    }
+
+    function _validateDiamondCore(
+        address diamondAddress,
+        address owner,
+        address cutFacetAddress,
+        address loupeFacetAddress
+    ) internal view {
+        IERC173 ownership = IERC173(diamondAddress);
+        IDiamondLoupe loupe = IDiamondLoupe(diamondAddress);
+
+        require(ownership.owner() == owner, "token host owner mismatch");
+        require(
+            loupe.facetAddress(DiamondCutFacet.diamondCut.selector) == cutFacetAddress,
+            "token host cut selector mismatch"
+        );
+        require(
+            loupe.facetAddress(DiamondLoupeFacet.facets.selector) == loupeFacetAddress,
+            "token host loupe selector mismatch"
+        );
+    }
+
+    function _writeTokenDeploymentArtifact(
+        string memory objectKey,
+        string memory outputRelativePath,
+        string memory tokenStandard,
+        address owner,
+        address diamondAddress,
+        address cutFacetAddress,
+        address loupeFacetAddress,
+        address tokenFacetAddress
+    ) internal {
+        string memory json = VM.serializeString(objectKey, "network", "local-anvil");
+        json = VM.serializeUint(objectKey, "chainId", block.chainid);
+        json = VM.serializeString(objectKey, "tokenStandard", tokenStandard);
+        json = VM.serializeAddress(objectKey, "owner", owner);
+        json = VM.serializeAddress(objectKey, "diamond", diamondAddress);
+        json = VM.serializeAddress(objectKey, "diamondCutFacet", cutFacetAddress);
+        json = VM.serializeAddress(objectKey, "diamondLoupeFacet", loupeFacetAddress);
+        json = VM.serializeAddress(objectKey, "tokenFacet", tokenFacetAddress);
+        VM.writeJson(json, string.concat(VM.projectRoot(), outputRelativePath));
+    }
+
+    function _containsAddress(address[] memory addresses, address expected) internal pure returns (bool) {
+        for (uint256 i = 0; i < addresses.length; i++) {
+            if (addresses[i] == expected) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    function _containsSelector(bytes4[] memory selectors, bytes4 selector) internal pure returns (bool) {
+        for (uint256 i = 0; i < selectors.length; i++) {
+            if (selectors[i] == selector) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/token/libraries/LibTokenFacetDeploymentSelectors.sol
+++ b/src/token/libraries/LibTokenFacetDeploymentSelectors.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "../../interfaces/IAccessControl.sol";
+import {IERC165} from "../../interfaces/IERC165.sol";
+import {IERC20} from "../../interfaces/IERC20.sol";
+import {IERC20Metadata} from "../../interfaces/IERC20Metadata.sol";
+import {IERC20Permit} from "../../interfaces/IERC20Permit.sol";
+import {IERC20TokenBase} from "../../interfaces/IERC20TokenBase.sol";
+import {IERC20TokenFacet} from "../../interfaces/IERC20TokenFacet.sol";
+import {IERC721} from "../../interfaces/IERC721.sol";
+import {IERC721Metadata} from "../../interfaces/IERC721Metadata.sol";
+import {IERC721TokenBase} from "../../interfaces/IERC721TokenBase.sol";
+import {IERC721TokenFacet} from "../../interfaces/IERC721TokenFacet.sol";
+import {IPausable} from "../../interfaces/IPausable.sol";
+import {DiamondLoupeFacet} from "../../diamond/facets/DiamondLoupeFacet.sol";
+import {DiamondCutFacet} from "../../diamond/facets/DiamondCutFacet.sol";
+
+/// @title LibTokenFacetDeploymentSelectors
+/// @notice Canonical selector sets for reference token-hosted diamond deployments.
+library LibTokenFacetDeploymentSelectors {
+    /// @notice Returns the selector set used to install the loupe facet.
+    /// @return selectors Loupe + ownership selectors.
+    function loupeSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](6);
+        selectors[0] = DiamondLoupeFacet.facets.selector;
+        selectors[1] = DiamondLoupeFacet.facetFunctionSelectors.selector;
+        selectors[2] = DiamondLoupeFacet.facetAddresses.selector;
+        selectors[3] = DiamondLoupeFacet.facetAddress.selector;
+        selectors[4] = DiamondLoupeFacet.owner.selector;
+        selectors[5] = DiamondLoupeFacet.transferOwnership.selector;
+    }
+
+    /// @notice Returns the selector set used to install the ERC20 host facet.
+    /// @return selectors ERC20 + shared control selectors.
+    function erc20HostSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](30);
+        selectors[0] = IERC20TokenFacet.initializeErc20.selector;
+        selectors[1] = IERC20Metadata.name.selector;
+        selectors[2] = IERC20Metadata.symbol.selector;
+        selectors[3] = IERC20Metadata.decimals.selector;
+        selectors[4] = IERC20.totalSupply.selector;
+        selectors[5] = IERC20.balanceOf.selector;
+        selectors[6] = IERC20.allowance.selector;
+        selectors[7] = IERC20.transfer.selector;
+        selectors[8] = IERC20.approve.selector;
+        selectors[9] = IERC20.transferFrom.selector;
+        selectors[10] = IERC20TokenFacet.mint.selector;
+        selectors[11] = IERC20TokenFacet.burn.selector;
+        selectors[12] = IERC20TokenBase.isErc20Initialized.selector;
+        selectors[13] = IAccessControl.DEFAULT_ADMIN_ROLE.selector;
+        selectors[14] = IPausable.PAUSER_ROLE.selector;
+        selectors[15] = IERC20TokenFacet.TOKEN_ADMIN_ROLE.selector;
+        selectors[16] = IERC20TokenFacet.ERC20_MINTER_ROLE.selector;
+        selectors[17] = IERC20TokenFacet.ERC20_BURNER_ROLE.selector;
+        selectors[18] = IERC20TokenFacet.ERC20_TRANSFER_SCOPE.selector;
+        selectors[19] = IERC20TokenFacet.ERC20_APPROVAL_SCOPE.selector;
+        selectors[20] = IAccessControl.hasRole.selector;
+        selectors[21] = IAccessControl.getRoleAdmin.selector;
+        selectors[22] = IAccessControl.grantRole.selector;
+        selectors[23] = IPausable.pauseScope.selector;
+        selectors[24] = IPausable.unpauseScope.selector;
+        selectors[25] = IPausable.scopePaused.selector;
+        selectors[26] = IERC20Permit.permit.selector;
+        selectors[27] = IERC20Permit.nonces.selector;
+        selectors[28] = IERC20Permit.DOMAIN_SEPARATOR.selector;
+        selectors[29] = IERC165.supportsInterface.selector;
+    }
+
+    /// @notice Returns the selector set used to install the ERC721 host facet.
+    /// @return selectors ERC721 + shared control selectors.
+    function erc721HostSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](35);
+        selectors[0] = IERC721TokenFacet.initializeErc721.selector;
+        selectors[1] = IERC721.balanceOf.selector;
+        selectors[2] = IERC721.ownerOf.selector;
+        selectors[3] = IERC721.approve.selector;
+        selectors[4] = IERC721.getApproved.selector;
+        selectors[5] = IERC721.setApprovalForAll.selector;
+        selectors[6] = IERC721.isApprovedForAll.selector;
+        selectors[7] = IERC721.transferFrom.selector;
+        selectors[8] = bytes4(keccak256("safeTransferFrom(address,address,uint256)"));
+        selectors[9] = bytes4(keccak256("safeTransferFrom(address,address,uint256,bytes)"));
+        selectors[10] = IERC721Metadata.tokenURI.selector;
+        selectors[11] = IERC721Metadata.name.selector;
+        selectors[12] = IERC721Metadata.symbol.selector;
+        selectors[13] = IERC721TokenFacet.totalSupply.selector;
+        selectors[14] = IERC721TokenBase.isErc721Initialized.selector;
+        selectors[15] = IERC721TokenFacet.mint.selector;
+        selectors[16] = IERC721TokenFacet.safeMint.selector;
+        selectors[17] = IERC721TokenFacet.burn.selector;
+        selectors[18] = IERC721TokenFacet.setBaseURI.selector;
+        selectors[19] = IERC721TokenFacet.setTokenURI.selector;
+        selectors[20] = IAccessControl.DEFAULT_ADMIN_ROLE.selector;
+        selectors[21] = IPausable.PAUSER_ROLE.selector;
+        selectors[22] = IERC721TokenFacet.TOKEN_ADMIN_ROLE.selector;
+        selectors[23] = IERC721TokenFacet.ERC721_MINTER_ROLE.selector;
+        selectors[24] = IERC721TokenFacet.ERC721_BURNER_ROLE.selector;
+        selectors[25] = IERC721TokenFacet.ERC721_METADATA_ROLE.selector;
+        selectors[26] = IERC721TokenFacet.ERC721_TRANSFER_SCOPE.selector;
+        selectors[27] = IERC721TokenFacet.ERC721_APPROVAL_SCOPE.selector;
+        selectors[28] = IAccessControl.hasRole.selector;
+        selectors[29] = IAccessControl.getRoleAdmin.selector;
+        selectors[30] = IAccessControl.grantRole.selector;
+        selectors[31] = IPausable.pauseScope.selector;
+        selectors[32] = IPausable.unpauseScope.selector;
+        selectors[33] = IPausable.scopePaused.selector;
+        selectors[34] = IERC165.supportsInterface.selector;
+    }
+}

--- a/test/DiamondTokenDeploymentIntegration.t.sol
+++ b/test/DiamondTokenDeploymentIntegration.t.sol
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {DiamondCutFacet} from "../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../src/diamond/facets/DiamondLoupeFacet.sol";
+import {IDiamondCut} from "../src/interfaces/IDiamondCut.sol";
+import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
+import {IERC165} from "../src/interfaces/IERC165.sol";
+import {IERC20Metadata} from "../src/interfaces/IERC20Metadata.sol";
+import {IERC20TokenBase} from "../src/interfaces/IERC20TokenBase.sol";
+import {IERC20TokenFacet} from "../src/interfaces/IERC20TokenFacet.sol";
+import {IERC721} from "../src/interfaces/IERC721.sol";
+import {IERC721Metadata} from "../src/interfaces/IERC721Metadata.sol";
+import {IERC721TokenBase} from "../src/interfaces/IERC721TokenBase.sol";
+import {IERC721TokenFacet} from "../src/interfaces/IERC721TokenFacet.sol";
+import {LibDiamond} from "../src/diamond/libraries/LibDiamond.sol";
+import {DiamondTokenDeploymentFixture} from "./helpers/DiamondTokenDeploymentTestHarness.sol";
+
+contract DiamondTokenDeploymentIntegrationTest is DiamondTokenDeploymentFixture {
+    function testErc20HostDeployInstallInitAndLoupeChecks() public {
+        _installErc20HostFacet();
+
+        VM.prank(admin);
+        IERC20TokenFacet(address(diamond)).initializeErc20("Facet Token", "FTKN", 18, admin);
+
+        IDiamondLoupe loupe = IDiamondLoupe(address(diamond));
+        address[] memory facetAddresses = loupe.facetAddresses();
+
+        assertTrue(facetAddresses.length == 3, "erc20 host facet count mismatch");
+        assertTrue(_containsAddress(facetAddresses, address(cutFacet)), "erc20 host missing cut facet");
+        assertTrue(_containsAddress(facetAddresses, address(loupeFacet)), "erc20 host missing loupe facet");
+        assertTrue(_containsAddress(facetAddresses, address(erc20Facet)), "erc20 host missing erc20 facet");
+        assertTrue(loupe.facetFunctionSelectors(address(erc20Facet)).length == 30, "erc20 host selector count mismatch");
+        assertTrue(
+            loupe.facetAddress(DiamondCutFacet.diamondCut.selector) == address(cutFacet), "erc20 cut owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(DiamondLoupeFacet.facets.selector) == address(loupeFacet), "erc20 loupe owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC20TokenFacet.initializeErc20.selector) == address(erc20Facet),
+            "erc20 init owner mismatch"
+        );
+        assertTrue(loupe.facetAddress(IERC20Metadata.name.selector) == address(erc20Facet), "erc20 name owner mismatch");
+        assertTrue(
+            loupe.facetAddress(IERC165.supportsInterface.selector) == address(erc20Facet),
+            "erc20 supportsInterface owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC20TokenFacet.TOKEN_ADMIN_ROLE.selector) == address(erc20Facet),
+            "erc20 token admin owner mismatch"
+        );
+        assertTrue(IERC20TokenFacet(address(diamond)).isErc20Initialized(), "erc20 host not initialized");
+        assertTrue(
+            keccak256(bytes(IERC20TokenFacet(address(diamond)).name())) == keccak256(bytes("Facet Token")),
+            "erc20 host name mismatch"
+        );
+        assertTrue(
+            keccak256(bytes(IERC20TokenFacet(address(diamond)).symbol())) == keccak256(bytes("FTKN")),
+            "erc20 host symbol mismatch"
+        );
+        assertTrue(IERC20TokenFacet(address(diamond)).decimals() == 18, "erc20 host decimals mismatch");
+        assertTrue(
+            IERC20TokenFacet(address(diamond)).hasRole(IERC20TokenFacet(address(diamond)).TOKEN_ADMIN_ROLE(), admin),
+            "erc20 host token admin missing"
+        );
+        assertTrue(
+            IERC20TokenFacet(address(diamond)).supportsInterface(type(IERC20TokenFacet).interfaceId),
+            "erc20 host interface missing"
+        );
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IERC20TokenBase.ERC20TokenAlreadyInitialized.selector));
+        IERC20TokenFacet(address(diamond)).initializeErc20("Facet Token", "FTKN", 18, admin);
+    }
+
+    function testErc721HostDeployInstallInitAndLoupeChecks() public {
+        _installErc721HostFacet();
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(diamond)).initializeErc721("Facet NFT", "FNFT", "ipfs://facet/", admin);
+
+        IDiamondLoupe loupe = IDiamondLoupe(address(diamond));
+        address[] memory facetAddresses = loupe.facetAddresses();
+
+        assertTrue(facetAddresses.length == 3, "erc721 host facet count mismatch");
+        assertTrue(_containsAddress(facetAddresses, address(cutFacet)), "erc721 host missing cut facet");
+        assertTrue(_containsAddress(facetAddresses, address(loupeFacet)), "erc721 host missing loupe facet");
+        assertTrue(_containsAddress(facetAddresses, address(erc721Facet)), "erc721 host missing erc721 facet");
+        assertTrue(
+            loupe.facetFunctionSelectors(address(erc721Facet)).length == 35, "erc721 host selector count mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(DiamondCutFacet.diamondCut.selector) == address(cutFacet), "erc721 cut owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(DiamondLoupeFacet.facets.selector) == address(loupeFacet), "erc721 loupe owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC721TokenFacet.initializeErc721.selector) == address(erc721Facet),
+            "erc721 init owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC721Metadata.name.selector) == address(erc721Facet), "erc721 name owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC165.supportsInterface.selector) == address(erc721Facet),
+            "erc721 supportsInterface owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC721TokenFacet.ERC721_METADATA_ROLE.selector) == address(erc721Facet),
+            "erc721 metadata owner mismatch"
+        );
+        assertTrue(IERC721TokenFacet(address(diamond)).isErc721Initialized(), "erc721 host not initialized");
+        assertTrue(
+            keccak256(bytes(IERC721TokenFacet(address(diamond)).name())) == keccak256(bytes("Facet NFT")),
+            "erc721 host name mismatch"
+        );
+        assertTrue(
+            keccak256(bytes(IERC721TokenFacet(address(diamond)).symbol())) == keccak256(bytes("FNFT")),
+            "erc721 host symbol mismatch"
+        );
+        assertTrue(IERC721TokenFacet(address(diamond)).totalSupply() == 0, "erc721 host supply mismatch");
+        assertTrue(
+            IERC721TokenFacet(address(diamond))
+                .hasRole(IERC721TokenFacet(address(diamond)).ERC721_METADATA_ROLE(), admin),
+            "erc721 metadata role missing"
+        );
+        assertTrue(
+            IERC721TokenFacet(address(diamond)).supportsInterface(type(IERC721TokenFacet).interfaceId),
+            "erc721 host interface missing"
+        );
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IERC721TokenBase.ERC721TokenAlreadyInitialized.selector));
+        IERC721TokenFacet(address(diamond)).initializeErc721("Facet NFT", "FNFT", "ipfs://facet/", admin);
+    }
+
+    function testErc20AndErc721SelectorsCannotCoexistUnchanged() public {
+        _installErc20HostFacet();
+
+        IDiamondLoupe loupe = IDiamondLoupe(address(diamond));
+        IDiamondCut.FacetCut[] memory collisionCut = new IDiamondCut.FacetCut[](1);
+        bytes4[] memory selectors = new bytes4[](2);
+        selectors[0] = IERC721.ownerOf.selector;
+        selectors[1] = IERC721Metadata.name.selector;
+        collisionCut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(erc721Facet), action: IDiamondCut.FacetCutAction.Add, functionSelectors: selectors
+        });
+
+        VM.prank(admin);
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                LibDiamond.DiamondSelectorAlreadyExists.selector, IERC721Metadata.name.selector, address(erc20Facet)
+            )
+        );
+        IDiamondCut(address(diamond)).diamondCut(collisionCut, address(0), "");
+
+        assertTrue(
+            loupe.facetAddress(IERC721.ownerOf.selector) == address(0), "erc721 ownerOf should not be partially routed"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC20Metadata.name.selector) == address(erc20Facet),
+            "erc20 name owner should remain unchanged"
+        );
+        assertTrue(loupe.facetAddresses().length == 3, "collision revert should preserve facet count");
+    }
+}

--- a/test/helpers/DiamondTokenDeploymentTestHarness.sol
+++ b/test/helpers/DiamondTokenDeploymentTestHarness.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
+import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
+import {IDiamondLoupe} from "../../src/interfaces/IDiamondLoupe.sol";
+import {IERC165} from "../../src/interfaces/IERC165.sol";
+import {IERC20Metadata} from "../../src/interfaces/IERC20Metadata.sol";
+import {IERC20TokenFacet} from "../../src/interfaces/IERC20TokenFacet.sol";
+import {IERC721} from "../../src/interfaces/IERC721.sol";
+import {IERC721Metadata} from "../../src/interfaces/IERC721Metadata.sol";
+import {IERC721TokenBase} from "../../src/interfaces/IERC721TokenBase.sol";
+import {IERC721TokenFacet} from "../../src/interfaces/IERC721TokenFacet.sol";
+import {ERC20TokenFacet} from "../../src/token/facets/ERC20TokenFacet.sol";
+import {ERC721TokenFacet} from "../../src/token/facets/ERC721TokenFacet.sol";
+import {LibDiamond} from "../../src/diamond/libraries/LibDiamond.sol";
+import {LibTokenFacetDeploymentSelectors} from "../../src/token/libraries/LibTokenFacetDeploymentSelectors.sol";
+import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+
+abstract contract DiamondTokenDeploymentFixture is TestBase {
+    address internal admin = address(0xA11CE);
+
+    DiamondCutFacet internal cutFacet;
+    DiamondLoupeFacet internal loupeFacet;
+    ERC20TokenFacet internal erc20Facet;
+    ERC721TokenFacet internal erc721Facet;
+    DiamondProxyHarness internal diamond;
+
+    function setUp() public virtual {
+        cutFacet = new DiamondCutFacet();
+        loupeFacet = new DiamondLoupeFacet();
+        erc20Facet = new ERC20TokenFacet();
+        erc721Facet = new ERC721TokenFacet();
+        diamond = new DiamondProxyHarness(admin, address(cutFacet));
+
+        _installLoupeFacet();
+    }
+
+    function _installLoupeFacet() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(loupeFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibTokenFacetDeploymentSelectors.loupeSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installErc20HostFacet() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(erc20Facet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibTokenFacetDeploymentSelectors.erc20HostSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installErc721HostFacet() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(erc721Facet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibTokenFacetDeploymentSelectors.erc721HostSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _containsAddress(address[] memory addresses, address expected) internal pure returns (bool) {
+        for (uint256 i = 0; i < addresses.length; i++) {
+            if (addresses[i] == expected) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- add separate ERC20-hosted and ERC721-hosted diamond deployment flows
- add shared selector and script helpers for token host installation and validation
- add integration coverage for token host install/init/loupe checks and selector collision regression
- document why standard ERC20 and ERC721 selector surfaces must be deployed as separate diamond hosts

## Validation
- `forge fmt --check`
- `forge test --offline --match-path test/DiamondTokenDeploymentIntegration.t.sol`
- `forge test --offline`
- `forge script script/DeployDiamondErc20Host.s.sol:DeployDiamondErc20HostScript --rpc-url http://127.0.0.1:8545 --broadcast`
- `forge script script/DeployDiamondErc721Host.s.sol:DeployDiamondErc721HostScript --rpc-url http://127.0.0.1:8545 --broadcast`

## Issue
- Closes #84