### PR TITLE
Add shared vault facet foundation

### DIFF
--- a/src/interfaces/IERC4626VaultControlsFacet.sol
+++ b/src/interfaces/IERC4626VaultControlsFacet.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "./IAccessControl.sol";
+import {IAccessControlTime} from "./IAccessControlTime.sol";
+import {IERC4626VaultControls} from "./IERC4626VaultControls.sol";
+import {IPausable} from "./IPausable.sol";
+import {IReentrancyGuard} from "./IReentrancyGuard.sol";
+
+/// @title IERC4626VaultControlsFacet
+/// @notice Hosted control-plane surface for future diamond vault facets.
+interface IERC4626VaultControlsFacet is
+    IERC4626VaultControls,
+    IAccessControl,
+    IAccessControlTime,
+    IPausable,
+    IReentrancyGuard
+{}

--- a/src/interfaces/IERC4626VaultFacet.sol
+++ b/src/interfaces/IERC4626VaultFacet.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC4626} from "./IERC4626.sol";
+
+/// @title IERC4626VaultFacet
+/// @notice Hosted ERC-4626 vault core surface for future diamond facets.
+interface IERC4626VaultFacet is IERC4626 {
+    /// @notice Returns true when vault storage is initialized.
+    /// @return True if initialized.
+    function isVaultInitialized() external view returns (bool);
+
+    /// @notice Returns currently managed asset accounting amount.
+    /// @return The tracked managed asset amount.
+    function totalManagedAssets() external view returns (uint256);
+
+    /// @notice Initializes the hosted vault core and shared control plane.
+    /// @param vaultAsset Underlying vault asset token.
+    /// @param vaultName ERC-20 share token name.
+    /// @param vaultSymbol ERC-20 share token symbol.
+    /// @param admin Account receiving admin, pauser, and vault manager roles.
+    function initializeVault(address vaultAsset, string calldata vaultName, string calldata vaultSymbol, address admin)
+        external;
+}

--- a/src/vault/ERC4626VaultControls.sol
+++ b/src/vault/ERC4626VaultControls.sol
@@ -1,19 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
-import {Pausable} from "../access/Pausable.sol";
 import {IERC165} from "../interfaces/IERC165.sol";
 import {IERC4626VaultControls} from "../interfaces/IERC4626VaultControls.sol";
-import {ReentrancyGuard} from "../security/ReentrancyGuard.sol";
 import {LibERC4626VaultStorage} from "./storage/LibERC4626VaultStorage.sol";
 import {ERC4626Vault} from "./ERC4626Vault.sol";
+import {VaultFacetControl} from "./VaultFacetControl.sol";
 
 /// @title ERC4626VaultControls
 /// @notice ERC-4626 extension with role-gated fee/limit controls and safety hooks.
-abstract contract ERC4626VaultControls is ERC4626Vault, Pausable, ReentrancyGuard, IERC4626VaultControls {
-    /// @notice Role that can manage fee and limit configuration.
-    bytes32 public constant VAULT_MANAGER_ROLE = keccak256("VAULT_MANAGER_ROLE");
-
+abstract contract ERC4626VaultControls is ERC4626Vault, VaultFacetControl, IERC4626VaultControls {
     /// @dev Basis points denominator.
     uint256 internal constant BPS_DENOMINATOR = 10_000;
 
@@ -21,12 +17,21 @@ abstract contract ERC4626VaultControls is ERC4626Vault, Pausable, ReentrancyGuar
     /// @param vaultAsset Underlying vault asset token.
     /// @param vaultName ERC-20 share token name.
     /// @param vaultSymbol ERC-20 share token symbol.
-    constructor(address initialAdmin, address vaultAsset, string memory vaultName, string memory vaultSymbol)
-        Pausable(initialAdmin)
-        ReentrancyGuard()
-    {
+    constructor(address initialAdmin, address vaultAsset, string memory vaultName, string memory vaultSymbol) {
+        _initializeVaultFacetControl(initialAdmin);
         _initializeErc4626Vault(vaultAsset, vaultName, vaultSymbol);
-        _initializeVaultControls(initialAdmin);
+    }
+
+    /// @notice Role that can manage vault fees and limits.
+    /// @return The vault manager role identifier.
+    function VAULT_MANAGER_ROLE()
+        public
+        pure
+        virtual
+        override(VaultFacetControl, IERC4626VaultControls)
+        returns (bytes32)
+    {
+        return VaultFacetControl.VAULT_MANAGER_ROLE();
     }
 
     /// @notice Returns true if this contract implements `interfaceId`.
@@ -36,11 +41,11 @@ abstract contract ERC4626VaultControls is ERC4626Vault, Pausable, ReentrancyGuar
         public
         view
         virtual
-        override(Pausable, ReentrancyGuard, IERC165)
+        override(VaultFacetControl, IERC165)
         returns (bool)
     {
         return interfaceId == type(IERC4626VaultControls).interfaceId || interfaceId == type(IERC165).interfaceId
-            || Pausable.supportsInterface(interfaceId) || ReentrancyGuard.supportsInterface(interfaceId);
+            || VaultFacetControl.supportsInterface(interfaceId);
     }
 
     /// @notice Returns current fee configuration.
@@ -80,7 +85,7 @@ abstract contract ERC4626VaultControls is ERC4626Vault, Pausable, ReentrancyGuar
     /// @param feeRecipient Fee recipient account.
     function setFeeConfig(uint16 depositFeeBps, uint16 withdrawFeeBps, address feeRecipient)
         public
-        onlyRole(VAULT_MANAGER_ROLE)
+        onlyRole(VAULT_MANAGER_ROLE())
     {
         _validateFeeBps(depositFeeBps);
         _validateFeeBps(withdrawFeeBps);
@@ -122,7 +127,7 @@ abstract contract ERC4626VaultControls is ERC4626Vault, Pausable, ReentrancyGuar
         uint128 limitMaxMint,
         uint128 limitMaxWithdraw,
         uint128 limitMaxRedeem
-    ) public onlyRole(VAULT_MANAGER_ROLE) {
+    ) public onlyRole(VAULT_MANAGER_ROLE()) {
         LibERC4626VaultStorage.LimitConfig storage limits = LibERC4626VaultStorage.layout().limits;
 
         limits.maxTotalAssets = limitMaxTotalAssets;
@@ -431,13 +436,6 @@ abstract contract ERC4626VaultControls is ERC4626Vault, Pausable, ReentrancyGuar
         _payoutFee(feeAssets);
 
         emit Withdraw(msg.sender, receiver, owner, assets, shares);
-    }
-
-    /// @dev Initializes control-plane defaults.
-    /// @param initialManager Account receiving `VAULT_MANAGER_ROLE`.
-    function _initializeVaultControls(address initialManager) internal {
-        LibERC4626VaultStorage.layout().fees.feeRecipient = initialManager;
-        _grantRole(VAULT_MANAGER_ROLE, initialManager);
     }
 
     /// @dev Enforces configured total-assets cap.

--- a/src/vault/VaultFacetControl.sol
+++ b/src/vault/VaultFacetControl.sol
@@ -1,0 +1,390 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "../interfaces/IAccessControl.sol";
+import {IAccessControlTime} from "../interfaces/IAccessControlTime.sol";
+import {IERC165} from "../interfaces/IERC165.sol";
+import {IPausable} from "../interfaces/IPausable.sol";
+import {IReentrancyGuard} from "../interfaces/IReentrancyGuard.sol";
+import {LibAccessControlStorage} from "../access/storage/LibAccessControlStorage.sol";
+import {LibAccessControlTimeStorage} from "../access/storage/LibAccessControlTimeStorage.sol";
+import {LibPausableStorage} from "../access/storage/LibPausableStorage.sol";
+import {LibReentrancyGuardStorage} from "../security/storage/LibReentrancyGuardStorage.sol";
+import {LibERC4626VaultStorage} from "./storage/LibERC4626VaultStorage.sol";
+import {LibVaultFacetConstants} from "./libraries/LibVaultFacetConstants.sol";
+
+/// @title VaultFacetControl
+/// @notice Constructor-free access, pause, and reentrancy layer for hosted vault facets.
+abstract contract VaultFacetControl is IAccessControl, IAccessControlTime, IPausable, IReentrancyGuard {
+    /// @notice Default admin for all roles unless overridden.
+    bytes32 public constant DEFAULT_ADMIN_ROLE = 0x00;
+
+    /// @notice Role required to call pause and unpause controls.
+    bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
+
+    /// @dev Role that can manage vault fees and limits.
+    bytes32 internal constant VAULT_MANAGER_ROLE_VALUE = LibVaultFacetConstants.VAULT_MANAGER_ROLE;
+
+    /// @dev Reentrancy status for a function call not currently entered.
+    uint256 internal constant NOT_ENTERED = 1;
+
+    /// @dev Reentrancy status for a function call currently entered.
+    uint256 internal constant ENTERED = 2;
+
+    /// @dev Reverts if the caller is missing `role`.
+    modifier onlyRole(bytes32 role) {
+        _checkRole(role, msg.sender);
+        _;
+    }
+
+    /// @dev Reverts if the caller does not currently have an active time-gated `role`.
+    modifier onlyActiveRole(bytes32 role) {
+        _checkActiveRole(role, msg.sender);
+        _;
+    }
+
+    /// @dev Prevents a function from being called reentrantly.
+    modifier nonReentrant() {
+        _nonReentrantBefore();
+        _;
+        _nonReentrantAfter();
+    }
+
+    /// @dev Reverts when contract is paused.
+    modifier whenNotPaused() {
+        _requireNotPaused();
+        _;
+    }
+
+    /// @dev Reverts when contract is not paused.
+    modifier whenPaused() {
+        _requirePaused();
+        _;
+    }
+
+    function hasRole(bytes32 role, address account) public view returns (bool) {
+        return LibAccessControlStorage.layout().roles[role].members[account];
+    }
+
+    function getRoleAdmin(bytes32 role) public view returns (bytes32) {
+        return LibAccessControlStorage.layout().roles[role].adminRole;
+    }
+
+    /// @notice Role that can manage vault fees and limits.
+    /// @return The vault manager role identifier.
+    function VAULT_MANAGER_ROLE() public pure virtual returns (bytes32) {
+        return VAULT_MANAGER_ROLE_VALUE;
+    }
+
+    function grantRole(bytes32 role, address account) public onlyRole(getRoleAdmin(role)) {
+        _grantRole(role, account);
+    }
+
+    function grantRoleWithWindow(bytes32 role, address account, uint64 start, uint64 end)
+        public
+        onlyRole(getRoleAdmin(role))
+    {
+        _grantRole(role, account);
+        _setRoleWindow(role, account, start, end, msg.sender);
+    }
+
+    function revokeRole(bytes32 role, address account) public onlyRole(getRoleAdmin(role)) {
+        _revokeRole(role, account);
+    }
+
+    function renounceRole(bytes32 role, address account) public {
+        if (account != msg.sender) {
+            revert AccessControlRenounceSelfOnly();
+        }
+        _revokeRole(role, account);
+    }
+
+    function getRoleMember(bytes32 role, uint256 index) public view returns (address) {
+        return LibAccessControlStorage.layout().roles[role].memberList[index];
+    }
+
+    function getRoleMemberCount(bytes32 role) public view returns (uint256) {
+        return LibAccessControlStorage.layout().roles[role].memberList.length;
+    }
+
+    function setRoleWindow(bytes32 role, address account, uint64 start, uint64 end)
+        public
+        onlyRole(getRoleAdmin(role))
+    {
+        _setRoleWindow(role, account, start, end, msg.sender);
+    }
+
+    function clearRoleWindow(bytes32 role, address account) public onlyRole(getRoleAdmin(role)) {
+        _requireNonZeroAccount(account);
+        _clearRoleWindow(role, account, msg.sender);
+    }
+
+    function getRoleWindow(bytes32 role, address account) public view returns (uint64 start, uint64 end, bool exists) {
+        LibAccessControlTimeStorage.RoleWindow storage window =
+            LibAccessControlTimeStorage.layout().roleWindows[role][account];
+        return (window.start, window.end, window.exists);
+    }
+
+    function hasActiveRole(bytes32 role, address account) public view returns (bool) {
+        if (!hasRole(role, account)) {
+            return false;
+        }
+
+        LibAccessControlTimeStorage.RoleWindow storage window =
+            LibAccessControlTimeStorage.layout().roleWindows[role][account];
+        if (!window.exists) {
+            return false;
+        }
+
+        uint256 timestamp = block.timestamp;
+        if (timestamp < window.start) {
+            return false;
+        }
+        if (window.end != 0 && timestamp >= window.end) {
+            return false;
+        }
+        return true;
+    }
+
+    function paused() public view returns (bool) {
+        return LibPausableStorage.layout().paused;
+    }
+
+    function paused(bytes32 scope) public view returns (bool) {
+        return paused() || scopePaused(scope);
+    }
+
+    function scopePaused(bytes32 scope) public view returns (bool) {
+        return LibPausableStorage.layout().pausedScopes[scope];
+    }
+
+    function pause() public onlyRole(PAUSER_ROLE) whenNotPaused {
+        LibPausableStorage.layout().paused = true;
+        emit Paused(msg.sender);
+    }
+
+    function unpause() public onlyRole(PAUSER_ROLE) whenPaused {
+        LibPausableStorage.layout().paused = false;
+        emit Unpaused(msg.sender);
+    }
+
+    function pauseScope(bytes32 scope) public onlyRole(PAUSER_ROLE) {
+        _requireValidScope(scope);
+        if (scopePaused(scope)) {
+            revert PausableScopeEnforcedPause(scope);
+        }
+
+        LibPausableStorage.layout().pausedScopes[scope] = true;
+        emit ScopePaused(scope, msg.sender);
+    }
+
+    function unpauseScope(bytes32 scope) public onlyRole(PAUSER_ROLE) {
+        _requireValidScope(scope);
+        if (!scopePaused(scope)) {
+            revert PausableScopeExpectedPause(scope);
+        }
+
+        LibPausableStorage.layout().pausedScopes[scope] = false;
+        emit ScopeUnpaused(scope, msg.sender);
+    }
+
+    function reentrancyGuardEntered() public view returns (bool) {
+        return LibReentrancyGuardStorage.layout().status == ENTERED;
+    }
+
+    function supportsInterface(bytes4 interfaceId) public view virtual returns (bool) {
+        return interfaceId == type(IERC165).interfaceId || interfaceId == type(IAccessControl).interfaceId
+            || interfaceId == type(IAccessControlTime).interfaceId || interfaceId == type(IPausable).interfaceId
+            || interfaceId == type(IReentrancyGuard).interfaceId;
+    }
+
+    /// @dev Initializes shared control storage and vault manager defaults when needed.
+    /// @param initialAdmin The default admin, pauser, and initial vault manager.
+    function _initializeVaultFacetControl(address initialAdmin) internal {
+        if (!_isAccessControlInitialized()) {
+            _initializeAccessControl(initialAdmin);
+        }
+        if (!_isPausableInitialized()) {
+            _initializePausable(initialAdmin);
+        }
+        if (!_isReentrancyGuardInitialized()) {
+            _initializeReentrancyGuard();
+        }
+        if (!LibERC4626VaultStorage.layout().controlPlaneInitialized) {
+            _initializeVaultManagerDefaults(initialAdmin);
+        }
+    }
+
+    function _isAccessControlInitialized() internal view returns (bool) {
+        return LibAccessControlStorage.layout().initialized;
+    }
+
+    function _isPausableInitialized() internal view returns (bool) {
+        return LibPausableStorage.layout().initialized;
+    }
+
+    function _isReentrancyGuardInitialized() internal view returns (bool) {
+        return LibReentrancyGuardStorage.layout().initialized;
+    }
+
+    function _initializeAccessControl(address initialAdmin) internal {
+        LibAccessControlStorage.Layout storage layout = LibAccessControlStorage.layout();
+        if (layout.initialized) {
+            revert AccessControlAlreadyInitialized();
+        }
+        if (initialAdmin == address(0)) {
+            revert AccessControlZeroAdmin();
+        }
+
+        layout.initialized = true;
+        layout.roles[DEFAULT_ADMIN_ROLE].adminRole = DEFAULT_ADMIN_ROLE;
+        _grantRole(DEFAULT_ADMIN_ROLE, initialAdmin);
+    }
+
+    function _initializePausable(address initialPauser) internal {
+        LibPausableStorage.Layout storage layout = LibPausableStorage.layout();
+        if (layout.initialized) {
+            revert PausableAlreadyInitialized();
+        }
+        _requireNonZeroAccount(initialPauser);
+
+        layout.initialized = true;
+        _grantRole(PAUSER_ROLE, initialPauser);
+    }
+
+    function _initializeReentrancyGuard() internal {
+        LibReentrancyGuardStorage.Layout storage layout = LibReentrancyGuardStorage.layout();
+        if (layout.initialized) {
+            revert ReentrancyGuardAlreadyInitialized();
+        }
+        layout.initialized = true;
+        layout.status = NOT_ENTERED;
+    }
+
+    /// @dev Seeds vault-manager defaults for a hosted vault control plane.
+    /// @param initialManager The account receiving the initial manager role and fee recipient status.
+    function _initializeVaultManagerDefaults(address initialManager) internal {
+        _requireNonZeroAccount(initialManager);
+
+        LibERC4626VaultStorage.Layout storage vaultLayout = LibERC4626VaultStorage.layout();
+        _setRoleAdmin(VAULT_MANAGER_ROLE_VALUE, DEFAULT_ADMIN_ROLE);
+        _grantRole(VAULT_MANAGER_ROLE_VALUE, initialManager);
+        vaultLayout.fees.feeRecipient = initialManager;
+        vaultLayout.controlPlaneInitialized = true;
+    }
+
+    function _checkRole(bytes32 role, address account) internal view {
+        if (!hasRole(role, account)) {
+            revert AccessControlUnauthorized(account, role);
+        }
+    }
+
+    function _checkActiveRole(bytes32 role, address account) internal view {
+        if (!hasActiveRole(role, account)) {
+            revert AccessControlRoleNotActive(account, role);
+        }
+    }
+
+    function _setRoleAdmin(bytes32 role, bytes32 adminRole) internal virtual {
+        LibAccessControlStorage.Layout storage layout = LibAccessControlStorage.layout();
+        bytes32 previousAdminRole = layout.roles[role].adminRole;
+        layout.roles[role].adminRole = adminRole;
+        emit RoleAdminChanged(role, previousAdminRole, adminRole);
+    }
+
+    function _grantRole(bytes32 role, address account) internal virtual {
+        _requireNonZeroAccount(account);
+        LibAccessControlStorage.RoleData storage roleData = LibAccessControlStorage.layout().roles[role];
+        if (!roleData.members[account]) {
+            roleData.members[account] = true;
+            if (roleData.memberIndex[account] == 0) {
+                roleData.memberList.push(account);
+                roleData.memberIndex[account] = roleData.memberList.length;
+            }
+            emit RoleGranted(role, account, msg.sender);
+        }
+    }
+
+    function _revokeRole(bytes32 role, address account) internal virtual {
+        _requireNonZeroAccount(account);
+        LibAccessControlStorage.RoleData storage roleData = LibAccessControlStorage.layout().roles[role];
+        if (roleData.members[account]) {
+            roleData.members[account] = false;
+            uint256 index = roleData.memberIndex[account];
+            if (index != 0) {
+                uint256 lastIndex = roleData.memberList.length;
+                if (index != lastIndex) {
+                    address lastMember = roleData.memberList[lastIndex - 1];
+                    roleData.memberList[index - 1] = lastMember;
+                    roleData.memberIndex[lastMember] = index;
+                }
+                roleData.memberList.pop();
+                roleData.memberIndex[account] = 0;
+            }
+            _clearRoleWindow(role, account, msg.sender);
+            emit RoleRevoked(role, account, msg.sender);
+        }
+    }
+
+    function _validateRoleWindow(uint64 start, uint64 end) internal pure {
+        if (end != 0 && end <= start) {
+            revert AccessControlInvalidRoleWindow(start, end);
+        }
+    }
+
+    function _setRoleWindow(bytes32 role, address account, uint64 start, uint64 end, address sender) internal {
+        _requireNonZeroAccount(account);
+        _validateRoleWindow(start, end);
+
+        LibAccessControlTimeStorage.RoleWindow storage window =
+            LibAccessControlTimeStorage.layout().roleWindows[role][account];
+        window.start = start;
+        window.end = end;
+        window.exists = true;
+        emit RoleWindowSet(role, account, start, end, sender);
+    }
+
+    function _clearRoleWindow(bytes32 role, address account, address sender) internal {
+        LibAccessControlTimeStorage.Layout storage layout = LibAccessControlTimeStorage.layout();
+        if (layout.roleWindows[role][account].exists) {
+            delete layout.roleWindows[role][account];
+            emit RoleWindowCleared(role, account, sender);
+        }
+    }
+
+    function _nonReentrantBefore() internal {
+        LibReentrancyGuardStorage.Layout storage layout = LibReentrancyGuardStorage.layout();
+        if (layout.status == ENTERED) {
+            revert ReentrancyGuardReentrantCall();
+        }
+        layout.status = ENTERED;
+    }
+
+    function _nonReentrantAfter() internal {
+        LibReentrancyGuardStorage.layout().status = NOT_ENTERED;
+    }
+
+    function _requireNotPaused() internal view {
+        if (paused()) {
+            revert PausableEnforcedPause();
+        }
+    }
+
+    function _requirePaused() internal view {
+        if (!paused()) {
+            revert PausableExpectedPause();
+        }
+    }
+
+    function _requireValidScope(bytes32 scope) internal pure {
+        if (scope == bytes32(0)) {
+            revert PausableZeroScope();
+        }
+    }
+
+    function _requireNonZeroAccount(address account) internal pure {
+        if (account == address(0)) {
+            revert AccessControlZeroAddressAccount();
+        }
+    }
+}

--- a/src/vault/libraries/LibVaultFacetConstants.sol
+++ b/src/vault/libraries/LibVaultFacetConstants.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title LibVaultFacetConstants
+/// @notice Canonical role identifiers for hosted vault facets.
+library LibVaultFacetConstants {
+    /// @dev Role that can manage vault fees and limits.
+    bytes32 internal constant VAULT_MANAGER_ROLE = keccak256("VAULT_MANAGER_ROLE");
+}

--- a/src/vault/libraries/LibVaultFacetSelectors.sol
+++ b/src/vault/libraries/LibVaultFacetSelectors.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "../../interfaces/IAccessControl.sol";
+import {IAccessControlTime} from "../../interfaces/IAccessControlTime.sol";
+import {IERC20} from "../../interfaces/IERC20.sol";
+import {IERC20Metadata} from "../../interfaces/IERC20Metadata.sol";
+import {IERC165} from "../../interfaces/IERC165.sol";
+import {IERC4626} from "../../interfaces/IERC4626.sol";
+import {IERC4626VaultBase} from "../../interfaces/IERC4626VaultBase.sol";
+import {IERC4626VaultControls} from "../../interfaces/IERC4626VaultControls.sol";
+import {IERC4626VaultFacet} from "../../interfaces/IERC4626VaultFacet.sol";
+import {IPausable} from "../../interfaces/IPausable.sol";
+import {IReentrancyGuard} from "../../interfaces/IReentrancyGuard.sol";
+
+/// @title LibVaultFacetSelectors
+/// @notice Canonical selector groups for future hosted vault facet splits.
+library LibVaultFacetSelectors {
+    /// @notice Returns the hosted vault core selector group.
+    function vaultCoreSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](28);
+        selectors[0] = IERC4626VaultFacet.initializeVault.selector;
+        selectors[1] = IERC4626VaultBase.isVaultInitialized.selector;
+        selectors[2] = IERC4626.asset.selector;
+        selectors[3] = IERC4626VaultBase.totalManagedAssets.selector;
+        selectors[4] = IERC20Metadata.name.selector;
+        selectors[5] = IERC20Metadata.symbol.selector;
+        selectors[6] = IERC20Metadata.decimals.selector;
+        selectors[7] = IERC20.totalSupply.selector;
+        selectors[8] = IERC20.balanceOf.selector;
+        selectors[9] = IERC20.allowance.selector;
+        selectors[10] = IERC20.transfer.selector;
+        selectors[11] = IERC20.approve.selector;
+        selectors[12] = IERC20.transferFrom.selector;
+        selectors[13] = IERC4626.totalAssets.selector;
+        selectors[14] = IERC4626.convertToShares.selector;
+        selectors[15] = IERC4626.convertToAssets.selector;
+        selectors[16] = IERC4626.maxDeposit.selector;
+        selectors[17] = IERC4626.previewDeposit.selector;
+        selectors[18] = IERC4626.deposit.selector;
+        selectors[19] = IERC4626.maxMint.selector;
+        selectors[20] = IERC4626.previewMint.selector;
+        selectors[21] = IERC4626.mint.selector;
+        selectors[22] = IERC4626.maxWithdraw.selector;
+        selectors[23] = IERC4626.previewWithdraw.selector;
+        selectors[24] = IERC4626.withdraw.selector;
+        selectors[25] = IERC4626.maxRedeem.selector;
+        selectors[26] = IERC4626.previewRedeem.selector;
+        selectors[27] = IERC4626.redeem.selector;
+    }
+
+    /// @notice Returns the hosted vault controls selector group.
+    function vaultControlsSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](28);
+        selectors[0] = IERC4626VaultControls.VAULT_MANAGER_ROLE.selector;
+        selectors[1] = IERC4626VaultControls.feeConfig.selector;
+        selectors[2] = IERC4626VaultControls.limitConfig.selector;
+        selectors[3] = IERC4626VaultControls.setFeeConfig.selector;
+        selectors[4] = IERC4626VaultControls.setLimitConfig.selector;
+        selectors[5] = IAccessControl.DEFAULT_ADMIN_ROLE.selector;
+        selectors[6] = IPausable.PAUSER_ROLE.selector;
+        selectors[7] = IAccessControl.hasRole.selector;
+        selectors[8] = IAccessControl.getRoleAdmin.selector;
+        selectors[9] = IAccessControl.grantRole.selector;
+        selectors[10] = IAccessControl.revokeRole.selector;
+        selectors[11] = IAccessControl.renounceRole.selector;
+        selectors[12] = IAccessControl.getRoleMember.selector;
+        selectors[13] = IAccessControl.getRoleMemberCount.selector;
+        selectors[14] = IAccessControlTime.grantRoleWithWindow.selector;
+        selectors[15] = IAccessControlTime.setRoleWindow.selector;
+        selectors[16] = IAccessControlTime.clearRoleWindow.selector;
+        selectors[17] = IAccessControlTime.getRoleWindow.selector;
+        selectors[18] = IAccessControlTime.hasActiveRole.selector;
+        selectors[19] = bytes4(keccak256("paused()"));
+        selectors[20] = bytes4(keccak256("paused(bytes32)"));
+        selectors[21] = IPausable.scopePaused.selector;
+        selectors[22] = IPausable.pause.selector;
+        selectors[23] = IPausable.unpause.selector;
+        selectors[24] = IPausable.pauseScope.selector;
+        selectors[25] = IPausable.unpauseScope.selector;
+        selectors[26] = IReentrancyGuard.reentrancyGuardEntered.selector;
+        selectors[27] = IERC165.supportsInterface.selector;
+    }
+}

--- a/src/vault/storage/LibERC4626VaultStorage.sol
+++ b/src/vault/storage/LibERC4626VaultStorage.sol
@@ -26,6 +26,7 @@ library LibERC4626VaultStorage {
     /// @notice Vault storage layout.
     struct Layout {
         bool initialized;
+        bool controlPlaneInitialized;
         address asset;
         uint8 decimals;
         string name;

--- a/test/VaultFacetFoundationCore.t.sol
+++ b/test/VaultFacetFoundationCore.t.sol
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
+import {IAccessControlTime} from "../src/interfaces/IAccessControlTime.sol";
+import {IERC165} from "../src/interfaces/IERC165.sol";
+import {IERC4626} from "../src/interfaces/IERC4626.sol";
+import {IERC4626VaultBase} from "../src/interfaces/IERC4626VaultBase.sol";
+import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol";
+import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControlsFacet.sol";
+import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
+import {IPausable} from "../src/interfaces/IPausable.sol";
+import {IReentrancyGuard} from "../src/interfaces/IReentrancyGuard.sol";
+import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
+import {NoMetadataAsset} from "./helpers/ERC4626VaultTestHarness.sol";
+import {VaultFacetFoundationFixture} from "./helpers/VaultFacetFoundationTestHarness.sol";
+
+contract VaultFacetFoundationCoreTest is VaultFacetFoundationFixture {
+    function testInitializeVaultSeedsHostedFoundationState() public {
+        _initializeVault();
+
+        assertTrue(vault.isVaultInitialized(), "vault should initialize");
+        assertTrue(vault.controlPlaneInitialized(), "control plane should initialize");
+        assertTrue(vault.asset() == address(asset), "asset mismatch");
+        assertTrue(keccak256(bytes(vault.name())) == keccak256(bytes("Vault Share")), "name mismatch");
+        assertTrue(keccak256(bytes(vault.symbol())) == keccak256(bytes("vSHARE")), "symbol mismatch");
+        assertTrue(vault.decimals() == 6, "decimals mismatch");
+        assertTrue(vault.feeRecipient() == admin, "fee recipient mismatch");
+        assertTrue(vault.hasRole(vault.DEFAULT_ADMIN_ROLE(), admin), "missing default admin role");
+        assertTrue(vault.hasRole(vault.PAUSER_ROLE(), admin), "missing pauser role");
+        assertTrue(vault.hasRole(vault.VAULT_MANAGER_ROLE(), admin), "missing vault manager role");
+        assertTrue(vault.reentrancyGuardEntered() == false, "reentrancy guard should be idle");
+    }
+
+    function testInitializeVaultDefaultsDecimalsWhenMetadataMissing() public {
+        NoMetadataAsset noMetadataAsset = _newNoMetadataAsset();
+
+        vault.initializeVault(address(noMetadataAsset), "Vault Share", "vSHARE", admin);
+
+        assertTrue(vault.decimals() == 18, "missing metadata should default to 18 decimals");
+    }
+
+    function testInitializeVaultRevertsOnZeroAsset() public {
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultZeroAsset.selector));
+        vault.initializeVault(address(0), "Vault Share", "vSHARE", admin);
+    }
+
+    function testInitializeVaultRevertsWhenAlreadyInitialized() public {
+        _initializeVault();
+
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultAlreadyInitialized.selector));
+        vault.initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function testConstructorFreeControlInitCanRunBeforeVaultInit() public {
+        vault.initializeControlOnly(admin);
+
+        assertFalse(vault.isVaultInitialized(), "vault storage should remain uninitialized");
+        assertTrue(vault.controlPlaneInitialized(), "control plane should initialize");
+        assertTrue(vault.feeRecipient() == admin, "fee recipient mismatch");
+        assertTrue(vault.hasRole(vault.DEFAULT_ADMIN_ROLE(), admin), "missing default admin role");
+        assertTrue(vault.hasRole(vault.PAUSER_ROLE(), admin), "missing pauser role");
+        assertTrue(vault.hasRole(vault.VAULT_MANAGER_ROLE(), admin), "missing vault manager role");
+
+        vault.initializeControlOnly(admin);
+        vault.initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+
+        assertTrue(vault.isVaultInitialized(), "vault should initialize after control-only init");
+        assertTrue(vault.asset() == address(asset), "asset mismatch after delayed vault init");
+    }
+
+    function testSupportsHostedControlInterfaces() public view {
+        assertTrue(vault.supportsInterface(type(IERC165).interfaceId), "erc165 unsupported");
+        assertTrue(vault.supportsInterface(type(IAccessControl).interfaceId), "access control unsupported");
+        assertTrue(vault.supportsInterface(type(IAccessControlTime).interfaceId), "access control time unsupported");
+        assertTrue(vault.supportsInterface(type(IPausable).interfaceId), "pausable unsupported");
+        assertTrue(vault.supportsInterface(type(IReentrancyGuard).interfaceId), "reentrancy unsupported");
+        assertTrue(
+            vault.supportsInterface(type(IERC4626VaultControlsFacet).interfaceId), "vault controls facet unsupported"
+        );
+    }
+
+    function testVaultSelectorGroupsCoverExpectedHostedSplit() public pure {
+        bytes4[] memory coreSelectors = LibVaultFacetSelectors.vaultCoreSelectors();
+        bytes4[] memory controlSelectors = LibVaultFacetSelectors.vaultControlsSelectors();
+
+        assertTrue(coreSelectors.length == 28, "unexpected core selector count");
+        assertTrue(controlSelectors.length == 28, "unexpected controls selector count");
+
+        _assertContains(coreSelectors, IERC4626VaultFacet.initializeVault.selector);
+        _assertContains(coreSelectors, IERC4626.deposit.selector);
+        _assertContains(coreSelectors, IERC4626.redeem.selector);
+        _assertContains(coreSelectors, IERC4626VaultBase.totalManagedAssets.selector);
+
+        _assertContains(controlSelectors, IERC4626VaultControls.setFeeConfig.selector);
+        _assertContains(controlSelectors, IERC4626VaultControls.setLimitConfig.selector);
+        _assertContains(controlSelectors, IAccessControlTime.grantRoleWithWindow.selector);
+        _assertContains(controlSelectors, IReentrancyGuard.reentrancyGuardEntered.selector);
+        _assertContains(controlSelectors, IERC165.supportsInterface.selector);
+
+        _assertUnique(coreSelectors);
+        _assertUnique(controlSelectors);
+        _assertDisjoint(coreSelectors, controlSelectors);
+    }
+
+    function _assertContains(bytes4[] memory selectors, bytes4 target) internal pure {
+        for (uint256 i = 0; i < selectors.length; i++) {
+            if (selectors[i] == target) {
+                return;
+            }
+        }
+        revert("missing selector");
+    }
+
+    function _assertUnique(bytes4[] memory selectors) internal pure {
+        for (uint256 i = 0; i < selectors.length; i++) {
+            for (uint256 j = i + 1; j < selectors.length; j++) {
+                if (selectors[i] == selectors[j]) {
+                    revert("duplicate selector");
+                }
+            }
+        }
+    }
+
+    function _assertDisjoint(bytes4[] memory left, bytes4[] memory right) internal pure {
+        for (uint256 i = 0; i < left.length; i++) {
+            for (uint256 j = 0; j < right.length; j++) {
+                if (left[i] == right[j]) {
+                    revert("selector overlap");
+                }
+            }
+        }
+    }
+}

--- a/test/helpers/VaultFacetFoundationTestHarness.sol
+++ b/test/helpers/VaultFacetFoundationTestHarness.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC165} from "../../src/interfaces/IERC165.sol";
+import {IERC4626VaultControlsFacet} from "../../src/interfaces/IERC4626VaultControlsFacet.sol";
+import {ERC4626VaultBase} from "../../src/vault/ERC4626VaultBase.sol";
+import {VaultFacetControl} from "../../src/vault/VaultFacetControl.sol";
+import {LibERC4626VaultStorage} from "../../src/vault/storage/LibERC4626VaultStorage.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+import {MockAssetWithDecimals, NoMetadataAsset} from "./ERC4626VaultTestHarness.sol";
+
+contract HostedVaultFacetFoundationHarness is ERC4626VaultBase, VaultFacetControl {
+    function initializeVault(address vaultAsset, string calldata vaultName, string calldata vaultSymbol, address admin)
+        external
+    {
+        _initializeErc4626Vault(vaultAsset, vaultName, vaultSymbol);
+        _initializeVaultFacetControl(admin);
+    }
+
+    function initializeControlOnly(address admin) external {
+        _initializeVaultFacetControl(admin);
+    }
+
+    function feeRecipient() external view returns (address) {
+        return LibERC4626VaultStorage.layout().fees.feeRecipient;
+    }
+
+    function controlPlaneInitialized() external view returns (bool) {
+        return LibERC4626VaultStorage.layout().controlPlaneInitialized;
+    }
+
+    function probeNonReentrant() external nonReentrant returns (bool) {
+        return true;
+    }
+
+    function transfer(address to, uint256 value) external returns (bool) {
+        _transferShares(msg.sender, to, value);
+        return true;
+    }
+
+    function approve(address spender, uint256 value) external returns (bool) {
+        _setAllowance(msg.sender, spender, value);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 value) external returns (bool) {
+        _spendAllowance(from, msg.sender, value);
+        _transferShares(from, to, value);
+        return true;
+    }
+
+    function supportsInterface(bytes4 interfaceId) public view override(VaultFacetControl) returns (bool) {
+        return
+            interfaceId == type(IERC4626VaultControlsFacet).interfaceId
+                || VaultFacetControl.supportsInterface(interfaceId);
+    }
+}
+
+abstract contract VaultFacetFoundationFixture is TestBase {
+    address internal admin = address(0xA11CE);
+    address internal bob = address(0xB0B);
+
+    MockAssetWithDecimals internal asset;
+    HostedVaultFacetFoundationHarness internal vault;
+
+    function setUp() public virtual {
+        asset = new MockAssetWithDecimals(6);
+        vault = new HostedVaultFacetFoundationHarness();
+    }
+
+    function _initializeVault() internal {
+        vault.initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function _newNoMetadataAsset() internal returns (NoMetadataAsset) {
+        return new NoMetadataAsset();
+    }
+}


### PR DESCRIPTION
## Summary
- add a constructor-free shared control base for future hosted vault facets
- define hosted vault core and controls interfaces plus canonical selector groups
- move vault manager role identity into a shared vault facet constants library
- refactor the standalone vault controls contract to consume the new foundation without changing its external behavior
- add hosted vault foundation tests covering init, shared control seeding, interface support, and selector grouping

## Validation
- `git diff --check`
- `forge test --offline`

## Issue
- Closes #95