### PR TITLE
Add hosted vault core facet

### DIFF
--- a/src/vault/ERC4626VaultBase.sol
+++ b/src/vault/ERC4626VaultBase.sol
@@ -16,7 +16,7 @@ abstract contract ERC4626VaultBase is IERC4626VaultBase {
 
     /// @notice Returns true when vault storage is initialized.
     /// @return True if initialized.
-    function isVaultInitialized() public view returns (bool) {
+    function isVaultInitialized() public view virtual returns (bool) {
         return LibERC4626VaultStorage.layout().initialized;
     }
 
@@ -28,7 +28,7 @@ abstract contract ERC4626VaultBase is IERC4626VaultBase {
 
     /// @notice Returns currently managed asset accounting amount.
     /// @return The tracked managed asset amount.
-    function totalManagedAssets() public view returns (uint256) {
+    function totalManagedAssets() public view virtual returns (uint256) {
         return LibERC4626VaultStorage.layout().totalManagedAssets;
     }
 

--- a/src/vault/facets/ERC4626VaultFacet.sol
+++ b/src/vault/facets/ERC4626VaultFacet.sol
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC4626} from "../../interfaces/IERC4626.sol";
+import {IERC4626VaultFacet} from "../../interfaces/IERC4626VaultFacet.sol";
+import {ERC4626Vault} from "../ERC4626Vault.sol";
+import {ERC4626VaultBase} from "../ERC4626VaultBase.sol";
+import {VaultFacetControl} from "../VaultFacetControl.sol";
+
+/// @title ERC4626VaultFacet
+/// @notice Hosted ERC-4626 core facet with constructor-free initialization.
+contract ERC4626VaultFacet is ERC4626Vault, VaultFacetControl, IERC4626VaultFacet {
+    /// @notice Returns true when vault storage is initialized.
+    /// @return True if initialized.
+    function isVaultInitialized() public view virtual override(IERC4626VaultFacet, ERC4626VaultBase) returns (bool) {
+        return ERC4626VaultBase.isVaultInitialized();
+    }
+
+    /// @notice Returns vault underlying asset token address.
+    /// @return The underlying asset token.
+    function asset() public view virtual override(ERC4626Vault, IERC4626) returns (address) {
+        return ERC4626Vault.asset();
+    }
+
+    /// @notice Returns currently managed asset accounting amount.
+    /// @return The tracked managed asset amount.
+    function totalManagedAssets() public view virtual override(IERC4626VaultFacet, ERC4626VaultBase) returns (uint256) {
+        return ERC4626VaultBase.totalManagedAssets();
+    }
+
+    /// @notice Initializes the hosted vault core and shared control plane.
+    /// @param vaultAsset Underlying vault asset token.
+    /// @param vaultName ERC-20 share token name.
+    /// @param vaultSymbol ERC-20 share token symbol.
+    /// @param admin Account receiving admin, pauser, and vault manager roles.
+    function initializeVault(address vaultAsset, string calldata vaultName, string calldata vaultSymbol, address admin)
+        external
+    {
+        if (isVaultInitialized()) {
+            revert ERC4626VaultAlreadyInitialized();
+        }
+
+        if (_isAccessControlInitialized()) {
+            _checkRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        }
+
+        _initializeVaultFacetControl(admin);
+        _initializeErc4626Vault(vaultAsset, vaultName, vaultSymbol);
+    }
+
+    /// @notice Deposits `assets` and mints shares to `receiver`.
+    /// @param assets Asset amount.
+    /// @param receiver Receiver of minted shares.
+    /// @return shares Minted shares.
+    function deposit(uint256 assets, address receiver)
+        public
+        virtual
+        override(ERC4626Vault, IERC4626)
+        whenNotPaused
+        nonReentrant
+        returns (uint256 shares)
+    {
+        return super.deposit(assets, receiver);
+    }
+
+    /// @notice Mints `shares` to `receiver`.
+    /// @param shares Share amount.
+    /// @param receiver Receiver of minted shares.
+    /// @return assets Deposited assets.
+    function mint(uint256 shares, address receiver)
+        public
+        virtual
+        override(ERC4626Vault, IERC4626)
+        whenNotPaused
+        nonReentrant
+        returns (uint256 assets)
+    {
+        return super.mint(shares, receiver);
+    }
+
+    /// @notice Withdraws `assets` to `receiver` from `owner`.
+    /// @param assets Asset amount.
+    /// @param receiver Asset receiver.
+    /// @param owner Share owner.
+    /// @return shares Burned shares.
+    function withdraw(uint256 assets, address receiver, address owner)
+        public
+        virtual
+        override(ERC4626Vault, IERC4626)
+        whenNotPaused
+        nonReentrant
+        returns (uint256 shares)
+    {
+        return super.withdraw(assets, receiver, owner);
+    }
+
+    /// @notice Redeems `shares` from `owner` to `receiver`.
+    /// @param shares Share amount.
+    /// @param receiver Asset receiver.
+    /// @param owner Share owner.
+    /// @return assets Returned assets.
+    function redeem(uint256 shares, address receiver, address owner)
+        public
+        virtual
+        override(ERC4626Vault, IERC4626)
+        whenNotPaused
+        nonReentrant
+        returns (uint256 assets)
+    {
+        return super.redeem(shares, receiver, owner);
+    }
+}

--- a/test/ERC4626VaultFacetCore.t.sol
+++ b/test/ERC4626VaultFacetCore.t.sol
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
+import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
+import {IERC4626VaultBase} from "../src/interfaces/IERC4626VaultBase.sol";
+import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
+import {IPausable} from "../src/interfaces/IPausable.sol";
+import {ERC4626Vault} from "../src/vault/ERC4626Vault.sol";
+import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
+import {ERC4626VaultFacetFixture, ERC4626VaultFacetHarness} from "./helpers/ERC4626VaultFacetTestHarness.sol";
+
+contract ERC4626VaultFacetCoreTest is ERC4626VaultFacetFixture {
+    function testInitializeVaultSeedsMetadataAndControlPlane() public {
+        _initializeHostedVault(address(facet));
+
+        assertTrue(facet.isVaultInitialized(), "vault should initialize");
+        assertTrue(facet.controlPlaneInitialized(), "control plane should initialize");
+        assertTrue(facet.asset() == address(asset), "asset mismatch");
+        assertTrue(keccak256(bytes(facet.name())) == keccak256(bytes("Vault Share")), "name mismatch");
+        assertTrue(keccak256(bytes(facet.symbol())) == keccak256(bytes("vSHARE")), "symbol mismatch");
+        assertTrue(facet.decimals() == 6, "decimals mismatch");
+        assertTrue(facet.feeRecipient() == admin, "fee recipient mismatch");
+        assertTrue(facet.hasRole(facet.DEFAULT_ADMIN_ROLE(), admin), "missing default admin role");
+        assertTrue(facet.hasRole(facet.PAUSER_ROLE(), admin), "missing pauser role");
+        assertTrue(facet.hasRole(facet.VAULT_MANAGER_ROLE(), admin), "missing vault manager role");
+        assertFalse(facet.reentrancyGuardEntered(), "reentrancy guard should be idle");
+    }
+
+    function testInitializeVaultRevertsOnZeroAsset() public {
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultZeroAsset.selector));
+        facet.initializeVault(address(0), "Vault Share", "vSHARE", admin);
+    }
+
+    function testInitializeVaultRevertsWhenCalledTwice() public {
+        _initializeHostedVault(address(facet));
+
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultAlreadyInitialized.selector));
+        _initializeHostedVault(address(facet));
+    }
+
+    function testInitializeVaultAfterControlOnlyInitRequiresDefaultAdmin() public {
+        facet.initializeControlOnly(admin);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, facet.DEFAULT_ADMIN_ROLE())
+        );
+        VM.prank(bob);
+        facet.initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+
+        VM.prank(admin);
+        facet.initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+
+        assertTrue(facet.isVaultInitialized(), "vault should initialize");
+        assertTrue(facet.controlPlaneInitialized(), "control plane should stay initialized");
+        assertTrue(facet.feeRecipient() == admin, "fee recipient mismatch");
+    }
+
+    function testCoreFlowsAndShareTokenRoutingWorkOnFacet() public {
+        _initializeHostedVault(address(facet));
+
+        assertTrue(facet.previewDeposit(8) == 8, "preview deposit mismatch");
+        assertTrue(facet.previewMint(8) == 8, "preview mint mismatch");
+
+        _approveAsset(bob, address(facet), 100);
+        _approveAsset(eve, address(facet), 100);
+
+        VM.prank(bob);
+        uint256 bobDepositShares = facet.deposit(40, bob);
+        VM.prank(eve);
+        uint256 eveMintAssets = facet.mint(10, eve);
+
+        VM.prank(bob);
+        bool approveSuccess = facet.approve(eve, 15);
+        VM.prank(eve);
+        bool transferFromSuccess = facet.transferFrom(bob, admin, 10);
+        VM.prank(bob);
+        bool transferSuccess = facet.transfer(admin, 5);
+
+        VM.prank(bob);
+        uint256 bobWithdrawShares = facet.withdraw(10, bob, bob);
+        VM.prank(eve);
+        uint256 eveRedeemAssets = facet.redeem(5, eve, eve);
+
+        assertTrue(bobDepositShares == 40, "deposit shares mismatch");
+        assertTrue(eveMintAssets == 10, "mint assets mismatch");
+        assertTrue(approveSuccess, "approve should succeed");
+        assertTrue(transferFromSuccess, "transferFrom should succeed");
+        assertTrue(transferSuccess, "transfer should succeed");
+        assertTrue(bobWithdrawShares == 10, "withdraw shares mismatch");
+        assertTrue(eveRedeemAssets == 5, "redeem assets mismatch");
+
+        assertTrue(facet.totalAssets() == 35, "total assets mismatch");
+        assertTrue(facet.totalManagedAssets() == 35, "managed assets mismatch");
+        assertTrue(facet.totalSupply() == 35, "total supply mismatch");
+        assertTrue(facet.balanceOf(bob) == 15, "bob balance mismatch");
+        assertTrue(facet.balanceOf(admin) == 15, "admin balance mismatch");
+        assertTrue(facet.balanceOf(eve) == 5, "eve balance mismatch");
+        assertTrue(facet.allowance(bob, eve) == 5, "allowance mismatch");
+        assertTrue(asset.balanceOf(address(facet)) == 35, "vault asset balance mismatch");
+        assertTrue(asset.balanceOf(bob) == INITIAL_ASSETS - 30, "bob asset balance mismatch");
+        assertTrue(asset.balanceOf(eve) == INITIAL_ASSETS - 5, "eve asset balance mismatch");
+    }
+
+    function testPauseBlocksVaultEntrypointsButLeavesShareTokenFlowsAvailable() public {
+        _initializeHostedVault(address(facet));
+        _approveAsset(bob, address(facet), 100);
+
+        VM.prank(bob);
+        facet.deposit(40, bob);
+
+        VM.prank(admin);
+        facet.pause();
+
+        assertTrue(facet.maxDeposit(bob) == type(uint256).max, "maxDeposit should remain baseline");
+        assertTrue(facet.maxMint(bob) == type(uint256).max, "maxMint should remain baseline");
+        assertTrue(facet.maxWithdraw(bob) == 40, "maxWithdraw should remain baseline");
+        assertTrue(facet.maxRedeem(bob) == 40, "maxRedeem should remain baseline");
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+        facet.deposit(1, bob);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+        facet.mint(1, bob);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+        facet.withdraw(1, bob, bob);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+        facet.redeem(1, bob, bob);
+
+        VM.prank(bob);
+        facet.approve(eve, 15);
+        VM.prank(eve);
+        facet.transferFrom(bob, admin, 10);
+        VM.prank(bob);
+        facet.transfer(admin, 5);
+
+        assertTrue(facet.allowance(bob, eve) == 5, "allowance mismatch");
+        assertTrue(facet.balanceOf(bob) == 25, "bob share balance mismatch");
+        assertTrue(facet.balanceOf(admin) == 15, "admin share balance mismatch");
+    }
+
+    function testReentrantAttemptDuringDepositIsBlocked() public {
+        _initializeHostedVault(address(facet));
+        bytes memory payload = abi.encodeCall(ERC4626VaultFacetHarness.probeNonReentrant, ());
+        asset.configureReentry(address(facet), payload, true);
+
+        _approveAsset(bob, address(facet), 100);
+
+        VM.prank(bob);
+        uint256 shares = facet.deposit(10, bob);
+
+        assertTrue(shares == 10, "deposit should succeed");
+        assertTrue(asset.reentryAttemptBlocked(), "expected reentry attempt to be blocked");
+        assertFalse(facet.reentrancyGuardEntered(), "reentrancy guard should reset");
+    }
+
+    function testDiamondRoutingAndInitWorkThroughFallback() public {
+        _installVaultCoreFacetToDiamond();
+
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond)).initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+
+        assertTrue(IERC4626VaultFacet(address(diamond)).isVaultInitialized(), "diamond vault should initialize");
+        assertTrue(IERC4626VaultFacet(address(diamond)).asset() == address(asset), "diamond asset mismatch");
+        assertTrue(
+            keccak256(bytes(IERC4626VaultFacet(address(diamond)).name())) == keccak256(bytes("Vault Share")),
+            "diamond name mismatch"
+        );
+        assertTrue(
+            keccak256(bytes(IERC4626VaultFacet(address(diamond)).symbol())) == keccak256(bytes("vSHARE")),
+            "diamond symbol mismatch"
+        );
+
+        _approveAsset(bob, address(diamond), 100);
+
+        VM.prank(bob);
+        uint256 shares = IERC4626VaultFacet(address(diamond)).deposit(25, bob);
+
+        VM.prank(bob);
+        bool approveSuccess = IERC4626VaultFacet(address(diamond)).approve(eve, 10);
+        VM.prank(eve);
+        bool transferFromSuccess = IERC4626VaultFacet(address(diamond)).transferFrom(bob, admin, 5);
+        VM.prank(bob);
+        uint256 withdrawnShares = IERC4626VaultFacet(address(diamond)).withdraw(10, bob, bob);
+
+        assertTrue(shares == 25, "diamond deposit shares mismatch");
+        assertTrue(approveSuccess, "diamond approve should succeed");
+        assertTrue(transferFromSuccess, "diamond transferFrom should succeed");
+        assertTrue(withdrawnShares == 10, "diamond withdrawn shares mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewDeposit(8) == 8, "diamond preview mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 15, "diamond total assets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 15, "diamond managed assets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).balanceOf(bob) == 10, "diamond bob share balance mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).balanceOf(admin) == 5, "diamond admin share balance mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).allowance(bob, eve) == 5, "diamond allowance mismatch");
+
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultCoreSelectors(), address(facet));
+        assertTrue(
+            IDiamondLoupe(address(diamond)).facetFunctionSelectors(address(facet)).length
+                == LibVaultFacetSelectors.vaultCoreSelectors().length,
+            "diamond core selector count mismatch"
+        );
+    }
+
+    function testDiamondReinitializeReverts() public {
+        _installVaultCoreFacetToDiamond();
+
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond)).initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultAlreadyInitialized.selector));
+        IERC4626VaultFacet(address(diamond)).initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function testDiamondCoreInstallDoesNotExposeControlsSelectors() public {
+        _installVaultCoreFacetToDiamond();
+
+        _assertSelectorsUnset(LibVaultFacetSelectors.vaultControlsSelectors());
+    }
+
+    function _assertSelectorsOwnedByFacet(bytes4[] memory selectors, address expectedFacet) internal view {
+        for (uint256 i = 0; i < selectors.length; i++) {
+            assertTrue(
+                IDiamondLoupe(address(diamond)).facetAddress(selectors[i]) == expectedFacet, "selector owner mismatch"
+            );
+        }
+    }
+
+    function _assertSelectorsUnset(bytes4[] memory selectors) internal view {
+        for (uint256 i = 0; i < selectors.length; i++) {
+            assertTrue(IDiamondLoupe(address(diamond)).facetAddress(selectors[i]) == address(0), "selector set");
+        }
+    }
+}

--- a/test/helpers/ERC4626VaultFacetTestHarness.sol
+++ b/test/helpers/ERC4626VaultFacetTestHarness.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
+import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
+import {IERC4626VaultFacet} from "../../src/interfaces/IERC4626VaultFacet.sol";
+import {ERC4626VaultFacet} from "../../src/vault/facets/ERC4626VaultFacet.sol";
+import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
+import {LibERC4626VaultStorage} from "../../src/vault/storage/LibERC4626VaultStorage.sol";
+import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+import {ReentrantMockVaultAsset} from "./ERC4626VaultControlsTestHarness.sol";
+
+contract ERC4626VaultFacetHarness is ERC4626VaultFacet {
+    function initializeControlOnly(address admin) external {
+        _initializeVaultFacetControl(admin);
+    }
+
+    function feeRecipient() external view returns (address) {
+        return LibERC4626VaultStorage.layout().fees.feeRecipient;
+    }
+
+    function controlPlaneInitialized() external view returns (bool) {
+        return LibERC4626VaultStorage.layout().controlPlaneInitialized;
+    }
+
+    function probeNonReentrant() external nonReentrant returns (bool) {
+        return true;
+    }
+}
+
+abstract contract ERC4626VaultFacetFixture is TestBase {
+    uint256 internal constant INITIAL_ASSETS = 1_000_000;
+
+    address internal admin = address(0xA11CE);
+    address internal bob = address(0xB0B);
+    address internal eve = address(0xE11E);
+
+    ReentrantMockVaultAsset internal asset;
+    ERC4626VaultFacetHarness internal facet;
+    DiamondCutFacet internal cutFacet;
+    DiamondLoupeFacet internal loupeFacet;
+    DiamondProxyHarness internal diamond;
+
+    function setUp() public virtual {
+        asset = new ReentrantMockVaultAsset();
+        facet = new ERC4626VaultFacetHarness();
+        cutFacet = new DiamondCutFacet();
+        loupeFacet = new DiamondLoupeFacet();
+        diamond = new DiamondProxyHarness(admin, address(cutFacet));
+
+        asset.mint(bob, INITIAL_ASSETS);
+        asset.mint(eve, INITIAL_ASSETS);
+
+        _installLoupeFacet();
+    }
+
+    function _initializeHostedVault(address target) internal {
+        IERC4626VaultFacet(target).initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function _approveAsset(address owner, address spender, uint256 amount) internal {
+        VM.prank(owner);
+        asset.approve(spender, amount);
+    }
+
+    function _installLoupeFacet() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(loupeFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: _loupeSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installVaultCoreFacetToDiamond() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(facet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultCoreSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _loupeSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](6);
+        selectors[0] = DiamondLoupeFacet.facets.selector;
+        selectors[1] = DiamondLoupeFacet.facetFunctionSelectors.selector;
+        selectors[2] = DiamondLoupeFacet.facetAddresses.selector;
+        selectors[3] = DiamondLoupeFacet.facetAddress.selector;
+        selectors[4] = DiamondLoupeFacet.owner.selector;
+        selectors[5] = DiamondLoupeFacet.transferOwnership.selector;
+    }
+}


### PR DESCRIPTION
## Summary
- add the hosted ERC-4626 vault core facet and constructor-free diamond init flow
- enforce global pause and reentrancy on hosted vault entrypoints while leaving share transfers and approvals unchanged
- add direct and diamond-routed test coverage for init, routing, core flows, pause behavior, and selector ownership

## Validation
- `git diff --check`
- `forge fmt --check`
- `forge test --offline --match-path test/ERC4626VaultFacetCore.t.sol`
- `forge test --offline`

## Issue
- Closes #96