### PR TITLE
Document diamond token host usage and safety assumptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ reviewable engineering system.
   circuit breakers, and controlled fallback behavior.
 - A diamond core with selector routing, cut/loupe support, ownership
   introspection, and selector-integrity regression coverage.
+- Hosted ERC20 and ERC721 token facets deployed behind separate diamond hosts,
+  with init, selector ownership, Permit/metadata support, and host-level
+  hardening coverage.
 - Operational maturity through local bootstrap, smoke validation, upgrade
   rehearsal, system-hardening flows, and matching CI gates.
 
@@ -41,6 +44,7 @@ Implemented milestones so far:
 - Access Control + Upgrade Safety Kit
 - Oracle Adapter + Circuit Breaker
 - Diamond Core (EIP-2535)
+- Diamond Token Facets
 - System-Level Testing & Hardening
 
 ## Validation
@@ -65,9 +69,9 @@ execution order collected in `docs/ops/runbook-system-hardening.md`.
 
 CI and local validation parity are documented in `docs/security-checks.md`.
 
-Token facet deployment notes live in `docs/token-facets.md`, including the
-current reference rule that standard ERC20 and ERC721 surfaces are deployed as
-separate diamond hosts because their selectors collide.
+Token-host architecture and safety assumptions live in `docs/token-facets.md`,
+including the init model, selector ownership rules, separate-host deployment
+constraint, and token-host upgrade assumptions.
 
 ## Tooling
 

--- a/docs/security-checks.md
+++ b/docs/security-checks.md
@@ -48,6 +48,21 @@ bash script/run-local-system-hardening.sh
 
 Use the targeted suites for faster iteration and the full hardening runner for the same deployment-backed flow used by the higher-signal CI gate.
 
+### Token Hosts
+
+The diamond token milestone also has reviewer-facing validation suites for the
+separate ERC20-host and ERC721-host deployment model:
+
+```bash
+forge test --offline --match-path test/DiamondTokenDeploymentIntegration.t.sol
+forge test --offline --match-path test/DiamondTokenHostHardening.t.sol
+forge test --offline --match-path test/DiamondErc20HostInvariant.t.sol
+forge test --offline --match-path test/DiamondErc721HostInvariant.t.sol
+```
+
+Use these to reproduce token-host deployment, selector ownership, replace and
+reinstall persistence, and diamond-routed invariant coverage locally.
+
 ### Slither
 
 Install and run the same high-severity gate locally:

--- a/docs/token-facets.md
+++ b/docs/token-facets.md
@@ -1,113 +1,231 @@
-## Token Facet Foundation
+# Diamond Token Facets
 
-This document defines the shared foundation for hosted token facets in the
-diamond roadmap.
+This document is the canonical guide for the hosted token model implemented in
+the `Diamond Token Facets` milestone.
 
-### Shared Interfaces
+The current supported deployment model is:
 
-The token foundation introduces:
+- one ERC20-hosted diamond
+- one ERC721-hosted diamond
 
-- `IERC20Permit` for future EIP-2612 support on the ERC-20 side
-- `IERC721`, `IERC721Metadata`, and `IERC721Receiver` for the ERC-721 side
-- `IERC20TokenBase` and `IERC721TokenBase` for foundation-specific init/error
-  surfaces used by the base contracts
+That split is intentional. The repo preserves standard ERC20 and ERC721
+external surfaces, and those standards collide on shared selectors such as
+`name()`, `symbol()`, `balanceOf(address)`, and `totalSupply()`. One diamond
+cannot expose both standards unchanged at the same address without namespacing
+or a different routing model.
 
-### Storage Conventions
+## Supported Hosts
 
-Hosted token facets use separate fixed storage slots:
+### ERC20 Host
 
-- ERC-20: `keccak256("smart-contracts.token.erc20.storage")`
-- ERC-721: `keccak256("smart-contracts.token.erc721.storage")`
+The ERC20 host installs:
 
-The milestone intentionally keeps those layouts separate so ERC-20 and ERC-721
-facets can coexist in one diamond without balance, allowance, ownership, or
-metadata collisions.
+- ERC20 metadata selectors
+- core ERC20 state-changing selectors
+- EIP-2612 Permit selectors
+- shared control selectors for access control, pause scopes, and
+  `supportsInterface`
 
-### Initializer Pattern
-
-Each hosted token standard owns its own one-time initializer:
-
-- `_initializeErc20Token(...)`
-- `_initializeErc721Token(...)`
-
-The initializer guards are per-token-standard, not global to the diamond. That
-lets one diamond host both token systems while still preventing duplicate init
-for either storage layout.
-
-### Access Control And Pause Rules
-
-The shared token constants library defines the canonical integration surface for
-later facets:
-
-- roles:
-  - `TOKEN_ADMIN_ROLE`
-  - `ERC20_MINTER_ROLE`
-  - `ERC20_BURNER_ROLE`
-  - `ERC721_MINTER_ROLE`
-  - `ERC721_BURNER_ROLE`
-  - `ERC721_METADATA_ROLE`
-- pause scopes:
-  - `ERC20_TRANSFER_SCOPE`
-  - `ERC20_APPROVAL_SCOPE`
-  - `ERC721_TRANSFER_SCOPE`
-  - `ERC721_APPROVAL_SCOPE`
-
-Later ERC20/721 facet issues should reuse those identifiers rather than invent
-parallel role or pause namespaces.
-
-### ERC165 Notes
-
-ERC-20 does not rely on ERC-165. ERC-721 does, and the shared ERC-721 base
-advertises:
-
-- `IERC165`
-- `IERC721`
-- `IERC721Metadata`
-
-When ERC-721 is installed behind a diamond, the init or deployment flow should
-ensure the diamond-level interface surface remains consistent with the facet
-selectors that are actually installed.
-
-### Selector Collision Constraint
-
-ERC20 and ERC721 storage layouts are intentionally separate and can coexist
-without storage collision. Their raw external selector surfaces cannot.
-
-The standard interfaces collide on shared selectors such as:
-
-- `name()`
-- `symbol()`
-- `totalSupply()`
-- `balanceOf(address)`
-- `supportsInterface(bytes4)` once shared control and ERC165 surfaces are
-  included
-
-That means one diamond cannot expose both standards unchanged at the same
-address. The reference deployment model in this repo is therefore:
-
-- one diamond hosting ERC20
-- one diamond hosting ERC721
-
-If both standards ever need to coexist in one host, that future design will
-need namespaced selectors or a different routing surface.
-
-### Reference Host Deployment Model
-
-The current reference deployment scripts install and initialize token facets as
-separate host flows:
+Reference deployment flow:
 
 - `script/DeployDiamondErc20Host.s.sol`
-- `script/DeployDiamondErc721Host.s.sol`
 
-Each flow:
-
-- deploys a fresh diamond core
-- installs loupe selectors
-- installs one token facet selector set
-- immediately calls the token initializer through the diamond
-- validates selector ownership and initialized token metadata
-
-Deployment artifacts are written separately for replayable local validation:
+Reference artifact:
 
 - `deployments/diamond-erc20.local.json`
+
+### ERC721 Host
+
+The ERC721 host installs:
+
+- ERC721 core selectors
+- ERC721 metadata selectors
+- hosted mint, burn, and metadata-management selectors
+- shared control selectors for access control, pause scopes, and
+  `supportsInterface`
+
+Reference deployment flow:
+
+- `script/DeployDiamondErc721Host.s.sol`
+
+Reference artifact:
+
 - `deployments/diamond-erc721.local.json`
+
+## Initialization Model
+
+Each token standard owns its own one-time initializer and is initialized through
+the diamond after the facet selectors are installed.
+
+### ERC20
+
+Initializer:
+
+- `initializeErc20(string name, string symbol, uint8 decimals, address admin)`
+
+Initialization seeds:
+
+- token metadata
+- Permit domain state
+- shared control state when the host is first initialized
+- role assignments for the provided `admin`
+
+Initialization expectations:
+
+- idempotent per ERC20 host
+- second initialization reverts
+- Permit uses the token name, version `"1"`, current `chainid`, and diamond
+  address for the domain separator
+
+### ERC721
+
+Initializer:
+
+- `initializeErc721(string name, string symbol, string baseURI, address admin)`
+
+Initialization seeds:
+
+- token metadata and base URI
+- shared control state when the host is first initialized
+- role assignments for the provided `admin`
+
+Initialization expectations:
+
+- idempotent per ERC721 host
+- second initialization reverts
+
+## Role Model And Pause Scopes
+
+Hosted token facets reuse the shared control plane. They do not maintain a
+token-local access-control or pause system.
+
+### Shared Admin Roles
+
+- `DEFAULT_ADMIN_ROLE`
+- `TOKEN_ADMIN_ROLE`
+- `PAUSER_ROLE`
+
+`TOKEN_ADMIN_ROLE` is administered by `DEFAULT_ADMIN_ROLE`.
+
+### ERC20 Roles
+
+- `ERC20_MINTER_ROLE`
+- `ERC20_BURNER_ROLE`
+
+Both are administered by `TOKEN_ADMIN_ROLE`.
+
+### ERC721 Roles
+
+- `ERC721_MINTER_ROLE`
+- `ERC721_BURNER_ROLE`
+- `ERC721_METADATA_ROLE`
+
+All are administered by `TOKEN_ADMIN_ROLE`.
+
+### Pause Scopes
+
+ERC20 host:
+
+- `ERC20_TRANSFER_SCOPE`
+  - gates `transfer`, `mint`, and `burn`
+- `ERC20_APPROVAL_SCOPE`
+  - gates `approve`, `permit`, and approval-dependent `transferFrom`
+
+ERC721 host:
+
+- `ERC721_TRANSFER_SCOPE`
+  - gates `transferFrom`, both `safeTransferFrom` overloads, `mint`, `safeMint`,
+    and `burn`
+- `ERC721_APPROVAL_SCOPE`
+  - gates `approve` and `setApprovalForAll`
+
+Metadata updates on the ERC721 host are role-gated but not controlled by the
+transfer or approval pause scopes.
+
+## Storage And Upgrade Assumptions
+
+The token facets use fixed storage slots:
+
+- ERC20: `keccak256("smart-contracts.token.erc20.storage")`
+- ERC721: `keccak256("smart-contracts.token.erc721.storage")`
+
+Those layouts are separate, so ERC20 and ERC721 state do not collide at the
+storage level. The repo still deploys them as separate hosts because the raw
+selector surfaces collide.
+
+Hosted token state lives in the diamond, not in the facet contract bytecode.
+That means the supported replace/remove/re-add flows preserve state as long as:
+
+- the replacement facet preserves the same storage layout
+- the relevant selectors are reinstalled
+- the upgrade does not rely on re-initialization
+
+Current hardening coverage explicitly validates persistence for:
+
+- ERC20 balances, allowances, Permit nonces, roles, and pause state
+- ERC721 ownership, approvals, operator approvals, metadata, roles, and pause
+  state
+
+## Selector Ownership Model
+
+For the reference token hosts:
+
+- `DiamondCutFacet` owns `diamondCut`
+- `DiamondLoupeFacet` owns loupe and ownership-introspection selectors
+- the token facet owns its token selectors
+- the token facet also owns the shared control selectors installed for that host
+
+In practice, that means the token facet owns selectors such as:
+
+- `supportsInterface(bytes4)`
+- `hasRole(bytes32,address)`
+- `grantRole(bytes32,address)`
+- `pauseScope(bytes32)`
+- `unpauseScope(bytes32)`
+- `scopePaused(bytes32)`
+- token role and scope getter selectors
+
+That selector ownership model is part of the supported upgrade story. When a
+token facet is replaced, the shared control selectors move with it for that
+host.
+
+## Supported Interface Surface
+
+### ERC20 Host
+
+The ERC20 host exposes:
+
+- ERC20 core + metadata
+- `IERC20Permit`
+- hosted ERC20 facet admin hooks
+- `IAccessControl`
+- `IPausable`
+- `IERC165`
+
+### ERC721 Host
+
+The ERC721 host exposes:
+
+- ERC721 core + metadata
+- hosted ERC721 facet admin hooks
+- `IAccessControl`
+- `IPausable`
+- `IERC165`
+
+## Safety Notes For Reviewers
+
+- Separate-host deployment is the supported model for this milestone.
+- No selector namespacing is used.
+- Re-initialization is not part of replace/remove/re-add flows.
+- Facet upgrades must preserve storage layout and hosted selector intent.
+- Shared control selectors are treated as part of the token host surface, not as
+  independent infrastructure selectors.
+
+## Validation References
+
+The implemented token-host model is covered by:
+
+- `test/DiamondTokenDeploymentIntegration.t.sol`
+- `test/DiamondTokenHostHardening.t.sol`
+- `test/DiamondErc20HostInvariant.t.sol`
+- `test/DiamondErc721HostInvariant.t.sol`


### PR DESCRIPTION
## Summary
- rewrite the token-facets doc into the canonical guide for hosted ERC20 and ERC721 diamond token hosts
- document init flows, role and pause scope behavior, selector ownership, supported interfaces, and upgrade assumptions
- update the README to surface the token milestone and point reviewers to the token-host architecture guide
- add a short token-host validation section in security checks for deployment, hardening, and invariant suites

## Validation
- `git diff --check`

## Issue
- Closes #86
