### PR TITLE
Add diamond token host hardening coverage

### DIFF
--- a/src/token/libraries/LibTokenFacetDeploymentSelectors.sol
+++ b/src/token/libraries/LibTokenFacetDeploymentSelectors.sol
@@ -14,7 +14,6 @@ import {IERC721TokenBase} from "../../interfaces/IERC721TokenBase.sol";
 import {IERC721TokenFacet} from "../../interfaces/IERC721TokenFacet.sol";
 import {IPausable} from "../../interfaces/IPausable.sol";
 import {DiamondLoupeFacet} from "../../diamond/facets/DiamondLoupeFacet.sol";
-import {DiamondCutFacet} from "../../diamond/facets/DiamondCutFacet.sol";
 
 /// @title LibTokenFacetDeploymentSelectors
 /// @notice Canonical selector sets for reference token-hosted diamond deployments.
@@ -31,10 +30,9 @@ library LibTokenFacetDeploymentSelectors {
         selectors[5] = DiamondLoupeFacet.transferOwnership.selector;
     }
 
-    /// @notice Returns the selector set used to install the ERC20 host facet.
-    /// @return selectors ERC20 + shared control selectors.
-    function erc20HostSelectors() internal pure returns (bytes4[] memory selectors) {
-        selectors = new bytes4[](30);
+    /// @notice Returns the ERC20 token selectors for hosted deployments.
+    function erc20TokenSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](16);
         selectors[0] = IERC20TokenFacet.initializeErc20.selector;
         selectors[1] = IERC20Metadata.name.selector;
         selectors[2] = IERC20Metadata.symbol.selector;
@@ -48,29 +46,39 @@ library LibTokenFacetDeploymentSelectors {
         selectors[10] = IERC20TokenFacet.mint.selector;
         selectors[11] = IERC20TokenFacet.burn.selector;
         selectors[12] = IERC20TokenBase.isErc20Initialized.selector;
-        selectors[13] = IAccessControl.DEFAULT_ADMIN_ROLE.selector;
-        selectors[14] = IPausable.PAUSER_ROLE.selector;
-        selectors[15] = IERC20TokenFacet.TOKEN_ADMIN_ROLE.selector;
-        selectors[16] = IERC20TokenFacet.ERC20_MINTER_ROLE.selector;
-        selectors[17] = IERC20TokenFacet.ERC20_BURNER_ROLE.selector;
-        selectors[18] = IERC20TokenFacet.ERC20_TRANSFER_SCOPE.selector;
-        selectors[19] = IERC20TokenFacet.ERC20_APPROVAL_SCOPE.selector;
-        selectors[20] = IAccessControl.hasRole.selector;
-        selectors[21] = IAccessControl.getRoleAdmin.selector;
-        selectors[22] = IAccessControl.grantRole.selector;
-        selectors[23] = IPausable.pauseScope.selector;
-        selectors[24] = IPausable.unpauseScope.selector;
-        selectors[25] = IPausable.scopePaused.selector;
-        selectors[26] = IERC20Permit.permit.selector;
-        selectors[27] = IERC20Permit.nonces.selector;
-        selectors[28] = IERC20Permit.DOMAIN_SEPARATOR.selector;
-        selectors[29] = IERC165.supportsInterface.selector;
+        selectors[13] = IERC20Permit.permit.selector;
+        selectors[14] = IERC20Permit.nonces.selector;
+        selectors[15] = IERC20Permit.DOMAIN_SEPARATOR.selector;
     }
 
-    /// @notice Returns the selector set used to install the ERC721 host facet.
-    /// @return selectors ERC721 + shared control selectors.
-    function erc721HostSelectors() internal pure returns (bytes4[] memory selectors) {
-        selectors = new bytes4[](35);
+    /// @notice Returns the ERC20 shared-control selectors for hosted deployments.
+    function erc20SharedControlSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](14);
+        selectors[0] = IAccessControl.DEFAULT_ADMIN_ROLE.selector;
+        selectors[1] = IPausable.PAUSER_ROLE.selector;
+        selectors[2] = IERC20TokenFacet.TOKEN_ADMIN_ROLE.selector;
+        selectors[3] = IERC20TokenFacet.ERC20_MINTER_ROLE.selector;
+        selectors[4] = IERC20TokenFacet.ERC20_BURNER_ROLE.selector;
+        selectors[5] = IERC20TokenFacet.ERC20_TRANSFER_SCOPE.selector;
+        selectors[6] = IERC20TokenFacet.ERC20_APPROVAL_SCOPE.selector;
+        selectors[7] = IAccessControl.hasRole.selector;
+        selectors[8] = IAccessControl.getRoleAdmin.selector;
+        selectors[9] = IAccessControl.grantRole.selector;
+        selectors[10] = IPausable.pauseScope.selector;
+        selectors[11] = IPausable.unpauseScope.selector;
+        selectors[12] = IPausable.scopePaused.selector;
+        selectors[13] = IERC165.supportsInterface.selector;
+    }
+
+    /// @notice Returns the selector set used to install the ERC20 host facet.
+    /// @return selectors ERC20 + shared control selectors.
+    function erc20HostSelectors() internal pure returns (bytes4[] memory selectors) {
+        return _concat(erc20TokenSelectors(), erc20SharedControlSelectors());
+    }
+
+    /// @notice Returns the ERC721 token selectors for hosted deployments.
+    function erc721TokenSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](20);
         selectors[0] = IERC721TokenFacet.initializeErc721.selector;
         selectors[1] = IERC721.balanceOf.selector;
         selectors[2] = IERC721.ownerOf.selector;
@@ -91,20 +99,44 @@ library LibTokenFacetDeploymentSelectors {
         selectors[17] = IERC721TokenFacet.burn.selector;
         selectors[18] = IERC721TokenFacet.setBaseURI.selector;
         selectors[19] = IERC721TokenFacet.setTokenURI.selector;
-        selectors[20] = IAccessControl.DEFAULT_ADMIN_ROLE.selector;
-        selectors[21] = IPausable.PAUSER_ROLE.selector;
-        selectors[22] = IERC721TokenFacet.TOKEN_ADMIN_ROLE.selector;
-        selectors[23] = IERC721TokenFacet.ERC721_MINTER_ROLE.selector;
-        selectors[24] = IERC721TokenFacet.ERC721_BURNER_ROLE.selector;
-        selectors[25] = IERC721TokenFacet.ERC721_METADATA_ROLE.selector;
-        selectors[26] = IERC721TokenFacet.ERC721_TRANSFER_SCOPE.selector;
-        selectors[27] = IERC721TokenFacet.ERC721_APPROVAL_SCOPE.selector;
-        selectors[28] = IAccessControl.hasRole.selector;
-        selectors[29] = IAccessControl.getRoleAdmin.selector;
-        selectors[30] = IAccessControl.grantRole.selector;
-        selectors[31] = IPausable.pauseScope.selector;
-        selectors[32] = IPausable.unpauseScope.selector;
-        selectors[33] = IPausable.scopePaused.selector;
-        selectors[34] = IERC165.supportsInterface.selector;
+    }
+
+    /// @notice Returns the ERC721 shared-control selectors for hosted deployments.
+    function erc721SharedControlSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](15);
+        selectors[0] = IAccessControl.DEFAULT_ADMIN_ROLE.selector;
+        selectors[1] = IPausable.PAUSER_ROLE.selector;
+        selectors[2] = IERC721TokenFacet.TOKEN_ADMIN_ROLE.selector;
+        selectors[3] = IERC721TokenFacet.ERC721_MINTER_ROLE.selector;
+        selectors[4] = IERC721TokenFacet.ERC721_BURNER_ROLE.selector;
+        selectors[5] = IERC721TokenFacet.ERC721_METADATA_ROLE.selector;
+        selectors[6] = IERC721TokenFacet.ERC721_TRANSFER_SCOPE.selector;
+        selectors[7] = IERC721TokenFacet.ERC721_APPROVAL_SCOPE.selector;
+        selectors[8] = IAccessControl.hasRole.selector;
+        selectors[9] = IAccessControl.getRoleAdmin.selector;
+        selectors[10] = IAccessControl.grantRole.selector;
+        selectors[11] = IPausable.pauseScope.selector;
+        selectors[12] = IPausable.unpauseScope.selector;
+        selectors[13] = IPausable.scopePaused.selector;
+        selectors[14] = IERC165.supportsInterface.selector;
+    }
+
+    /// @notice Returns the selector set used to install the ERC721 host facet.
+    /// @return selectors ERC721 + shared control selectors.
+    function erc721HostSelectors() internal pure returns (bytes4[] memory selectors) {
+        return _concat(erc721TokenSelectors(), erc721SharedControlSelectors());
+    }
+
+    function _concat(bytes4[] memory first, bytes4[] memory second) private pure returns (bytes4[] memory combined) {
+        combined = new bytes4[](first.length + second.length);
+
+        uint256 i;
+        for (; i < first.length; i++) {
+            combined[i] = first[i];
+        }
+
+        for (uint256 j = 0; j < second.length; j++) {
+            combined[i + j] = second[j];
+        }
     }
 }

--- a/test/DiamondErc20HostInvariant.t.sol
+++ b/test/DiamondErc20HostInvariant.t.sol
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC20TokenFacet} from "../src/interfaces/IERC20TokenFacet.sol";
+import {IPausable} from "../src/interfaces/IPausable.sol";
+import {DiamondTokenHostHardeningFixture} from "./helpers/DiamondTokenHostHardeningTestHarness.sol";
+
+contract DiamondErc20HostInvariantTest is DiamondTokenHostHardeningFixture {
+    struct AccountingSnapshot {
+        uint256 totalSupply;
+        uint256 totalTrackedBalances;
+    }
+
+    uint256 internal constant ACTOR_COUNT = 5;
+    uint256 internal constant INITIAL_BALANCE = 1_000_000;
+
+    address[ACTOR_COUNT] internal actors;
+    mapping(address => uint256) internal trackedPermitSuccesses;
+
+    function setUp() public override {
+        super.setUp();
+        _installErc20HostFacet(address(erc20Facet));
+        _erc20InitDiamond();
+
+        actors[0] = admin;
+        actors[1] = bob;
+        actors[2] = eve;
+        actors[3] = carol;
+        actors[4] = dave;
+
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            VM.prank(admin);
+            IERC20TokenFacet(address(diamond)).mint(actors[i], INITIAL_BALANCE);
+        }
+    }
+
+    function targetContracts() external view returns (address[] memory contracts) {
+        contracts = new address[](1);
+        contracts[0] = address(this);
+    }
+
+    function actionApprove(uint8 ownerSeed, uint8 spenderSeed, uint96 valueRaw) external {
+        IERC20TokenFacet token = IERC20TokenFacet(address(diamond));
+        address owner = _actor(ownerSeed);
+        address spender = _actorExcluding(owner, spenderSeed);
+        bytes32 approvalScope = token.ERC20_APPROVAL_SCOPE();
+        uint256 value = uint256(valueRaw);
+
+        if (token.scopePaused(approvalScope)) {
+            AccountingSnapshot memory snapshot = _snapshotAccounting();
+            VM.startPrank(owner);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, approvalScope));
+            token.approve(spender, value);
+            VM.stopPrank();
+            _assertAccountingUnchanged(snapshot, "paused approve should not mutate accounting");
+            return;
+        }
+
+        VM.prank(owner);
+        token.approve(spender, value);
+    }
+
+    function actionPermit(uint8 ownerSeed, uint8 spenderSeed, uint96 valueRaw, uint32 deadlineOffsetRaw) external {
+        IERC20TokenFacet token = IERC20TokenFacet(address(diamond));
+        address owner = _actor(ownerSeed);
+        address spender = _actorExcluding(owner, spenderSeed);
+        bytes32 approvalScope = token.ERC20_APPROVAL_SCOPE();
+        uint256 value = uint256(valueRaw);
+        uint256 deadline = block.timestamp + uint256(deadlineOffsetRaw) + 1;
+        uint256 nonce = token.nonces(owner);
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(address(diamond), owner, spender, value, nonce, deadline);
+
+        if (token.scopePaused(approvalScope)) {
+            AccountingSnapshot memory snapshot = _snapshotAccounting();
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, approvalScope));
+            token.permit(owner, spender, value, deadline, v, r, s);
+            _assertAccountingUnchanged(snapshot, "paused permit should not mutate accounting");
+            return;
+        }
+
+        token.permit(owner, spender, value, deadline, v, r, s);
+        trackedPermitSuccesses[owner] += 1;
+    }
+
+    function actionTransfer(uint8 fromSeed, uint8 toSeed, uint96 valueRaw) external {
+        IERC20TokenFacet token = IERC20TokenFacet(address(diamond));
+        address from = _actor(fromSeed);
+        address to = _actorExcluding(from, toSeed);
+        bytes32 transferScope = token.ERC20_TRANSFER_SCOPE();
+        uint256 value = _boundAmount(valueRaw, token.balanceOf(from));
+        if (value == 0) return;
+
+        if (token.scopePaused(transferScope)) {
+            AccountingSnapshot memory snapshot = _snapshotAccounting();
+            VM.startPrank(from);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+            token.transfer(to, value);
+            VM.stopPrank();
+            _assertAccountingUnchanged(snapshot, "paused transfer should not mutate accounting");
+            return;
+        }
+
+        VM.prank(from);
+        token.transfer(to, value);
+    }
+
+    function actionTransferFrom(uint8 spenderSeed, uint8 ownerSeed, uint8 toSeed, uint96 valueRaw) external {
+        IERC20TokenFacet token = IERC20TokenFacet(address(diamond));
+        address spender = _actor(spenderSeed);
+        address owner = _actor(ownerSeed);
+        address to = _actorExcluding(owner, toSeed);
+        if (spender == owner) return;
+
+        uint256 allowance = token.allowance(owner, spender);
+        uint256 balance = token.balanceOf(owner);
+        uint256 value = _boundAmount(valueRaw, allowance < balance ? allowance : balance);
+        if (value == 0) return;
+
+        bytes32 transferScope = token.ERC20_TRANSFER_SCOPE();
+        bytes32 approvalScope = token.ERC20_APPROVAL_SCOPE();
+        if (token.scopePaused(transferScope) || token.scopePaused(approvalScope)) {
+            bytes32 expectedScope = token.scopePaused(approvalScope) ? approvalScope : transferScope;
+            AccountingSnapshot memory snapshot = _snapshotAccounting();
+            VM.startPrank(spender);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, expectedScope));
+            token.transferFrom(owner, to, value);
+            VM.stopPrank();
+            _assertAccountingUnchanged(snapshot, "paused transferFrom should not mutate accounting");
+            return;
+        }
+
+        VM.prank(spender);
+        token.transferFrom(owner, to, value);
+    }
+
+    function actionMint(uint8 actorSeed, uint96 valueRaw) external {
+        IERC20TokenFacet token = IERC20TokenFacet(address(diamond));
+        bytes32 transferScope = token.ERC20_TRANSFER_SCOPE();
+        uint256 value = uint256(valueRaw);
+        if (value == 0) return;
+
+        if (token.scopePaused(transferScope)) {
+            AccountingSnapshot memory snapshot = _snapshotAccounting();
+            VM.prank(admin);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+            token.mint(_actor(actorSeed), value);
+            _assertAccountingUnchanged(snapshot, "paused mint should not mutate accounting");
+            return;
+        }
+
+        VM.prank(admin);
+        token.mint(_actor(actorSeed), value);
+    }
+
+    function actionBurn(uint8 actorSeed, uint96 valueRaw) external {
+        IERC20TokenFacet token = IERC20TokenFacet(address(diamond));
+        address actor = _actor(actorSeed);
+        bytes32 transferScope = token.ERC20_TRANSFER_SCOPE();
+        uint256 value = _boundAmount(valueRaw, token.balanceOf(actor));
+        if (value == 0) return;
+
+        if (token.scopePaused(transferScope)) {
+            AccountingSnapshot memory snapshot = _snapshotAccounting();
+            VM.prank(admin);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+            token.burn(actor, value);
+            _assertAccountingUnchanged(snapshot, "paused burn should not mutate accounting");
+            return;
+        }
+
+        VM.prank(admin);
+        token.burn(actor, value);
+    }
+
+    function actionSetApprovalScopePaused(bool paused_) external {
+        IERC20TokenFacet token = IERC20TokenFacet(address(diamond));
+        bytes32 approvalScope = token.ERC20_APPROVAL_SCOPE();
+        bool isPaused = token.scopePaused(approvalScope);
+        if (paused_ && !isPaused) {
+            VM.prank(admin);
+            token.pauseScope(approvalScope);
+        } else if (!paused_ && isPaused) {
+            VM.prank(admin);
+            token.unpauseScope(approvalScope);
+        }
+    }
+
+    function actionSetTransferScopePaused(bool paused_) external {
+        IERC20TokenFacet token = IERC20TokenFacet(address(diamond));
+        bytes32 transferScope = token.ERC20_TRANSFER_SCOPE();
+        bool isPaused = token.scopePaused(transferScope);
+        if (paused_ && !isPaused) {
+            VM.prank(admin);
+            token.pauseScope(transferScope);
+        } else if (!paused_ && isPaused) {
+            VM.prank(admin);
+            token.unpauseScope(transferScope);
+        }
+    }
+
+    function invariantTotalSupplyEqualsTrackedBalances() public view {
+        assertTrue(
+            IERC20TokenFacet(address(diamond)).totalSupply() == _sumTrackedBalances(),
+            "host total supply must equal tracked balances"
+        );
+    }
+
+    function invariantTrackedPermitNoncesMatchSuccessfulCalls() public view {
+        IERC20TokenFacet token = IERC20TokenFacet(address(diamond));
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            address actor = actors[i];
+            assertTrue(
+                token.nonces(actor) == trackedPermitSuccesses[actor],
+                "host permit nonces must match successful permit calls"
+            );
+        }
+    }
+
+    function _boundAmount(uint256 raw, uint256 max) internal pure returns (uint256) {
+        if (max == 0) return 0;
+        return (raw % max) + 1;
+    }
+
+    function _sumTrackedBalances() internal view returns (uint256 sum) {
+        IERC20TokenFacet token = IERC20TokenFacet(address(diamond));
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            sum += token.balanceOf(actors[i]);
+        }
+    }
+
+    function _snapshotAccounting() internal view returns (AccountingSnapshot memory snapshot) {
+        IERC20TokenFacet token = IERC20TokenFacet(address(diamond));
+        snapshot.totalSupply = token.totalSupply();
+        snapshot.totalTrackedBalances = _sumTrackedBalances();
+    }
+
+    function _assertAccountingUnchanged(AccountingSnapshot memory snapshot, string memory reason) internal view {
+        IERC20TokenFacet token = IERC20TokenFacet(address(diamond));
+        assertTrue(token.totalSupply() == snapshot.totalSupply, reason);
+        assertTrue(_sumTrackedBalances() == snapshot.totalTrackedBalances, reason);
+    }
+}

--- a/test/DiamondErc721HostInvariant.t.sol
+++ b/test/DiamondErc721HostInvariant.t.sol
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC721TokenBase} from "../src/interfaces/IERC721TokenBase.sol";
+import {IERC721TokenFacet} from "../src/interfaces/IERC721TokenFacet.sol";
+import {IPausable} from "../src/interfaces/IPausable.sol";
+import {DiamondTokenHostHardeningFixture} from "./helpers/DiamondTokenHostHardeningTestHarness.sol";
+
+contract DiamondErc721HostInvariantTest is DiamondTokenHostHardeningFixture {
+    uint256 internal constant TOKEN_POOL = 8;
+    uint256 internal constant ACTOR_COUNT = 5;
+
+    address[ACTOR_COUNT] internal actors;
+
+    function setUp() public override {
+        super.setUp();
+        _installErc721HostFacet(address(erc721Facet));
+        _erc721InitDiamond();
+
+        actors[0] = admin;
+        actors[1] = bob;
+        actors[2] = eve;
+        actors[3] = carol;
+        actors[4] = dave;
+    }
+
+    function targetContracts() external view returns (address[] memory contracts) {
+        contracts = new address[](1);
+        contracts[0] = address(this);
+    }
+
+    function actionMint(uint8 toSeed, uint8 tokenSeed) external {
+        IERC721TokenFacet token = IERC721TokenFacet(address(diamond));
+        uint256 tokenId = _tokenId(tokenSeed);
+        bytes32 transferScope = token.ERC721_TRANSFER_SCOPE();
+        if (_erc721Exists(tokenId)) return;
+
+        if (token.scopePaused(transferScope)) {
+            VM.prank(admin);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+            token.mint(_actor(toSeed), tokenId);
+            return;
+        }
+
+        VM.prank(admin);
+        token.mint(_actor(toSeed), tokenId);
+    }
+
+    function actionSafeMint(uint8 toSeed, uint8 tokenSeed, bytes4 dataSeed) external {
+        IERC721TokenFacet token = IERC721TokenFacet(address(diamond));
+        uint256 tokenId = _tokenId(tokenSeed);
+        bytes32 transferScope = token.ERC721_TRANSFER_SCOPE();
+        if (_erc721Exists(tokenId)) return;
+
+        if (token.scopePaused(transferScope)) {
+            VM.prank(admin);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+            token.safeMint(_actor(toSeed), tokenId, abi.encodePacked(dataSeed));
+            return;
+        }
+
+        VM.prank(admin);
+        token.safeMint(_actor(toSeed), tokenId, abi.encodePacked(dataSeed));
+    }
+
+    function actionApprove(uint8 operatorSeed, uint8 tokenSeed) external {
+        IERC721TokenFacet token = IERC721TokenFacet(address(diamond));
+        uint256 tokenId = _tokenId(tokenSeed);
+        if (!_erc721Exists(tokenId)) return;
+
+        address owner = token.ownerOf(tokenId);
+        address operator = _actorExcluding(owner, operatorSeed);
+        bytes32 approvalScope = token.ERC721_APPROVAL_SCOPE();
+
+        if (token.scopePaused(approvalScope)) {
+            VM.prank(owner);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, approvalScope));
+            token.approve(operator, tokenId);
+            return;
+        }
+
+        VM.prank(owner);
+        token.approve(operator, tokenId);
+        assertTrue(token.getApproved(tokenId) == operator, "host erc721 approval should update");
+    }
+
+    function actionSetApprovalForAll(uint8 ownerSeed, uint8 operatorSeed, bool approved) external {
+        IERC721TokenFacet token = IERC721TokenFacet(address(diamond));
+        address owner = _actor(ownerSeed);
+        address operator = _actorExcluding(owner, operatorSeed);
+        bytes32 approvalScope = token.ERC721_APPROVAL_SCOPE();
+
+        if (token.scopePaused(approvalScope)) {
+            VM.prank(owner);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, approvalScope));
+            token.setApprovalForAll(operator, approved);
+            return;
+        }
+
+        VM.prank(owner);
+        token.setApprovalForAll(operator, approved);
+        assertTrue(token.isApprovedForAll(owner, operator) == approved, "host erc721 operator approval mismatch");
+    }
+
+    function actionTransferFrom(uint8 toSeed, uint8 tokenSeed, uint8 approvalSeed) external {
+        IERC721TokenFacet token = IERC721TokenFacet(address(diamond));
+        uint256 tokenId = _tokenId(tokenSeed);
+        if (!_erc721Exists(tokenId)) return;
+
+        address owner = token.ownerOf(tokenId);
+        address to = _actorExcluding(owner, toSeed);
+        bytes32 transferScope = token.ERC721_TRANSFER_SCOPE();
+        bytes32 approvalScope = token.ERC721_APPROVAL_SCOPE();
+
+        if (!token.scopePaused(approvalScope)) {
+            VM.prank(owner);
+            token.approve(_actorExcluding(owner, approvalSeed), tokenId);
+        }
+
+        if (token.scopePaused(transferScope)) {
+            VM.prank(owner);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+            token.transferFrom(owner, to, tokenId);
+            return;
+        }
+
+        VM.prank(owner);
+        token.transferFrom(owner, to, tokenId);
+        assertTrue(token.ownerOf(tokenId) == to, "host erc721 transfer owner mismatch");
+        assertTrue(token.getApproved(tokenId) == address(0), "host erc721 transfer should clear approval");
+    }
+
+    function actionSafeTransferFrom(uint8 toSeed, uint8 tokenSeed, uint8 approvalSeed, bool withData) external {
+        IERC721TokenFacet token = IERC721TokenFacet(address(diamond));
+        uint256 tokenId = _tokenId(tokenSeed);
+        if (!_erc721Exists(tokenId)) return;
+
+        address owner = token.ownerOf(tokenId);
+        address to = _actorExcluding(owner, toSeed);
+        bytes32 transferScope = token.ERC721_TRANSFER_SCOPE();
+        bytes32 approvalScope = token.ERC721_APPROVAL_SCOPE();
+
+        if (!token.scopePaused(approvalScope)) {
+            VM.prank(owner);
+            token.approve(_actorExcluding(owner, approvalSeed), tokenId);
+        }
+
+        if (token.scopePaused(transferScope)) {
+            VM.prank(owner);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+            if (withData) {
+                token.safeTransferFrom(owner, to, tokenId, hex"cafe");
+            } else {
+                token.safeTransferFrom(owner, to, tokenId);
+            }
+            return;
+        }
+
+        VM.prank(owner);
+        if (withData) {
+            token.safeTransferFrom(owner, to, tokenId, hex"cafe");
+        } else {
+            token.safeTransferFrom(owner, to, tokenId);
+        }
+        assertTrue(token.ownerOf(tokenId) == to, "host erc721 safe transfer owner mismatch");
+        assertTrue(token.getApproved(tokenId) == address(0), "host erc721 safe transfer should clear approval");
+    }
+
+    function actionBurn(uint8 tokenSeed, uint8 approvalSeed) external {
+        IERC721TokenFacet token = IERC721TokenFacet(address(diamond));
+        uint256 tokenId = _tokenId(tokenSeed);
+        if (!_erc721Exists(tokenId)) return;
+
+        bytes32 transferScope = token.ERC721_TRANSFER_SCOPE();
+        bytes32 approvalScope = token.ERC721_APPROVAL_SCOPE();
+        address owner = token.ownerOf(tokenId);
+        if (!token.scopePaused(approvalScope)) {
+            VM.prank(owner);
+            token.approve(_actorExcluding(owner, approvalSeed), tokenId);
+        }
+
+        if (token.scopePaused(transferScope)) {
+            VM.prank(admin);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, transferScope));
+            token.burn(tokenId);
+            return;
+        }
+
+        VM.prank(admin);
+        token.burn(tokenId);
+        _expectNonexistentToken(tokenId);
+        assertTrue(_erc721ApprovalOrZero(tokenId) == address(0), "host erc721 burn should clear approval");
+    }
+
+    function actionSetBaseURI(bool alternate) external {
+        IERC721TokenFacet token = IERC721TokenFacet(address(diamond));
+        string memory baseUri = alternate ? "ipfs://updated-a/" : "ipfs://updated-b/";
+        VM.prank(admin);
+        token.setBaseURI(baseUri);
+    }
+
+    function actionSetTokenURI(uint8 tokenSeed, bool alternate) external {
+        IERC721TokenFacet token = IERC721TokenFacet(address(diamond));
+        uint256 tokenId = _tokenId(tokenSeed);
+        if (!_erc721Exists(tokenId)) return;
+
+        string memory customUri = alternate ? "ipfs://custom-a" : "ipfs://custom-b";
+        VM.prank(admin);
+        token.setTokenURI(tokenId, customUri);
+        assertTrue(
+            keccak256(bytes(token.tokenURI(tokenId))) == keccak256(bytes(customUri)),
+            "host erc721 token uri update mismatch"
+        );
+    }
+
+    function actionSetApprovalScopePaused(bool paused_) external {
+        IERC721TokenFacet token = IERC721TokenFacet(address(diamond));
+        bytes32 approvalScope = token.ERC721_APPROVAL_SCOPE();
+        bool isPaused = token.scopePaused(approvalScope);
+        if (paused_ && !isPaused) {
+            VM.prank(admin);
+            token.pauseScope(approvalScope);
+        } else if (!paused_ && isPaused) {
+            VM.prank(admin);
+            token.unpauseScope(approvalScope);
+        }
+    }
+
+    function actionSetTransferScopePaused(bool paused_) external {
+        IERC721TokenFacet token = IERC721TokenFacet(address(diamond));
+        bytes32 transferScope = token.ERC721_TRANSFER_SCOPE();
+        bool isPaused = token.scopePaused(transferScope);
+        if (paused_ && !isPaused) {
+            VM.prank(admin);
+            token.pauseScope(transferScope);
+        } else if (!paused_ && isPaused) {
+            VM.prank(admin);
+            token.unpauseScope(transferScope);
+        }
+    }
+
+    function invariantTotalSupplyMatchesLiveTokenCount() public view {
+        IERC721TokenFacet token = IERC721TokenFacet(address(diamond));
+        uint256 liveCount;
+        for (uint256 tokenId = 1; tokenId <= TOKEN_POOL; tokenId++) {
+            if (_erc721Exists(tokenId)) {
+                liveCount++;
+            }
+        }
+
+        assertTrue(token.totalSupply() == liveCount, "host erc721 total supply should match live tokens");
+    }
+
+    function invariantBalancesMatchTrackedOwnershipCounts() public view {
+        IERC721TokenFacet token = IERC721TokenFacet(address(diamond));
+        uint256[ACTOR_COUNT] memory counts;
+
+        for (uint256 tokenId = 1; tokenId <= TOKEN_POOL; tokenId++) {
+            address owner = _erc721OwnerOrZero(tokenId);
+            for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+                if (owner == actors[i]) {
+                    counts[i] += 1;
+                    break;
+                }
+            }
+        }
+
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            assertTrue(token.balanceOf(actors[i]) == counts[i], "host erc721 balances should match ownership counts");
+        }
+    }
+
+    function invariantApprovalsOnlyExistForLiveTokens() public view {
+        for (uint256 tokenId = 1; tokenId <= TOKEN_POOL; tokenId++) {
+            if (!_erc721Exists(tokenId)) {
+                assertTrue(_erc721ApprovalOrZero(tokenId) == address(0), "burned tokens must not retain approval");
+            }
+        }
+    }
+
+    function _tokenId(uint8 seed) internal pure returns (uint256) {
+        return (uint256(seed) % TOKEN_POOL) + 1;
+    }
+}

--- a/test/DiamondTokenHostHardening.t.sol
+++ b/test/DiamondTokenHostHardening.t.sol
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
+import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
+import {IERC165} from "../src/interfaces/IERC165.sol";
+import {IERC20Metadata} from "../src/interfaces/IERC20Metadata.sol";
+import {IERC721} from "../src/interfaces/IERC721.sol";
+import {IERC721Metadata} from "../src/interfaces/IERC721Metadata.sol";
+import {IERC20TokenFacet} from "../src/interfaces/IERC20TokenFacet.sol";
+import {IERC721TokenFacet} from "../src/interfaces/IERC721TokenFacet.sol";
+import {IPausable} from "../src/interfaces/IPausable.sol";
+import {
+    DiamondTokenHostHardeningFixture,
+    IFacetVersionMarker
+} from "./helpers/DiamondTokenHostHardeningTestHarness.sol";
+
+contract DiamondTokenHostHardeningTest is DiamondTokenHostHardeningFixture {
+    function testErc20HostReplaceRemoveAndReAddPreservesState() public {
+        _installErc20HostFacet(address(erc20Facet));
+        _erc20InitDiamond();
+        _seedErc20HostState();
+
+        bytes32 tokenAdminRole = IERC20TokenFacet(address(diamond)).TOKEN_ADMIN_ROLE();
+        bytes32 approvalScope = IERC20TokenFacet(address(diamond)).ERC20_APPROVAL_SCOPE();
+
+        _replaceErc20HostFacet(address(erc20Replacement));
+        _addErc20ReplacementMarker(address(erc20Replacement));
+
+        IDiamondLoupe loupe = IDiamondLoupe(address(diamond));
+        assertTrue(loupe.facetAddresses().length == 3, "erc20 replace facet count mismatch");
+        assertTrue(
+            loupe.facetFunctionSelectors(address(erc20Replacement)).length == 31,
+            "erc20 replacement selector count mismatch"
+        );
+        assertTrue(loupe.facetFunctionSelectors(address(erc20Facet)).length == 0, "erc20 old facet should be empty");
+        assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "erc20 marker routing mismatch");
+
+        _assertErc20State(address(erc20Replacement));
+
+        _removeErc20HostFacetWithMarker();
+
+        assertTrue(loupe.facetAddresses().length == 2, "erc20 removal should leave core facets only");
+        _assertMissingSelector(abi.encodeCall(IERC20Metadata.name, ()), "erc20 name should be missing after removal");
+        _assertMissingSelector(
+            abi.encodeCall(IAccessControl.hasRole, (tokenAdminRole, eve)),
+            "erc20 hasRole should be missing after removal"
+        );
+        _assertMissingSelector(
+            abi.encodeCall(IPausable.scopePaused, (approvalScope)), "erc20 scopePaused should be missing after removal"
+        );
+        _assertMissingSelector(
+            abi.encodeWithSelector(IFacetVersionMarker.facetVersion.selector),
+            "erc20 marker should be missing after removal"
+        );
+
+        _reAddErc20HostFacetWithMarker(address(erc20Replacement));
+
+        assertTrue(loupe.facetAddresses().length == 3, "erc20 re-add facet count mismatch");
+        assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "erc20 marker should survive re-add");
+        _assertErc20State(address(erc20Replacement));
+    }
+
+    function testErc721HostReplaceRemoveAndReAddPreservesState() public {
+        _installErc721HostFacet(address(erc721Facet));
+        _erc721InitDiamond();
+        _seedErc721HostState();
+
+        bytes32 metadataRole = IERC721TokenFacet(address(diamond)).ERC721_METADATA_ROLE();
+        bytes32 approvalScope = IERC721TokenFacet(address(diamond)).ERC721_APPROVAL_SCOPE();
+
+        _replaceErc721HostFacet(address(erc721Replacement));
+        _addErc721ReplacementMarker(address(erc721Replacement));
+
+        IDiamondLoupe loupe = IDiamondLoupe(address(diamond));
+        assertTrue(loupe.facetAddresses().length == 3, "erc721 replace facet count mismatch");
+        assertTrue(
+            loupe.facetFunctionSelectors(address(erc721Replacement)).length == 36,
+            "erc721 replacement selector count mismatch"
+        );
+        assertTrue(loupe.facetFunctionSelectors(address(erc721Facet)).length == 0, "erc721 old facet should be empty");
+        assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "erc721 marker routing mismatch");
+
+        _assertErc721State(address(erc721Replacement));
+
+        _removeErc721HostFacetWithMarker();
+
+        assertTrue(loupe.facetAddresses().length == 2, "erc721 removal should leave core facets only");
+        _assertMissingSelector(abi.encodeCall(IERC721Metadata.name, ()), "erc721 name should be missing after removal");
+        _assertMissingSelector(abi.encodeCall(IERC721.ownerOf, (1)), "erc721 ownerOf should be missing after removal");
+        _assertMissingSelector(
+            abi.encodeCall(IAccessControl.hasRole, (metadataRole, eve)),
+            "erc721 hasRole should be missing after removal"
+        );
+        _assertMissingSelector(
+            abi.encodeCall(IPausable.scopePaused, (approvalScope)), "erc721 scopePaused should be missing after removal"
+        );
+        _assertMissingSelector(
+            abi.encodeWithSelector(IFacetVersionMarker.facetVersion.selector),
+            "erc721 marker should be missing after removal"
+        );
+
+        _reAddErc721HostFacetWithMarker(address(erc721Replacement));
+
+        assertTrue(loupe.facetAddresses().length == 3, "erc721 re-add facet count mismatch");
+        assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "erc721 marker should survive re-add");
+        _assertErc721State(address(erc721Replacement));
+    }
+
+    function _assertErc20State(address expectedFacetOwner) internal view {
+        IERC20TokenFacet token = IERC20TokenFacet(address(diamond));
+        IDiamondLoupe loupe = IDiamondLoupe(address(diamond));
+
+        assertTrue(keccak256(bytes(token.name())) == keccak256(bytes("Facet Token")), "erc20 name mismatch");
+        assertTrue(keccak256(bytes(token.symbol())) == keccak256(bytes("FTKN")), "erc20 symbol mismatch");
+        assertTrue(token.decimals() == 18, "erc20 decimals mismatch");
+        assertTrue(token.totalSupply() == 150, "erc20 total supply mismatch");
+        assertTrue(token.balanceOf(bob) == 100, "erc20 bob balance mismatch");
+        assertTrue(token.balanceOf(carol) == 50, "erc20 carol balance mismatch");
+        assertTrue(token.allowance(bob, eve) == 25, "erc20 approval allowance mismatch");
+        assertTrue(token.allowance(bob, dave) == 40, "erc20 permit allowance mismatch");
+        assertTrue(token.nonces(bob) == 1, "erc20 nonce mismatch");
+        assertTrue(token.hasRole(token.TOKEN_ADMIN_ROLE(), eve), "erc20 role state mismatch");
+        assertTrue(token.scopePaused(token.ERC20_APPROVAL_SCOPE()), "erc20 approval scope pause mismatch");
+        assertTrue(!token.scopePaused(token.ERC20_TRANSFER_SCOPE()), "erc20 transfer scope should remain live");
+        assertTrue(token.supportsInterface(type(IERC20TokenFacet).interfaceId), "erc20 interface support mismatch");
+        assertTrue(
+            loupe.facetAddress(IERC20Metadata.name.selector) == expectedFacetOwner, "erc20 name selector owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC165.supportsInterface.selector) == expectedFacetOwner,
+            "erc20 supportsInterface owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IAccessControl.hasRole.selector) == expectedFacetOwner, "erc20 hasRole owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IPausable.pauseScope.selector) == expectedFacetOwner, "erc20 pauseScope owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC20TokenFacet.TOKEN_ADMIN_ROLE.selector) == expectedFacetOwner,
+            "erc20 token admin selector owner mismatch"
+        );
+    }
+
+    function _assertErc721State(address expectedFacetOwner) internal view {
+        IERC721TokenFacet token = IERC721TokenFacet(address(diamond));
+        IDiamondLoupe loupe = IDiamondLoupe(address(diamond));
+
+        assertTrue(keccak256(bytes(token.name())) == keccak256(bytes("Facet NFT")), "erc721 name mismatch");
+        assertTrue(keccak256(bytes(token.symbol())) == keccak256(bytes("FNFT")), "erc721 symbol mismatch");
+        assertTrue(token.totalSupply() == 2, "erc721 total supply mismatch");
+        assertTrue(token.ownerOf(1) == bob, "erc721 token 1 owner mismatch");
+        assertTrue(token.ownerOf(2) == carol, "erc721 token 2 owner mismatch");
+        assertTrue(token.balanceOf(bob) == 1, "erc721 bob balance mismatch");
+        assertTrue(token.balanceOf(carol) == 1, "erc721 carol balance mismatch");
+        assertTrue(token.getApproved(1) == eve, "erc721 approval mismatch");
+        assertTrue(token.isApprovedForAll(bob, dave), "erc721 operator approval mismatch");
+        assertTrue(
+            keccak256(bytes(token.tokenURI(1))) == keccak256(bytes("ipfs://facet/custom-1")),
+            "erc721 explicit uri mismatch"
+        );
+        assertTrue(
+            keccak256(bytes(token.tokenURI(2))) == keccak256(bytes("ipfs://facet/2")), "erc721 base uri mismatch"
+        );
+        assertTrue(token.hasRole(token.ERC721_METADATA_ROLE(), eve), "erc721 metadata role mismatch");
+        assertTrue(token.scopePaused(token.ERC721_APPROVAL_SCOPE()), "erc721 approval scope pause mismatch");
+        assertTrue(token.scopePaused(token.ERC721_TRANSFER_SCOPE()), "erc721 transfer scope pause mismatch");
+        assertTrue(token.supportsInterface(type(IERC721TokenFacet).interfaceId), "erc721 interface support mismatch");
+        assertTrue(
+            loupe.facetAddress(IERC721Metadata.name.selector) == expectedFacetOwner,
+            "erc721 name selector owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC165.supportsInterface.selector) == expectedFacetOwner,
+            "erc721 supportsInterface owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IAccessControl.hasRole.selector) == expectedFacetOwner, "erc721 hasRole owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IPausable.pauseScope.selector) == expectedFacetOwner, "erc721 pauseScope owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC721TokenFacet.ERC721_METADATA_ROLE.selector) == expectedFacetOwner,
+            "erc721 metadata selector owner mismatch"
+        );
+    }
+}

--- a/test/helpers/DiamondTokenHostHardeningTestHarness.sol
+++ b/test/helpers/DiamondTokenHostHardeningTestHarness.sol
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
+import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
+import {IERC20Metadata} from "../../src/interfaces/IERC20Metadata.sol";
+import {IERC20Permit} from "../../src/interfaces/IERC20Permit.sol";
+import {IERC20TokenFacet} from "../../src/interfaces/IERC20TokenFacet.sol";
+import {IERC721TokenBase} from "../../src/interfaces/IERC721TokenBase.sol";
+import {IERC721TokenFacet} from "../../src/interfaces/IERC721TokenFacet.sol";
+import {ERC20TokenFacet} from "../../src/token/facets/ERC20TokenFacet.sol";
+import {ERC721TokenFacet} from "../../src/token/facets/ERC721TokenFacet.sol";
+import {LibTokenFacetDeploymentSelectors} from "../../src/token/libraries/LibTokenFacetDeploymentSelectors.sol";
+import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+
+interface IFacetVersionMarker {
+    function facetVersion() external view returns (uint256);
+}
+
+contract ERC20TokenFacetReplacement is ERC20TokenFacet {
+    function facetVersion() external pure returns (uint256) {
+        return 2;
+    }
+}
+
+contract ERC721TokenFacetReplacement is ERC721TokenFacet {
+    function facetVersion() external pure returns (uint256) {
+        return 2;
+    }
+}
+
+abstract contract DiamondTokenHostHardeningFixture is TestBase {
+    bytes32 internal constant PERMIT_TYPEHASH =
+        keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+    uint256 internal constant ADMIN_PK = uint256(keccak256("erc20-facet-admin"));
+    uint256 internal constant BOB_PK = uint256(keccak256("erc20-facet-bob"));
+    uint256 internal constant EVE_PK = uint256(keccak256("erc20-facet-eve"));
+    uint256 internal constant CAROL_PK = uint256(keccak256("erc20-facet-carol"));
+    uint256 internal constant DAVE_PK = uint256(keccak256("erc20-facet-dave"));
+
+    address internal admin;
+    address internal bob;
+    address internal eve;
+    address internal carol;
+    address internal dave;
+
+    DiamondCutFacet internal cutFacet;
+    DiamondLoupeFacet internal loupeFacet;
+    ERC20TokenFacet internal erc20Facet;
+    ERC20TokenFacetReplacement internal erc20Replacement;
+    ERC721TokenFacet internal erc721Facet;
+    ERC721TokenFacetReplacement internal erc721Replacement;
+    DiamondProxyHarness internal diamond;
+
+    function setUp() public virtual {
+        admin = VM.addr(ADMIN_PK);
+        bob = VM.addr(BOB_PK);
+        eve = VM.addr(EVE_PK);
+        carol = VM.addr(CAROL_PK);
+        dave = VM.addr(DAVE_PK);
+
+        cutFacet = new DiamondCutFacet();
+        loupeFacet = new DiamondLoupeFacet();
+        erc20Facet = new ERC20TokenFacet();
+        erc20Replacement = new ERC20TokenFacetReplacement();
+        erc721Facet = new ERC721TokenFacet();
+        erc721Replacement = new ERC721TokenFacetReplacement();
+        diamond = new DiamondProxyHarness(admin, address(cutFacet));
+
+        _installLoupeFacet();
+    }
+
+    function _installLoupeFacet() internal {
+        _addFacet(address(loupeFacet), LibTokenFacetDeploymentSelectors.loupeSelectors());
+    }
+
+    function _installErc20HostFacet(address facetAddress_) internal {
+        _addFacet(facetAddress_, LibTokenFacetDeploymentSelectors.erc20HostSelectors());
+    }
+
+    function _installErc721HostFacet(address facetAddress_) internal {
+        _addFacet(facetAddress_, LibTokenFacetDeploymentSelectors.erc721HostSelectors());
+    }
+
+    function _replaceErc20HostFacet(address facetAddress_) internal {
+        _replaceFacet(facetAddress_, LibTokenFacetDeploymentSelectors.erc20HostSelectors());
+    }
+
+    function _replaceErc721HostFacet(address facetAddress_) internal {
+        _replaceFacet(facetAddress_, LibTokenFacetDeploymentSelectors.erc721HostSelectors());
+    }
+
+    function _addErc20ReplacementMarker(address facetAddress_) internal {
+        _addFacet(facetAddress_, _markerSelectors());
+    }
+
+    function _addErc721ReplacementMarker(address facetAddress_) internal {
+        _addFacet(facetAddress_, _markerSelectors());
+    }
+
+    function _removeErc20HostFacetWithMarker() internal {
+        _removeSelectors(_concat(LibTokenFacetDeploymentSelectors.erc20HostSelectors(), _markerSelectors()));
+    }
+
+    function _removeErc721HostFacetWithMarker() internal {
+        _removeSelectors(_concat(LibTokenFacetDeploymentSelectors.erc721HostSelectors(), _markerSelectors()));
+    }
+
+    function _reAddErc20HostFacetWithMarker(address facetAddress_) internal {
+        _addFacet(facetAddress_, _concat(LibTokenFacetDeploymentSelectors.erc20HostSelectors(), _markerSelectors()));
+    }
+
+    function _reAddErc721HostFacetWithMarker(address facetAddress_) internal {
+        _addFacet(facetAddress_, _concat(LibTokenFacetDeploymentSelectors.erc721HostSelectors(), _markerSelectors()));
+    }
+
+    function _erc20InitDiamond() internal {
+        IERC20TokenFacet(address(diamond)).initializeErc20("Facet Token", "FTKN", 18, admin);
+    }
+
+    function _erc721InitDiamond() internal {
+        IERC721TokenFacet(address(diamond)).initializeErc721("Facet NFT", "FNFT", "ipfs://facet/", admin);
+    }
+
+    function _seedErc20HostState() internal {
+        IERC20TokenFacet token = IERC20TokenFacet(address(diamond));
+        bytes32 tokenAdminRole = token.TOKEN_ADMIN_ROLE();
+        bytes32 approvalScope = token.ERC20_APPROVAL_SCOPE();
+
+        VM.prank(admin);
+        token.mint(bob, 100);
+        VM.prank(admin);
+        token.mint(carol, 50);
+
+        VM.prank(bob);
+        token.approve(eve, 25);
+
+        uint256 deadline = block.timestamp + 1 days;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(address(diamond), bob, dave, 40, token.nonces(bob), deadline);
+        token.permit(bob, dave, 40, deadline, v, r, s);
+
+        VM.prank(admin);
+        token.grantRole(tokenAdminRole, eve);
+
+        VM.prank(admin);
+        token.pauseScope(approvalScope);
+    }
+
+    function _seedErc721HostState() internal {
+        IERC721TokenFacet token = IERC721TokenFacet(address(diamond));
+        bytes32 metadataRole = token.ERC721_METADATA_ROLE();
+        bytes32 approvalScope = token.ERC721_APPROVAL_SCOPE();
+        bytes32 transferScope = token.ERC721_TRANSFER_SCOPE();
+
+        VM.prank(admin);
+        token.mint(bob, 1);
+        VM.prank(admin);
+        token.mint(carol, 2);
+
+        VM.prank(bob);
+        token.approve(eve, 1);
+        VM.prank(bob);
+        token.setApprovalForAll(dave, true);
+
+        VM.prank(admin);
+        token.setTokenURI(1, "ipfs://facet/custom-1");
+
+        VM.prank(admin);
+        token.grantRole(metadataRole, eve);
+
+        VM.prank(admin);
+        token.pauseScope(approvalScope);
+        VM.prank(admin);
+        token.pauseScope(transferScope);
+    }
+
+    function _permitDigest(
+        address target,
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 nonce,
+        uint256 deadline
+    ) internal view returns (bytes32) {
+        bytes32 structHash = keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, nonce, deadline));
+        return keccak256(abi.encodePacked("\x19\x01", IERC20Permit(target).DOMAIN_SEPARATOR(), structHash));
+    }
+
+    function _signPermit(
+        address target,
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 nonce,
+        uint256 deadline
+    ) internal returns (uint8 v, bytes32 r, bytes32 s) {
+        return VM.sign(_privateKeyFor(owner), _permitDigest(target, owner, spender, value, nonce, deadline));
+    }
+
+    function _privateKeyFor(address actor) internal view returns (uint256) {
+        if (actor == admin) return ADMIN_PK;
+        if (actor == bob) return BOB_PK;
+        if (actor == eve) return EVE_PK;
+        if (actor == carol) return CAROL_PK;
+        if (actor == dave) return DAVE_PK;
+        revert("unknown actor");
+    }
+
+    function _actor(uint8 seed) internal view returns (address) {
+        uint256 normalized = uint256(seed) % 5;
+        if (normalized == 0) return admin;
+        if (normalized == 1) return bob;
+        if (normalized == 2) return eve;
+        if (normalized == 3) return carol;
+        return dave;
+    }
+
+    function _actorExcluding(address excluded, uint8 seed) internal view returns (address actor) {
+        actor = _actor(seed);
+        if (actor == excluded) {
+            actor = _actor(seed + 1);
+        }
+    }
+
+    function _markerSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](1);
+        selectors[0] = IFacetVersionMarker.facetVersion.selector;
+    }
+
+    function _addFacet(address facetAddress_, bytes4[] memory selectors) internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: facetAddress_, action: IDiamondCut.FacetCutAction.Add, functionSelectors: selectors
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _replaceFacet(address facetAddress_, bytes4[] memory selectors) internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: facetAddress_, action: IDiamondCut.FacetCutAction.Replace, functionSelectors: selectors
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _removeSelectors(bytes4[] memory selectors) internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(0), action: IDiamondCut.FacetCutAction.Remove, functionSelectors: selectors
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _assertMissingSelector(bytes memory callData, string memory reason) internal {
+        (bool success,) = address(diamond).call(callData);
+        assertTrue(!success, reason);
+    }
+
+    function _concat(bytes4[] memory first, bytes4[] memory second) internal pure returns (bytes4[] memory combined) {
+        combined = new bytes4[](first.length + second.length);
+
+        uint256 i;
+        for (; i < first.length; i++) {
+            combined[i] = first[i];
+        }
+
+        for (uint256 j = 0; j < second.length; j++) {
+            combined[i + j] = second[j];
+        }
+    }
+
+    function _erc721Exists(uint256 tokenId) internal view returns (bool) {
+        try IERC721TokenFacet(address(diamond)).ownerOf(tokenId) returns (address) {
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    function _erc721OwnerOrZero(uint256 tokenId) internal view returns (address owner) {
+        try IERC721TokenFacet(address(diamond)).ownerOf(tokenId) returns (address owner_) {
+            return owner_;
+        } catch {
+            return address(0);
+        }
+    }
+
+    function _erc721ApprovalOrZero(uint256 tokenId) internal view returns (address approved) {
+        try IERC721TokenFacet(address(diamond)).getApproved(tokenId) returns (address approved_) {
+            return approved_;
+        } catch {
+            return address(0);
+        }
+    }
+
+    function _expectNonexistentToken(uint256 tokenId) internal {
+        VM.expectRevert(abi.encodeWithSelector(IERC721TokenBase.ERC721TokenNonexistentToken.selector, tokenId));
+        IERC721TokenFacet(address(diamond)).ownerOf(tokenId);
+    }
+}

--- a/test/helpers/ERC20TokenFacetTestHarness.sol
+++ b/test/helpers/ERC20TokenFacetTestHarness.sol
@@ -2,15 +2,11 @@
 pragma solidity ^0.8.30;
 
 import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
-import {IAccessControl} from "../../src/interfaces/IAccessControl.sol";
-import {IERC20} from "../../src/interfaces/IERC20.sol";
-import {IERC20Metadata} from "../../src/interfaces/IERC20Metadata.sol";
 import {IERC20Permit} from "../../src/interfaces/IERC20Permit.sol";
-import {IERC20TokenBase} from "../../src/interfaces/IERC20TokenBase.sol";
 import {IERC20TokenFacet} from "../../src/interfaces/IERC20TokenFacet.sol";
-import {IPausable} from "../../src/interfaces/IPausable.sol";
 import {ERC20TokenFacet} from "../../src/token/facets/ERC20TokenFacet.sol";
 import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
+import {LibTokenFacetDeploymentSelectors} from "../../src/token/libraries/LibTokenFacetDeploymentSelectors.sol";
 import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
 import {TestBase} from "./AccessControlTestHarness.sol";
 
@@ -50,40 +46,11 @@ abstract contract ERC20TokenFacetFixture is TestBase {
     }
 
     function _addErc20FacetToDiamond() internal {
-        bytes4[] memory selectors = new bytes4[](29);
-        selectors[0] = IERC20TokenFacet.initializeErc20.selector;
-        selectors[1] = IERC20Metadata.name.selector;
-        selectors[2] = IERC20Metadata.symbol.selector;
-        selectors[3] = IERC20Metadata.decimals.selector;
-        selectors[4] = IERC20.totalSupply.selector;
-        selectors[5] = IERC20.balanceOf.selector;
-        selectors[6] = IERC20.allowance.selector;
-        selectors[7] = IERC20.transfer.selector;
-        selectors[8] = IERC20.approve.selector;
-        selectors[9] = IERC20.transferFrom.selector;
-        selectors[10] = IERC20TokenFacet.mint.selector;
-        selectors[11] = IERC20TokenFacet.burn.selector;
-        selectors[12] = IERC20TokenBase.isErc20Initialized.selector;
-        selectors[13] = IAccessControl.DEFAULT_ADMIN_ROLE.selector;
-        selectors[14] = IPausable.PAUSER_ROLE.selector;
-        selectors[15] = IERC20TokenFacet.TOKEN_ADMIN_ROLE.selector;
-        selectors[16] = IERC20TokenFacet.ERC20_MINTER_ROLE.selector;
-        selectors[17] = IERC20TokenFacet.ERC20_BURNER_ROLE.selector;
-        selectors[18] = IERC20TokenFacet.ERC20_TRANSFER_SCOPE.selector;
-        selectors[19] = IERC20TokenFacet.ERC20_APPROVAL_SCOPE.selector;
-        selectors[20] = IAccessControl.hasRole.selector;
-        selectors[21] = IAccessControl.getRoleAdmin.selector;
-        selectors[22] = IAccessControl.grantRole.selector;
-        selectors[23] = IPausable.pauseScope.selector;
-        selectors[24] = IPausable.unpauseScope.selector;
-        selectors[25] = IPausable.scopePaused.selector;
-        selectors[26] = IERC20Permit.permit.selector;
-        selectors[27] = IERC20Permit.nonces.selector;
-        selectors[28] = IERC20Permit.DOMAIN_SEPARATOR.selector;
-
         IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
         cut[0] = IDiamondCut.FacetCut({
-            facetAddress: address(facet), action: IDiamondCut.FacetCutAction.Add, functionSelectors: selectors
+            facetAddress: address(facet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibTokenFacetDeploymentSelectors.erc20HostSelectors()
         });
 
         VM.prank(admin);

--- a/test/helpers/ERC721TokenFacetTestHarness.sol
+++ b/test/helpers/ERC721TokenFacetTestHarness.sol
@@ -1,17 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
-import {IAccessControl} from "../../src/interfaces/IAccessControl.sol";
 import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
-import {IERC165} from "../../src/interfaces/IERC165.sol";
-import {IERC721} from "../../src/interfaces/IERC721.sol";
-import {IERC721Metadata} from "../../src/interfaces/IERC721Metadata.sol";
 import {IERC721Receiver} from "../../src/interfaces/IERC721Receiver.sol";
-import {IERC721TokenBase} from "../../src/interfaces/IERC721TokenBase.sol";
 import {IERC721TokenFacet} from "../../src/interfaces/IERC721TokenFacet.sol";
-import {IPausable} from "../../src/interfaces/IPausable.sol";
 import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
 import {ERC721TokenFacet} from "../../src/token/facets/ERC721TokenFacet.sol";
+import {LibTokenFacetDeploymentSelectors} from "../../src/token/libraries/LibTokenFacetDeploymentSelectors.sol";
 import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
 import {TestBase} from "./AccessControlTestHarness.sol";
 import {ERC721ReceiverMock, ERC721ReceiverRejector} from "./TokenFacetFoundationTestHarness.sol";
@@ -41,46 +36,11 @@ abstract contract ERC721TokenFacetFixture is TestBase {
     }
 
     function _addErc721FacetToDiamond() internal {
-        bytes4[] memory selectors = new bytes4[](35);
-        selectors[0] = IERC721TokenFacet.initializeErc721.selector;
-        selectors[1] = IERC721.balanceOf.selector;
-        selectors[2] = IERC721.ownerOf.selector;
-        selectors[3] = IERC721.approve.selector;
-        selectors[4] = IERC721.getApproved.selector;
-        selectors[5] = IERC721.setApprovalForAll.selector;
-        selectors[6] = IERC721.isApprovedForAll.selector;
-        selectors[7] = IERC721.transferFrom.selector;
-        selectors[8] = bytes4(keccak256("safeTransferFrom(address,address,uint256)"));
-        selectors[9] = bytes4(keccak256("safeTransferFrom(address,address,uint256,bytes)"));
-        selectors[10] = IERC721Metadata.tokenURI.selector;
-        selectors[11] = IERC721Metadata.name.selector;
-        selectors[12] = IERC721Metadata.symbol.selector;
-        selectors[13] = IERC721TokenFacet.totalSupply.selector;
-        selectors[14] = IERC721TokenBase.isErc721Initialized.selector;
-        selectors[15] = IERC721TokenFacet.mint.selector;
-        selectors[16] = IERC721TokenFacet.safeMint.selector;
-        selectors[17] = IERC721TokenFacet.burn.selector;
-        selectors[18] = IERC721TokenFacet.setBaseURI.selector;
-        selectors[19] = IERC721TokenFacet.setTokenURI.selector;
-        selectors[20] = IAccessControl.DEFAULT_ADMIN_ROLE.selector;
-        selectors[21] = IPausable.PAUSER_ROLE.selector;
-        selectors[22] = IERC721TokenFacet.TOKEN_ADMIN_ROLE.selector;
-        selectors[23] = IERC721TokenFacet.ERC721_MINTER_ROLE.selector;
-        selectors[24] = IERC721TokenFacet.ERC721_BURNER_ROLE.selector;
-        selectors[25] = IERC721TokenFacet.ERC721_METADATA_ROLE.selector;
-        selectors[26] = IERC721TokenFacet.ERC721_TRANSFER_SCOPE.selector;
-        selectors[27] = IERC721TokenFacet.ERC721_APPROVAL_SCOPE.selector;
-        selectors[28] = IAccessControl.hasRole.selector;
-        selectors[29] = IAccessControl.getRoleAdmin.selector;
-        selectors[30] = IAccessControl.grantRole.selector;
-        selectors[31] = IPausable.pauseScope.selector;
-        selectors[32] = IPausable.unpauseScope.selector;
-        selectors[33] = IPausable.scopePaused.selector;
-        selectors[34] = IERC165.supportsInterface.selector;
-
         IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
         cut[0] = IDiamondCut.FacetCut({
-            facetAddress: address(facet), action: IDiamondCut.FacetCutAction.Add, functionSelectors: selectors
+            facetAddress: address(facet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibTokenFacetDeploymentSelectors.erc721HostSelectors()
         });
 
         VM.prank(admin);


### PR DESCRIPTION
## Summary
- add host-level hardening coverage for separate ERC20 and ERC721 diamond token hosts
- add replacement/remove/re-add regression tests proving token state and shared-control state survive facet ownership changes
- add diamond-host ERC20 and ERC721 invariant/stateful coverage through routed calls against the diamond address
- refactor token host selector helpers into reusable token/shared-control subsets for cleaner host hardening coverage

## Validation
- `forge fmt --check`
- `git diff --check`
- `forge test --offline --match-path test/DiamondTokenHostHardening.t.sol`
- `forge test --offline --match-path test/DiamondErc20HostInvariant.t.sol`
- `forge test --offline --match-path test/DiamondErc721HostInvariant.t.sol`
- `forge test --offline`

## Issue
- Closes #85
