### PR TITLE
Complete Diamond-Hosted Vault Platform milestone

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ reviewable engineering system.
 - Hosted ERC20 and ERC721 token facets deployed behind separate diamond hosts,
   with init, selector ownership, Permit/metadata support, and host-level
   hardening coverage.
+- A hosted ERC-4626 vault platform deployed behind a diamond host, split across
+  core, controls, and integration facets with deployment-backed init, oracle
+  wiring, replace/remove/re-add hardening, and diamond-routed invariant
+  coverage.
 - Operational maturity through local bootstrap, smoke validation, upgrade
   rehearsal, system-hardening flows, and matching CI gates.
 
@@ -44,8 +48,9 @@ Implemented milestones so far:
 - Access Control + Upgrade Safety Kit
 - Oracle Adapter + Circuit Breaker
 - Diamond Core (EIP-2535)
-- Diamond Token Facets
 - System-Level Testing & Hardening
+- Diamond Token Facets
+- Diamond-Hosted Vault Platform
 
 ## Validation
 
@@ -61,8 +66,8 @@ bash script/run-local-system-hardening.sh
 ## Documentation
 
 Architecture and module docs live in `docs/diamond-core.md`,
-`docs/oracle-adapter.md`, `docs/erc4626-vault.md`, `docs/token-facets.md`, and
-`docs/threat-model.md`.
+`docs/oracle-adapter.md`, `docs/erc4626-vault.md`, `docs/vault-facets.md`,
+`docs/token-facets.md`, and `docs/threat-model.md`.
 
 Operational guidance lives in `docs/ops/README.md`, with the end-to-end
 execution order collected in `docs/ops/runbook-system-hardening.md`.
@@ -72,6 +77,10 @@ CI and local validation parity are documented in `docs/security-checks.md`.
 Token-host architecture and safety assumptions live in `docs/token-facets.md`,
 including the init model, selector ownership rules, separate-host deployment
 constraint, and token-host upgrade assumptions.
+
+Hosted-vault architecture and safety assumptions live in
+`docs/vault-facets.md`, including the init model, selector ownership split,
+pause behavior, deployment references, and hosted-vault upgrade assumptions.
 
 ## Tooling
 

--- a/docs/erc4626-vault.md
+++ b/docs/erc4626-vault.md
@@ -6,6 +6,9 @@ repository:
 - `ERC4626Vault`
 - `ERC4626VaultControls`
 
+It covers the standalone vault modules and their math/control behavior. For the
+diamond-hosted vault platform, see `docs/vault-facets.md`.
+
 ## Contract Roles
 
 - `ERC4626VaultBase`: initializer + share/asset accounting primitives.

--- a/docs/security-checks.md
+++ b/docs/security-checks.md
@@ -63,6 +63,20 @@ forge test --offline --match-path test/DiamondErc721HostInvariant.t.sol
 Use these to reproduce token-host deployment, selector ownership, replace and
 reinstall persistence, and diamond-routed invariant coverage locally.
 
+### Hosted Vault
+
+The hosted vault milestone has matching deployment, hardening, and invariant
+coverage for the supported three-facet vault host:
+
+```bash
+forge test --offline --match-path test/DiamondVaultDeploymentIntegration.t.sol
+forge test --offline --match-path test/DiamondVaultHostHardening.t.sol
+forge test --offline --match-path test/DiamondVaultHostInvariant.t.sol
+```
+
+Use these to reproduce hosted-vault deployment, selector ownership, facet
+replacement/reinstall persistence, and diamond-routed vault invariants locally.
+
 ### Slither
 
 Install and run the same high-severity gate locally:

--- a/docs/vault-facets.md
+++ b/docs/vault-facets.md
@@ -1,0 +1,204 @@
+# Diamond Vault Facets
+
+This document is the canonical guide for the hosted vault model implemented in
+the `Diamond-Hosted Vault Platform` milestone.
+
+It covers the supported diamond-hosted vault deployment:
+
+- one diamond
+- one `ERC4626VaultFacet`
+- one `ERC4626VaultControlsFacet`
+- one `ERC4626VaultIntegrationFacet`
+
+For the standalone ERC-4626 module behavior and math reference, see
+`docs/erc4626-vault.md`.
+
+## Supported Host Model
+
+The hosted vault diamond preserves a split between user-facing vault flows,
+control-plane selectors, and integration/config selectors.
+
+### Core Facet
+
+`ERC4626VaultFacet` owns the ERC-4626/share-token selector group:
+
+- vault initialization
+- share metadata and share-token flows
+- `deposit`, `mint`, `withdraw`, `redeem`
+- conversion, preview, and `max*` helpers
+- `asset()` and `totalManagedAssets()`
+
+### Controls Facet
+
+`ERC4626VaultControlsFacet` owns the control-plane selector group:
+
+- fee config and limit config
+- access control and time-window role selectors
+- global and scoped pause selectors
+- reentrancy introspection
+- `supportsInterface(bytes4)`
+
+### Integration Facet
+
+`ERC4626VaultIntegrationFacet` owns the integration/config selector group:
+
+- oracle adapter reference
+- strategy reference
+- strategy report hook
+- `idleAssets()`
+- `estimatedTotalManagedAssets()`
+- `oracleQuote()`
+
+## Initialization Model
+
+The hosted vault uses one initializer on the core facet only.
+
+Initialization sequence:
+
+1. Install loupe selectors.
+2. Install the core, controls, and integration selector groups.
+3. Call
+   `initializeVault(address vaultAsset, string vaultName, string vaultSymbol, address admin)`
+   through the diamond.
+4. Optionally call `setOracleAdapter(address newAdapter)` through the
+   integration facet.
+
+Initialization behavior:
+
+- `initializeVault(...)` initializes vault storage and shared control storage.
+- `DEFAULT_ADMIN_ROLE`, `PAUSER_ROLE`, and `VAULT_MANAGER_ROLE` are granted to
+  `admin`.
+- `feeRecipient` defaults to `admin` at initialization.
+- `ERC4626VaultControlsFacet` has no independent initializer.
+- `ERC4626VaultIntegrationFacet` has no independent initializer.
+- a second call to `initializeVault(...)` reverts.
+
+## Role Model And Pause Behavior
+
+Hosted vault facets reuse the shared control plane.
+
+### Roles
+
+- `DEFAULT_ADMIN_ROLE`
+- `PAUSER_ROLE`
+- `VAULT_MANAGER_ROLE`
+
+`VAULT_MANAGER_ROLE` is used for:
+
+- `setFeeConfig(...)`
+- `setLimitConfig(...)`
+- `setOracleAdapter(...)`
+- `setStrategy(...)`
+- manager-authorized `reportStrategyAssets(...)`
+
+If a strategy is configured, the strategy address may also call
+`reportStrategyAssets(...)`.
+
+### Pause Behavior
+
+The hosted vault currently uses a global pause model for vault entrypoints.
+
+Global pause blocks:
+
+- `deposit`
+- `mint`
+- `withdraw`
+- `redeem`
+
+Global pause does not block share-token flows:
+
+- `approve`
+- `transfer`
+- `transferFrom`
+
+Scoped pause selectors still route through the controls facet, but the hosted
+vault does not currently use per-scope pause behavior for ERC-4626 entrypoints.
+
+## Integration Behavior
+
+The integration facet is config/report infrastructure, not an active strategy
+engine.
+
+Oracle behavior:
+
+- the oracle adapter is an external contract reference
+- the reference host deployment wires it after vault initialization
+- `oracleQuote()` reads through the configured adapter
+
+Strategy behavior:
+
+- `setStrategy(...)` stores a configured strategy reference
+- `reportStrategyAssets(...)` updates an advisory reported amount
+- `strategyReportedAssets` does not mutate core ERC-4626 liquidity accounting
+
+Asset helpers:
+
+- `idleAssets()` returns the underlying balance held directly by the vault
+- `estimatedTotalManagedAssets()` returns
+  `idleAssets() + strategyReportedAssets()`
+- `totalManagedAssets()` and ERC-4626 preview/liquidity math continue to use the
+  vault's managed accounting only
+
+That means strategy reports are visible to operators and reviewers, but they do
+not automatically change `withdraw`, `redeem`, preview math, or live liquidity
+semantics in this milestone.
+
+## Selector Ownership Model
+
+For the supported hosted vault deployment:
+
+- `diamondCut` is owned by `DiamondCutFacet`
+- loupe and ownership-introspection selectors are owned by
+  `DiamondLoupeFacet`
+- core selectors are owned by `ERC4626VaultFacet`
+- controls selectors and `supportsInterface(bytes4)` are owned by
+  `ERC4626VaultControlsFacet`
+- integration selectors are owned by `ERC4626VaultIntegrationFacet`
+
+One important implication:
+
+- support for `IERC4626VaultFacet` and `IERC4626VaultIntegrationFacet` is
+  reported through the controls facet
+- those interface IDs are only reported when the corresponding core or
+  integration selectors are installed
+
+## Storage And Upgrade Assumptions
+
+Hosted vault state lives in the diamond, not in the facet bytecode.
+
+Supported replace/remove/re-add flows assume:
+
+- replacement facets preserve the same storage layout
+- selectors are restored before the corresponding surface is expected to route
+- no re-initialization is performed during upgrades
+
+Current hardening coverage explicitly validates persistence for:
+
+- vault metadata and ERC-4626/share-token state
+- fee config, limit config, roles, role windows, and pause state
+- oracle adapter, strategy reference, and reported strategy assets
+
+## Deployment References
+
+Reference local deployment flow:
+
+- `script/DeployDiamondVaultHost.s.sol`
+
+Reference local artifact:
+
+- `deployments/diamond-vault.local.json`
+
+The reference deployment:
+
+- installs loupe, core, controls, and integration selectors
+- initializes the vault through the core facet
+- wires the oracle adapter through the integration facet
+- leaves `strategy == address(0)` and `strategyReportedAssets == 0`
+
+## Validation References
+
+The hosted vault model is covered by:
+
+- `test/DiamondVaultDeploymentIntegration.t.sol`
+- `test/DiamondVaultHostHardening.t.sol`
+- `test/DiamondVaultHostInvariant.t.sol`

--- a/script/DeployDiamondVaultHost.s.sol
+++ b/script/DeployDiamondVaultHost.s.sol
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {DiamondCutFacet} from "../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../src/diamond/facets/DiamondLoupeFacet.sol";
+import {IDiamondCut} from "../src/interfaces/IDiamondCut.sol";
+import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
+import {IERC165} from "../src/interfaces/IERC165.sol";
+import {IERC20Metadata} from "../src/interfaces/IERC20Metadata.sol";
+import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol";
+import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControlsFacet.sol";
+import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
+import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
+import {IOracleAdapter} from "../src/interfaces/IOracleAdapter.sol";
+import {ERC4626VaultControlsFacet} from "../src/vault/facets/ERC4626VaultControlsFacet.sol";
+import {ERC4626VaultFacet} from "../src/vault/facets/ERC4626VaultFacet.sol";
+import {ERC4626VaultIntegrationFacet} from "../src/vault/facets/ERC4626VaultIntegrationFacet.sol";
+import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
+import {DiamondVaultHostScriptBase} from "./common/DiamondVaultHostScriptBase.sol";
+import {
+    LocalMintableVaultAsset,
+    LocalMockOracleFeed,
+    LocalOracleAdapterHarness
+} from "./mocks/LocalVaultDeploymentMocks.sol";
+
+/// @title DeployDiamondVaultHostScript
+/// @notice Reference local deployment flow for the hosted vault diamond.
+contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
+    struct VaultHostDeploymentState {
+        address diamondAddress;
+        address cutFacetAddress;
+        address loupeFacetAddress;
+        address vaultCoreFacetAddress;
+        address vaultControlsFacetAddress;
+        address vaultIntegrationFacetAddress;
+        address vaultAssetAddress;
+        address oracleFeedAddress;
+        address oracleAdapterAddress;
+    }
+
+    string internal constant VAULT_OBJECT = "diamondVaultHost";
+    string internal constant VAULT_OUTPUT_RELATIVE_PATH = "/deployments/diamond-vault.local.json";
+    string internal constant VAULT_NAME = "Vault Share";
+    string internal constant VAULT_SYMBOL = "vSHARE";
+    uint64 internal constant MAX_STALENESS = 1 hours;
+    uint8 internal constant ORACLE_DECIMALS = 8;
+    int256 internal constant ORACLE_ANSWER = 100_000_000;
+
+    function run()
+        external
+        returns (
+            address diamondAddress,
+            address vaultCoreFacetAddress,
+            address vaultControlsFacetAddress,
+            address vaultIntegrationFacetAddress
+        )
+    {
+        uint256 deployerPrivateKey = VM.envUint("PRIVATE_KEY");
+        address owner = VM.addr(deployerPrivateKey);
+        VaultHostDeploymentState memory state;
+
+        VM.startBroadcast(deployerPrivateKey);
+
+        (state.diamondAddress, state.cutFacetAddress, state.loupeFacetAddress) = _deployDiamondCore(owner);
+        state = _deployVaultSupportContracts(state, owner);
+        _installVaultHostFacets(state);
+
+        IERC4626VaultFacet(state.diamondAddress)
+            .initializeVault(state.vaultAssetAddress, VAULT_NAME, VAULT_SYMBOL, owner);
+        IERC4626VaultIntegrationFacet(state.diamondAddress).setOracleAdapter(state.oracleAdapterAddress);
+
+        VM.stopBroadcast();
+
+        _validateVaultHost(state, owner);
+        _writeVaultDeploymentArtifact(
+            VAULT_OBJECT,
+            VAULT_OUTPUT_RELATIVE_PATH,
+            VaultHostDeploymentArtifact({
+                diamond: state.diamondAddress,
+                diamondCutFacet: state.cutFacetAddress,
+                diamondLoupeFacet: state.loupeFacetAddress,
+                vaultCoreFacet: state.vaultCoreFacetAddress,
+                vaultControlsFacet: state.vaultControlsFacetAddress,
+                vaultIntegrationFacet: state.vaultIntegrationFacetAddress,
+                vaultAsset: state.vaultAssetAddress,
+                oracleFeed: state.oracleFeedAddress,
+                oracleAdapter: state.oracleAdapterAddress,
+                strategy: address(0),
+                owner: owner,
+                chainId: block.chainid,
+                vaultName: VAULT_NAME,
+                vaultSymbol: VAULT_SYMBOL
+            })
+        );
+
+        diamondAddress = state.diamondAddress;
+        vaultCoreFacetAddress = state.vaultCoreFacetAddress;
+        vaultControlsFacetAddress = state.vaultControlsFacetAddress;
+        vaultIntegrationFacetAddress = state.vaultIntegrationFacetAddress;
+    }
+
+    function _deployVaultSupportContracts(VaultHostDeploymentState memory state, address owner)
+        internal
+        returns (VaultHostDeploymentState memory)
+    {
+        state.vaultCoreFacetAddress = address(new ERC4626VaultFacet());
+        state.vaultControlsFacetAddress = address(new ERC4626VaultControlsFacet());
+        state.vaultIntegrationFacetAddress = address(new ERC4626VaultIntegrationFacet());
+        state.vaultAssetAddress = address(new LocalMintableVaultAsset("Mock USD", "mUSD", 6));
+        state.oracleFeedAddress = address(new LocalMockOracleFeed(ORACLE_DECIMALS, ORACLE_ANSWER, block.timestamp - 1));
+        state.oracleAdapterAddress =
+            address(new LocalOracleAdapterHarness(owner, state.oracleFeedAddress, MAX_STALENESS));
+        return state;
+    }
+
+    function _installVaultHostFacets(VaultHostDeploymentState memory state) internal {
+        IDiamondCut.FacetCut[] memory vaultCut = new IDiamondCut.FacetCut[](3);
+        vaultCut[0] = IDiamondCut.FacetCut({
+            facetAddress: state.vaultCoreFacetAddress,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultCoreSelectors()
+        });
+        vaultCut[1] = IDiamondCut.FacetCut({
+            facetAddress: state.vaultControlsFacetAddress,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultControlsSelectors()
+        });
+        vaultCut[2] = IDiamondCut.FacetCut({
+            facetAddress: state.vaultIntegrationFacetAddress,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultIntegrationSelectors()
+        });
+        IDiamondCut(state.diamondAddress).diamondCut(vaultCut, address(0), "");
+    }
+
+    function _validateVaultHost(VaultHostDeploymentState memory state, address owner) internal view {
+        _validateDiamondCore(state.diamondAddress, owner, state.cutFacetAddress, state.loupeFacetAddress);
+
+        IDiamondLoupe loupe = IDiamondLoupe(state.diamondAddress);
+        IERC4626VaultFacet vaultCore = IERC4626VaultFacet(state.diamondAddress);
+        IERC4626VaultControlsFacet vaultControls = IERC4626VaultControlsFacet(state.diamondAddress);
+        IERC4626VaultIntegrationFacet vaultIntegration = IERC4626VaultIntegrationFacet(state.diamondAddress);
+        address[] memory facetAddresses = loupe.facetAddresses();
+
+        require(facetAddresses.length == 5, "vault host facet count mismatch");
+        require(_containsAddress(facetAddresses, state.cutFacetAddress), "vault host missing cut facet");
+        require(_containsAddress(facetAddresses, state.loupeFacetAddress), "vault host missing loupe facet");
+        require(_containsAddress(facetAddresses, state.vaultCoreFacetAddress), "vault host missing core facet");
+        require(_containsAddress(facetAddresses, state.vaultControlsFacetAddress), "vault host missing controls facet");
+        require(
+            _containsAddress(facetAddresses, state.vaultIntegrationFacetAddress), "vault host missing integration facet"
+        );
+
+        require(
+            loupe.facetFunctionSelectors(state.vaultCoreFacetAddress).length
+                == LibVaultFacetSelectors.vaultCoreSelectors().length,
+            "vault host core selector count mismatch"
+        );
+        require(
+            loupe.facetFunctionSelectors(state.vaultControlsFacetAddress).length
+                == LibVaultFacetSelectors.vaultControlsSelectors().length,
+            "vault host controls selector count mismatch"
+        );
+        require(
+            loupe.facetFunctionSelectors(state.vaultIntegrationFacetAddress).length
+                == LibVaultFacetSelectors.vaultIntegrationSelectors().length,
+            "vault host integration selector count mismatch"
+        );
+
+        require(vaultCore.isVaultInitialized(), "vault host not initialized");
+        require(vaultCore.asset() == state.vaultAssetAddress, "vault host asset mismatch");
+        require(
+            keccak256(bytes(IERC20Metadata(state.diamondAddress).name())) == keccak256(bytes(VAULT_NAME)),
+            "vault name mismatch"
+        );
+        require(
+            keccak256(bytes(IERC20Metadata(state.diamondAddress).symbol())) == keccak256(bytes(VAULT_SYMBOL)),
+            "vault symbol mismatch"
+        );
+        require(vaultControls.hasRole(vaultControls.DEFAULT_ADMIN_ROLE(), owner), "vault default admin missing");
+        require(vaultControls.hasRole(vaultControls.PAUSER_ROLE(), owner), "vault pauser missing");
+        require(vaultControls.hasRole(vaultControls.VAULT_MANAGER_ROLE(), owner), "vault manager missing");
+
+        (,, address feeRecipient) = vaultControls.feeConfig();
+        require(feeRecipient == owner, "vault fee recipient mismatch");
+
+        require(vaultIntegration.oracleAdapter() == state.oracleAdapterAddress, "vault oracle adapter mismatch");
+        require(vaultIntegration.strategy() == address(0), "vault strategy should be unset");
+        require(vaultIntegration.strategyReportedAssets() == 0, "vault reported assets should be zero");
+
+        IOracleAdapter.OracleQuote memory quotePayload = vaultIntegration.oracleQuote();
+        require(quotePayload.value == ORACLE_ANSWER, "vault quote value mismatch");
+        require(quotePayload.decimals == ORACLE_DECIMALS, "vault quote decimals mismatch");
+        require(quotePayload.updatedAt != 0, "vault quote timestamp missing");
+
+        require(
+            IERC165(state.diamondAddress).supportsInterface(type(IERC4626VaultFacet).interfaceId),
+            "vault host missing core interface"
+        );
+        require(
+            IERC165(state.diamondAddress).supportsInterface(type(IERC4626VaultControlsFacet).interfaceId),
+            "vault host missing controls interface"
+        );
+        require(
+            IERC165(state.diamondAddress).supportsInterface(type(IERC4626VaultIntegrationFacet).interfaceId),
+            "vault host missing integration interface"
+        );
+
+        _requireSelectorOwner(loupe, DiamondCutFacet.diamondCut.selector, state.cutFacetAddress, "vault cut owner");
+        _requireSelectorOwner(loupe, DiamondLoupeFacet.facets.selector, state.loupeFacetAddress, "vault loupe owner");
+        _requireSelectorOwner(
+            loupe, IERC4626VaultFacet.initializeVault.selector, state.vaultCoreFacetAddress, "vault init owner"
+        );
+        _requireSelectorOwner(
+            loupe,
+            IERC4626VaultControls.VAULT_MANAGER_ROLE.selector,
+            state.vaultControlsFacetAddress,
+            "vault manager owner"
+        );
+        _requireSelectorOwner(
+            loupe,
+            IERC4626VaultIntegrationFacet.oracleAdapter.selector,
+            state.vaultIntegrationFacetAddress,
+            "vault oracle owner"
+        );
+        _requireSelectorOwner(
+            loupe, IERC165.supportsInterface.selector, state.vaultControlsFacetAddress, "vault erc165 owner"
+        );
+    }
+
+    function _requireSelectorOwner(IDiamondLoupe loupe, bytes4 selector, address expected, string memory message)
+        internal
+        view
+    {
+        require(loupe.facetAddress(selector) == expected, message);
+    }
+}

--- a/script/common/DiamondVaultHostScriptBase.sol
+++ b/script/common/DiamondVaultHostScriptBase.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Diamond} from "../../src/diamond/Diamond.sol";
+import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
+import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
+import {IDiamondLoupe} from "../../src/interfaces/IDiamondLoupe.sol";
+import {IERC173} from "../../src/interfaces/IERC173.sol";
+import {DiamondCoreScriptBase} from "./DiamondCoreScriptBase.sol";
+
+/// @title DiamondVaultHostScriptBase
+/// @notice Shared deployment helpers for the reference hosted vault diamond.
+abstract contract DiamondVaultHostScriptBase is DiamondCoreScriptBase {
+    /// @notice Parsed addresses from a hosted vault deployment artifact.
+    struct VaultHostDeploymentArtifact {
+        address diamond;
+        address diamondCutFacet;
+        address diamondLoupeFacet;
+        address vaultCoreFacet;
+        address vaultControlsFacet;
+        address vaultIntegrationFacet;
+        address vaultAsset;
+        address oracleFeed;
+        address oracleAdapter;
+        address strategy;
+        address owner;
+        uint256 chainId;
+        string vaultName;
+        string vaultSymbol;
+    }
+
+    function _deployDiamondCore(address owner)
+        internal
+        returns (address diamondAddress, address cutFacetAddress, address loupeFacetAddress)
+    {
+        DiamondCutFacet cutFacet = new DiamondCutFacet();
+        Diamond diamond = new Diamond(owner, address(cutFacet));
+        DiamondLoupeFacet loupeFacet = new DiamondLoupeFacet();
+
+        IDiamondCut.FacetCut[] memory initialCut = new IDiamondCut.FacetCut[](1);
+        initialCut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(loupeFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: _loupeSelectors()
+        });
+        IDiamondCut(address(diamond)).diamondCut(initialCut, address(0), "");
+
+        diamondAddress = address(diamond);
+        cutFacetAddress = address(cutFacet);
+        loupeFacetAddress = address(loupeFacet);
+    }
+
+    function _validateDiamondCore(
+        address diamondAddress,
+        address owner,
+        address cutFacetAddress,
+        address loupeFacetAddress
+    ) internal view {
+        IERC173 ownership = IERC173(diamondAddress);
+        IDiamondLoupe loupe = IDiamondLoupe(diamondAddress);
+
+        require(ownership.owner() == owner, "vault host owner mismatch");
+        require(
+            loupe.facetAddress(DiamondCutFacet.diamondCut.selector) == cutFacetAddress,
+            "vault host cut selector mismatch"
+        );
+        require(
+            loupe.facetAddress(DiamondLoupeFacet.facets.selector) == loupeFacetAddress,
+            "vault host loupe selector mismatch"
+        );
+    }
+
+    function _writeVaultDeploymentArtifact(
+        string memory objectKey,
+        string memory outputRelativePath,
+        VaultHostDeploymentArtifact memory artifact
+    ) internal {
+        string memory json = VM.serializeString(objectKey, "network", "local-anvil");
+        json = VM.serializeUint(objectKey, "chainId", block.chainid);
+        json = VM.serializeAddress(objectKey, "owner", artifact.owner);
+        json = VM.serializeAddress(objectKey, "diamond", artifact.diamond);
+        json = VM.serializeAddress(objectKey, "diamondCutFacet", artifact.diamondCutFacet);
+        json = VM.serializeAddress(objectKey, "diamondLoupeFacet", artifact.diamondLoupeFacet);
+        json = VM.serializeAddress(objectKey, "vaultCoreFacet", artifact.vaultCoreFacet);
+        json = VM.serializeAddress(objectKey, "vaultControlsFacet", artifact.vaultControlsFacet);
+        json = VM.serializeAddress(objectKey, "vaultIntegrationFacet", artifact.vaultIntegrationFacet);
+        json = VM.serializeAddress(objectKey, "vaultAsset", artifact.vaultAsset);
+        json = VM.serializeAddress(objectKey, "oracleFeed", artifact.oracleFeed);
+        json = VM.serializeAddress(objectKey, "oracleAdapter", artifact.oracleAdapter);
+        json = VM.serializeAddress(objectKey, "strategy", artifact.strategy);
+        json = VM.serializeString(objectKey, "vaultName", artifact.vaultName);
+        json = VM.serializeString(objectKey, "vaultSymbol", artifact.vaultSymbol);
+        VM.writeJson(json, string.concat(VM.projectRoot(), outputRelativePath));
+    }
+
+    function _loupeSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](6);
+        selectors[0] = DiamondLoupeFacet.facets.selector;
+        selectors[1] = DiamondLoupeFacet.facetFunctionSelectors.selector;
+        selectors[2] = DiamondLoupeFacet.facetAddresses.selector;
+        selectors[3] = DiamondLoupeFacet.facetAddress.selector;
+        selectors[4] = DiamondLoupeFacet.owner.selector;
+        selectors[5] = DiamondLoupeFacet.transferOwnership.selector;
+    }
+
+    function _containsAddress(address[] memory addresses, address expected) internal pure returns (bool) {
+        for (uint256 i = 0; i < addresses.length; i++) {
+            if (addresses[i] == expected) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/script/mocks/LocalVaultDeploymentMocks.sol
+++ b/script/mocks/LocalVaultDeploymentMocks.sol
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC20Metadata} from "../../src/interfaces/IERC20Metadata.sol";
+import {IOracleFeed} from "../../src/interfaces/IOracleFeed.sol";
+import {OracleAdapter} from "../../src/oracle/OracleAdapter.sol";
+
+/// @title LocalMintableVaultAsset
+/// @notice Minimal mintable ERC20 used for local hosted-vault deployment rehearsal.
+contract LocalMintableVaultAsset is IERC20Metadata {
+    string internal _name;
+    string internal _symbol;
+    uint8 internal _decimals;
+    uint256 internal _totalSupply;
+
+    mapping(address => uint256) internal _balances;
+    mapping(address => mapping(address => uint256)) internal _allowances;
+
+    constructor(string memory name_, string memory symbol_, uint8 decimals_) {
+        _name = name_;
+        _symbol = symbol_;
+        _decimals = decimals_;
+    }
+
+    function name() external view returns (string memory) {
+        return _name;
+    }
+
+    function symbol() external view returns (string memory) {
+        return _symbol;
+    }
+
+    function decimals() external view returns (uint8) {
+        return _decimals;
+    }
+
+    function totalSupply() external view returns (uint256) {
+        return _totalSupply;
+    }
+
+    function balanceOf(address account) external view returns (uint256) {
+        return _balances[account];
+    }
+
+    function allowance(address owner, address spender) external view returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    function mint(address to, uint256 amount) external {
+        _balances[to] += amount;
+        _totalSupply += amount;
+        emit Transfer(address(0), to, amount);
+    }
+
+    function approve(address spender, uint256 value) external returns (bool) {
+        _allowances[msg.sender][spender] = value;
+        emit Approval(msg.sender, spender, value);
+        return true;
+    }
+
+    function transfer(address to, uint256 value) external returns (bool) {
+        _transfer(msg.sender, to, value);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 value) external returns (bool) {
+        uint256 currentAllowance = _allowances[from][msg.sender];
+        require(currentAllowance >= value, "INSUFFICIENT_ALLOWANCE");
+        if (currentAllowance != type(uint256).max) {
+            unchecked {
+                _allowances[from][msg.sender] = currentAllowance - value;
+            }
+            emit Approval(from, msg.sender, _allowances[from][msg.sender]);
+        }
+
+        _transfer(from, to, value);
+        return true;
+    }
+
+    function _transfer(address from, address to, uint256 value) internal {
+        require(to != address(0), "ZERO_TO");
+
+        uint256 fromBalance = _balances[from];
+        require(fromBalance >= value, "INSUFFICIENT_BALANCE");
+
+        unchecked {
+            _balances[from] = fromBalance - value;
+        }
+        _balances[to] += value;
+
+        emit Transfer(from, to, value);
+    }
+}
+
+/// @title LocalMockOracleFeed
+/// @notice Minimal oracle feed used for local hosted-vault deployment rehearsal.
+contract LocalMockOracleFeed is IOracleFeed {
+    uint8 internal immutable _decimals;
+    uint80 internal immutable _roundId;
+    int256 internal immutable _answer;
+    uint256 internal immutable _updatedAt;
+    uint80 internal immutable _answeredInRound;
+
+    constructor(uint8 decimals_, int256 answer_, uint256 updatedAt_) {
+        _decimals = decimals_;
+        _roundId = 1;
+        _answer = answer_;
+        _updatedAt = updatedAt_;
+        _answeredInRound = 1;
+    }
+
+    function decimals() external view returns (uint8) {
+        return _decimals;
+    }
+
+    function latestRoundData()
+        external
+        view
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+    {
+        return (_roundId, _answer, _updatedAt, _updatedAt, _answeredInRound);
+    }
+}
+
+/// @title LocalOracleAdapterHarness
+/// @notice Concrete oracle adapter used by the local hosted-vault deployment flow.
+contract LocalOracleAdapterHarness is OracleAdapter {
+    constructor(address initialAdmin, address initialSource, uint64 initialMaxStaleness)
+        OracleAdapter(initialAdmin, initialSource, initialMaxStaleness)
+    {}
+}

--- a/src/interfaces/IERC4626VaultControlsFacet.sol
+++ b/src/interfaces/IERC4626VaultControlsFacet.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "./IAccessControl.sol";
+import {IAccessControlTime} from "./IAccessControlTime.sol";
+import {IERC4626VaultControls} from "./IERC4626VaultControls.sol";
+import {IPausable} from "./IPausable.sol";
+import {IReentrancyGuard} from "./IReentrancyGuard.sol";
+
+/// @title IERC4626VaultControlsFacet
+/// @notice Hosted control-plane surface for future diamond vault facets.
+interface IERC4626VaultControlsFacet is
+    IERC4626VaultControls,
+    IAccessControl,
+    IAccessControlTime,
+    IPausable,
+    IReentrancyGuard
+{}

--- a/src/interfaces/IERC4626VaultFacet.sol
+++ b/src/interfaces/IERC4626VaultFacet.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC4626} from "./IERC4626.sol";
+
+/// @title IERC4626VaultFacet
+/// @notice Hosted ERC-4626 vault core surface for future diamond facets.
+interface IERC4626VaultFacet is IERC4626 {
+    /// @notice Returns true when vault storage is initialized.
+    /// @return True if initialized.
+    function isVaultInitialized() external view returns (bool);
+
+    /// @notice Returns currently managed asset accounting amount.
+    /// @return The tracked managed asset amount.
+    function totalManagedAssets() external view returns (uint256);
+
+    /// @notice Initializes the hosted vault core and shared control plane.
+    /// @param vaultAsset Underlying vault asset token.
+    /// @param vaultName ERC-20 share token name.
+    /// @param vaultSymbol ERC-20 share token symbol.
+    /// @param admin Account receiving admin, pauser, and vault manager roles.
+    function initializeVault(address vaultAsset, string calldata vaultName, string calldata vaultSymbol, address admin)
+        external;
+}

--- a/src/interfaces/IERC4626VaultIntegrationFacet.sol
+++ b/src/interfaces/IERC4626VaultIntegrationFacet.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC165} from "./IERC165.sol";
+import {IOracleAdapter} from "./IOracleAdapter.sol";
+
+/// @title IERC4626VaultIntegrationFacet
+/// @notice Hosted integration/config surface for vault oracle and strategy wiring.
+interface IERC4626VaultIntegrationFacet is IERC165 {
+    /// @notice Emitted when the configured oracle adapter is updated.
+    event VaultOracleAdapterUpdated(
+        address indexed previousAdapter, address indexed newAdapter, address indexed sender
+    );
+
+    /// @notice Emitted when the configured strategy address is updated.
+    event VaultStrategyUpdated(address indexed previousStrategy, address indexed newStrategy, address indexed sender);
+
+    /// @notice Emitted when reported strategy assets are updated.
+    event VaultStrategyAssetsReported(uint256 previousAssets, uint256 newAssets, address indexed sender);
+
+    /// @notice Thrown when `oracleQuote()` is called without a configured adapter.
+    error ERC4626VaultOracleAdapterNotConfigured();
+
+    /// @notice Thrown when `reportStrategyAssets()` is called by an unauthorized account.
+    /// @param caller The unauthorized caller.
+    /// @param strategy The currently configured strategy address.
+    error ERC4626VaultStrategyReporterUnauthorized(address caller, address strategy);
+
+    /// @notice Returns the configured external oracle adapter address.
+    /// @return The adapter address, or zero when unset.
+    function oracleAdapter() external view returns (address);
+
+    /// @notice Returns the configured strategy address.
+    /// @return The strategy address, or zero when unset.
+    function strategy() external view returns (address);
+
+    /// @notice Returns the latest reported strategy-held asset amount.
+    /// @return The reported asset amount.
+    function strategyReportedAssets() external view returns (uint256);
+
+    /// @notice Returns the vault's idle underlying asset balance.
+    /// @return The idle asset amount held directly by the vault.
+    function idleAssets() external view returns (uint256);
+
+    /// @notice Returns idle assets plus the latest reported strategy assets.
+    /// @return The estimated total assets across idle vault balance and strategy reports.
+    function estimatedTotalManagedAssets() external view returns (uint256);
+
+    /// @notice Returns the latest normalized quote from the configured oracle adapter.
+    /// @return quotePayload The latest quote payload.
+    function oracleQuote() external view returns (IOracleAdapter.OracleQuote memory quotePayload);
+
+    /// @notice Sets the external oracle adapter reference.
+    /// @param newAdapter The new adapter address, or zero to clear.
+    function setOracleAdapter(address newAdapter) external;
+
+    /// @notice Sets the configured strategy reference.
+    /// @param newStrategy The new strategy address, or zero to clear.
+    function setStrategy(address newStrategy) external;
+
+    /// @notice Updates the latest reported strategy-held asset amount.
+    /// @param assets The latest reported asset amount.
+    function reportStrategyAssets(uint256 assets) external;
+}

--- a/src/vault/ERC4626VaultBase.sol
+++ b/src/vault/ERC4626VaultBase.sol
@@ -16,7 +16,7 @@ abstract contract ERC4626VaultBase is IERC4626VaultBase {
 
     /// @notice Returns true when vault storage is initialized.
     /// @return True if initialized.
-    function isVaultInitialized() public view returns (bool) {
+    function isVaultInitialized() public view virtual returns (bool) {
         return LibERC4626VaultStorage.layout().initialized;
     }
 
@@ -28,7 +28,7 @@ abstract contract ERC4626VaultBase is IERC4626VaultBase {
 
     /// @notice Returns currently managed asset accounting amount.
     /// @return The tracked managed asset amount.
-    function totalManagedAssets() public view returns (uint256) {
+    function totalManagedAssets() public view virtual returns (uint256) {
         return LibERC4626VaultStorage.layout().totalManagedAssets;
     }
 

--- a/src/vault/ERC4626VaultControlLogic.sol
+++ b/src/vault/ERC4626VaultControlLogic.sol
@@ -1,0 +1,436 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC4626VaultControls} from "../interfaces/IERC4626VaultControls.sol";
+import {ERC4626Vault} from "./ERC4626Vault.sol";
+import {LibERC4626VaultStorage} from "./storage/LibERC4626VaultStorage.sol";
+import {VaultFacetControl} from "./VaultFacetControl.sol";
+
+/// @title LibERC4626VaultControlLogic
+/// @notice Shared fee and limit logic for standalone and hosted vault flows.
+library LibERC4626VaultControlLogic {
+    uint256 internal constant BPS_DENOMINATOR = 10_000;
+
+    enum FeeRounding {
+        Down,
+        Up
+    }
+
+    function feeConfig() internal view returns (uint16 depositFeeBps, uint16 withdrawFeeBps, address recipient) {
+        LibERC4626VaultStorage.FeeConfig storage fees = LibERC4626VaultStorage.layout().fees;
+        return (fees.depositFeeBps, fees.withdrawFeeBps, fees.feeRecipient);
+    }
+
+    function limitConfig()
+        internal
+        view
+        returns (uint128 maxTotalAssets, uint128 maxDeposit, uint128 maxMint, uint128 maxWithdraw, uint128 maxRedeem)
+    {
+        LibERC4626VaultStorage.LimitConfig storage limits = LibERC4626VaultStorage.layout().limits;
+        return (limits.maxTotalAssets, limits.maxDeposit, limits.maxMint, limits.maxWithdraw, limits.maxRedeem);
+    }
+
+    function feeRecipient() internal view returns (address) {
+        return LibERC4626VaultStorage.layout().fees.feeRecipient;
+    }
+
+    function validateFeeBps(uint16 feeBps) internal pure {
+        if (feeBps >= BPS_DENOMINATOR) {
+            revert IERC4626VaultControls.ERC4626VaultInvalidFeeBps(feeBps);
+        }
+    }
+
+    function netAfterDepositFee(uint256 assets) internal view returns (uint256 netAssets, uint256 feeAssets) {
+        uint16 depositFeeBps = LibERC4626VaultStorage.layout().fees.depositFeeBps;
+        feeAssets = feeOnRaw(assets, depositFeeBps, FeeRounding.Down);
+        netAssets = assets - feeAssets;
+    }
+
+    function grossUpForDepositFee(uint256 netAssets) internal view returns (uint256 grossAssets) {
+        uint16 depositFeeBps = LibERC4626VaultStorage.layout().fees.depositFeeBps;
+        if (depositFeeBps == 0 || netAssets == 0) {
+            return netAssets;
+        }
+
+        uint256 denominator = BPS_DENOMINATOR - depositFeeBps;
+        grossAssets = mulDiv(netAssets, BPS_DENOMINATOR, denominator, FeeRounding.Up);
+
+        (uint256 creditedAssets,) = netAfterDepositFee(grossAssets);
+        if (creditedAssets < netAssets) {
+            grossAssets += 1;
+        }
+    }
+
+    function withdrawGrossFromNet(uint256 assets) internal view returns (uint256 grossAssets, uint256 feeAssets) {
+        uint16 withdrawFeeBps = LibERC4626VaultStorage.layout().fees.withdrawFeeBps;
+        feeAssets = feeOnRaw(assets, withdrawFeeBps, FeeRounding.Up);
+        grossAssets = assets + feeAssets;
+    }
+
+    function withdrawNetFromGross(uint256 grossAssets) internal view returns (uint256 netAssets, uint256 feeAssets) {
+        uint16 withdrawFeeBps = LibERC4626VaultStorage.layout().fees.withdrawFeeBps;
+        feeAssets = feeOnRaw(grossAssets, withdrawFeeBps, FeeRounding.Down);
+        netAssets = grossAssets - feeAssets;
+    }
+
+    function feeOnRaw(uint256 assets, uint16 feeBps, FeeRounding rounding) internal pure returns (uint256) {
+        if (feeBps == 0 || assets == 0) {
+            return 0;
+        }
+
+        return mulDiv(assets, feeBps, BPS_DENOMINATOR, rounding);
+    }
+
+    function mulDiv(uint256 x, uint256 y, uint256 denominator, FeeRounding rounding)
+        internal
+        pure
+        returns (uint256 result)
+    {
+        uint256 product = x * y;
+        result = product / denominator;
+
+        if (rounding == FeeRounding.Up && product % denominator != 0) {
+            result += 1;
+        }
+    }
+}
+
+/// @title ERC4626VaultControlledCore
+/// @notice Shared fee-aware and limit-aware ERC-4626 core behavior.
+abstract contract ERC4626VaultControlledCore is ERC4626Vault {
+    function maxDeposit(address receiver) public view virtual override returns (uint256) {
+        if (receiver == address(0) || _vaultOperationsPaused()) {
+            return 0;
+        }
+
+        uint256 maxAssets = type(uint256).max;
+        (uint128 maxTotalAssets_, uint128 maxDeposit_,,,) = LibERC4626VaultControlLogic.limitConfig();
+
+        if (maxDeposit_ != 0) {
+            maxAssets = maxDeposit_;
+        }
+
+        if (maxTotalAssets_ != 0) {
+            uint256 currentAssets = totalAssets();
+            if (currentAssets >= maxTotalAssets_) {
+                return 0;
+            }
+
+            uint256 remainingAssets = maxTotalAssets_ - currentAssets;
+            uint256 capBasedMaxAssets = LibERC4626VaultControlLogic.grossUpForDepositFee(remainingAssets);
+            if (capBasedMaxAssets < maxAssets) {
+                maxAssets = capBasedMaxAssets;
+            }
+        }
+
+        return maxAssets;
+    }
+
+    function maxMint(address receiver) public view virtual override returns (uint256) {
+        if (receiver == address(0) || _vaultOperationsPaused()) {
+            return 0;
+        }
+
+        uint256 maxShares = type(uint256).max;
+        (uint128 maxTotalAssets_,, uint128 maxMint_,,) = LibERC4626VaultControlLogic.limitConfig();
+
+        if (maxMint_ != 0) {
+            maxShares = maxMint_;
+        }
+
+        if (maxTotalAssets_ != 0) {
+            uint256 currentAssets = totalAssets();
+            if (currentAssets >= maxTotalAssets_) {
+                return 0;
+            }
+
+            uint256 remainingAssets = maxTotalAssets_ - currentAssets;
+            uint256 capBasedMaxShares = _convertToShares(remainingAssets, Rounding.Down);
+            if (capBasedMaxShares < maxShares) {
+                maxShares = capBasedMaxShares;
+            }
+        }
+
+        return maxShares;
+    }
+
+    function maxWithdraw(address owner) public view virtual override returns (uint256) {
+        if (owner == address(0) || _vaultOperationsPaused()) {
+            return 0;
+        }
+
+        uint256 grossAssets = _convertToAssets(balanceOf(owner), Rounding.Down);
+        (uint256 netAssets,) = LibERC4626VaultControlLogic.withdrawNetFromGross(grossAssets);
+
+        (,,, uint128 maxWithdraw_,) = LibERC4626VaultControlLogic.limitConfig();
+        if (maxWithdraw_ != 0 && netAssets > maxWithdraw_) {
+            return maxWithdraw_;
+        }
+
+        return netAssets;
+    }
+
+    function maxRedeem(address owner) public view virtual override returns (uint256) {
+        if (owner == address(0) || _vaultOperationsPaused()) {
+            return 0;
+        }
+
+        uint256 redeemableShares = balanceOf(owner);
+        (,,,, uint128 maxRedeem_) = LibERC4626VaultControlLogic.limitConfig();
+        if (maxRedeem_ != 0 && redeemableShares > maxRedeem_) {
+            return maxRedeem_;
+        }
+
+        return redeemableShares;
+    }
+
+    function previewDeposit(uint256 assets) public view virtual override returns (uint256) {
+        (uint256 netAssets,) = LibERC4626VaultControlLogic.netAfterDepositFee(assets);
+        return _convertToShares(netAssets, Rounding.Down);
+    }
+
+    function previewMint(uint256 shares) public view virtual override returns (uint256) {
+        uint256 netAssets = _convertToAssets(shares, Rounding.Up);
+        return LibERC4626VaultControlLogic.grossUpForDepositFee(netAssets);
+    }
+
+    function previewWithdraw(uint256 assets) public view virtual override returns (uint256) {
+        (uint256 grossAssets,) = LibERC4626VaultControlLogic.withdrawGrossFromNet(assets);
+        return _convertToShares(grossAssets, Rounding.Up);
+    }
+
+    function previewRedeem(uint256 shares) public view virtual override returns (uint256) {
+        uint256 grossAssets = _convertToAssets(shares, Rounding.Down);
+        (uint256 netAssets,) = LibERC4626VaultControlLogic.withdrawNetFromGross(grossAssets);
+        return netAssets;
+    }
+
+    function _depositWithControls(uint256 assets, address receiver) internal returns (uint256 shares) {
+        _requireInitialized();
+        _requireNonZeroAddress(receiver);
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        uint256 maxAssets = maxDeposit(receiver);
+        if (assets > maxAssets) {
+            revert IERC4626VaultControls.ERC4626VaultDepositLimitExceeded(assets, maxAssets);
+        }
+
+        (uint256 netAssets, uint256 feeAssets) = LibERC4626VaultControlLogic.netAfterDepositFee(assets);
+        _enforceTotalAssetsCap(netAssets);
+
+        shares = _convertToShares(netAssets, Rounding.Down);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        _safeTransferFromAsset(msg.sender, address(this), assets);
+        _increaseManagedAssets(netAssets);
+        _mintShares(receiver, shares);
+        _payoutFee(feeAssets);
+
+        emit Deposit(msg.sender, receiver, assets, shares);
+    }
+
+    function _mintWithControls(uint256 shares, address receiver) internal returns (uint256 assets) {
+        _requireInitialized();
+        _requireNonZeroAddress(receiver);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        uint256 maxShares = maxMint(receiver);
+        if (shares > maxShares) {
+            revert IERC4626VaultControls.ERC4626VaultMintLimitExceeded(shares, maxShares);
+        }
+
+        uint256 netAssets = _convertToAssets(shares, Rounding.Up);
+        if (netAssets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        assets = LibERC4626VaultControlLogic.grossUpForDepositFee(netAssets);
+        uint256 feeAssets = assets - netAssets;
+
+        _enforceTotalAssetsCap(netAssets);
+        _safeTransferFromAsset(msg.sender, address(this), assets);
+        _increaseManagedAssets(netAssets);
+        _mintShares(receiver, shares);
+        _payoutFee(feeAssets);
+
+        emit Deposit(msg.sender, receiver, assets, shares);
+    }
+
+    function _withdrawWithControls(uint256 assets, address receiver, address owner) internal returns (uint256 shares) {
+        _requireInitialized();
+        _requireNonZeroAddress(receiver);
+        _requireNonZeroAddress(owner);
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        uint256 maxAssets = maxWithdraw(owner);
+        if (assets > maxAssets) {
+            revert IERC4626VaultControls.ERC4626VaultWithdrawLimitExceeded(assets, maxAssets);
+        }
+
+        (uint256 grossAssets, uint256 feeAssets) = LibERC4626VaultControlLogic.withdrawGrossFromNet(assets);
+        shares = _convertToShares(grossAssets, Rounding.Up);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        if (msg.sender != owner) {
+            _spendAllowance(owner, msg.sender, shares);
+        }
+
+        _burnShares(owner, shares);
+        _decreaseManagedAssets(grossAssets);
+        _safeTransferAsset(receiver, assets);
+        _payoutFee(feeAssets);
+
+        emit Withdraw(msg.sender, receiver, owner, assets, shares);
+    }
+
+    function _redeemWithControls(uint256 shares, address receiver, address owner) internal returns (uint256 assets) {
+        _requireInitialized();
+        _requireNonZeroAddress(receiver);
+        _requireNonZeroAddress(owner);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        uint256 maxShares = maxRedeem(owner);
+        if (shares > maxShares) {
+            revert IERC4626VaultControls.ERC4626VaultRedeemLimitExceeded(shares, maxShares);
+        }
+
+        uint256 grossAssets = _convertToAssets(shares, Rounding.Down);
+        uint256 feeAssets;
+        (assets, feeAssets) = LibERC4626VaultControlLogic.withdrawNetFromGross(grossAssets);
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        if (msg.sender != owner) {
+            _spendAllowance(owner, msg.sender, shares);
+        }
+
+        _burnShares(owner, shares);
+        _decreaseManagedAssets(grossAssets);
+        _safeTransferAsset(receiver, assets);
+        _payoutFee(feeAssets);
+
+        emit Withdraw(msg.sender, receiver, owner, assets, shares);
+    }
+
+    function _enforceTotalAssetsCap(uint256 additionalAssets) internal view {
+        (uint128 maxTotalAssets_,,,,) = LibERC4626VaultControlLogic.limitConfig();
+        if (maxTotalAssets_ == 0) {
+            return;
+        }
+
+        uint256 currentAssets = totalAssets();
+        uint256 nextAssets = currentAssets + additionalAssets;
+        if (nextAssets > maxTotalAssets_) {
+            revert IERC4626VaultControls.ERC4626VaultTotalAssetsCapExceeded(
+                currentAssets, additionalAssets, maxTotalAssets_
+            );
+        }
+    }
+
+    function _payoutFee(uint256 feeAssets) internal {
+        if (feeAssets == 0) {
+            return;
+        }
+
+        _safeTransferAsset(LibERC4626VaultControlLogic.feeRecipient(), feeAssets);
+    }
+
+    function _vaultOperationsPaused() internal view virtual returns (bool);
+}
+
+/// @title ERC4626VaultControlSurface
+/// @notice Shared hosted and standalone control-plane surface for vault config and governance.
+abstract contract ERC4626VaultControlSurface is VaultFacetControl, IERC4626VaultControls {
+    function VAULT_MANAGER_ROLE()
+        public
+        pure
+        virtual
+        override(VaultFacetControl, IERC4626VaultControls)
+        returns (bytes32)
+    {
+        return VaultFacetControl.VAULT_MANAGER_ROLE();
+    }
+
+    function feeConfig()
+        public
+        view
+        virtual
+        override
+        returns (uint16 depositFeeBps, uint16 withdrawFeeBps, address feeRecipient)
+    {
+        return LibERC4626VaultControlLogic.feeConfig();
+    }
+
+    function limitConfig()
+        public
+        view
+        virtual
+        override
+        returns (uint128 maxTotalAssets, uint128 maxDeposit, uint128 maxMint, uint128 maxWithdraw, uint128 maxRedeem)
+    {
+        return LibERC4626VaultControlLogic.limitConfig();
+    }
+
+    function setFeeConfig(uint16 depositFeeBps, uint16 withdrawFeeBps, address feeRecipient)
+        public
+        virtual
+        override
+        onlyRole(VAULT_MANAGER_ROLE())
+    {
+        LibERC4626VaultControlLogic.validateFeeBps(depositFeeBps);
+        LibERC4626VaultControlLogic.validateFeeBps(withdrawFeeBps);
+
+        if ((depositFeeBps != 0 || withdrawFeeBps != 0) && feeRecipient == address(0)) {
+            revert IERC4626VaultControls.ERC4626VaultInvalidFeeRecipient();
+        }
+
+        (uint16 previousDepositFeeBps, uint16 previousWithdrawFeeBps, address previousFeeRecipient) =
+            LibERC4626VaultControlLogic.feeConfig();
+        LibERC4626VaultStorage.FeeConfig storage fees = LibERC4626VaultStorage.layout().fees;
+
+        fees.depositFeeBps = depositFeeBps;
+        fees.withdrawFeeBps = withdrawFeeBps;
+        fees.feeRecipient = feeRecipient;
+
+        emit VaultFeeConfigUpdated(
+            previousDepositFeeBps,
+            previousWithdrawFeeBps,
+            previousFeeRecipient,
+            depositFeeBps,
+            withdrawFeeBps,
+            feeRecipient,
+            msg.sender
+        );
+    }
+
+    function setLimitConfig(
+        uint128 maxTotalAssets,
+        uint128 maxDeposit,
+        uint128 maxMint,
+        uint128 maxWithdraw,
+        uint128 maxRedeem
+    ) public virtual override onlyRole(VAULT_MANAGER_ROLE()) {
+        LibERC4626VaultStorage.LimitConfig storage limits = LibERC4626VaultStorage.layout().limits;
+
+        limits.maxTotalAssets = maxTotalAssets;
+        limits.maxDeposit = maxDeposit;
+        limits.maxMint = maxMint;
+        limits.maxWithdraw = maxWithdraw;
+        limits.maxRedeem = maxRedeem;
+
+        emit VaultLimitConfigUpdated(maxTotalAssets, maxDeposit, maxMint, maxWithdraw, maxRedeem, msg.sender);
+    }
+}

--- a/src/vault/ERC4626VaultControls.sol
+++ b/src/vault/ERC4626VaultControls.sol
@@ -1,19 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
-import {Pausable} from "../access/Pausable.sol";
 import {IERC165} from "../interfaces/IERC165.sol";
 import {IERC4626VaultControls} from "../interfaces/IERC4626VaultControls.sol";
-import {ReentrancyGuard} from "../security/ReentrancyGuard.sol";
 import {LibERC4626VaultStorage} from "./storage/LibERC4626VaultStorage.sol";
 import {ERC4626Vault} from "./ERC4626Vault.sol";
+import {VaultFacetControl} from "./VaultFacetControl.sol";
 
 /// @title ERC4626VaultControls
 /// @notice ERC-4626 extension with role-gated fee/limit controls and safety hooks.
-abstract contract ERC4626VaultControls is ERC4626Vault, Pausable, ReentrancyGuard, IERC4626VaultControls {
-    /// @notice Role that can manage fee and limit configuration.
-    bytes32 public constant VAULT_MANAGER_ROLE = keccak256("VAULT_MANAGER_ROLE");
-
+abstract contract ERC4626VaultControls is ERC4626Vault, VaultFacetControl, IERC4626VaultControls {
     /// @dev Basis points denominator.
     uint256 internal constant BPS_DENOMINATOR = 10_000;
 
@@ -21,12 +17,21 @@ abstract contract ERC4626VaultControls is ERC4626Vault, Pausable, ReentrancyGuar
     /// @param vaultAsset Underlying vault asset token.
     /// @param vaultName ERC-20 share token name.
     /// @param vaultSymbol ERC-20 share token symbol.
-    constructor(address initialAdmin, address vaultAsset, string memory vaultName, string memory vaultSymbol)
-        Pausable(initialAdmin)
-        ReentrancyGuard()
-    {
+    constructor(address initialAdmin, address vaultAsset, string memory vaultName, string memory vaultSymbol) {
+        _initializeVaultFacetControl(initialAdmin);
         _initializeErc4626Vault(vaultAsset, vaultName, vaultSymbol);
-        _initializeVaultControls(initialAdmin);
+    }
+
+    /// @notice Role that can manage vault fees and limits.
+    /// @return The vault manager role identifier.
+    function VAULT_MANAGER_ROLE()
+        public
+        pure
+        virtual
+        override(VaultFacetControl, IERC4626VaultControls)
+        returns (bytes32)
+    {
+        return VaultFacetControl.VAULT_MANAGER_ROLE();
     }
 
     /// @notice Returns true if this contract implements `interfaceId`.
@@ -36,11 +41,11 @@ abstract contract ERC4626VaultControls is ERC4626Vault, Pausable, ReentrancyGuar
         public
         view
         virtual
-        override(Pausable, ReentrancyGuard, IERC165)
+        override(VaultFacetControl, IERC165)
         returns (bool)
     {
         return interfaceId == type(IERC4626VaultControls).interfaceId || interfaceId == type(IERC165).interfaceId
-            || Pausable.supportsInterface(interfaceId) || ReentrancyGuard.supportsInterface(interfaceId);
+            || VaultFacetControl.supportsInterface(interfaceId);
     }
 
     /// @notice Returns current fee configuration.
@@ -80,7 +85,7 @@ abstract contract ERC4626VaultControls is ERC4626Vault, Pausable, ReentrancyGuar
     /// @param feeRecipient Fee recipient account.
     function setFeeConfig(uint16 depositFeeBps, uint16 withdrawFeeBps, address feeRecipient)
         public
-        onlyRole(VAULT_MANAGER_ROLE)
+        onlyRole(VAULT_MANAGER_ROLE())
     {
         _validateFeeBps(depositFeeBps);
         _validateFeeBps(withdrawFeeBps);
@@ -122,7 +127,7 @@ abstract contract ERC4626VaultControls is ERC4626Vault, Pausable, ReentrancyGuar
         uint128 limitMaxMint,
         uint128 limitMaxWithdraw,
         uint128 limitMaxRedeem
-    ) public onlyRole(VAULT_MANAGER_ROLE) {
+    ) public onlyRole(VAULT_MANAGER_ROLE()) {
         LibERC4626VaultStorage.LimitConfig storage limits = LibERC4626VaultStorage.layout().limits;
 
         limits.maxTotalAssets = limitMaxTotalAssets;
@@ -431,13 +436,6 @@ abstract contract ERC4626VaultControls is ERC4626Vault, Pausable, ReentrancyGuar
         _payoutFee(feeAssets);
 
         emit Withdraw(msg.sender, receiver, owner, assets, shares);
-    }
-
-    /// @dev Initializes control-plane defaults.
-    /// @param initialManager Account receiving `VAULT_MANAGER_ROLE`.
-    function _initializeVaultControls(address initialManager) internal {
-        LibERC4626VaultStorage.layout().fees.feeRecipient = initialManager;
-        _grantRole(VAULT_MANAGER_ROLE, initialManager);
     }
 
     /// @dev Enforces configured total-assets cap.

--- a/src/vault/ERC4626VaultControls.sol
+++ b/src/vault/ERC4626VaultControls.sol
@@ -2,17 +2,15 @@
 pragma solidity ^0.8.30;
 
 import {IERC165} from "../interfaces/IERC165.sol";
+import {IERC4626} from "../interfaces/IERC4626.sol";
 import {IERC4626VaultControls} from "../interfaces/IERC4626VaultControls.sol";
-import {LibERC4626VaultStorage} from "./storage/LibERC4626VaultStorage.sol";
 import {ERC4626Vault} from "./ERC4626Vault.sol";
+import {ERC4626VaultControlledCore, ERC4626VaultControlSurface} from "./ERC4626VaultControlLogic.sol";
 import {VaultFacetControl} from "./VaultFacetControl.sol";
 
 /// @title ERC4626VaultControls
-/// @notice ERC-4626 extension with role-gated fee/limit controls and safety hooks.
-abstract contract ERC4626VaultControls is ERC4626Vault, VaultFacetControl, IERC4626VaultControls {
-    /// @dev Basis points denominator.
-    uint256 internal constant BPS_DENOMINATOR = 10_000;
-
+/// @notice ERC-4626 extension with role-gated fee, limit, and safety controls.
+abstract contract ERC4626VaultControls is ERC4626VaultControlSurface, ERC4626VaultControlledCore {
     /// @param initialAdmin Account receiving admin, pauser, and manager roles.
     /// @param vaultAsset Underlying vault asset token.
     /// @param vaultName ERC-20 share token name.
@@ -20,18 +18,6 @@ abstract contract ERC4626VaultControls is ERC4626Vault, VaultFacetControl, IERC4
     constructor(address initialAdmin, address vaultAsset, string memory vaultName, string memory vaultSymbol) {
         _initializeVaultFacetControl(initialAdmin);
         _initializeErc4626Vault(vaultAsset, vaultName, vaultSymbol);
-    }
-
-    /// @notice Role that can manage vault fees and limits.
-    /// @return The vault manager role identifier.
-    function VAULT_MANAGER_ROLE()
-        public
-        pure
-        virtual
-        override(VaultFacetControl, IERC4626VaultControls)
-        returns (bytes32)
-    {
-        return VaultFacetControl.VAULT_MANAGER_ROLE();
     }
 
     /// @notice Returns true if this contract implements `interfaceId`.
@@ -48,230 +34,6 @@ abstract contract ERC4626VaultControls is ERC4626Vault, VaultFacetControl, IERC4
             || VaultFacetControl.supportsInterface(interfaceId);
     }
 
-    /// @notice Returns current fee configuration.
-    /// @return depositFeeBps Deposit fee in basis points.
-    /// @return withdrawFeeBps Withdraw fee in basis points.
-    /// @return feeRecipient Fee recipient account.
-    function feeConfig() public view returns (uint16 depositFeeBps, uint16 withdrawFeeBps, address feeRecipient) {
-        LibERC4626VaultStorage.FeeConfig storage fees = LibERC4626VaultStorage.layout().fees;
-        return (fees.depositFeeBps, fees.withdrawFeeBps, fees.feeRecipient);
-    }
-
-    /// @notice Returns current limit configuration.
-    /// @return limitMaxTotalAssets Cap for managed assets (`0` means unlimited).
-    /// @return limitMaxDeposit Per-call deposit limit (`0` means unlimited).
-    /// @return limitMaxMint Per-call mint limit (`0` means unlimited).
-    /// @return limitMaxWithdraw Per-call withdraw limit (`0` means unlimited).
-    /// @return limitMaxRedeem Per-call redeem limit (`0` means unlimited).
-    function limitConfig()
-        public
-        view
-        returns (
-            uint128 limitMaxTotalAssets,
-            uint128 limitMaxDeposit,
-            uint128 limitMaxMint,
-            uint128 limitMaxWithdraw,
-            uint128 limitMaxRedeem
-        )
-    {
-        LibERC4626VaultStorage.LimitConfig storage limits = LibERC4626VaultStorage.layout().limits;
-        return (limits.maxTotalAssets, limits.maxDeposit, limits.maxMint, limits.maxWithdraw, limits.maxRedeem);
-    }
-
-    /// @notice Sets fee configuration.
-    /// @dev Caller must have `VAULT_MANAGER_ROLE`.
-    /// @param depositFeeBps Deposit fee in basis points.
-    /// @param withdrawFeeBps Withdraw fee in basis points.
-    /// @param feeRecipient Fee recipient account.
-    function setFeeConfig(uint16 depositFeeBps, uint16 withdrawFeeBps, address feeRecipient)
-        public
-        onlyRole(VAULT_MANAGER_ROLE())
-    {
-        _validateFeeBps(depositFeeBps);
-        _validateFeeBps(withdrawFeeBps);
-
-        if ((depositFeeBps != 0 || withdrawFeeBps != 0) && feeRecipient == address(0)) {
-            revert ERC4626VaultInvalidFeeRecipient();
-        }
-
-        LibERC4626VaultStorage.FeeConfig storage fees = LibERC4626VaultStorage.layout().fees;
-        uint16 previousDepositFeeBps = fees.depositFeeBps;
-        uint16 previousWithdrawFeeBps = fees.withdrawFeeBps;
-        address previousFeeRecipient = fees.feeRecipient;
-
-        fees.depositFeeBps = depositFeeBps;
-        fees.withdrawFeeBps = withdrawFeeBps;
-        fees.feeRecipient = feeRecipient;
-
-        emit VaultFeeConfigUpdated(
-            previousDepositFeeBps,
-            previousWithdrawFeeBps,
-            previousFeeRecipient,
-            depositFeeBps,
-            withdrawFeeBps,
-            feeRecipient,
-            msg.sender
-        );
-    }
-
-    /// @notice Sets limit configuration.
-    /// @dev Caller must have `VAULT_MANAGER_ROLE`.
-    /// @param limitMaxTotalAssets Cap for managed assets (`0` means unlimited).
-    /// @param limitMaxDeposit Per-call deposit limit (`0` means unlimited).
-    /// @param limitMaxMint Per-call mint limit (`0` means unlimited).
-    /// @param limitMaxWithdraw Per-call withdraw limit (`0` means unlimited).
-    /// @param limitMaxRedeem Per-call redeem limit (`0` means unlimited).
-    function setLimitConfig(
-        uint128 limitMaxTotalAssets,
-        uint128 limitMaxDeposit,
-        uint128 limitMaxMint,
-        uint128 limitMaxWithdraw,
-        uint128 limitMaxRedeem
-    ) public onlyRole(VAULT_MANAGER_ROLE()) {
-        LibERC4626VaultStorage.LimitConfig storage limits = LibERC4626VaultStorage.layout().limits;
-
-        limits.maxTotalAssets = limitMaxTotalAssets;
-        limits.maxDeposit = limitMaxDeposit;
-        limits.maxMint = limitMaxMint;
-        limits.maxWithdraw = limitMaxWithdraw;
-        limits.maxRedeem = limitMaxRedeem;
-
-        emit VaultLimitConfigUpdated(
-            limitMaxTotalAssets, limitMaxDeposit, limitMaxMint, limitMaxWithdraw, limitMaxRedeem, msg.sender
-        );
-    }
-
-    /// @notice Returns max assets `receiver` can deposit.
-    /// @param receiver Target receiver.
-    /// @return Max asset amount accepted.
-    function maxDeposit(address receiver) public view virtual override returns (uint256) {
-        if (receiver == address(0) || paused()) {
-            return 0;
-        }
-
-        uint256 maxAssets = type(uint256).max;
-        LibERC4626VaultStorage.LimitConfig storage limits = LibERC4626VaultStorage.layout().limits;
-
-        if (limits.maxDeposit != 0) {
-            maxAssets = limits.maxDeposit;
-        }
-
-        if (limits.maxTotalAssets != 0) {
-            uint256 currentAssets = totalAssets();
-            if (currentAssets >= limits.maxTotalAssets) {
-                return 0;
-            }
-
-            uint256 remainingAssets = limits.maxTotalAssets - currentAssets;
-            uint256 capBasedMaxAssets = _grossUpForDepositFee(remainingAssets);
-            if (capBasedMaxAssets < maxAssets) {
-                maxAssets = capBasedMaxAssets;
-            }
-        }
-
-        return maxAssets;
-    }
-
-    /// @notice Returns max shares `receiver` can mint.
-    /// @param receiver Target receiver.
-    /// @return Max shares accepted.
-    function maxMint(address receiver) public view virtual override returns (uint256) {
-        if (receiver == address(0) || paused()) {
-            return 0;
-        }
-
-        uint256 maxShares = type(uint256).max;
-        LibERC4626VaultStorage.LimitConfig storage limits = LibERC4626VaultStorage.layout().limits;
-
-        if (limits.maxMint != 0) {
-            maxShares = limits.maxMint;
-        }
-
-        if (limits.maxTotalAssets != 0) {
-            uint256 currentAssets = totalAssets();
-            if (currentAssets >= limits.maxTotalAssets) {
-                return 0;
-            }
-
-            uint256 remainingAssets = limits.maxTotalAssets - currentAssets;
-            uint256 capBasedMaxShares = _convertToShares(remainingAssets, Rounding.Down);
-            if (capBasedMaxShares < maxShares) {
-                maxShares = capBasedMaxShares;
-            }
-        }
-
-        return maxShares;
-    }
-
-    /// @notice Returns max assets `owner` can withdraw.
-    /// @param owner Share owner.
-    /// @return Max withdrawable assets.
-    function maxWithdraw(address owner) public view virtual override returns (uint256) {
-        if (owner == address(0) || paused()) {
-            return 0;
-        }
-
-        uint256 grossAssets = _convertToAssets(balanceOf(owner), Rounding.Down);
-        (uint256 netAssets,) = _withdrawNetFromGross(grossAssets);
-
-        uint128 configuredMaxWithdraw = LibERC4626VaultStorage.layout().limits.maxWithdraw;
-        if (configuredMaxWithdraw != 0 && netAssets > configuredMaxWithdraw) {
-            return configuredMaxWithdraw;
-        }
-
-        return netAssets;
-    }
-
-    /// @notice Returns max shares `owner` can redeem.
-    /// @param owner Share owner.
-    /// @return Max redeemable shares.
-    function maxRedeem(address owner) public view virtual override returns (uint256) {
-        if (owner == address(0) || paused()) {
-            return 0;
-        }
-
-        uint256 redeemableShares = balanceOf(owner);
-        uint128 configuredMaxRedeem = LibERC4626VaultStorage.layout().limits.maxRedeem;
-        if (configuredMaxRedeem != 0 && redeemableShares > configuredMaxRedeem) {
-            return configuredMaxRedeem;
-        }
-
-        return redeemableShares;
-    }
-
-    /// @notice Returns shares minted by depositing `assets`.
-    /// @param assets Asset amount.
-    /// @return Estimated shares.
-    function previewDeposit(uint256 assets) public view virtual override returns (uint256) {
-        (uint256 netAssets,) = _netAfterDepositFee(assets);
-        return _convertToShares(netAssets, Rounding.Down);
-    }
-
-    /// @notice Returns assets required to mint `shares`.
-    /// @param shares Share amount.
-    /// @return Required assets.
-    function previewMint(uint256 shares) public view virtual override returns (uint256) {
-        uint256 netAssets = _convertToAssets(shares, Rounding.Up);
-        return _grossUpForDepositFee(netAssets);
-    }
-
-    /// @notice Returns shares burned by withdrawing `assets`.
-    /// @param assets Asset amount.
-    /// @return Estimated shares burned.
-    function previewWithdraw(uint256 assets) public view virtual override returns (uint256) {
-        (uint256 grossAssets,) = _withdrawGrossFromNet(assets);
-        return _convertToShares(grossAssets, Rounding.Up);
-    }
-
-    /// @notice Returns assets received by redeeming `shares`.
-    /// @param shares Share amount.
-    /// @return Estimated assets returned.
-    function previewRedeem(uint256 shares) public view virtual override returns (uint256) {
-        uint256 grossAssets = _convertToAssets(shares, Rounding.Down);
-        (uint256 netAssets,) = _withdrawNetFromGross(grossAssets);
-        return netAssets;
-    }
-
     /// @notice Deposits `assets` and mints shares to `receiver`.
     /// @param assets Asset amount.
     /// @param receiver Receiver of minted shares.
@@ -279,36 +41,12 @@ abstract contract ERC4626VaultControls is ERC4626Vault, VaultFacetControl, IERC4
     function deposit(uint256 assets, address receiver)
         public
         virtual
-        override
+        override(ERC4626Vault)
         whenNotPaused
         nonReentrant
         returns (uint256 shares)
     {
-        _requireInitialized();
-        _requireNonZeroAddress(receiver);
-        if (assets == 0) {
-            revert ERC4626VaultZeroAssets();
-        }
-
-        uint256 maxAssets = maxDeposit(receiver);
-        if (assets > maxAssets) {
-            revert ERC4626VaultDepositLimitExceeded(assets, maxAssets);
-        }
-
-        (uint256 netAssets, uint256 feeAssets) = _netAfterDepositFee(assets);
-        _enforceTotalAssetsCap(netAssets);
-
-        shares = _convertToShares(netAssets, Rounding.Down);
-        if (shares == 0) {
-            revert ERC4626VaultZeroShares();
-        }
-
-        _safeTransferFromAsset(msg.sender, address(this), assets);
-        _increaseManagedAssets(netAssets);
-        _mintShares(receiver, shares);
-        _payoutFee(feeAssets);
-
-        emit Deposit(msg.sender, receiver, assets, shares);
+        return _depositWithControls(assets, receiver);
     }
 
     /// @notice Mints `shares` to `receiver`.
@@ -318,37 +56,12 @@ abstract contract ERC4626VaultControls is ERC4626Vault, VaultFacetControl, IERC4
     function mint(uint256 shares, address receiver)
         public
         virtual
-        override
+        override(ERC4626Vault)
         whenNotPaused
         nonReentrant
         returns (uint256 assets)
     {
-        _requireInitialized();
-        _requireNonZeroAddress(receiver);
-        if (shares == 0) {
-            revert ERC4626VaultZeroShares();
-        }
-
-        uint256 maxShares = maxMint(receiver);
-        if (shares > maxShares) {
-            revert ERC4626VaultMintLimitExceeded(shares, maxShares);
-        }
-
-        uint256 netAssets = _convertToAssets(shares, Rounding.Up);
-        if (netAssets == 0) {
-            revert ERC4626VaultZeroAssets();
-        }
-
-        assets = _grossUpForDepositFee(netAssets);
-        uint256 feeAssets = assets - netAssets;
-
-        _enforceTotalAssetsCap(netAssets);
-        _safeTransferFromAsset(msg.sender, address(this), assets);
-        _increaseManagedAssets(netAssets);
-        _mintShares(receiver, shares);
-        _payoutFee(feeAssets);
-
-        emit Deposit(msg.sender, receiver, assets, shares);
+        return _mintWithControls(shares, receiver);
     }
 
     /// @notice Withdraws `assets` to `receiver` from `owner`.
@@ -359,39 +72,12 @@ abstract contract ERC4626VaultControls is ERC4626Vault, VaultFacetControl, IERC4
     function withdraw(uint256 assets, address receiver, address owner)
         public
         virtual
-        override
+        override(ERC4626Vault)
         whenNotPaused
         nonReentrant
         returns (uint256 shares)
     {
-        _requireInitialized();
-        _requireNonZeroAddress(receiver);
-        _requireNonZeroAddress(owner);
-        if (assets == 0) {
-            revert ERC4626VaultZeroAssets();
-        }
-
-        uint256 maxAssets = maxWithdraw(owner);
-        if (assets > maxAssets) {
-            revert ERC4626VaultWithdrawLimitExceeded(assets, maxAssets);
-        }
-
-        (uint256 grossAssets, uint256 feeAssets) = _withdrawGrossFromNet(assets);
-        shares = _convertToShares(grossAssets, Rounding.Up);
-        if (shares == 0) {
-            revert ERC4626VaultZeroShares();
-        }
-
-        if (msg.sender != owner) {
-            _spendAllowance(owner, msg.sender, shares);
-        }
-
-        _burnShares(owner, shares);
-        _decreaseManagedAssets(grossAssets);
-        _safeTransferAsset(receiver, assets);
-        _payoutFee(feeAssets);
-
-        emit Withdraw(msg.sender, receiver, owner, assets, shares);
+        return _withdrawWithControls(assets, receiver, owner);
     }
 
     /// @notice Redeems `shares` from `owner` to `receiver`.
@@ -402,134 +88,15 @@ abstract contract ERC4626VaultControls is ERC4626Vault, VaultFacetControl, IERC4
     function redeem(uint256 shares, address receiver, address owner)
         public
         virtual
-        override
+        override(ERC4626Vault)
         whenNotPaused
         nonReentrant
         returns (uint256 assets)
     {
-        _requireInitialized();
-        _requireNonZeroAddress(receiver);
-        _requireNonZeroAddress(owner);
-        if (shares == 0) {
-            revert ERC4626VaultZeroShares();
-        }
-
-        uint256 maxShares = maxRedeem(owner);
-        if (shares > maxShares) {
-            revert ERC4626VaultRedeemLimitExceeded(shares, maxShares);
-        }
-
-        uint256 grossAssets = _convertToAssets(shares, Rounding.Down);
-        uint256 feeAssets;
-        (assets, feeAssets) = _withdrawNetFromGross(grossAssets);
-        if (assets == 0) {
-            revert ERC4626VaultZeroAssets();
-        }
-
-        if (msg.sender != owner) {
-            _spendAllowance(owner, msg.sender, shares);
-        }
-
-        _burnShares(owner, shares);
-        _decreaseManagedAssets(grossAssets);
-        _safeTransferAsset(receiver, assets);
-        _payoutFee(feeAssets);
-
-        emit Withdraw(msg.sender, receiver, owner, assets, shares);
+        return _redeemWithControls(shares, receiver, owner);
     }
 
-    /// @dev Enforces configured total-assets cap.
-    /// @param additionalAssets Assets to be added to managed accounting.
-    function _enforceTotalAssetsCap(uint256 additionalAssets) internal view {
-        uint128 cap = LibERC4626VaultStorage.layout().limits.maxTotalAssets;
-        if (cap == 0) {
-            return;
-        }
-
-        uint256 currentAssets = totalAssets();
-        uint256 nextAssets = currentAssets + additionalAssets;
-        if (nextAssets > cap) {
-            revert ERC4626VaultTotalAssetsCapExceeded(currentAssets, additionalAssets, cap);
-        }
-    }
-
-    /// @dev Returns net deposit assets and fee amount from a gross input.
-    /// @param assets Gross deposit asset amount.
-    /// @return netAssets Net assets credited to vault accounting.
-    /// @return feeAssets Fee assets paid out.
-    function _netAfterDepositFee(uint256 assets) internal view returns (uint256 netAssets, uint256 feeAssets) {
-        uint16 depositFeeBps = LibERC4626VaultStorage.layout().fees.depositFeeBps;
-        feeAssets = _feeOnRaw(assets, depositFeeBps, Rounding.Down);
-        netAssets = assets - feeAssets;
-    }
-
-    /// @dev Returns gross deposit amount needed to credit `netAssets`.
-    /// @param netAssets Desired net assets credited to vault accounting.
-    /// @return grossAssets Gross assets that must be transferred in.
-    function _grossUpForDepositFee(uint256 netAssets) internal view returns (uint256 grossAssets) {
-        uint16 depositFeeBps = LibERC4626VaultStorage.layout().fees.depositFeeBps;
-        if (depositFeeBps == 0 || netAssets == 0) {
-            return netAssets;
-        }
-
-        uint256 denominator = BPS_DENOMINATOR - depositFeeBps;
-        grossAssets = _mulDiv(netAssets, BPS_DENOMINATOR, denominator, Rounding.Up);
-
-        (uint256 creditedAssets,) = _netAfterDepositFee(grossAssets);
-        if (creditedAssets < netAssets) {
-            grossAssets += 1;
-        }
-    }
-
-    /// @dev Returns gross withdraw assets and fee from a requested net output.
-    /// @param assets Requested receiver assets.
-    /// @return grossAssets Gross assets removed from managed accounting.
-    /// @return feeAssets Fee assets paid out.
-    function _withdrawGrossFromNet(uint256 assets) internal view returns (uint256 grossAssets, uint256 feeAssets) {
-        uint16 withdrawFeeBps = LibERC4626VaultStorage.layout().fees.withdrawFeeBps;
-        feeAssets = _feeOnRaw(assets, withdrawFeeBps, Rounding.Up);
-        grossAssets = assets + feeAssets;
-    }
-
-    /// @dev Returns receiver assets and fee from a gross redeemed amount.
-    /// @param grossAssets Gross assets removed from managed accounting.
-    /// @return netAssets Assets sent to receiver.
-    /// @return feeAssets Fee assets paid out.
-    function _withdrawNetFromGross(uint256 grossAssets) internal view returns (uint256 netAssets, uint256 feeAssets) {
-        uint16 withdrawFeeBps = LibERC4626VaultStorage.layout().fees.withdrawFeeBps;
-        feeAssets = _feeOnRaw(grossAssets, withdrawFeeBps, Rounding.Down);
-        netAssets = grossAssets - feeAssets;
-    }
-
-    /// @dev Pays `feeAssets` to configured fee recipient when non-zero.
-    /// @param feeAssets Fee amount to transfer.
-    function _payoutFee(uint256 feeAssets) internal {
-        if (feeAssets == 0) {
-            return;
-        }
-
-        address recipient = LibERC4626VaultStorage.layout().fees.feeRecipient;
-        _safeTransferAsset(recipient, feeAssets);
-    }
-
-    /// @dev Reverts when `feeBps` is invalid.
-    /// @param feeBps Fee basis points.
-    function _validateFeeBps(uint16 feeBps) internal pure {
-        if (feeBps >= BPS_DENOMINATOR) {
-            revert ERC4626VaultInvalidFeeBps(feeBps);
-        }
-    }
-
-    /// @dev Returns fee amount for `assets` and `feeBps` with controlled rounding.
-    /// @param assets Asset amount used for fee computation.
-    /// @param feeBps Fee basis points.
-    /// @param rounding Rounding direction.
-    /// @return Computed fee amount.
-    function _feeOnRaw(uint256 assets, uint16 feeBps, Rounding rounding) internal pure returns (uint256) {
-        if (feeBps == 0 || assets == 0) {
-            return 0;
-        }
-
-        return _mulDiv(assets, feeBps, BPS_DENOMINATOR, rounding);
+    function _vaultOperationsPaused() internal view virtual override returns (bool) {
+        return paused();
     }
 }

--- a/src/vault/VaultFacetControl.sol
+++ b/src/vault/VaultFacetControl.sol
@@ -1,0 +1,390 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "../interfaces/IAccessControl.sol";
+import {IAccessControlTime} from "../interfaces/IAccessControlTime.sol";
+import {IERC165} from "../interfaces/IERC165.sol";
+import {IPausable} from "../interfaces/IPausable.sol";
+import {IReentrancyGuard} from "../interfaces/IReentrancyGuard.sol";
+import {LibAccessControlStorage} from "../access/storage/LibAccessControlStorage.sol";
+import {LibAccessControlTimeStorage} from "../access/storage/LibAccessControlTimeStorage.sol";
+import {LibPausableStorage} from "../access/storage/LibPausableStorage.sol";
+import {LibReentrancyGuardStorage} from "../security/storage/LibReentrancyGuardStorage.sol";
+import {LibERC4626VaultStorage} from "./storage/LibERC4626VaultStorage.sol";
+import {LibVaultFacetConstants} from "./libraries/LibVaultFacetConstants.sol";
+
+/// @title VaultFacetControl
+/// @notice Constructor-free access, pause, and reentrancy layer for hosted vault facets.
+abstract contract VaultFacetControl is IAccessControl, IAccessControlTime, IPausable, IReentrancyGuard {
+    /// @notice Default admin for all roles unless overridden.
+    bytes32 public constant DEFAULT_ADMIN_ROLE = 0x00;
+
+    /// @notice Role required to call pause and unpause controls.
+    bytes32 public constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
+
+    /// @dev Role that can manage vault fees and limits.
+    bytes32 internal constant VAULT_MANAGER_ROLE_VALUE = LibVaultFacetConstants.VAULT_MANAGER_ROLE;
+
+    /// @dev Reentrancy status for a function call not currently entered.
+    uint256 internal constant NOT_ENTERED = 1;
+
+    /// @dev Reentrancy status for a function call currently entered.
+    uint256 internal constant ENTERED = 2;
+
+    /// @dev Reverts if the caller is missing `role`.
+    modifier onlyRole(bytes32 role) {
+        _checkRole(role, msg.sender);
+        _;
+    }
+
+    /// @dev Reverts if the caller does not currently have an active time-gated `role`.
+    modifier onlyActiveRole(bytes32 role) {
+        _checkActiveRole(role, msg.sender);
+        _;
+    }
+
+    /// @dev Prevents a function from being called reentrantly.
+    modifier nonReentrant() {
+        _nonReentrantBefore();
+        _;
+        _nonReentrantAfter();
+    }
+
+    /// @dev Reverts when contract is paused.
+    modifier whenNotPaused() {
+        _requireNotPaused();
+        _;
+    }
+
+    /// @dev Reverts when contract is not paused.
+    modifier whenPaused() {
+        _requirePaused();
+        _;
+    }
+
+    function hasRole(bytes32 role, address account) public view returns (bool) {
+        return LibAccessControlStorage.layout().roles[role].members[account];
+    }
+
+    function getRoleAdmin(bytes32 role) public view returns (bytes32) {
+        return LibAccessControlStorage.layout().roles[role].adminRole;
+    }
+
+    /// @notice Role that can manage vault fees and limits.
+    /// @return The vault manager role identifier.
+    function VAULT_MANAGER_ROLE() public pure virtual returns (bytes32) {
+        return VAULT_MANAGER_ROLE_VALUE;
+    }
+
+    function grantRole(bytes32 role, address account) public onlyRole(getRoleAdmin(role)) {
+        _grantRole(role, account);
+    }
+
+    function grantRoleWithWindow(bytes32 role, address account, uint64 start, uint64 end)
+        public
+        onlyRole(getRoleAdmin(role))
+    {
+        _grantRole(role, account);
+        _setRoleWindow(role, account, start, end, msg.sender);
+    }
+
+    function revokeRole(bytes32 role, address account) public onlyRole(getRoleAdmin(role)) {
+        _revokeRole(role, account);
+    }
+
+    function renounceRole(bytes32 role, address account) public {
+        if (account != msg.sender) {
+            revert AccessControlRenounceSelfOnly();
+        }
+        _revokeRole(role, account);
+    }
+
+    function getRoleMember(bytes32 role, uint256 index) public view returns (address) {
+        return LibAccessControlStorage.layout().roles[role].memberList[index];
+    }
+
+    function getRoleMemberCount(bytes32 role) public view returns (uint256) {
+        return LibAccessControlStorage.layout().roles[role].memberList.length;
+    }
+
+    function setRoleWindow(bytes32 role, address account, uint64 start, uint64 end)
+        public
+        onlyRole(getRoleAdmin(role))
+    {
+        _setRoleWindow(role, account, start, end, msg.sender);
+    }
+
+    function clearRoleWindow(bytes32 role, address account) public onlyRole(getRoleAdmin(role)) {
+        _requireNonZeroAccount(account);
+        _clearRoleWindow(role, account, msg.sender);
+    }
+
+    function getRoleWindow(bytes32 role, address account) public view returns (uint64 start, uint64 end, bool exists) {
+        LibAccessControlTimeStorage.RoleWindow storage window =
+            LibAccessControlTimeStorage.layout().roleWindows[role][account];
+        return (window.start, window.end, window.exists);
+    }
+
+    function hasActiveRole(bytes32 role, address account) public view returns (bool) {
+        if (!hasRole(role, account)) {
+            return false;
+        }
+
+        LibAccessControlTimeStorage.RoleWindow storage window =
+            LibAccessControlTimeStorage.layout().roleWindows[role][account];
+        if (!window.exists) {
+            return false;
+        }
+
+        uint256 timestamp = block.timestamp;
+        if (timestamp < window.start) {
+            return false;
+        }
+        if (window.end != 0 && timestamp >= window.end) {
+            return false;
+        }
+        return true;
+    }
+
+    function paused() public view returns (bool) {
+        return LibPausableStorage.layout().paused;
+    }
+
+    function paused(bytes32 scope) public view returns (bool) {
+        return paused() || scopePaused(scope);
+    }
+
+    function scopePaused(bytes32 scope) public view returns (bool) {
+        return LibPausableStorage.layout().pausedScopes[scope];
+    }
+
+    function pause() public onlyRole(PAUSER_ROLE) whenNotPaused {
+        LibPausableStorage.layout().paused = true;
+        emit Paused(msg.sender);
+    }
+
+    function unpause() public onlyRole(PAUSER_ROLE) whenPaused {
+        LibPausableStorage.layout().paused = false;
+        emit Unpaused(msg.sender);
+    }
+
+    function pauseScope(bytes32 scope) public onlyRole(PAUSER_ROLE) {
+        _requireValidScope(scope);
+        if (scopePaused(scope)) {
+            revert PausableScopeEnforcedPause(scope);
+        }
+
+        LibPausableStorage.layout().pausedScopes[scope] = true;
+        emit ScopePaused(scope, msg.sender);
+    }
+
+    function unpauseScope(bytes32 scope) public onlyRole(PAUSER_ROLE) {
+        _requireValidScope(scope);
+        if (!scopePaused(scope)) {
+            revert PausableScopeExpectedPause(scope);
+        }
+
+        LibPausableStorage.layout().pausedScopes[scope] = false;
+        emit ScopeUnpaused(scope, msg.sender);
+    }
+
+    function reentrancyGuardEntered() public view returns (bool) {
+        return LibReentrancyGuardStorage.layout().status == ENTERED;
+    }
+
+    function supportsInterface(bytes4 interfaceId) public view virtual returns (bool) {
+        return interfaceId == type(IERC165).interfaceId || interfaceId == type(IAccessControl).interfaceId
+            || interfaceId == type(IAccessControlTime).interfaceId || interfaceId == type(IPausable).interfaceId
+            || interfaceId == type(IReentrancyGuard).interfaceId;
+    }
+
+    /// @dev Initializes shared control storage and vault manager defaults when needed.
+    /// @param initialAdmin The default admin, pauser, and initial vault manager.
+    function _initializeVaultFacetControl(address initialAdmin) internal {
+        if (!_isAccessControlInitialized()) {
+            _initializeAccessControl(initialAdmin);
+        }
+        if (!_isPausableInitialized()) {
+            _initializePausable(initialAdmin);
+        }
+        if (!_isReentrancyGuardInitialized()) {
+            _initializeReentrancyGuard();
+        }
+        if (!LibERC4626VaultStorage.layout().controlPlaneInitialized) {
+            _initializeVaultManagerDefaults(initialAdmin);
+        }
+    }
+
+    function _isAccessControlInitialized() internal view returns (bool) {
+        return LibAccessControlStorage.layout().initialized;
+    }
+
+    function _isPausableInitialized() internal view returns (bool) {
+        return LibPausableStorage.layout().initialized;
+    }
+
+    function _isReentrancyGuardInitialized() internal view returns (bool) {
+        return LibReentrancyGuardStorage.layout().initialized;
+    }
+
+    function _initializeAccessControl(address initialAdmin) internal {
+        LibAccessControlStorage.Layout storage layout = LibAccessControlStorage.layout();
+        if (layout.initialized) {
+            revert AccessControlAlreadyInitialized();
+        }
+        if (initialAdmin == address(0)) {
+            revert AccessControlZeroAdmin();
+        }
+
+        layout.initialized = true;
+        layout.roles[DEFAULT_ADMIN_ROLE].adminRole = DEFAULT_ADMIN_ROLE;
+        _grantRole(DEFAULT_ADMIN_ROLE, initialAdmin);
+    }
+
+    function _initializePausable(address initialPauser) internal {
+        LibPausableStorage.Layout storage layout = LibPausableStorage.layout();
+        if (layout.initialized) {
+            revert PausableAlreadyInitialized();
+        }
+        _requireNonZeroAccount(initialPauser);
+
+        layout.initialized = true;
+        _grantRole(PAUSER_ROLE, initialPauser);
+    }
+
+    function _initializeReentrancyGuard() internal {
+        LibReentrancyGuardStorage.Layout storage layout = LibReentrancyGuardStorage.layout();
+        if (layout.initialized) {
+            revert ReentrancyGuardAlreadyInitialized();
+        }
+        layout.initialized = true;
+        layout.status = NOT_ENTERED;
+    }
+
+    /// @dev Seeds vault-manager defaults for a hosted vault control plane.
+    /// @param initialManager The account receiving the initial manager role and fee recipient status.
+    function _initializeVaultManagerDefaults(address initialManager) internal {
+        _requireNonZeroAccount(initialManager);
+
+        LibERC4626VaultStorage.Layout storage vaultLayout = LibERC4626VaultStorage.layout();
+        _setRoleAdmin(VAULT_MANAGER_ROLE_VALUE, DEFAULT_ADMIN_ROLE);
+        _grantRole(VAULT_MANAGER_ROLE_VALUE, initialManager);
+        vaultLayout.fees.feeRecipient = initialManager;
+        vaultLayout.controlPlaneInitialized = true;
+    }
+
+    function _checkRole(bytes32 role, address account) internal view {
+        if (!hasRole(role, account)) {
+            revert AccessControlUnauthorized(account, role);
+        }
+    }
+
+    function _checkActiveRole(bytes32 role, address account) internal view {
+        if (!hasActiveRole(role, account)) {
+            revert AccessControlRoleNotActive(account, role);
+        }
+    }
+
+    function _setRoleAdmin(bytes32 role, bytes32 adminRole) internal virtual {
+        LibAccessControlStorage.Layout storage layout = LibAccessControlStorage.layout();
+        bytes32 previousAdminRole = layout.roles[role].adminRole;
+        layout.roles[role].adminRole = adminRole;
+        emit RoleAdminChanged(role, previousAdminRole, adminRole);
+    }
+
+    function _grantRole(bytes32 role, address account) internal virtual {
+        _requireNonZeroAccount(account);
+        LibAccessControlStorage.RoleData storage roleData = LibAccessControlStorage.layout().roles[role];
+        if (!roleData.members[account]) {
+            roleData.members[account] = true;
+            if (roleData.memberIndex[account] == 0) {
+                roleData.memberList.push(account);
+                roleData.memberIndex[account] = roleData.memberList.length;
+            }
+            emit RoleGranted(role, account, msg.sender);
+        }
+    }
+
+    function _revokeRole(bytes32 role, address account) internal virtual {
+        _requireNonZeroAccount(account);
+        LibAccessControlStorage.RoleData storage roleData = LibAccessControlStorage.layout().roles[role];
+        if (roleData.members[account]) {
+            roleData.members[account] = false;
+            uint256 index = roleData.memberIndex[account];
+            if (index != 0) {
+                uint256 lastIndex = roleData.memberList.length;
+                if (index != lastIndex) {
+                    address lastMember = roleData.memberList[lastIndex - 1];
+                    roleData.memberList[index - 1] = lastMember;
+                    roleData.memberIndex[lastMember] = index;
+                }
+                roleData.memberList.pop();
+                roleData.memberIndex[account] = 0;
+            }
+            _clearRoleWindow(role, account, msg.sender);
+            emit RoleRevoked(role, account, msg.sender);
+        }
+    }
+
+    function _validateRoleWindow(uint64 start, uint64 end) internal pure {
+        if (end != 0 && end <= start) {
+            revert AccessControlInvalidRoleWindow(start, end);
+        }
+    }
+
+    function _setRoleWindow(bytes32 role, address account, uint64 start, uint64 end, address sender) internal {
+        _requireNonZeroAccount(account);
+        _validateRoleWindow(start, end);
+
+        LibAccessControlTimeStorage.RoleWindow storage window =
+            LibAccessControlTimeStorage.layout().roleWindows[role][account];
+        window.start = start;
+        window.end = end;
+        window.exists = true;
+        emit RoleWindowSet(role, account, start, end, sender);
+    }
+
+    function _clearRoleWindow(bytes32 role, address account, address sender) internal {
+        LibAccessControlTimeStorage.Layout storage layout = LibAccessControlTimeStorage.layout();
+        if (layout.roleWindows[role][account].exists) {
+            delete layout.roleWindows[role][account];
+            emit RoleWindowCleared(role, account, sender);
+        }
+    }
+
+    function _nonReentrantBefore() internal {
+        LibReentrancyGuardStorage.Layout storage layout = LibReentrancyGuardStorage.layout();
+        if (layout.status == ENTERED) {
+            revert ReentrancyGuardReentrantCall();
+        }
+        layout.status = ENTERED;
+    }
+
+    function _nonReentrantAfter() internal {
+        LibReentrancyGuardStorage.layout().status = NOT_ENTERED;
+    }
+
+    function _requireNotPaused() internal view {
+        if (paused()) {
+            revert PausableEnforcedPause();
+        }
+    }
+
+    function _requirePaused() internal view {
+        if (!paused()) {
+            revert PausableExpectedPause();
+        }
+    }
+
+    function _requireValidScope(bytes32 scope) internal pure {
+        if (scope == bytes32(0)) {
+            revert PausableZeroScope();
+        }
+    }
+
+    function _requireNonZeroAccount(address account) internal pure {
+        if (account == address(0)) {
+            revert AccessControlZeroAddressAccount();
+        }
+    }
+}

--- a/src/vault/facets/ERC4626VaultControlsFacet.sol
+++ b/src/vault/facets/ERC4626VaultControlsFacet.sol
@@ -6,6 +6,7 @@ import {IAccessControlTime} from "../../interfaces/IAccessControlTime.sol";
 import {IERC165} from "../../interfaces/IERC165.sol";
 import {IERC4626VaultControls} from "../../interfaces/IERC4626VaultControls.sol";
 import {IERC4626VaultControlsFacet} from "../../interfaces/IERC4626VaultControlsFacet.sol";
+import {IERC4626VaultFacet} from "../../interfaces/IERC4626VaultFacet.sol";
 import {IERC4626VaultIntegrationFacet} from "../../interfaces/IERC4626VaultIntegrationFacet.sol";
 import {IPausable} from "../../interfaces/IPausable.sol";
 import {IReentrancyGuard} from "../../interfaces/IReentrancyGuard.sol";
@@ -28,6 +29,8 @@ contract ERC4626VaultControlsFacet is ERC4626VaultControlSurface {
     {
         return interfaceId == type(IERC165).interfaceId || interfaceId == type(IERC4626VaultControls).interfaceId
             || interfaceId == type(IERC4626VaultControlsFacet).interfaceId
+            || (interfaceId == type(IERC4626VaultFacet).interfaceId
+                && LibDiamond.selectorExists(IERC4626VaultFacet.initializeVault.selector))
             || (interfaceId == type(IERC4626VaultIntegrationFacet).interfaceId
                 && LibDiamond.selectorExists(IERC4626VaultIntegrationFacet.oracleAdapter.selector))
             || interfaceId == type(IAccessControl).interfaceId || interfaceId == type(IAccessControlTime).interfaceId

--- a/src/vault/facets/ERC4626VaultControlsFacet.sol
+++ b/src/vault/facets/ERC4626VaultControlsFacet.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "../../interfaces/IAccessControl.sol";
+import {IAccessControlTime} from "../../interfaces/IAccessControlTime.sol";
+import {IERC165} from "../../interfaces/IERC165.sol";
+import {IERC4626VaultControls} from "../../interfaces/IERC4626VaultControls.sol";
+import {IERC4626VaultControlsFacet} from "../../interfaces/IERC4626VaultControlsFacet.sol";
+import {IPausable} from "../../interfaces/IPausable.sol";
+import {IReentrancyGuard} from "../../interfaces/IReentrancyGuard.sol";
+import {ERC4626VaultControlSurface} from "../ERC4626VaultControlLogic.sol";
+import {VaultFacetControl} from "../VaultFacetControl.sol";
+
+/// @title ERC4626VaultControlsFacet
+/// @notice Hosted control-plane facet for vault fee, limit, and governance operations.
+contract ERC4626VaultControlsFacet is ERC4626VaultControlSurface {
+    /// @notice Returns true if this contract implements `interfaceId`.
+    /// @param interfaceId The interface identifier.
+    /// @return True if the interface is supported.
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(VaultFacetControl, IERC165)
+        returns (bool)
+    {
+        return interfaceId == type(IERC165).interfaceId || interfaceId == type(IERC4626VaultControls).interfaceId
+            || interfaceId == type(IERC4626VaultControlsFacet).interfaceId
+            || interfaceId == type(IAccessControl).interfaceId || interfaceId == type(IAccessControlTime).interfaceId
+            || interfaceId == type(IPausable).interfaceId || interfaceId == type(IReentrancyGuard).interfaceId
+            || VaultFacetControl.supportsInterface(interfaceId);
+    }
+}

--- a/src/vault/facets/ERC4626VaultControlsFacet.sol
+++ b/src/vault/facets/ERC4626VaultControlsFacet.sol
@@ -6,8 +6,10 @@ import {IAccessControlTime} from "../../interfaces/IAccessControlTime.sol";
 import {IERC165} from "../../interfaces/IERC165.sol";
 import {IERC4626VaultControls} from "../../interfaces/IERC4626VaultControls.sol";
 import {IERC4626VaultControlsFacet} from "../../interfaces/IERC4626VaultControlsFacet.sol";
+import {IERC4626VaultIntegrationFacet} from "../../interfaces/IERC4626VaultIntegrationFacet.sol";
 import {IPausable} from "../../interfaces/IPausable.sol";
 import {IReentrancyGuard} from "../../interfaces/IReentrancyGuard.sol";
+import {LibDiamond} from "../../diamond/libraries/LibDiamond.sol";
 import {ERC4626VaultControlSurface} from "../ERC4626VaultControlLogic.sol";
 import {VaultFacetControl} from "../VaultFacetControl.sol";
 
@@ -26,6 +28,8 @@ contract ERC4626VaultControlsFacet is ERC4626VaultControlSurface {
     {
         return interfaceId == type(IERC165).interfaceId || interfaceId == type(IERC4626VaultControls).interfaceId
             || interfaceId == type(IERC4626VaultControlsFacet).interfaceId
+            || (interfaceId == type(IERC4626VaultIntegrationFacet).interfaceId
+                && LibDiamond.selectorExists(IERC4626VaultIntegrationFacet.oracleAdapter.selector))
             || interfaceId == type(IAccessControl).interfaceId || interfaceId == type(IAccessControlTime).interfaceId
             || interfaceId == type(IPausable).interfaceId || interfaceId == type(IReentrancyGuard).interfaceId
             || VaultFacetControl.supportsInterface(interfaceId);

--- a/src/vault/facets/ERC4626VaultFacet.sol
+++ b/src/vault/facets/ERC4626VaultFacet.sol
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC4626} from "../../interfaces/IERC4626.sol";
+import {IERC4626VaultFacet} from "../../interfaces/IERC4626VaultFacet.sol";
+import {ERC4626Vault} from "../ERC4626Vault.sol";
+import {ERC4626VaultBase} from "../ERC4626VaultBase.sol";
+import {VaultFacetControl} from "../VaultFacetControl.sol";
+
+/// @title ERC4626VaultFacet
+/// @notice Hosted ERC-4626 core facet with constructor-free initialization.
+contract ERC4626VaultFacet is ERC4626Vault, VaultFacetControl, IERC4626VaultFacet {
+    /// @notice Returns true when vault storage is initialized.
+    /// @return True if initialized.
+    function isVaultInitialized() public view virtual override(IERC4626VaultFacet, ERC4626VaultBase) returns (bool) {
+        return ERC4626VaultBase.isVaultInitialized();
+    }
+
+    /// @notice Returns vault underlying asset token address.
+    /// @return The underlying asset token.
+    function asset() public view virtual override(ERC4626Vault, IERC4626) returns (address) {
+        return ERC4626Vault.asset();
+    }
+
+    /// @notice Returns currently managed asset accounting amount.
+    /// @return The tracked managed asset amount.
+    function totalManagedAssets() public view virtual override(IERC4626VaultFacet, ERC4626VaultBase) returns (uint256) {
+        return ERC4626VaultBase.totalManagedAssets();
+    }
+
+    /// @notice Initializes the hosted vault core and shared control plane.
+    /// @param vaultAsset Underlying vault asset token.
+    /// @param vaultName ERC-20 share token name.
+    /// @param vaultSymbol ERC-20 share token symbol.
+    /// @param admin Account receiving admin, pauser, and vault manager roles.
+    function initializeVault(address vaultAsset, string calldata vaultName, string calldata vaultSymbol, address admin)
+        external
+    {
+        if (isVaultInitialized()) {
+            revert ERC4626VaultAlreadyInitialized();
+        }
+
+        if (_isAccessControlInitialized()) {
+            _checkRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        }
+
+        _initializeVaultFacetControl(admin);
+        _initializeErc4626Vault(vaultAsset, vaultName, vaultSymbol);
+    }
+
+    /// @notice Deposits `assets` and mints shares to `receiver`.
+    /// @param assets Asset amount.
+    /// @param receiver Receiver of minted shares.
+    /// @return shares Minted shares.
+    function deposit(uint256 assets, address receiver)
+        public
+        virtual
+        override(ERC4626Vault, IERC4626)
+        whenNotPaused
+        nonReentrant
+        returns (uint256 shares)
+    {
+        return super.deposit(assets, receiver);
+    }
+
+    /// @notice Mints `shares` to `receiver`.
+    /// @param shares Share amount.
+    /// @param receiver Receiver of minted shares.
+    /// @return assets Deposited assets.
+    function mint(uint256 shares, address receiver)
+        public
+        virtual
+        override(ERC4626Vault, IERC4626)
+        whenNotPaused
+        nonReentrant
+        returns (uint256 assets)
+    {
+        return super.mint(shares, receiver);
+    }
+
+    /// @notice Withdraws `assets` to `receiver` from `owner`.
+    /// @param assets Asset amount.
+    /// @param receiver Asset receiver.
+    /// @param owner Share owner.
+    /// @return shares Burned shares.
+    function withdraw(uint256 assets, address receiver, address owner)
+        public
+        virtual
+        override(ERC4626Vault, IERC4626)
+        whenNotPaused
+        nonReentrant
+        returns (uint256 shares)
+    {
+        return super.withdraw(assets, receiver, owner);
+    }
+
+    /// @notice Redeems `shares` from `owner` to `receiver`.
+    /// @param shares Share amount.
+    /// @param receiver Asset receiver.
+    /// @param owner Share owner.
+    /// @return assets Returned assets.
+    function redeem(uint256 shares, address receiver, address owner)
+        public
+        virtual
+        override(ERC4626Vault, IERC4626)
+        whenNotPaused
+        nonReentrant
+        returns (uint256 assets)
+    {
+        return super.redeem(shares, receiver, owner);
+    }
+}

--- a/src/vault/facets/ERC4626VaultFacet.sol
+++ b/src/vault/facets/ERC4626VaultFacet.sol
@@ -5,11 +5,12 @@ import {IERC4626} from "../../interfaces/IERC4626.sol";
 import {IERC4626VaultFacet} from "../../interfaces/IERC4626VaultFacet.sol";
 import {ERC4626Vault} from "../ERC4626Vault.sol";
 import {ERC4626VaultBase} from "../ERC4626VaultBase.sol";
+import {ERC4626VaultControlledCore} from "../ERC4626VaultControlLogic.sol";
 import {VaultFacetControl} from "../VaultFacetControl.sol";
 
 /// @title ERC4626VaultFacet
 /// @notice Hosted ERC-4626 core facet with constructor-free initialization.
-contract ERC4626VaultFacet is ERC4626Vault, VaultFacetControl, IERC4626VaultFacet {
+contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IERC4626VaultFacet {
     /// @notice Returns true when vault storage is initialized.
     /// @return True if initialized.
     function isVaultInitialized() public view virtual override(IERC4626VaultFacet, ERC4626VaultBase) returns (bool) {
@@ -60,7 +61,7 @@ contract ERC4626VaultFacet is ERC4626Vault, VaultFacetControl, IERC4626VaultFace
         nonReentrant
         returns (uint256 shares)
     {
-        return super.deposit(assets, receiver);
+        return _depositWithControls(assets, receiver);
     }
 
     /// @notice Mints `shares` to `receiver`.
@@ -75,7 +76,7 @@ contract ERC4626VaultFacet is ERC4626Vault, VaultFacetControl, IERC4626VaultFace
         nonReentrant
         returns (uint256 assets)
     {
-        return super.mint(shares, receiver);
+        return _mintWithControls(shares, receiver);
     }
 
     /// @notice Withdraws `assets` to `receiver` from `owner`.
@@ -91,7 +92,7 @@ contract ERC4626VaultFacet is ERC4626Vault, VaultFacetControl, IERC4626VaultFace
         nonReentrant
         returns (uint256 shares)
     {
-        return super.withdraw(assets, receiver, owner);
+        return _withdrawWithControls(assets, receiver, owner);
     }
 
     /// @notice Redeems `shares` from `owner` to `receiver`.
@@ -107,6 +108,10 @@ contract ERC4626VaultFacet is ERC4626Vault, VaultFacetControl, IERC4626VaultFace
         nonReentrant
         returns (uint256 assets)
     {
-        return super.redeem(shares, receiver, owner);
+        return _redeemWithControls(shares, receiver, owner);
+    }
+
+    function _vaultOperationsPaused() internal view virtual override returns (bool) {
+        return paused();
     }
 }

--- a/src/vault/facets/ERC4626VaultIntegrationFacet.sol
+++ b/src/vault/facets/ERC4626VaultIntegrationFacet.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC20} from "../../interfaces/IERC20.sol";
+import {IERC4626VaultIntegrationFacet} from "../../interfaces/IERC4626VaultIntegrationFacet.sol";
+import {IOracleAdapter} from "../../interfaces/IOracleAdapter.sol";
+import {ERC4626Vault} from "../ERC4626Vault.sol";
+import {VaultFacetControl} from "../VaultFacetControl.sol";
+import {LibERC4626VaultStorage} from "../storage/LibERC4626VaultStorage.sol";
+
+/// @title ERC4626VaultIntegrationFacet
+/// @notice Hosted integration/config facet for oracle references and strategy reports.
+contract ERC4626VaultIntegrationFacet is ERC4626Vault, VaultFacetControl, IERC4626VaultIntegrationFacet {
+    /// @notice Returns the configured external oracle adapter address.
+    /// @return The adapter address, or zero when unset.
+    function oracleAdapter() public view returns (address) {
+        return LibERC4626VaultStorage.layout().oracleAdapter;
+    }
+
+    /// @notice Returns the configured strategy address.
+    /// @return The strategy address, or zero when unset.
+    function strategy() public view returns (address) {
+        return LibERC4626VaultStorage.layout().strategy;
+    }
+
+    /// @notice Returns the latest reported strategy-held asset amount.
+    /// @return The reported asset amount.
+    function strategyReportedAssets() public view returns (uint256) {
+        return LibERC4626VaultStorage.layout().strategyReportedAssets;
+    }
+
+    /// @notice Returns the vault's idle underlying asset balance.
+    /// @return The idle asset amount held directly by the vault.
+    function idleAssets() public view returns (uint256) {
+        _requireInitialized();
+        return IERC20(asset()).balanceOf(address(this));
+    }
+
+    /// @notice Returns idle assets plus the latest reported strategy assets.
+    /// @return The estimated total assets across idle vault balance and strategy reports.
+    function estimatedTotalManagedAssets() public view returns (uint256) {
+        return idleAssets() + strategyReportedAssets();
+    }
+
+    /// @notice Returns the latest normalized quote from the configured oracle adapter.
+    /// @return quotePayload The latest quote payload.
+    function oracleQuote() public view returns (IOracleAdapter.OracleQuote memory quotePayload) {
+        _requireInitialized();
+        address adapter = oracleAdapter();
+        if (adapter == address(0)) {
+            revert ERC4626VaultOracleAdapterNotConfigured();
+        }
+
+        return IOracleAdapter(adapter).quote();
+    }
+
+    /// @notice Sets the external oracle adapter reference.
+    /// @param newAdapter The new adapter address, or zero to clear.
+    function setOracleAdapter(address newAdapter) public {
+        _requireInitialized();
+        _checkRole(VAULT_MANAGER_ROLE(), msg.sender);
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        address previousAdapter = layout.oracleAdapter;
+        layout.oracleAdapter = newAdapter;
+
+        emit VaultOracleAdapterUpdated(previousAdapter, newAdapter, msg.sender);
+    }
+
+    /// @notice Sets the configured strategy reference.
+    /// @param newStrategy The new strategy address, or zero to clear.
+    function setStrategy(address newStrategy) public {
+        _requireInitialized();
+        _checkRole(VAULT_MANAGER_ROLE(), msg.sender);
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        address previousStrategy = layout.strategy;
+        layout.strategy = newStrategy;
+        layout.strategyReportedAssets = 0;
+
+        emit VaultStrategyUpdated(previousStrategy, newStrategy, msg.sender);
+    }
+
+    /// @notice Updates the latest reported strategy-held asset amount.
+    /// @param assets The latest reported asset amount.
+    function reportStrategyAssets(uint256 assets) public {
+        _requireInitialized();
+        address configuredStrategy = strategy();
+        if (msg.sender != configuredStrategy || configuredStrategy == address(0)) {
+            if (!hasRole(VAULT_MANAGER_ROLE(), msg.sender)) {
+                revert ERC4626VaultStrategyReporterUnauthorized(msg.sender, configuredStrategy);
+            }
+        }
+
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        uint256 previousAssets = layout.strategyReportedAssets;
+        layout.strategyReportedAssets = assets;
+
+        emit VaultStrategyAssetsReported(previousAssets, assets, msg.sender);
+    }
+}

--- a/src/vault/libraries/LibVaultFacetConstants.sol
+++ b/src/vault/libraries/LibVaultFacetConstants.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title LibVaultFacetConstants
+/// @notice Canonical role identifiers for hosted vault facets.
+library LibVaultFacetConstants {
+    /// @dev Role that can manage vault fees and limits.
+    bytes32 internal constant VAULT_MANAGER_ROLE = keccak256("VAULT_MANAGER_ROLE");
+}

--- a/src/vault/libraries/LibVaultFacetSelectors.sol
+++ b/src/vault/libraries/LibVaultFacetSelectors.sol
@@ -10,6 +10,7 @@ import {IERC4626} from "../../interfaces/IERC4626.sol";
 import {IERC4626VaultBase} from "../../interfaces/IERC4626VaultBase.sol";
 import {IERC4626VaultControls} from "../../interfaces/IERC4626VaultControls.sol";
 import {IERC4626VaultFacet} from "../../interfaces/IERC4626VaultFacet.sol";
+import {IERC4626VaultIntegrationFacet} from "../../interfaces/IERC4626VaultIntegrationFacet.sol";
 import {IPausable} from "../../interfaces/IPausable.sol";
 import {IReentrancyGuard} from "../../interfaces/IReentrancyGuard.sol";
 
@@ -80,5 +81,19 @@ library LibVaultFacetSelectors {
         selectors[25] = IPausable.unpauseScope.selector;
         selectors[26] = IReentrancyGuard.reentrancyGuardEntered.selector;
         selectors[27] = IERC165.supportsInterface.selector;
+    }
+
+    /// @notice Returns the hosted vault integration selector group.
+    function vaultIntegrationSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](9);
+        selectors[0] = IERC4626VaultIntegrationFacet.oracleAdapter.selector;
+        selectors[1] = IERC4626VaultIntegrationFacet.strategy.selector;
+        selectors[2] = IERC4626VaultIntegrationFacet.strategyReportedAssets.selector;
+        selectors[3] = IERC4626VaultIntegrationFacet.idleAssets.selector;
+        selectors[4] = IERC4626VaultIntegrationFacet.estimatedTotalManagedAssets.selector;
+        selectors[5] = IERC4626VaultIntegrationFacet.oracleQuote.selector;
+        selectors[6] = IERC4626VaultIntegrationFacet.setOracleAdapter.selector;
+        selectors[7] = IERC4626VaultIntegrationFacet.setStrategy.selector;
+        selectors[8] = IERC4626VaultIntegrationFacet.reportStrategyAssets.selector;
     }
 }

--- a/src/vault/libraries/LibVaultFacetSelectors.sol
+++ b/src/vault/libraries/LibVaultFacetSelectors.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "../../interfaces/IAccessControl.sol";
+import {IAccessControlTime} from "../../interfaces/IAccessControlTime.sol";
+import {IERC20} from "../../interfaces/IERC20.sol";
+import {IERC20Metadata} from "../../interfaces/IERC20Metadata.sol";
+import {IERC165} from "../../interfaces/IERC165.sol";
+import {IERC4626} from "../../interfaces/IERC4626.sol";
+import {IERC4626VaultBase} from "../../interfaces/IERC4626VaultBase.sol";
+import {IERC4626VaultControls} from "../../interfaces/IERC4626VaultControls.sol";
+import {IERC4626VaultFacet} from "../../interfaces/IERC4626VaultFacet.sol";
+import {IPausable} from "../../interfaces/IPausable.sol";
+import {IReentrancyGuard} from "../../interfaces/IReentrancyGuard.sol";
+
+/// @title LibVaultFacetSelectors
+/// @notice Canonical selector groups for future hosted vault facet splits.
+library LibVaultFacetSelectors {
+    /// @notice Returns the hosted vault core selector group.
+    function vaultCoreSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](28);
+        selectors[0] = IERC4626VaultFacet.initializeVault.selector;
+        selectors[1] = IERC4626VaultBase.isVaultInitialized.selector;
+        selectors[2] = IERC4626.asset.selector;
+        selectors[3] = IERC4626VaultBase.totalManagedAssets.selector;
+        selectors[4] = IERC20Metadata.name.selector;
+        selectors[5] = IERC20Metadata.symbol.selector;
+        selectors[6] = IERC20Metadata.decimals.selector;
+        selectors[7] = IERC20.totalSupply.selector;
+        selectors[8] = IERC20.balanceOf.selector;
+        selectors[9] = IERC20.allowance.selector;
+        selectors[10] = IERC20.transfer.selector;
+        selectors[11] = IERC20.approve.selector;
+        selectors[12] = IERC20.transferFrom.selector;
+        selectors[13] = IERC4626.totalAssets.selector;
+        selectors[14] = IERC4626.convertToShares.selector;
+        selectors[15] = IERC4626.convertToAssets.selector;
+        selectors[16] = IERC4626.maxDeposit.selector;
+        selectors[17] = IERC4626.previewDeposit.selector;
+        selectors[18] = IERC4626.deposit.selector;
+        selectors[19] = IERC4626.maxMint.selector;
+        selectors[20] = IERC4626.previewMint.selector;
+        selectors[21] = IERC4626.mint.selector;
+        selectors[22] = IERC4626.maxWithdraw.selector;
+        selectors[23] = IERC4626.previewWithdraw.selector;
+        selectors[24] = IERC4626.withdraw.selector;
+        selectors[25] = IERC4626.maxRedeem.selector;
+        selectors[26] = IERC4626.previewRedeem.selector;
+        selectors[27] = IERC4626.redeem.selector;
+    }
+
+    /// @notice Returns the hosted vault controls selector group.
+    function vaultControlsSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](28);
+        selectors[0] = IERC4626VaultControls.VAULT_MANAGER_ROLE.selector;
+        selectors[1] = IERC4626VaultControls.feeConfig.selector;
+        selectors[2] = IERC4626VaultControls.limitConfig.selector;
+        selectors[3] = IERC4626VaultControls.setFeeConfig.selector;
+        selectors[4] = IERC4626VaultControls.setLimitConfig.selector;
+        selectors[5] = IAccessControl.DEFAULT_ADMIN_ROLE.selector;
+        selectors[6] = IPausable.PAUSER_ROLE.selector;
+        selectors[7] = IAccessControl.hasRole.selector;
+        selectors[8] = IAccessControl.getRoleAdmin.selector;
+        selectors[9] = IAccessControl.grantRole.selector;
+        selectors[10] = IAccessControl.revokeRole.selector;
+        selectors[11] = IAccessControl.renounceRole.selector;
+        selectors[12] = IAccessControl.getRoleMember.selector;
+        selectors[13] = IAccessControl.getRoleMemberCount.selector;
+        selectors[14] = IAccessControlTime.grantRoleWithWindow.selector;
+        selectors[15] = IAccessControlTime.setRoleWindow.selector;
+        selectors[16] = IAccessControlTime.clearRoleWindow.selector;
+        selectors[17] = IAccessControlTime.getRoleWindow.selector;
+        selectors[18] = IAccessControlTime.hasActiveRole.selector;
+        selectors[19] = bytes4(keccak256("paused()"));
+        selectors[20] = bytes4(keccak256("paused(bytes32)"));
+        selectors[21] = IPausable.scopePaused.selector;
+        selectors[22] = IPausable.pause.selector;
+        selectors[23] = IPausable.unpause.selector;
+        selectors[24] = IPausable.pauseScope.selector;
+        selectors[25] = IPausable.unpauseScope.selector;
+        selectors[26] = IReentrancyGuard.reentrancyGuardEntered.selector;
+        selectors[27] = IERC165.supportsInterface.selector;
+    }
+}

--- a/src/vault/storage/LibERC4626VaultStorage.sol
+++ b/src/vault/storage/LibERC4626VaultStorage.sol
@@ -26,6 +26,7 @@ library LibERC4626VaultStorage {
     /// @notice Vault storage layout.
     struct Layout {
         bool initialized;
+        bool controlPlaneInitialized;
         address asset;
         uint8 decimals;
         string name;

--- a/src/vault/storage/LibERC4626VaultStorage.sol
+++ b/src/vault/storage/LibERC4626VaultStorage.sol
@@ -37,6 +37,9 @@ library LibERC4626VaultStorage {
         uint256 totalManagedAssets;
         FeeConfig fees;
         LimitConfig limits;
+        address oracleAdapter;
+        address strategy;
+        uint256 strategyReportedAssets;
     }
 
     /// @notice Returns the storage layout for vault state.

--- a/test/DiamondVaultDeploymentIntegration.t.sol
+++ b/test/DiamondVaultDeploymentIntegration.t.sol
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {DiamondCutFacet} from "../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../src/diamond/facets/DiamondLoupeFacet.sol";
+import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
+import {IERC165} from "../src/interfaces/IERC165.sol";
+import {IERC20Metadata} from "../src/interfaces/IERC20Metadata.sol";
+import {IERC4626VaultBase} from "../src/interfaces/IERC4626VaultBase.sol";
+import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol";
+import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControlsFacet.sol";
+import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
+import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
+import {IOracleAdapter} from "../src/interfaces/IOracleAdapter.sol";
+import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
+import {DiamondVaultDeploymentFixture} from "./helpers/DiamondVaultDeploymentTestHarness.sol";
+
+contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture {
+    function testVaultHostDeployInstallInitAndOracleWiring() public {
+        _installVaultHostFacets();
+        _initializeVaultHost();
+        _wireOracleAdapter();
+
+        IDiamondLoupe loupe = IDiamondLoupe(address(diamond));
+        address[] memory facetAddresses = loupe.facetAddresses();
+        IOracleAdapter.OracleQuote memory quotePayload = integrationFacetInterface().oracleQuote();
+
+        assertTrue(facetAddresses.length == 5, "vault host facet count mismatch");
+        assertTrue(_containsAddress(facetAddresses, address(cutFacet)), "missing cut facet");
+        assertTrue(_containsAddress(facetAddresses, address(loupeFacet)), "missing loupe facet");
+        assertTrue(_containsAddress(facetAddresses, address(coreFacet)), "missing core facet");
+        assertTrue(_containsAddress(facetAddresses, address(controlsFacet)), "missing controls facet");
+        assertTrue(_containsAddress(facetAddresses, address(integrationFacet)), "missing integration facet");
+
+        assertTrue(
+            loupe.facetFunctionSelectors(address(coreFacet)).length
+                == LibVaultFacetSelectors.vaultCoreSelectors().length,
+            "unexpected core selector count"
+        );
+        assertTrue(
+            loupe.facetFunctionSelectors(address(controlsFacet)).length
+                == LibVaultFacetSelectors.vaultControlsSelectors().length,
+            "unexpected controls selector count"
+        );
+        assertTrue(
+            loupe.facetFunctionSelectors(address(integrationFacet)).length
+                == LibVaultFacetSelectors.vaultIntegrationSelectors().length,
+            "unexpected integration selector count"
+        );
+
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultCoreSelectors(), address(coreFacet));
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultControlsSelectors(), address(controlsFacet));
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultIntegrationSelectors(), address(integrationFacet));
+
+        assertTrue(loupe.facetAddress(DiamondCutFacet.diamondCut.selector) == address(cutFacet), "cut owner mismatch");
+        assertTrue(loupe.facetAddress(DiamondLoupeFacet.facets.selector) == address(loupeFacet), "loupe owner mismatch");
+        assertTrue(
+            loupe.facetAddress(IERC4626VaultFacet.initializeVault.selector) == address(coreFacet), "init owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC4626VaultControls.VAULT_MANAGER_ROLE.selector) == address(controlsFacet),
+            "vault manager owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC4626VaultIntegrationFacet.oracleAdapter.selector) == address(integrationFacet),
+            "oracle selector owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC165.supportsInterface.selector) == address(controlsFacet),
+            "supportsInterface owner mismatch"
+        );
+
+        assertTrue(coreFacetInterface().isVaultInitialized(), "vault should be initialized");
+        assertTrue(coreFacetInterface().asset() == address(asset), "asset mismatch");
+        assertTrue(
+            keccak256(bytes(IERC20Metadata(address(diamond)).name())) == keccak256(bytes("Vault Share")),
+            "name mismatch"
+        );
+        assertTrue(
+            keccak256(bytes(IERC20Metadata(address(diamond)).symbol())) == keccak256(bytes("vSHARE")), "symbol mismatch"
+        );
+
+        assertTrue(
+            controlsFacetInterface().hasRole(controlsFacetInterface().DEFAULT_ADMIN_ROLE(), admin),
+            "missing default admin"
+        );
+        assertTrue(controlsFacetInterface().hasRole(controlsFacetInterface().PAUSER_ROLE(), admin), "missing pauser");
+        assertTrue(
+            controlsFacetInterface().hasRole(controlsFacetInterface().VAULT_MANAGER_ROLE(), admin),
+            "missing vault manager"
+        );
+        (,, address feeRecipient) = controlsFacetInterface().feeConfig();
+        assertTrue(feeRecipient == admin, "fee recipient mismatch");
+
+        assertTrue(integrationFacetInterface().oracleAdapter() == address(adapter), "adapter mismatch");
+        assertTrue(integrationFacetInterface().strategy() == address(0), "strategy should be unset");
+        assertTrue(integrationFacetInterface().strategyReportedAssets() == 0, "reported assets should be zero");
+        assertTrue(quotePayload.value == 100_000_000, "quote value mismatch");
+        assertTrue(quotePayload.updatedAt == quoteUpdatedAt, "quote timestamp mismatch");
+        assertTrue(quotePayload.decimals == 8, "quote decimals mismatch");
+
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC4626VaultFacet).interfaceId), "missing core interface"
+        );
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC4626VaultControlsFacet).interfaceId),
+            "missing controls interface"
+        );
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC4626VaultIntegrationFacet).interfaceId),
+            "missing integration interface"
+        );
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultAlreadyInitialized.selector));
+        coreFacetInterface().initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function _assertSelectorsOwnedByFacet(bytes4[] memory selectors, address expectedFacet) internal view {
+        for (uint256 i = 0; i < selectors.length; i++) {
+            assertTrue(
+                IDiamondLoupe(address(diamond)).facetAddress(selectors[i]) == expectedFacet, "selector owner mismatch"
+            );
+        }
+    }
+}

--- a/test/DiamondVaultHostHardening.t.sol
+++ b/test/DiamondVaultHostHardening.t.sol
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
+import {IERC165} from "../src/interfaces/IERC165.sol";
+import {IERC20Metadata} from "../src/interfaces/IERC20Metadata.sol";
+import {IERC4626} from "../src/interfaces/IERC4626.sol";
+import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol";
+import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControlsFacet.sol";
+import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
+import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
+import {IPausable} from "../src/interfaces/IPausable.sol";
+import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
+import {
+    DiamondVaultHostHardeningFixture,
+    IFacetVersionMarker
+} from "./helpers/DiamondVaultHostHardeningTestHarness.sol";
+
+contract DiamondVaultHostHardeningTest is DiamondVaultHostHardeningFixture {
+    function testCoreFacetReplaceRemoveReAddPreservesState() public {
+        _installAndSeedVaultHost();
+
+        _replaceCoreFacet(address(coreReplacement));
+        _addCoreReplacementMarker(address(coreReplacement));
+
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultCoreSelectors(), address(coreReplacement));
+        assertTrue(
+            IDiamondLoupe(address(diamond)).facetAddress(IFacetVersionMarker.facetVersion.selector)
+                == address(coreReplacement),
+            "core marker owner mismatch"
+        );
+        assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "core replacement marker mismatch");
+        assertTrue(coreFacetInterface().asset() == address(asset), "core asset mismatch after replace");
+        assertTrue(
+            keccak256(bytes(IERC20Metadata(address(diamond)).name())) == keccak256(bytes("Vault Share")),
+            "core name mismatch after replace"
+        );
+        assertTrue(
+            keccak256(bytes(IERC20Metadata(address(diamond)).symbol())) == keccak256(bytes("vSHARE")),
+            "core symbol mismatch after replace"
+        );
+        assertTrue(coreFacetInterface().totalManagedAssets() == BOB_DEPOSIT + CAROL_DEPOSIT, "managed assets mismatch");
+        assertTrue(coreFacetInterface().totalAssets() == BOB_DEPOSIT + CAROL_DEPOSIT, "total assets mismatch");
+        assertTrue(coreFacetInterface().totalSupply() == BOB_DEPOSIT + CAROL_DEPOSIT, "total supply mismatch");
+        assertTrue(coreFacetInterface().balanceOf(bob) == BOB_DEPOSIT, "bob balance mismatch");
+        assertTrue(coreFacetInterface().balanceOf(carol) == CAROL_DEPOSIT, "carol balance mismatch");
+        assertTrue(coreFacetInterface().allowance(bob, eve) == SHARE_ALLOWANCE, "share allowance mismatch");
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC4626VaultFacet).interfaceId),
+            "core interface missing after replace"
+        );
+
+        _removeCoreFacetWithMarker();
+
+        _assertMissingSelector(abi.encodeWithSelector(IERC4626.asset.selector), "core asset selector should be missing");
+        _assertMissingSelector(
+            abi.encodeWithSelector(IERC20Metadata.name.selector), "core metadata selector should be missing"
+        );
+        assertTrue(
+            !IERC165(address(diamond)).supportsInterface(type(IERC4626VaultFacet).interfaceId),
+            "core interface should be absent when selectors removed"
+        );
+        (,, address feeRecipient) = controlsFacetInterface().feeConfig();
+        assertTrue(feeRecipient == feeSink, "controls should still route after core removal");
+        assertTrue(
+            integrationFacetInterface().oracleAdapter() == address(adapter),
+            "integration should still route after core removal"
+        );
+
+        _reAddCoreFacetWithMarker(address(coreReplacement));
+
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultCoreSelectors(), address(coreReplacement));
+        assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "core marker mismatch after re-add");
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC4626VaultFacet).interfaceId),
+            "core interface missing after re-add"
+        );
+        assertTrue(coreFacetInterface().asset() == address(asset), "core asset mismatch after re-add");
+        assertTrue(
+            coreFacetInterface().totalSupply() == BOB_DEPOSIT + CAROL_DEPOSIT, "core supply mismatch after re-add"
+        );
+        assertTrue(coreFacetInterface().balanceOf(bob) == BOB_DEPOSIT, "bob balance mismatch after re-add");
+        assertTrue(coreFacetInterface().balanceOf(carol) == CAROL_DEPOSIT, "carol balance mismatch after re-add");
+        assertTrue(coreFacetInterface().allowance(bob, eve) == SHARE_ALLOWANCE, "allowance mismatch after re-add");
+    }
+
+    function testControlsFacetReplaceRemoveReAddPreservesControlState() public {
+        _installAndSeedVaultHost();
+        _pauseVault();
+
+        _replaceControlsFacet(address(controlsReplacement));
+        _addControlsReplacementMarker(address(controlsReplacement));
+
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultControlsSelectors(), address(controlsReplacement));
+        assertTrue(
+            IDiamondLoupe(address(diamond)).facetAddress(IERC165.supportsInterface.selector)
+                == address(controlsReplacement),
+            "supportsInterface owner mismatch after controls replace"
+        );
+        assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "controls replacement marker mismatch");
+        _assertControlsState();
+        assertTrue(controlsFacetInterface().paused(), "paused state should persist after replace");
+        assertFalse(controlsFacetInterface().reentrancyGuardEntered(), "reentrancy should not be entered");
+
+        _removeControlsFacetWithMarker();
+
+        _assertMissingSelector(
+            abi.encodeWithSelector(IERC4626VaultControls.feeConfig.selector),
+            "controls fee config selector should be missing"
+        );
+        _assertMissingSelector(
+            abi.encodeWithSelector(IERC165.supportsInterface.selector, type(IERC4626VaultFacet).interfaceId),
+            "supportsInterface selector should be missing"
+        );
+        assertTrue(coreFacetInterface().asset() == address(asset), "core should still route after controls removal");
+        assertTrue(
+            integrationFacetInterface().strategyReportedAssets() == STRATEGY_REPORTED_ASSETS,
+            "integration should still route after controls removal"
+        );
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+        coreFacetInterface().deposit(1, bob);
+
+        _reAddControlsFacetWithMarker(address(controlsReplacement));
+
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultControlsSelectors(), address(controlsReplacement));
+        assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "controls marker mismatch after re-add");
+        _assertControlsState();
+        assertTrue(controlsFacetInterface().paused(), "paused state should persist after re-add");
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC4626VaultFacet).interfaceId),
+            "core interface should be reported after controls re-add"
+        );
+        _unpauseVault();
+
+        VM.prank(dave);
+        coreFacetInterface().deposit(1, dave);
+        assertTrue(coreFacetInterface().balanceOf(dave) == 1, "dave should receive shares after unpause");
+    }
+
+    function testIntegrationFacetReplaceRemoveReAddPreservesIntegrationState() public {
+        _installAndSeedVaultHost();
+
+        _replaceIntegrationFacet(address(integrationReplacement));
+        _addIntegrationReplacementMarker(address(integrationReplacement));
+
+        _assertSelectorsOwnedByFacet(
+            LibVaultFacetSelectors.vaultIntegrationSelectors(), address(integrationReplacement)
+        );
+        assertTrue(
+            IDiamondLoupe(address(diamond)).facetAddress(IFacetVersionMarker.facetVersion.selector)
+                == address(integrationReplacement),
+            "integration marker owner mismatch"
+        );
+        assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "integration replacement marker mismatch");
+        _assertIntegrationState();
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC4626VaultIntegrationFacet).interfaceId),
+            "integration interface missing after replace"
+        );
+
+        _removeIntegrationFacetWithMarker();
+
+        _assertMissingSelector(
+            abi.encodeWithSelector(IERC4626VaultIntegrationFacet.oracleAdapter.selector),
+            "integration oracle selector should be missing"
+        );
+        assertTrue(coreFacetInterface().asset() == address(asset), "core should still route after integration removal");
+        assertTrue(
+            controlsFacetInterface().hasRole(controlsFacetInterface().VAULT_MANAGER_ROLE(), eve),
+            "controls should still route after integration removal"
+        );
+        assertTrue(
+            !IERC165(address(diamond)).supportsInterface(type(IERC4626VaultIntegrationFacet).interfaceId),
+            "integration interface should be absent when selectors removed"
+        );
+
+        _reAddIntegrationFacetWithMarker(address(integrationReplacement));
+
+        _assertSelectorsOwnedByFacet(
+            LibVaultFacetSelectors.vaultIntegrationSelectors(), address(integrationReplacement)
+        );
+        assertTrue(
+            IFacetVersionMarker(address(diamond)).facetVersion() == 2, "integration marker mismatch after re-add"
+        );
+        _assertIntegrationState();
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC4626VaultIntegrationFacet).interfaceId),
+            "integration interface missing after re-add"
+        );
+    }
+
+    function _assertSelectorsOwnedByFacet(bytes4[] memory selectors, address expectedFacet) internal view {
+        for (uint256 i = 0; i < selectors.length; i++) {
+            assertTrue(
+                IDiamondLoupe(address(diamond)).facetAddress(selectors[i]) == expectedFacet, "selector owner mismatch"
+            );
+        }
+    }
+
+    function _assertControlsState() internal view {
+        bytes32 managerRole = controlsFacetInterface().VAULT_MANAGER_ROLE();
+        (uint16 depositFeeBps, uint16 withdrawFeeBps, address feeRecipient) = controlsFacetInterface().feeConfig();
+        (uint128 maxTotalAssets, uint128 maxDeposit, uint128 maxMint, uint128 maxWithdraw, uint128 maxRedeem) =
+            controlsFacetInterface().limitConfig();
+        (uint64 start, uint64 end, bool exists) = controlsFacetInterface().getRoleWindow(managerRole, dave);
+
+        assertTrue(depositFeeBps == 100, "deposit fee mismatch");
+        assertTrue(withdrawFeeBps == 50, "withdraw fee mismatch");
+        assertTrue(feeRecipient == feeSink, "fee recipient mismatch");
+        assertTrue(maxTotalAssets == 900_000, "max total assets mismatch");
+        assertTrue(maxDeposit == 300_000, "max deposit mismatch");
+        assertTrue(maxMint == 300_000, "max mint mismatch");
+        assertTrue(maxWithdraw == 250_000, "max withdraw mismatch");
+        assertTrue(maxRedeem == 250_000, "max redeem mismatch");
+        assertTrue(controlsFacetInterface().hasRole(managerRole, eve), "eve manager role mismatch");
+        assertTrue(start == uint64(currentTime - 100), "role window start mismatch");
+        assertTrue(end == uint64(currentTime + 1_000), "role window end mismatch");
+        assertTrue(exists, "role window should exist");
+        assertTrue(controlsFacetInterface().hasActiveRole(managerRole, dave), "dave active manager role mismatch");
+    }
+
+    function _assertIntegrationState() internal view {
+        assertTrue(integrationFacetInterface().oracleAdapter() == address(adapter), "oracle adapter mismatch");
+        assertTrue(integrationFacetInterface().strategy() == strategyReporter, "strategy mismatch");
+        assertTrue(
+            integrationFacetInterface().strategyReportedAssets() == STRATEGY_REPORTED_ASSETS,
+            "strategy reported assets mismatch"
+        );
+        assertTrue(integrationFacetInterface().idleAssets() == BOB_DEPOSIT + CAROL_DEPOSIT, "idle assets mismatch");
+        assertTrue(
+            integrationFacetInterface().estimatedTotalManagedAssets()
+                == BOB_DEPOSIT + CAROL_DEPOSIT + STRATEGY_REPORTED_ASSETS,
+            "estimated managed assets mismatch"
+        );
+    }
+}

--- a/test/DiamondVaultHostInvariant.t.sol
+++ b/test/DiamondVaultHostInvariant.t.sol
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol";
+import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
+import {IPausable} from "../src/interfaces/IPausable.sol";
+import {DiamondVaultHostHardeningFixture} from "./helpers/DiamondVaultHostHardeningTestHarness.sol";
+
+contract DiamondVaultHostInvariantTest is DiamondVaultHostHardeningFixture {
+    uint256 internal constant EXPECTED_INITIAL_ASSET_SUPPLY = INITIAL_ASSETS * ACTOR_COUNT;
+
+    function setUp() public override {
+        super.setUp();
+        _installVaultHostFacets();
+        _initializeVaultHost();
+        _wireOracleAdapter();
+
+        VM.prank(admin);
+        controlsFacetInterface().setFeeConfig(0, 0, feeSink);
+    }
+
+    function targetContracts() external view returns (address[] memory contracts) {
+        contracts = new address[](1);
+        contracts[0] = address(this);
+    }
+
+    function actionDeposit(uint8 actorSeed, uint96 assetsRaw) external {
+        address actor = _actor(actorSeed);
+        uint256 maxAssets = _min(coreFacetInterface().maxDeposit(actor), asset.balanceOf(actor));
+        uint256 assets_ = _boundAmount(assetsRaw, maxAssets);
+        if (assets_ == 0 || coreFacetInterface().previewDeposit(assets_) == 0) {
+            return;
+        }
+
+        if (controlsFacetInterface().paused()) {
+            VM.startPrank(actor);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+            coreFacetInterface().deposit(assets_, actor);
+            VM.stopPrank();
+            return;
+        }
+
+        VM.prank(actor);
+        coreFacetInterface().deposit(assets_, actor);
+    }
+
+    function actionMint(uint8 actorSeed, uint96 sharesRaw) external {
+        address actor = _actor(actorSeed);
+        uint256 feasibleShares = coreFacetInterface().previewDeposit(asset.balanceOf(actor));
+        uint256 maxShares = _min(coreFacetInterface().maxMint(actor), feasibleShares);
+        uint256 shares = _boundAmount(sharesRaw, maxShares);
+        if (shares == 0) {
+            return;
+        }
+
+        uint256 requiredAssets = coreFacetInterface().previewMint(shares);
+        if (requiredAssets == 0 || requiredAssets > asset.balanceOf(actor)) {
+            return;
+        }
+
+        if (controlsFacetInterface().paused()) {
+            VM.startPrank(actor);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+            coreFacetInterface().mint(shares, actor);
+            VM.stopPrank();
+            return;
+        }
+
+        VM.prank(actor);
+        coreFacetInterface().mint(shares, actor);
+    }
+
+    function actionWithdraw(uint8 actorSeed, uint96 assetsRaw) external {
+        address actor = _actor(actorSeed);
+        uint256 assets_ = _boundAmount(assetsRaw, coreFacetInterface().maxWithdraw(actor));
+        if (assets_ == 0) {
+            return;
+        }
+
+        if (controlsFacetInterface().paused()) {
+            VM.startPrank(actor);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+            coreFacetInterface().withdraw(assets_, actor, actor);
+            VM.stopPrank();
+            return;
+        }
+
+        VM.prank(actor);
+        coreFacetInterface().withdraw(assets_, actor, actor);
+    }
+
+    function actionRedeem(uint8 actorSeed, uint96 sharesRaw) external {
+        address actor = _actor(actorSeed);
+        uint256 shares = _boundAmount(sharesRaw, coreFacetInterface().maxRedeem(actor));
+        if (shares == 0 || coreFacetInterface().previewRedeem(shares) == 0) {
+            return;
+        }
+
+        if (controlsFacetInterface().paused()) {
+            VM.startPrank(actor);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+            coreFacetInterface().redeem(shares, actor, actor);
+            VM.stopPrank();
+            return;
+        }
+
+        VM.prank(actor);
+        coreFacetInterface().redeem(shares, actor, actor);
+    }
+
+    function actionApprove(uint8 ownerSeed, uint8 spenderSeed, uint96 sharesRaw) external {
+        address owner = _actor(ownerSeed);
+        address spender = _actorExcluding(owner, spenderSeed);
+
+        VM.prank(owner);
+        coreFacetInterface().approve(spender, uint256(sharesRaw));
+    }
+
+    function actionTransfer(uint8 fromSeed, uint8 toSeed, uint96 sharesRaw) external {
+        address from = _actor(fromSeed);
+        address to = _actorExcluding(from, toSeed);
+        uint256 shares = _boundAmount(sharesRaw, coreFacetInterface().balanceOf(from));
+        if (shares == 0) {
+            return;
+        }
+
+        VM.prank(from);
+        coreFacetInterface().transfer(to, shares);
+    }
+
+    function actionTransferFrom(uint8 spenderSeed, uint8 ownerSeed, uint8 toSeed, uint96 sharesRaw) external {
+        address spender = _actor(spenderSeed);
+        address owner = _actor(ownerSeed);
+        if (spender == owner) {
+            return;
+        }
+
+        address to = _actorExcluding(owner, toSeed);
+        uint256 allowance = coreFacetInterface().allowance(owner, spender);
+        uint256 balance = coreFacetInterface().balanceOf(owner);
+        uint256 shares = _boundAmount(sharesRaw, allowance < balance ? allowance : balance);
+        if (shares == 0) {
+            return;
+        }
+
+        VM.prank(spender);
+        coreFacetInterface().transferFrom(owner, to, shares);
+    }
+
+    function actionPauseToggle(bool shouldPause) external {
+        bool isPaused = controlsFacetInterface().paused();
+        if (shouldPause && !isPaused) {
+            _pauseVault();
+        } else if (!shouldPause && isPaused) {
+            _unpauseVault();
+        }
+    }
+
+    function actionSetFeeConfig(uint16 depositFeeRaw, uint16 withdrawFeeRaw) external {
+        AccountingSnapshot memory snapshot = _snapshotAccounting();
+        uint16 depositFeeBps = uint16(uint256(depositFeeRaw) % 2_001);
+        uint16 withdrawFeeBps = uint16(uint256(withdrawFeeRaw) % 2_001);
+
+        VM.prank(admin);
+        controlsFacetInterface().setFeeConfig(depositFeeBps, withdrawFeeBps, feeSink);
+
+        _assertAccountingUnchanged(snapshot, "fee config updates should not mutate core accounting");
+    }
+
+    function actionSetLimitConfig(
+        uint96 totalCapRaw,
+        uint96 depositRaw,
+        uint96 mintRaw,
+        uint96 withdrawRaw,
+        uint96 redeemRaw
+    ) external {
+        AccountingSnapshot memory snapshot = _snapshotAccounting();
+
+        uint256 currentAssets = coreFacetInterface().totalAssets();
+        uint128 maxTotalAssets = totalCapRaw % 4 == 0
+            ? 0
+            : uint128(currentAssets + (uint256(totalCapRaw) % EXPECTED_INITIAL_ASSET_SUPPLY) + 1);
+        uint128 maxDeposit = depositRaw % 4 == 0 ? 0 : uint128((uint256(depositRaw) % INITIAL_ASSETS) + 1);
+        uint128 maxMint = mintRaw % 4 == 0 ? 0 : uint128((uint256(mintRaw) % INITIAL_ASSETS) + 1);
+        uint128 maxWithdraw = withdrawRaw % 4 == 0 ? 0 : uint128((uint256(withdrawRaw) % INITIAL_ASSETS) + 1);
+        uint128 maxRedeem = redeemRaw % 4 == 0 ? 0 : uint128((uint256(redeemRaw) % INITIAL_ASSETS) + 1);
+
+        VM.prank(admin);
+        controlsFacetInterface().setLimitConfig(maxTotalAssets, maxDeposit, maxMint, maxWithdraw, maxRedeem);
+
+        _assertAccountingUnchanged(snapshot, "limit config updates should not mutate core accounting");
+    }
+
+    function actionSetOracleAdapter(bool configured) external {
+        AccountingSnapshot memory snapshot = _snapshotAccounting();
+
+        VM.prank(admin);
+        integrationFacetInterface().setOracleAdapter(configured ? address(adapter) : address(0));
+
+        _assertAccountingUnchanged(snapshot, "oracle adapter updates should not mutate core accounting");
+    }
+
+    function actionSetStrategy(bool configured) external {
+        AccountingSnapshot memory snapshot = _snapshotAccounting();
+
+        VM.prank(admin);
+        integrationFacetInterface().setStrategy(configured ? strategyReporter : address(0));
+
+        _assertAccountingUnchanged(snapshot, "strategy updates should not mutate core accounting");
+    }
+
+    function actionReportStrategyAssets(uint96 assetsRaw, bool asStrategyReporter) external {
+        AccountingSnapshot memory snapshot = _snapshotAccounting();
+        uint256 assets_ = uint256(assetsRaw);
+        address configuredStrategy = integrationFacetInterface().strategy();
+        address caller = asStrategyReporter && configuredStrategy != address(0) ? strategyReporter : admin;
+
+        VM.prank(caller);
+        integrationFacetInterface().reportStrategyAssets(assets_);
+
+        _assertAccountingUnchanged(snapshot, "strategy reports should not mutate core accounting");
+    }
+
+    function invariantManagedAssetsTrackUnderlyingBalance() public view {
+        assertTrue(
+            coreFacetInterface().totalAssets() == asset.balanceOf(address(diamond)),
+            "managed assets should match vault-held underlying"
+        );
+    }
+
+    function invariantShareSupplyMatchesTrackedActorBalances() public view {
+        assertTrue(
+            coreFacetInterface().totalSupply() == _sumTrackedShareBalances(),
+            "share supply should remain equal to tracked balances"
+        );
+    }
+
+    function invariantTrackedUnderlyingRemainsConserved() public view {
+        assertTrue(
+            _sumTrackedUnderlying() == EXPECTED_INITIAL_ASSET_SUPPLY,
+            "tracked underlying should remain conserved across actors, vault, and fee sink"
+        );
+    }
+
+    function invariantEstimatedManagedAssetsReflectIdlePlusReported() public view {
+        assertTrue(
+            integrationFacetInterface().estimatedTotalManagedAssets()
+                == integrationFacetInterface().idleAssets() + integrationFacetInterface().strategyReportedAssets(),
+            "estimated assets should equal idle plus reported strategy assets"
+        );
+        assertTrue(
+            integrationFacetInterface().estimatedTotalManagedAssets() >= coreFacetInterface().totalManagedAssets(),
+            "estimated managed assets should not be less than managed assets"
+        );
+    }
+
+    function invariantPausedStateZeroesMutatingMaxFunctions() public view {
+        if (!controlsFacetInterface().paused()) {
+            return;
+        }
+
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            address actor = actors[i];
+            assertTrue(coreFacetInterface().maxDeposit(actor) == 0, "paused vault should expose zero maxDeposit");
+            assertTrue(coreFacetInterface().maxMint(actor) == 0, "paused vault should expose zero maxMint");
+            assertTrue(coreFacetInterface().maxWithdraw(actor) == 0, "paused vault should expose zero maxWithdraw");
+            assertTrue(coreFacetInterface().maxRedeem(actor) == 0, "paused vault should expose zero maxRedeem");
+        }
+    }
+}

--- a/test/ERC4626VaultControlsFacetCore.t.sol
+++ b/test/ERC4626VaultControlsFacetCore.t.sol
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
+import {IAccessControlTime} from "../src/interfaces/IAccessControlTime.sol";
+import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
+import {IERC165} from "../src/interfaces/IERC165.sol";
+import {IERC4626} from "../src/interfaces/IERC4626.sol";
+import {IERC4626VaultBase} from "../src/interfaces/IERC4626VaultBase.sol";
+import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol";
+import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControlsFacet.sol";
+import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
+import {IPausable} from "../src/interfaces/IPausable.sol";
+import {IReentrancyGuard} from "../src/interfaces/IReentrancyGuard.sol";
+import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
+import {ERC4626VaultControlsFacetFixture} from "./helpers/ERC4626VaultControlsFacetTestHarness.sol";
+
+contract ERC4626VaultControlsFacetCoreTest is ERC4626VaultControlsFacetFixture {
+    function testDirectControlsFacetReadWriteAndInterfaceSupportAfterTestInit() public {
+        _initializeDirectControlsFacet();
+
+        assertTrue(controlsFacet.hasRole(controlsFacet.DEFAULT_ADMIN_ROLE(), admin), "missing default admin role");
+        assertTrue(controlsFacet.hasRole(controlsFacet.PAUSER_ROLE(), admin), "missing pauser role");
+        assertTrue(controlsFacet.hasRole(controlsFacet.VAULT_MANAGER_ROLE(), admin), "missing vault manager role");
+        assertFalse(controlsFacet.reentrancyGuardEntered(), "reentrancy guard should be idle");
+
+        (uint16 depositFeeBps, uint16 withdrawFeeBps, address feeRecipient) = controlsFacet.feeConfig();
+        assertTrue(depositFeeBps == 0, "unexpected deposit fee");
+        assertTrue(withdrawFeeBps == 0, "unexpected withdraw fee");
+        assertTrue(feeRecipient == admin, "unexpected fee recipient");
+
+        (uint128 maxTotalAssets, uint128 maxDeposit, uint128 maxMint, uint128 maxWithdraw, uint128 maxRedeem) =
+            controlsFacet.limitConfig();
+        assertTrue(maxTotalAssets == 0, "unexpected max total assets");
+        assertTrue(maxDeposit == 0, "unexpected max deposit");
+        assertTrue(maxMint == 0, "unexpected max mint");
+        assertTrue(maxWithdraw == 0, "unexpected max withdraw");
+        assertTrue(maxRedeem == 0, "unexpected max redeem");
+
+        assertTrue(controlsFacet.supportsInterface(type(IERC165).interfaceId), "erc165 unsupported");
+        assertTrue(controlsFacet.supportsInterface(type(IERC4626VaultControls).interfaceId), "controls unsupported");
+        assertTrue(
+            controlsFacet.supportsInterface(type(IERC4626VaultControlsFacet).interfaceId), "controls facet unsupported"
+        );
+        assertTrue(controlsFacet.supportsInterface(type(IAccessControl).interfaceId), "access control unsupported");
+        assertTrue(
+            controlsFacet.supportsInterface(type(IAccessControlTime).interfaceId), "access control time unsupported"
+        );
+        assertTrue(controlsFacet.supportsInterface(type(IPausable).interfaceId), "pausable unsupported");
+        assertTrue(controlsFacet.supportsInterface(type(IReentrancyGuard).interfaceId), "reentrancy unsupported");
+        assertFalse(controlsFacet.supportsInterface(type(IERC4626).interfaceId), "erc4626 should not be reported");
+
+        VM.prank(admin);
+        controlsFacet.setFeeConfig(500, 250, eve);
+        VM.prank(admin);
+        controlsFacet.setLimitConfig(1_000, 500, 300, 200, 100);
+
+        (depositFeeBps, withdrawFeeBps, feeRecipient) = controlsFacet.feeConfig();
+        assertTrue(depositFeeBps == 500, "deposit fee not updated");
+        assertTrue(withdrawFeeBps == 250, "withdraw fee not updated");
+        assertTrue(feeRecipient == eve, "fee recipient not updated");
+
+        (maxTotalAssets, maxDeposit, maxMint, maxWithdraw, maxRedeem) = controlsFacet.limitConfig();
+        assertTrue(maxTotalAssets == 1_000, "max total assets not updated");
+        assertTrue(maxDeposit == 500, "max deposit not updated");
+        assertTrue(maxMint == 300, "max mint not updated");
+        assertTrue(maxWithdraw == 200, "max withdraw not updated");
+        assertTrue(maxRedeem == 100, "max redeem not updated");
+    }
+
+    function testDirectControlsFacetRejectsInvalidFeeConfigAndNonManagerCalls() public {
+        _initializeDirectControlsFacet();
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorized.selector, eve, controlsFacet.VAULT_MANAGER_ROLE()
+            )
+        );
+        VM.prank(eve);
+        controlsFacet.setFeeConfig(100, 0, eve);
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultControls.ERC4626VaultInvalidFeeBps.selector, 10_000));
+        controlsFacet.setFeeConfig(10_000, 0, admin);
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultControls.ERC4626VaultInvalidFeeRecipient.selector));
+        controlsFacet.setFeeConfig(100, 0, address(0));
+    }
+
+    function testDirectControlsFacetPauseAndRoleWindowSmoke() public {
+        _initializeDirectControlsFacet();
+        bytes32 scope = keccak256("ops");
+
+        VM.prank(admin);
+        controlsFacet.pauseScope(scope);
+        assertTrue(controlsFacet.scopePaused(scope), "scope should be paused");
+        assertTrue(controlsFacet.paused(scope), "effective scope pause mismatch");
+        assertFalse(controlsFacet.paused(), "global pause should remain unset");
+
+        VM.prank(admin);
+        controlsFacet.unpauseScope(scope);
+        assertFalse(controlsFacet.scopePaused(scope), "scope should be unpaused");
+
+        VM.prank(admin);
+        controlsFacet.pause();
+        assertTrue(controlsFacet.paused(), "global pause should be set");
+
+        VM.prank(admin);
+        controlsFacet.unpause();
+        assertFalse(controlsFacet.paused(), "global pause should clear");
+
+        bytes32 managerRole = controlsFacet.VAULT_MANAGER_ROLE();
+
+        VM.prank(admin);
+        controlsFacet.grantRoleWithWindow(managerRole, eve, 100, 200);
+        assertTrue(controlsFacet.hasRole(managerRole, eve), "manager role missing");
+
+        (uint64 start, uint64 end, bool exists) = controlsFacet.getRoleWindow(managerRole, eve);
+        assertTrue(exists, "window should exist");
+        assertTrue(start == 100, "window start mismatch");
+        assertTrue(end == 200, "window end mismatch");
+
+        VM.warp(99);
+        assertFalse(controlsFacet.hasActiveRole(managerRole, eve), "window should be inactive");
+        VM.warp(100);
+        assertTrue(controlsFacet.hasActiveRole(managerRole, eve), "window should be active");
+        VM.warp(200);
+        assertFalse(controlsFacet.hasActiveRole(managerRole, eve), "window should expire");
+    }
+
+    function testDiamondSelectorsSplitBetweenCoreAndControlsFacets() public {
+        _installHostedVaultFacetsToDiamond();
+        _initializeDiamondVault();
+
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultCoreSelectors(), address(coreFacet));
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultControlsSelectors(), address(controlsFacet));
+
+        assertTrue(
+            IDiamondLoupe(address(diamond)).facetFunctionSelectors(address(coreFacet)).length
+                == LibVaultFacetSelectors.vaultCoreSelectors().length,
+            "unexpected core selector count"
+        );
+        assertTrue(
+            IDiamondLoupe(address(diamond)).facetFunctionSelectors(address(controlsFacet)).length
+                == LibVaultFacetSelectors.vaultControlsSelectors().length,
+            "unexpected controls selector count"
+        );
+        assertTrue(
+            IDiamondLoupe(address(diamond)).facetAddress(IERC4626VaultFacet.initializeVault.selector)
+                == address(coreFacet),
+            "initializer owner mismatch"
+        );
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultAlreadyInitialized.selector));
+        IERC4626VaultFacet(address(diamond)).initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function testDiamondControlsConfigReshapesCoreRouting() public {
+        _installHostedVaultFacetsToDiamond();
+        _initializeDiamondVault();
+        _approveAsset(bob, address(diamond), 200);
+
+        VM.prank(admin);
+        IERC4626VaultControlsFacet(address(diamond)).setFeeConfig(1_000, 1_000, eve);
+        VM.prank(admin);
+        IERC4626VaultControlsFacet(address(diamond)).setLimitConfig(60, 50, 40, 25, 20);
+
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewDeposit(100) == 90, "previewDeposit mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewMint(50) == 56, "previewMint mismatch");
+
+        VM.prank(bob);
+        uint256 shares = IERC4626VaultFacet(address(diamond)).deposit(50, bob);
+        assertTrue(shares == 45, "deposit shares mismatch");
+        assertTrue(asset.balanceOf(eve) == INITIAL_ASSETS + 5, "fee recipient balance mismatch");
+
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxDeposit(bob) == 17, "maxDeposit mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxMint(bob) == 15, "maxMint mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxWithdraw(bob) == 25, "maxWithdraw mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxRedeem(bob) == 20, "maxRedeem mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewWithdraw(20) == 22, "previewWithdraw mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewRedeem(20) == 18, "previewRedeem mismatch");
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultControls.ERC4626VaultDepositLimitExceeded.selector, 18, 17));
+        IERC4626VaultFacet(address(diamond)).deposit(18, bob);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultControls.ERC4626VaultMintLimitExceeded.selector, 16, 15));
+        IERC4626VaultFacet(address(diamond)).mint(16, bob);
+
+        VM.prank(bob);
+        VM.expectRevert(
+            abi.encodeWithSelector(IERC4626VaultControls.ERC4626VaultWithdrawLimitExceeded.selector, 26, 25)
+        );
+        IERC4626VaultFacet(address(diamond)).withdraw(26, bob, bob);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultControls.ERC4626VaultRedeemLimitExceeded.selector, 21, 20));
+        IERC4626VaultFacet(address(diamond)).redeem(21, bob, bob);
+    }
+
+    function testDiamondGlobalPauseBlocksVaultEntrypointsButNotShareTokenFlows() public {
+        _installHostedVaultFacetsToDiamond();
+        _initializeDiamondVault();
+        _approveAsset(bob, address(diamond), 100);
+
+        VM.prank(bob);
+        IERC4626VaultFacet(address(diamond)).deposit(40, bob);
+
+        VM.prank(admin);
+        IERC4626VaultControlsFacet(address(diamond)).pause();
+
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxDeposit(bob) == 0, "maxDeposit should pause");
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxMint(bob) == 0, "maxMint should pause");
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxWithdraw(bob) == 0, "maxWithdraw should pause");
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxRedeem(bob) == 0, "maxRedeem should pause");
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+        IERC4626VaultFacet(address(diamond)).deposit(1, bob);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+        IERC4626VaultFacet(address(diamond)).mint(1, bob);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+        IERC4626VaultFacet(address(diamond)).withdraw(1, bob, bob);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+        IERC4626VaultFacet(address(diamond)).redeem(1, bob, bob);
+
+        VM.prank(bob);
+        IERC4626VaultFacet(address(diamond)).approve(eve, 15);
+        VM.prank(eve);
+        IERC4626VaultFacet(address(diamond)).transferFrom(bob, admin, 10);
+        VM.prank(bob);
+        IERC4626VaultFacet(address(diamond)).transfer(admin, 5);
+
+        assertTrue(IERC4626VaultFacet(address(diamond)).allowance(bob, eve) == 5, "allowance mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).balanceOf(bob) == 25, "bob balance mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).balanceOf(admin) == 15, "admin balance mismatch");
+    }
+
+    function testDiamondScopePauseRoutesButDoesNotBlockVaultEntrypoints() public {
+        _installHostedVaultFacetsToDiamond();
+        _initializeDiamondVault();
+        _approveAsset(bob, address(diamond), 100);
+        bytes32 scope = keccak256("vault-ops");
+
+        VM.prank(admin);
+        IERC4626VaultControlsFacet(address(diamond)).pauseScope(scope);
+
+        assertTrue(IERC4626VaultControlsFacet(address(diamond)).scopePaused(scope), "scope pause mismatch");
+        assertTrue(IERC4626VaultControlsFacet(address(diamond)).paused(scope), "effective scope pause mismatch");
+        assertFalse(IERC4626VaultControlsFacet(address(diamond)).paused(), "global pause should remain unset");
+
+        VM.prank(bob);
+        uint256 shares = IERC4626VaultFacet(address(diamond)).deposit(10, bob);
+        assertTrue(shares == 10, "scope pause should not block deposit");
+    }
+
+    function testDiamondTimeWindowSelectorsRouteForManagerDelegation() public {
+        _installHostedVaultFacetsToDiamond();
+        _initializeDiamondVault();
+
+        bytes32 managerRole = IERC4626VaultControlsFacet(address(diamond)).VAULT_MANAGER_ROLE();
+
+        VM.prank(admin);
+        IERC4626VaultControlsFacet(address(diamond)).grantRoleWithWindow(managerRole, eve, 100, 200);
+
+        (uint64 start, uint64 end, bool exists) =
+            IERC4626VaultControlsFacet(address(diamond)).getRoleWindow(managerRole, eve);
+        assertTrue(exists, "window should exist");
+        assertTrue(start == 100, "window start mismatch");
+        assertTrue(end == 200, "window end mismatch");
+
+        VM.warp(150);
+        assertTrue(
+            IERC4626VaultControlsFacet(address(diamond)).hasActiveRole(managerRole, eve), "window should be active"
+        );
+    }
+
+    function _assertSelectorsOwnedByFacet(bytes4[] memory selectors, address expectedFacet) internal view {
+        for (uint256 i = 0; i < selectors.length; i++) {
+            assertTrue(
+                IDiamondLoupe(address(diamond)).facetAddress(selectors[i]) == expectedFacet, "selector owner mismatch"
+            );
+        }
+    }
+}

--- a/test/ERC4626VaultFacetCore.t.sol
+++ b/test/ERC4626VaultFacetCore.t.sol
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
+import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
+import {IERC4626VaultBase} from "../src/interfaces/IERC4626VaultBase.sol";
+import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
+import {IPausable} from "../src/interfaces/IPausable.sol";
+import {ERC4626Vault} from "../src/vault/ERC4626Vault.sol";
+import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
+import {ERC4626VaultFacetFixture, ERC4626VaultFacetHarness} from "./helpers/ERC4626VaultFacetTestHarness.sol";
+
+contract ERC4626VaultFacetCoreTest is ERC4626VaultFacetFixture {
+    function testInitializeVaultSeedsMetadataAndControlPlane() public {
+        _initializeHostedVault(address(facet));
+
+        assertTrue(facet.isVaultInitialized(), "vault should initialize");
+        assertTrue(facet.controlPlaneInitialized(), "control plane should initialize");
+        assertTrue(facet.asset() == address(asset), "asset mismatch");
+        assertTrue(keccak256(bytes(facet.name())) == keccak256(bytes("Vault Share")), "name mismatch");
+        assertTrue(keccak256(bytes(facet.symbol())) == keccak256(bytes("vSHARE")), "symbol mismatch");
+        assertTrue(facet.decimals() == 6, "decimals mismatch");
+        assertTrue(facet.feeRecipient() == admin, "fee recipient mismatch");
+        assertTrue(facet.hasRole(facet.DEFAULT_ADMIN_ROLE(), admin), "missing default admin role");
+        assertTrue(facet.hasRole(facet.PAUSER_ROLE(), admin), "missing pauser role");
+        assertTrue(facet.hasRole(facet.VAULT_MANAGER_ROLE(), admin), "missing vault manager role");
+        assertFalse(facet.reentrancyGuardEntered(), "reentrancy guard should be idle");
+    }
+
+    function testInitializeVaultRevertsOnZeroAsset() public {
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultZeroAsset.selector));
+        facet.initializeVault(address(0), "Vault Share", "vSHARE", admin);
+    }
+
+    function testInitializeVaultRevertsWhenCalledTwice() public {
+        _initializeHostedVault(address(facet));
+
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultAlreadyInitialized.selector));
+        _initializeHostedVault(address(facet));
+    }
+
+    function testInitializeVaultAfterControlOnlyInitRequiresDefaultAdmin() public {
+        facet.initializeControlOnly(admin);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, facet.DEFAULT_ADMIN_ROLE())
+        );
+        VM.prank(bob);
+        facet.initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+
+        VM.prank(admin);
+        facet.initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+
+        assertTrue(facet.isVaultInitialized(), "vault should initialize");
+        assertTrue(facet.controlPlaneInitialized(), "control plane should stay initialized");
+        assertTrue(facet.feeRecipient() == admin, "fee recipient mismatch");
+    }
+
+    function testCoreFlowsAndShareTokenRoutingWorkOnFacet() public {
+        _initializeHostedVault(address(facet));
+
+        assertTrue(facet.previewDeposit(8) == 8, "preview deposit mismatch");
+        assertTrue(facet.previewMint(8) == 8, "preview mint mismatch");
+
+        _approveAsset(bob, address(facet), 100);
+        _approveAsset(eve, address(facet), 100);
+
+        VM.prank(bob);
+        uint256 bobDepositShares = facet.deposit(40, bob);
+        VM.prank(eve);
+        uint256 eveMintAssets = facet.mint(10, eve);
+
+        VM.prank(bob);
+        bool approveSuccess = facet.approve(eve, 15);
+        VM.prank(eve);
+        bool transferFromSuccess = facet.transferFrom(bob, admin, 10);
+        VM.prank(bob);
+        bool transferSuccess = facet.transfer(admin, 5);
+
+        VM.prank(bob);
+        uint256 bobWithdrawShares = facet.withdraw(10, bob, bob);
+        VM.prank(eve);
+        uint256 eveRedeemAssets = facet.redeem(5, eve, eve);
+
+        assertTrue(bobDepositShares == 40, "deposit shares mismatch");
+        assertTrue(eveMintAssets == 10, "mint assets mismatch");
+        assertTrue(approveSuccess, "approve should succeed");
+        assertTrue(transferFromSuccess, "transferFrom should succeed");
+        assertTrue(transferSuccess, "transfer should succeed");
+        assertTrue(bobWithdrawShares == 10, "withdraw shares mismatch");
+        assertTrue(eveRedeemAssets == 5, "redeem assets mismatch");
+
+        assertTrue(facet.totalAssets() == 35, "total assets mismatch");
+        assertTrue(facet.totalManagedAssets() == 35, "managed assets mismatch");
+        assertTrue(facet.totalSupply() == 35, "total supply mismatch");
+        assertTrue(facet.balanceOf(bob) == 15, "bob balance mismatch");
+        assertTrue(facet.balanceOf(admin) == 15, "admin balance mismatch");
+        assertTrue(facet.balanceOf(eve) == 5, "eve balance mismatch");
+        assertTrue(facet.allowance(bob, eve) == 5, "allowance mismatch");
+        assertTrue(asset.balanceOf(address(facet)) == 35, "vault asset balance mismatch");
+        assertTrue(asset.balanceOf(bob) == INITIAL_ASSETS - 30, "bob asset balance mismatch");
+        assertTrue(asset.balanceOf(eve) == INITIAL_ASSETS - 5, "eve asset balance mismatch");
+    }
+
+    function testPauseBlocksVaultEntrypointsButLeavesShareTokenFlowsAvailable() public {
+        _initializeHostedVault(address(facet));
+        _approveAsset(bob, address(facet), 100);
+
+        VM.prank(bob);
+        facet.deposit(40, bob);
+
+        VM.prank(admin);
+        facet.pause();
+
+        assertTrue(facet.maxDeposit(bob) == type(uint256).max, "maxDeposit should remain baseline");
+        assertTrue(facet.maxMint(bob) == type(uint256).max, "maxMint should remain baseline");
+        assertTrue(facet.maxWithdraw(bob) == 40, "maxWithdraw should remain baseline");
+        assertTrue(facet.maxRedeem(bob) == 40, "maxRedeem should remain baseline");
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+        facet.deposit(1, bob);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+        facet.mint(1, bob);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+        facet.withdraw(1, bob, bob);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+        facet.redeem(1, bob, bob);
+
+        VM.prank(bob);
+        facet.approve(eve, 15);
+        VM.prank(eve);
+        facet.transferFrom(bob, admin, 10);
+        VM.prank(bob);
+        facet.transfer(admin, 5);
+
+        assertTrue(facet.allowance(bob, eve) == 5, "allowance mismatch");
+        assertTrue(facet.balanceOf(bob) == 25, "bob share balance mismatch");
+        assertTrue(facet.balanceOf(admin) == 15, "admin share balance mismatch");
+    }
+
+    function testReentrantAttemptDuringDepositIsBlocked() public {
+        _initializeHostedVault(address(facet));
+        bytes memory payload = abi.encodeCall(ERC4626VaultFacetHarness.probeNonReentrant, ());
+        asset.configureReentry(address(facet), payload, true);
+
+        _approveAsset(bob, address(facet), 100);
+
+        VM.prank(bob);
+        uint256 shares = facet.deposit(10, bob);
+
+        assertTrue(shares == 10, "deposit should succeed");
+        assertTrue(asset.reentryAttemptBlocked(), "expected reentry attempt to be blocked");
+        assertFalse(facet.reentrancyGuardEntered(), "reentrancy guard should reset");
+    }
+
+    function testDiamondRoutingAndInitWorkThroughFallback() public {
+        _installVaultCoreFacetToDiamond();
+
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond)).initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+
+        assertTrue(IERC4626VaultFacet(address(diamond)).isVaultInitialized(), "diamond vault should initialize");
+        assertTrue(IERC4626VaultFacet(address(diamond)).asset() == address(asset), "diamond asset mismatch");
+        assertTrue(
+            keccak256(bytes(IERC4626VaultFacet(address(diamond)).name())) == keccak256(bytes("Vault Share")),
+            "diamond name mismatch"
+        );
+        assertTrue(
+            keccak256(bytes(IERC4626VaultFacet(address(diamond)).symbol())) == keccak256(bytes("vSHARE")),
+            "diamond symbol mismatch"
+        );
+
+        _approveAsset(bob, address(diamond), 100);
+
+        VM.prank(bob);
+        uint256 shares = IERC4626VaultFacet(address(diamond)).deposit(25, bob);
+
+        VM.prank(bob);
+        bool approveSuccess = IERC4626VaultFacet(address(diamond)).approve(eve, 10);
+        VM.prank(eve);
+        bool transferFromSuccess = IERC4626VaultFacet(address(diamond)).transferFrom(bob, admin, 5);
+        VM.prank(bob);
+        uint256 withdrawnShares = IERC4626VaultFacet(address(diamond)).withdraw(10, bob, bob);
+
+        assertTrue(shares == 25, "diamond deposit shares mismatch");
+        assertTrue(approveSuccess, "diamond approve should succeed");
+        assertTrue(transferFromSuccess, "diamond transferFrom should succeed");
+        assertTrue(withdrawnShares == 10, "diamond withdrawn shares mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewDeposit(8) == 8, "diamond preview mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 15, "diamond total assets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 15, "diamond managed assets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).balanceOf(bob) == 10, "diamond bob share balance mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).balanceOf(admin) == 5, "diamond admin share balance mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).allowance(bob, eve) == 5, "diamond allowance mismatch");
+
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultCoreSelectors(), address(facet));
+        assertTrue(
+            IDiamondLoupe(address(diamond)).facetFunctionSelectors(address(facet)).length
+                == LibVaultFacetSelectors.vaultCoreSelectors().length,
+            "diamond core selector count mismatch"
+        );
+    }
+
+    function testDiamondReinitializeReverts() public {
+        _installVaultCoreFacetToDiamond();
+
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond)).initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultAlreadyInitialized.selector));
+        IERC4626VaultFacet(address(diamond)).initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function testDiamondCoreInstallDoesNotExposeControlsSelectors() public {
+        _installVaultCoreFacetToDiamond();
+
+        _assertSelectorsUnset(LibVaultFacetSelectors.vaultControlsSelectors());
+    }
+
+    function _assertSelectorsOwnedByFacet(bytes4[] memory selectors, address expectedFacet) internal view {
+        for (uint256 i = 0; i < selectors.length; i++) {
+            assertTrue(
+                IDiamondLoupe(address(diamond)).facetAddress(selectors[i]) == expectedFacet, "selector owner mismatch"
+            );
+        }
+    }
+
+    function _assertSelectorsUnset(bytes4[] memory selectors) internal view {
+        for (uint256 i = 0; i < selectors.length; i++) {
+            assertTrue(IDiamondLoupe(address(diamond)).facetAddress(selectors[i]) == address(0), "selector set");
+        }
+    }
+}

--- a/test/ERC4626VaultFacetCore.t.sol
+++ b/test/ERC4626VaultFacetCore.t.sol
@@ -112,10 +112,10 @@ contract ERC4626VaultFacetCoreTest is ERC4626VaultFacetFixture {
         VM.prank(admin);
         facet.pause();
 
-        assertTrue(facet.maxDeposit(bob) == type(uint256).max, "maxDeposit should remain baseline");
-        assertTrue(facet.maxMint(bob) == type(uint256).max, "maxMint should remain baseline");
-        assertTrue(facet.maxWithdraw(bob) == 40, "maxWithdraw should remain baseline");
-        assertTrue(facet.maxRedeem(bob) == 40, "maxRedeem should remain baseline");
+        assertTrue(facet.maxDeposit(bob) == 0, "maxDeposit should pause");
+        assertTrue(facet.maxMint(bob) == 0, "maxMint should pause");
+        assertTrue(facet.maxWithdraw(bob) == 0, "maxWithdraw should pause");
+        assertTrue(facet.maxRedeem(bob) == 0, "maxRedeem should pause");
 
         VM.prank(bob);
         VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));

--- a/test/ERC4626VaultIntegrationFacetCore.t.sol
+++ b/test/ERC4626VaultIntegrationFacetCore.t.sol
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
+import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
+import {IERC165} from "../src/interfaces/IERC165.sol";
+import {IERC4626VaultBase} from "../src/interfaces/IERC4626VaultBase.sol";
+import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
+import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
+import {IOracleAdapter} from "../src/interfaces/IOracleAdapter.sol";
+import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
+import {ERC4626VaultIntegrationFacetFixture} from "./helpers/ERC4626VaultIntegrationFacetTestHarness.sol";
+
+contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFixture {
+    function testDirectIntegrationFacetRequiresManagerForConfigAndReporterAuth() public {
+        _initializeDirectIntegrationFacet();
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorized.selector, bob, integrationFacet.VAULT_MANAGER_ROLE()
+            )
+        );
+        VM.prank(bob);
+        integrationFacet.setOracleAdapter(address(adapter));
+
+        VM.prank(admin);
+        integrationFacet.setOracleAdapter(address(adapter));
+        assertTrue(integrationFacet.oracleAdapter() == address(adapter), "adapter mismatch");
+
+        VM.prank(admin);
+        integrationFacet.setStrategy(bob);
+        assertTrue(integrationFacet.strategy() == bob, "strategy mismatch");
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IERC4626VaultIntegrationFacet.ERC4626VaultStrategyReporterUnauthorized.selector, eve, bob
+            )
+        );
+        VM.prank(eve);
+        integrationFacet.reportStrategyAssets(25);
+
+        VM.prank(bob);
+        integrationFacet.reportStrategyAssets(25);
+        assertTrue(integrationFacet.strategyReportedAssets() == 25, "reported assets mismatch");
+    }
+
+    function testDirectIntegrationFacetChangingStrategyClearsReportedAssets() public {
+        _initializeDirectIntegrationFacet();
+
+        VM.prank(admin);
+        integrationFacet.setStrategy(bob);
+        VM.prank(bob);
+        integrationFacet.reportStrategyAssets(75);
+
+        VM.prank(admin);
+        integrationFacet.setStrategy(eve);
+
+        assertTrue(integrationFacet.strategy() == eve, "strategy should update");
+        assertTrue(integrationFacet.strategyReportedAssets() == 0, "reported assets should reset");
+
+        VM.prank(admin);
+        integrationFacet.setStrategy(address(0));
+        assertTrue(integrationFacet.strategy() == address(0), "strategy should clear");
+        assertTrue(integrationFacet.strategyReportedAssets() == 0, "reported assets should stay cleared");
+    }
+
+    function testDirectIntegrationFacetOracleQuoteAndEstimatedAssets() public {
+        _initializeDirectIntegrationFacet();
+
+        VM.expectRevert(
+            abi.encodeWithSelector(IERC4626VaultIntegrationFacet.ERC4626VaultOracleAdapterNotConfigured.selector)
+        );
+        integrationFacet.oracleQuote();
+
+        VM.prank(admin);
+        integrationFacet.setOracleAdapter(address(adapter));
+
+        asset.mint(address(integrationFacet), 40);
+
+        VM.prank(admin);
+        integrationFacet.reportStrategyAssets(25);
+
+        IOracleAdapter.OracleQuote memory quotePayload = integrationFacet.oracleQuote();
+
+        assertTrue(quotePayload.value == 100_000_000, "quote value mismatch");
+        assertTrue(quotePayload.updatedAt == quoteUpdatedAt, "quote timestamp mismatch");
+        assertTrue(quotePayload.decimals == 8, "quote decimals mismatch");
+        assertTrue(integrationFacet.idleAssets() == 40, "idle assets mismatch");
+        assertTrue(integrationFacet.estimatedTotalManagedAssets() == 65, "estimated assets mismatch");
+        assertTrue(integrationFacet.totalManagedAssets() == 0, "managed assets should remain unchanged");
+    }
+
+    function testDirectIntegrationFacetHelpersRevertBeforeVaultInit() public {
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultNotInitialized.selector));
+        integrationFacet.idleAssets();
+
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultNotInitialized.selector));
+        integrationFacet.estimatedTotalManagedAssets();
+
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultNotInitialized.selector));
+        VM.prank(admin);
+        integrationFacet.setOracleAdapter(address(adapter));
+    }
+
+    function testDiamondIntegrationFacetRoutesAndComposesWithCoreAndControls() public {
+        _installHostedVaultFacetsToDiamond();
+        _initializeDiamondVault();
+
+        _approveAsset(bob, address(diamond), 100);
+
+        VM.prank(bob);
+        uint256 mintedShares = IERC4626VaultFacet(address(diamond)).deposit(40, bob);
+
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).setOracleAdapter(address(adapter));
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(eve);
+
+        VM.prank(eve);
+        IERC4626VaultIntegrationFacet(address(diamond)).reportStrategyAssets(25);
+
+        IOracleAdapter.OracleQuote memory quotePayload = IERC4626VaultIntegrationFacet(address(diamond)).oracleQuote();
+
+        assertTrue(mintedShares == 40, "deposit shares mismatch");
+        assertTrue(
+            IERC4626VaultIntegrationFacet(address(diamond)).oracleAdapter() == address(adapter), "adapter mismatch"
+        );
+        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).strategy() == eve, "strategy mismatch");
+        assertTrue(
+            IERC4626VaultIntegrationFacet(address(diamond)).strategyReportedAssets() == 25, "reported assets mismatch"
+        );
+        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).idleAssets() == 40, "idle assets mismatch");
+        assertTrue(
+            IERC4626VaultIntegrationFacet(address(diamond)).estimatedTotalManagedAssets() == 65,
+            "estimated assets mismatch"
+        );
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 40, "managed assets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewDeposit(10) == 10, "preview should remain core-based");
+        assertTrue(quotePayload.value == 100_000_000, "quote value mismatch");
+        assertTrue(quotePayload.updatedAt == quoteUpdatedAt, "quote timestamp mismatch");
+        assertTrue(quotePayload.decimals == 8, "quote decimals mismatch");
+
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultCoreSelectors(), address(coreFacet));
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultControlsSelectors(), address(controlsFacet));
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultIntegrationSelectors(), address(integrationFacet));
+
+        assertTrue(
+            IDiamondLoupe(address(diamond)).facetAddress(IERC4626VaultFacet.initializeVault.selector)
+                == address(coreFacet),
+            "initializer selector should stay on core facet"
+        );
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC4626VaultIntegrationFacet).interfaceId),
+            "diamond should report integration interface support"
+        );
+    }
+
+    function testDiamondIntegrationFacetHasNoInitializerSelector() public {
+        _installHostedVaultFacetsToDiamond();
+
+        bytes4[] memory selectors = LibVaultFacetSelectors.vaultIntegrationSelectors();
+        for (uint256 i = 0; i < selectors.length; i++) {
+            assertTrue(
+                selectors[i] != IERC4626VaultFacet.initializeVault.selector,
+                "integration facet should not own initializer selector"
+            );
+        }
+    }
+
+    function _assertSelectorsOwnedByFacet(bytes4[] memory selectors, address expectedFacet) internal view {
+        for (uint256 i = 0; i < selectors.length; i++) {
+            assertTrue(
+                IDiamondLoupe(address(diamond)).facetAddress(selectors[i]) == expectedFacet, "selector owner mismatch"
+            );
+        }
+    }
+}

--- a/test/VaultFacetFoundationCore.t.sol
+++ b/test/VaultFacetFoundationCore.t.sol
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
+import {IAccessControlTime} from "../src/interfaces/IAccessControlTime.sol";
+import {IERC165} from "../src/interfaces/IERC165.sol";
+import {IERC4626} from "../src/interfaces/IERC4626.sol";
+import {IERC4626VaultBase} from "../src/interfaces/IERC4626VaultBase.sol";
+import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol";
+import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControlsFacet.sol";
+import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
+import {IPausable} from "../src/interfaces/IPausable.sol";
+import {IReentrancyGuard} from "../src/interfaces/IReentrancyGuard.sol";
+import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
+import {NoMetadataAsset} from "./helpers/ERC4626VaultTestHarness.sol";
+import {VaultFacetFoundationFixture} from "./helpers/VaultFacetFoundationTestHarness.sol";
+
+contract VaultFacetFoundationCoreTest is VaultFacetFoundationFixture {
+    function testInitializeVaultSeedsHostedFoundationState() public {
+        _initializeVault();
+
+        assertTrue(vault.isVaultInitialized(), "vault should initialize");
+        assertTrue(vault.controlPlaneInitialized(), "control plane should initialize");
+        assertTrue(vault.asset() == address(asset), "asset mismatch");
+        assertTrue(keccak256(bytes(vault.name())) == keccak256(bytes("Vault Share")), "name mismatch");
+        assertTrue(keccak256(bytes(vault.symbol())) == keccak256(bytes("vSHARE")), "symbol mismatch");
+        assertTrue(vault.decimals() == 6, "decimals mismatch");
+        assertTrue(vault.feeRecipient() == admin, "fee recipient mismatch");
+        assertTrue(vault.hasRole(vault.DEFAULT_ADMIN_ROLE(), admin), "missing default admin role");
+        assertTrue(vault.hasRole(vault.PAUSER_ROLE(), admin), "missing pauser role");
+        assertTrue(vault.hasRole(vault.VAULT_MANAGER_ROLE(), admin), "missing vault manager role");
+        assertTrue(vault.reentrancyGuardEntered() == false, "reentrancy guard should be idle");
+    }
+
+    function testInitializeVaultDefaultsDecimalsWhenMetadataMissing() public {
+        NoMetadataAsset noMetadataAsset = _newNoMetadataAsset();
+
+        vault.initializeVault(address(noMetadataAsset), "Vault Share", "vSHARE", admin);
+
+        assertTrue(vault.decimals() == 18, "missing metadata should default to 18 decimals");
+    }
+
+    function testInitializeVaultRevertsOnZeroAsset() public {
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultZeroAsset.selector));
+        vault.initializeVault(address(0), "Vault Share", "vSHARE", admin);
+    }
+
+    function testInitializeVaultRevertsWhenAlreadyInitialized() public {
+        _initializeVault();
+
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultAlreadyInitialized.selector));
+        vault.initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function testConstructorFreeControlInitCanRunBeforeVaultInit() public {
+        vault.initializeControlOnly(admin);
+
+        assertFalse(vault.isVaultInitialized(), "vault storage should remain uninitialized");
+        assertTrue(vault.controlPlaneInitialized(), "control plane should initialize");
+        assertTrue(vault.feeRecipient() == admin, "fee recipient mismatch");
+        assertTrue(vault.hasRole(vault.DEFAULT_ADMIN_ROLE(), admin), "missing default admin role");
+        assertTrue(vault.hasRole(vault.PAUSER_ROLE(), admin), "missing pauser role");
+        assertTrue(vault.hasRole(vault.VAULT_MANAGER_ROLE(), admin), "missing vault manager role");
+
+        vault.initializeControlOnly(admin);
+        vault.initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+
+        assertTrue(vault.isVaultInitialized(), "vault should initialize after control-only init");
+        assertTrue(vault.asset() == address(asset), "asset mismatch after delayed vault init");
+    }
+
+    function testSupportsHostedControlInterfaces() public view {
+        assertTrue(vault.supportsInterface(type(IERC165).interfaceId), "erc165 unsupported");
+        assertTrue(vault.supportsInterface(type(IAccessControl).interfaceId), "access control unsupported");
+        assertTrue(vault.supportsInterface(type(IAccessControlTime).interfaceId), "access control time unsupported");
+        assertTrue(vault.supportsInterface(type(IPausable).interfaceId), "pausable unsupported");
+        assertTrue(vault.supportsInterface(type(IReentrancyGuard).interfaceId), "reentrancy unsupported");
+        assertTrue(
+            vault.supportsInterface(type(IERC4626VaultControlsFacet).interfaceId), "vault controls facet unsupported"
+        );
+    }
+
+    function testVaultSelectorGroupsCoverExpectedHostedSplit() public pure {
+        bytes4[] memory coreSelectors = LibVaultFacetSelectors.vaultCoreSelectors();
+        bytes4[] memory controlSelectors = LibVaultFacetSelectors.vaultControlsSelectors();
+
+        assertTrue(coreSelectors.length == 28, "unexpected core selector count");
+        assertTrue(controlSelectors.length == 28, "unexpected controls selector count");
+
+        _assertContains(coreSelectors, IERC4626VaultFacet.initializeVault.selector);
+        _assertContains(coreSelectors, IERC4626.deposit.selector);
+        _assertContains(coreSelectors, IERC4626.redeem.selector);
+        _assertContains(coreSelectors, IERC4626VaultBase.totalManagedAssets.selector);
+
+        _assertContains(controlSelectors, IERC4626VaultControls.setFeeConfig.selector);
+        _assertContains(controlSelectors, IERC4626VaultControls.setLimitConfig.selector);
+        _assertContains(controlSelectors, IAccessControlTime.grantRoleWithWindow.selector);
+        _assertContains(controlSelectors, IReentrancyGuard.reentrancyGuardEntered.selector);
+        _assertContains(controlSelectors, IERC165.supportsInterface.selector);
+
+        _assertUnique(coreSelectors);
+        _assertUnique(controlSelectors);
+        _assertDisjoint(coreSelectors, controlSelectors);
+    }
+
+    function _assertContains(bytes4[] memory selectors, bytes4 target) internal pure {
+        for (uint256 i = 0; i < selectors.length; i++) {
+            if (selectors[i] == target) {
+                return;
+            }
+        }
+        revert("missing selector");
+    }
+
+    function _assertUnique(bytes4[] memory selectors) internal pure {
+        for (uint256 i = 0; i < selectors.length; i++) {
+            for (uint256 j = i + 1; j < selectors.length; j++) {
+                if (selectors[i] == selectors[j]) {
+                    revert("duplicate selector");
+                }
+            }
+        }
+    }
+
+    function _assertDisjoint(bytes4[] memory left, bytes4[] memory right) internal pure {
+        for (uint256 i = 0; i < left.length; i++) {
+            for (uint256 j = 0; j < right.length; j++) {
+                if (left[i] == right[j]) {
+                    revert("selector overlap");
+                }
+            }
+        }
+    }
+}

--- a/test/helpers/DiamondVaultDeploymentTestHarness.sol
+++ b/test/helpers/DiamondVaultDeploymentTestHarness.sol
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
+import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
+import {ERC4626VaultControlsFacetHarness} from "./ERC4626VaultControlsFacetTestHarness.sol";
+import {ERC4626VaultFacetHarness} from "./ERC4626VaultFacetTestHarness.sol";
+import {ERC4626VaultIntegrationFacetHarness} from "./ERC4626VaultIntegrationFacetTestHarness.sol";
+import {MockVaultAsset} from "./ERC4626CoreTestHarness.sol";
+import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
+import {MockOracleFeed, OracleAdapterHarness} from "./OracleAdapterTestHarness.sol";
+import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+
+abstract contract DiamondVaultDeploymentFixture is TestBase {
+    address internal admin = address(0xA11CE);
+
+    uint64 internal maxStaleness = 1 hours;
+    uint64 internal currentTime = 1_000_000;
+    uint64 internal quoteUpdatedAt = 999_900;
+
+    DiamondCutFacet internal cutFacet;
+    DiamondLoupeFacet internal loupeFacet;
+    ERC4626VaultFacetHarness internal coreFacet;
+    ERC4626VaultControlsFacetHarness internal controlsFacet;
+    ERC4626VaultIntegrationFacetHarness internal integrationFacet;
+    DiamondProxyHarness internal diamond;
+    MockVaultAsset internal asset;
+    MockOracleFeed internal feed;
+    OracleAdapterHarness internal adapter;
+
+    function setUp() public virtual {
+        VM.warp(currentTime);
+
+        cutFacet = new DiamondCutFacet();
+        loupeFacet = new DiamondLoupeFacet();
+        coreFacet = new ERC4626VaultFacetHarness();
+        controlsFacet = new ERC4626VaultControlsFacetHarness();
+        integrationFacet = new ERC4626VaultIntegrationFacetHarness();
+        diamond = new DiamondProxyHarness(admin, address(cutFacet));
+        asset = new MockVaultAsset("Mock USD", "mUSD", 6);
+        feed = new MockOracleFeed(8);
+        feed.setLatestRoundData(1, 100_000_000, quoteUpdatedAt, quoteUpdatedAt, 1);
+        adapter = new OracleAdapterHarness(admin, address(feed), maxStaleness);
+
+        _installLoupeFacet();
+    }
+
+    function _installLoupeFacet() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(loupeFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: _loupeSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installVaultHostFacets() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](3);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(coreFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultCoreSelectors()
+        });
+        cut[1] = IDiamondCut.FacetCut({
+            facetAddress: address(controlsFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultControlsSelectors()
+        });
+        cut[2] = IDiamondCut.FacetCut({
+            facetAddress: address(integrationFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultIntegrationSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _initializeVaultHost() internal {
+        VM.prank(admin);
+        coreFacetInterface().initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function _wireOracleAdapter() internal {
+        VM.prank(admin);
+        integrationFacetInterface().setOracleAdapter(address(adapter));
+    }
+
+    function coreFacetInterface() internal view returns (ERC4626VaultFacetHarness) {
+        return ERC4626VaultFacetHarness(address(diamond));
+    }
+
+    function controlsFacetInterface() internal view returns (ERC4626VaultControlsFacetHarness) {
+        return ERC4626VaultControlsFacetHarness(address(diamond));
+    }
+
+    function integrationFacetInterface() internal view returns (ERC4626VaultIntegrationFacetHarness) {
+        return ERC4626VaultIntegrationFacetHarness(address(diamond));
+    }
+
+    function _containsAddress(address[] memory addresses, address expected) internal pure returns (bool) {
+        for (uint256 i = 0; i < addresses.length; i++) {
+            if (addresses[i] == expected) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    function _loupeSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](6);
+        selectors[0] = DiamondLoupeFacet.facets.selector;
+        selectors[1] = DiamondLoupeFacet.facetFunctionSelectors.selector;
+        selectors[2] = DiamondLoupeFacet.facetAddresses.selector;
+        selectors[3] = DiamondLoupeFacet.facetAddress.selector;
+        selectors[4] = DiamondLoupeFacet.owner.selector;
+        selectors[5] = DiamondLoupeFacet.transferOwnership.selector;
+    }
+}

--- a/test/helpers/DiamondVaultHostHardeningTestHarness.sol
+++ b/test/helpers/DiamondVaultHostHardeningTestHarness.sol
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
+import {IERC4626VaultControls} from "../../src/interfaces/IERC4626VaultControls.sol";
+import {IERC4626VaultFacet} from "../../src/interfaces/IERC4626VaultFacet.sol";
+import {IERC4626VaultIntegrationFacet} from "../../src/interfaces/IERC4626VaultIntegrationFacet.sol";
+import {ERC4626VaultControlsFacet} from "../../src/vault/facets/ERC4626VaultControlsFacet.sol";
+import {ERC4626VaultFacet} from "../../src/vault/facets/ERC4626VaultFacet.sol";
+import {ERC4626VaultIntegrationFacet} from "../../src/vault/facets/ERC4626VaultIntegrationFacet.sol";
+import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
+import {DiamondVaultDeploymentFixture} from "./DiamondVaultDeploymentTestHarness.sol";
+
+interface IFacetVersionMarker {
+    function facetVersion() external view returns (uint256);
+}
+
+contract ERC4626VaultFacetReplacement is ERC4626VaultFacet {
+    function facetVersion() external pure returns (uint256) {
+        return 2;
+    }
+}
+
+contract ERC4626VaultControlsFacetReplacement is ERC4626VaultControlsFacet {
+    function facetVersion() external pure returns (uint256) {
+        return 2;
+    }
+}
+
+contract ERC4626VaultIntegrationFacetReplacement is ERC4626VaultIntegrationFacet {
+    function facetVersion() external pure returns (uint256) {
+        return 2;
+    }
+}
+
+abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixture {
+    struct AccountingSnapshot {
+        uint256 totalAssets;
+        uint256 totalSupply;
+        uint256 vaultUnderlyingBalance;
+        uint256 feeSinkBalance;
+        uint256 actorUnderlyingBalanceSum;
+        uint256 actorShareBalanceSum;
+    }
+
+    uint256 internal constant INITIAL_ASSETS = 1_000_000;
+    uint256 internal constant ACTOR_COUNT = 4;
+    uint256 internal constant BOB_DEPOSIT = 200_000;
+    uint256 internal constant CAROL_DEPOSIT = 150_000;
+    uint256 internal constant SHARE_ALLOWANCE = 25_000;
+    uint256 internal constant STRATEGY_REPORTED_ASSETS = 75_000;
+
+    address internal bob = address(0xB0B);
+    address internal carol = address(0xCA11);
+    address internal dave = address(0xD0D);
+    address internal eve = address(0xE11E);
+    address internal feeSink = address(0xFEE);
+    address internal strategyReporter = address(0x57A7);
+
+    address[ACTOR_COUNT] internal actors;
+
+    ERC4626VaultFacetReplacement internal coreReplacement;
+    ERC4626VaultControlsFacetReplacement internal controlsReplacement;
+    ERC4626VaultIntegrationFacetReplacement internal integrationReplacement;
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        coreReplacement = new ERC4626VaultFacetReplacement();
+        controlsReplacement = new ERC4626VaultControlsFacetReplacement();
+        integrationReplacement = new ERC4626VaultIntegrationFacetReplacement();
+
+        actors[0] = bob;
+        actors[1] = carol;
+        actors[2] = dave;
+        actors[3] = eve;
+
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            address actor = actors[i];
+            asset.mint(actor, INITIAL_ASSETS);
+            VM.prank(actor);
+            asset.approve(address(diamond), type(uint256).max);
+        }
+    }
+
+    function _installAndSeedVaultHost() internal {
+        _installVaultHostFacets();
+        _initializeVaultHost();
+        _wireOracleAdapter();
+        _seedCoreState();
+        _seedControlsState();
+        _seedIntegrationState();
+    }
+
+    function _seedCoreState() internal {
+        VM.prank(bob);
+        coreFacetInterface().deposit(BOB_DEPOSIT, bob);
+
+        VM.prank(carol);
+        coreFacetInterface().deposit(CAROL_DEPOSIT, carol);
+
+        VM.prank(bob);
+        coreFacetInterface().approve(eve, SHARE_ALLOWANCE);
+    }
+
+    function _seedControlsState() internal {
+        bytes32 managerRole = controlsFacetInterface().VAULT_MANAGER_ROLE();
+
+        VM.prank(admin);
+        controlsFacetInterface().setFeeConfig(100, 50, feeSink);
+
+        VM.prank(admin);
+        controlsFacetInterface().setLimitConfig(900_000, 300_000, 300_000, 250_000, 250_000);
+
+        VM.prank(admin);
+        controlsFacetInterface().grantRole(managerRole, eve);
+
+        VM.prank(admin);
+        controlsFacetInterface()
+            .grantRoleWithWindow(managerRole, dave, uint64(currentTime - 100), uint64(currentTime + 1_000));
+    }
+
+    function _seedIntegrationState() internal {
+        VM.prank(admin);
+        integrationFacetInterface().setStrategy(strategyReporter);
+
+        VM.prank(strategyReporter);
+        integrationFacetInterface().reportStrategyAssets(STRATEGY_REPORTED_ASSETS);
+    }
+
+    function _replaceCoreFacet(address facetAddress_) internal {
+        _replaceFacet(facetAddress_, LibVaultFacetSelectors.vaultCoreSelectors());
+    }
+
+    function _replaceControlsFacet(address facetAddress_) internal {
+        _replaceFacet(facetAddress_, LibVaultFacetSelectors.vaultControlsSelectors());
+    }
+
+    function _replaceIntegrationFacet(address facetAddress_) internal {
+        _replaceFacet(facetAddress_, LibVaultFacetSelectors.vaultIntegrationSelectors());
+    }
+
+    function _addCoreReplacementMarker(address facetAddress_) internal {
+        _addFacet(facetAddress_, _markerSelectors());
+    }
+
+    function _addControlsReplacementMarker(address facetAddress_) internal {
+        _addFacet(facetAddress_, _markerSelectors());
+    }
+
+    function _addIntegrationReplacementMarker(address facetAddress_) internal {
+        _addFacet(facetAddress_, _markerSelectors());
+    }
+
+    function _removeCoreFacetWithMarker() internal {
+        _removeSelectors(_concat(LibVaultFacetSelectors.vaultCoreSelectors(), _markerSelectors()));
+    }
+
+    function _removeControlsFacetWithMarker() internal {
+        _removeSelectors(_concat(LibVaultFacetSelectors.vaultControlsSelectors(), _markerSelectors()));
+    }
+
+    function _removeIntegrationFacetWithMarker() internal {
+        _removeSelectors(_concat(LibVaultFacetSelectors.vaultIntegrationSelectors(), _markerSelectors()));
+    }
+
+    function _reAddCoreFacetWithMarker(address facetAddress_) internal {
+        _addFacet(facetAddress_, _concat(LibVaultFacetSelectors.vaultCoreSelectors(), _markerSelectors()));
+    }
+
+    function _reAddControlsFacetWithMarker(address facetAddress_) internal {
+        _addFacet(facetAddress_, _concat(LibVaultFacetSelectors.vaultControlsSelectors(), _markerSelectors()));
+    }
+
+    function _reAddIntegrationFacetWithMarker(address facetAddress_) internal {
+        _addFacet(facetAddress_, _concat(LibVaultFacetSelectors.vaultIntegrationSelectors(), _markerSelectors()));
+    }
+
+    function _pauseVault() internal {
+        VM.prank(admin);
+        controlsFacetInterface().pause();
+    }
+
+    function _unpauseVault() internal {
+        VM.prank(admin);
+        controlsFacetInterface().unpause();
+    }
+
+    function _actor(uint8 seed) internal view returns (address) {
+        return actors[uint256(seed) % ACTOR_COUNT];
+    }
+
+    function _actorExcluding(address excluded, uint8 seed) internal view returns (address actor) {
+        actor = _actor(seed);
+        if (actor == excluded) {
+            actor = _actor(seed + 1);
+        }
+    }
+
+    function _boundAmount(uint256 raw, uint256 max) internal pure returns (uint256) {
+        if (max == 0) {
+            return 0;
+        }
+        return (raw % max) + 1;
+    }
+
+    function _min(uint256 x, uint256 y) internal pure returns (uint256) {
+        return x < y ? x : y;
+    }
+
+    function _sumTrackedShareBalances() internal view returns (uint256 sum) {
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            sum += coreFacetInterface().balanceOf(actors[i]);
+        }
+    }
+
+    function _sumTrackedUnderlying() internal view returns (uint256 sum) {
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            sum += asset.balanceOf(actors[i]);
+        }
+
+        sum += asset.balanceOf(address(diamond));
+        sum += asset.balanceOf(feeSink);
+    }
+
+    function _snapshotAccounting() internal view returns (AccountingSnapshot memory snapshot) {
+        snapshot.totalAssets = coreFacetInterface().totalAssets();
+        snapshot.totalSupply = coreFacetInterface().totalSupply();
+        snapshot.vaultUnderlyingBalance = asset.balanceOf(address(diamond));
+        snapshot.feeSinkBalance = asset.balanceOf(feeSink);
+
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            snapshot.actorUnderlyingBalanceSum += asset.balanceOf(actors[i]);
+            snapshot.actorShareBalanceSum += coreFacetInterface().balanceOf(actors[i]);
+        }
+    }
+
+    function _assertAccountingUnchanged(AccountingSnapshot memory snapshot, string memory reason) internal view {
+        AccountingSnapshot memory afterSnapshot = _snapshotAccounting();
+        assertTrue(afterSnapshot.totalAssets == snapshot.totalAssets, reason);
+        assertTrue(afterSnapshot.totalSupply == snapshot.totalSupply, reason);
+        assertTrue(afterSnapshot.vaultUnderlyingBalance == snapshot.vaultUnderlyingBalance, reason);
+        assertTrue(afterSnapshot.feeSinkBalance == snapshot.feeSinkBalance, reason);
+        assertTrue(afterSnapshot.actorUnderlyingBalanceSum == snapshot.actorUnderlyingBalanceSum, reason);
+        assertTrue(afterSnapshot.actorShareBalanceSum == snapshot.actorShareBalanceSum, reason);
+    }
+
+    function _addFacet(address facetAddress_, bytes4[] memory selectors) internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: facetAddress_, action: IDiamondCut.FacetCutAction.Add, functionSelectors: selectors
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _replaceFacet(address facetAddress_, bytes4[] memory selectors) internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: facetAddress_, action: IDiamondCut.FacetCutAction.Replace, functionSelectors: selectors
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _removeSelectors(bytes4[] memory selectors) internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(0), action: IDiamondCut.FacetCutAction.Remove, functionSelectors: selectors
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _assertMissingSelector(bytes memory callData, string memory reason) internal {
+        (bool success,) = address(diamond).call(callData);
+        assertFalse(success, reason);
+    }
+
+    function _markerSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](1);
+        selectors[0] = IFacetVersionMarker.facetVersion.selector;
+    }
+
+    function _concat(bytes4[] memory first, bytes4[] memory second) internal pure returns (bytes4[] memory combined) {
+        combined = new bytes4[](first.length + second.length);
+
+        uint256 i;
+        for (; i < first.length; i++) {
+            combined[i] = first[i];
+        }
+
+        for (uint256 j = 0; j < second.length; j++) {
+            combined[i + j] = second[j];
+        }
+    }
+}

--- a/test/helpers/ERC4626VaultControlsFacetTestHarness.sol
+++ b/test/helpers/ERC4626VaultControlsFacetTestHarness.sol
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
+import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
+import {IERC4626VaultControlsFacet} from "../../src/interfaces/IERC4626VaultControlsFacet.sol";
+import {IERC4626VaultFacet} from "../../src/interfaces/IERC4626VaultFacet.sol";
+import {ERC4626Vault} from "../../src/vault/ERC4626Vault.sol";
+import {ERC4626VaultControlsFacet} from "../../src/vault/facets/ERC4626VaultControlsFacet.sol";
+import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
+import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
+import {ERC4626VaultFacetHarness} from "./ERC4626VaultFacetTestHarness.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+import {ReentrantMockVaultAsset} from "./ERC4626VaultControlsTestHarness.sol";
+
+contract ERC4626VaultControlsFacetHarness is ERC4626VaultControlsFacet, ERC4626Vault {
+    function initializeHostedVaultForTest(
+        address vaultAsset,
+        string memory vaultName,
+        string memory vaultSymbol,
+        address admin
+    ) external {
+        _initializeVaultFacetControl(admin);
+        _initializeErc4626Vault(vaultAsset, vaultName, vaultSymbol);
+    }
+}
+
+abstract contract ERC4626VaultControlsFacetFixture is TestBase {
+    uint256 internal constant INITIAL_ASSETS = 1_000_000;
+
+    address internal admin = address(0xA11CE);
+    address internal bob = address(0xB0B);
+    address internal eve = address(0xE11E);
+
+    ReentrantMockVaultAsset internal asset;
+    ERC4626VaultFacetHarness internal coreFacet;
+    ERC4626VaultControlsFacetHarness internal controlsFacet;
+    DiamondCutFacet internal cutFacet;
+    DiamondLoupeFacet internal loupeFacet;
+    DiamondProxyHarness internal diamond;
+
+    function setUp() public virtual {
+        asset = new ReentrantMockVaultAsset();
+        coreFacet = new ERC4626VaultFacetHarness();
+        controlsFacet = new ERC4626VaultControlsFacetHarness();
+        cutFacet = new DiamondCutFacet();
+        loupeFacet = new DiamondLoupeFacet();
+        diamond = new DiamondProxyHarness(admin, address(cutFacet));
+
+        asset.mint(bob, INITIAL_ASSETS);
+        asset.mint(eve, INITIAL_ASSETS);
+
+        _installLoupeFacet();
+    }
+
+    function _initializeDirectControlsFacet() internal {
+        controlsFacet.initializeHostedVaultForTest(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function _initializeDiamondVault() internal {
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond)).initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function _approveAsset(address owner, address spender, uint256 amount) internal {
+        VM.prank(owner);
+        asset.approve(spender, amount);
+    }
+
+    function _installLoupeFacet() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(loupeFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: _loupeSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installVaultCoreFacetToDiamond() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(coreFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultCoreSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installVaultControlsFacetToDiamond() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(controlsFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultControlsSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installHostedVaultFacetsToDiamond() internal {
+        _installVaultCoreFacetToDiamond();
+        _installVaultControlsFacetToDiamond();
+    }
+
+    function _loupeSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](6);
+        selectors[0] = DiamondLoupeFacet.facets.selector;
+        selectors[1] = DiamondLoupeFacet.facetFunctionSelectors.selector;
+        selectors[2] = DiamondLoupeFacet.facetAddresses.selector;
+        selectors[3] = DiamondLoupeFacet.facetAddress.selector;
+        selectors[4] = DiamondLoupeFacet.owner.selector;
+        selectors[5] = DiamondLoupeFacet.transferOwnership.selector;
+    }
+}

--- a/test/helpers/ERC4626VaultFacetTestHarness.sol
+++ b/test/helpers/ERC4626VaultFacetTestHarness.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
+import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
+import {IERC4626VaultFacet} from "../../src/interfaces/IERC4626VaultFacet.sol";
+import {ERC4626VaultFacet} from "../../src/vault/facets/ERC4626VaultFacet.sol";
+import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
+import {LibERC4626VaultStorage} from "../../src/vault/storage/LibERC4626VaultStorage.sol";
+import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+import {ReentrantMockVaultAsset} from "./ERC4626VaultControlsTestHarness.sol";
+
+contract ERC4626VaultFacetHarness is ERC4626VaultFacet {
+    function initializeControlOnly(address admin) external {
+        _initializeVaultFacetControl(admin);
+    }
+
+    function feeRecipient() external view returns (address) {
+        return LibERC4626VaultStorage.layout().fees.feeRecipient;
+    }
+
+    function controlPlaneInitialized() external view returns (bool) {
+        return LibERC4626VaultStorage.layout().controlPlaneInitialized;
+    }
+
+    function probeNonReentrant() external nonReentrant returns (bool) {
+        return true;
+    }
+}
+
+abstract contract ERC4626VaultFacetFixture is TestBase {
+    uint256 internal constant INITIAL_ASSETS = 1_000_000;
+
+    address internal admin = address(0xA11CE);
+    address internal bob = address(0xB0B);
+    address internal eve = address(0xE11E);
+
+    ReentrantMockVaultAsset internal asset;
+    ERC4626VaultFacetHarness internal facet;
+    DiamondCutFacet internal cutFacet;
+    DiamondLoupeFacet internal loupeFacet;
+    DiamondProxyHarness internal diamond;
+
+    function setUp() public virtual {
+        asset = new ReentrantMockVaultAsset();
+        facet = new ERC4626VaultFacetHarness();
+        cutFacet = new DiamondCutFacet();
+        loupeFacet = new DiamondLoupeFacet();
+        diamond = new DiamondProxyHarness(admin, address(cutFacet));
+
+        asset.mint(bob, INITIAL_ASSETS);
+        asset.mint(eve, INITIAL_ASSETS);
+
+        _installLoupeFacet();
+    }
+
+    function _initializeHostedVault(address target) internal {
+        IERC4626VaultFacet(target).initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function _approveAsset(address owner, address spender, uint256 amount) internal {
+        VM.prank(owner);
+        asset.approve(spender, amount);
+    }
+
+    function _installLoupeFacet() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(loupeFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: _loupeSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installVaultCoreFacetToDiamond() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(facet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultCoreSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _loupeSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](6);
+        selectors[0] = DiamondLoupeFacet.facets.selector;
+        selectors[1] = DiamondLoupeFacet.facetFunctionSelectors.selector;
+        selectors[2] = DiamondLoupeFacet.facetAddresses.selector;
+        selectors[3] = DiamondLoupeFacet.facetAddress.selector;
+        selectors[4] = DiamondLoupeFacet.owner.selector;
+        selectors[5] = DiamondLoupeFacet.transferOwnership.selector;
+    }
+}

--- a/test/helpers/ERC4626VaultIntegrationFacetTestHarness.sol
+++ b/test/helpers/ERC4626VaultIntegrationFacetTestHarness.sol
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
+import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
+import {IERC4626VaultFacet} from "../../src/interfaces/IERC4626VaultFacet.sol";
+import {ERC4626VaultIntegrationFacet} from "../../src/vault/facets/ERC4626VaultIntegrationFacet.sol";
+import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
+import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+import {ERC4626VaultControlsFacetHarness} from "./ERC4626VaultControlsFacetTestHarness.sol";
+import {ReentrantMockVaultAsset} from "./ERC4626VaultControlsTestHarness.sol";
+import {ERC4626VaultFacetHarness} from "./ERC4626VaultFacetTestHarness.sol";
+import {MockOracleFeed, OracleAdapterHarness} from "./OracleAdapterTestHarness.sol";
+
+contract ERC4626VaultIntegrationFacetHarness is ERC4626VaultIntegrationFacet {
+    function initializeHostedVaultForTest(
+        address vaultAsset,
+        string memory vaultName,
+        string memory vaultSymbol,
+        address admin
+    ) external {
+        _initializeVaultFacetControl(admin);
+        _initializeErc4626Vault(vaultAsset, vaultName, vaultSymbol);
+    }
+}
+
+abstract contract ERC4626VaultIntegrationFacetFixture is TestBase {
+    uint256 internal constant INITIAL_ASSETS = 1_000_000;
+
+    address internal admin = address(0xA11CE);
+    address internal bob = address(0xB0B);
+    address internal eve = address(0xE11E);
+
+    uint64 internal maxStaleness = 1 hours;
+    uint64 internal currentTime = 1_000_000;
+    uint64 internal quoteUpdatedAt = 999_900;
+
+    ReentrantMockVaultAsset internal asset;
+    ERC4626VaultFacetHarness internal coreFacet;
+    ERC4626VaultControlsFacetHarness internal controlsFacet;
+    ERC4626VaultIntegrationFacetHarness internal integrationFacet;
+    DiamondCutFacet internal cutFacet;
+    DiamondLoupeFacet internal loupeFacet;
+    DiamondProxyHarness internal diamond;
+    MockOracleFeed internal feed;
+    OracleAdapterHarness internal adapter;
+
+    function setUp() public virtual {
+        VM.warp(currentTime);
+
+        asset = new ReentrantMockVaultAsset();
+        coreFacet = new ERC4626VaultFacetHarness();
+        controlsFacet = new ERC4626VaultControlsFacetHarness();
+        integrationFacet = new ERC4626VaultIntegrationFacetHarness();
+        cutFacet = new DiamondCutFacet();
+        loupeFacet = new DiamondLoupeFacet();
+        diamond = new DiamondProxyHarness(admin, address(cutFacet));
+        feed = new MockOracleFeed(8);
+        feed.setLatestRoundData(1, 100_000_000, quoteUpdatedAt, quoteUpdatedAt, 1);
+        adapter = new OracleAdapterHarness(admin, address(feed), maxStaleness);
+
+        asset.mint(bob, INITIAL_ASSETS);
+        asset.mint(eve, INITIAL_ASSETS);
+
+        _installLoupeFacet();
+    }
+
+    function _initializeDirectIntegrationFacet() internal {
+        integrationFacet.initializeHostedVaultForTest(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function _initializeDiamondVault() internal {
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond)).initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function _approveAsset(address owner, address spender, uint256 amount) internal {
+        VM.prank(owner);
+        asset.approve(spender, amount);
+    }
+
+    function _installLoupeFacet() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(loupeFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: _loupeSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installVaultCoreFacetToDiamond() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(coreFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultCoreSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installVaultControlsFacetToDiamond() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(controlsFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultControlsSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installVaultIntegrationFacetToDiamond() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(integrationFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultIntegrationSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installHostedVaultFacetsToDiamond() internal {
+        _installVaultCoreFacetToDiamond();
+        _installVaultControlsFacetToDiamond();
+        _installVaultIntegrationFacetToDiamond();
+    }
+
+    function _loupeSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](6);
+        selectors[0] = DiamondLoupeFacet.facets.selector;
+        selectors[1] = DiamondLoupeFacet.facetFunctionSelectors.selector;
+        selectors[2] = DiamondLoupeFacet.facetAddresses.selector;
+        selectors[3] = DiamondLoupeFacet.facetAddress.selector;
+        selectors[4] = DiamondLoupeFacet.owner.selector;
+        selectors[5] = DiamondLoupeFacet.transferOwnership.selector;
+    }
+}

--- a/test/helpers/VaultFacetFoundationTestHarness.sol
+++ b/test/helpers/VaultFacetFoundationTestHarness.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC165} from "../../src/interfaces/IERC165.sol";
+import {IERC4626VaultControlsFacet} from "../../src/interfaces/IERC4626VaultControlsFacet.sol";
+import {ERC4626VaultBase} from "../../src/vault/ERC4626VaultBase.sol";
+import {VaultFacetControl} from "../../src/vault/VaultFacetControl.sol";
+import {LibERC4626VaultStorage} from "../../src/vault/storage/LibERC4626VaultStorage.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+import {MockAssetWithDecimals, NoMetadataAsset} from "./ERC4626VaultTestHarness.sol";
+
+contract HostedVaultFacetFoundationHarness is ERC4626VaultBase, VaultFacetControl {
+    function initializeVault(address vaultAsset, string calldata vaultName, string calldata vaultSymbol, address admin)
+        external
+    {
+        _initializeErc4626Vault(vaultAsset, vaultName, vaultSymbol);
+        _initializeVaultFacetControl(admin);
+    }
+
+    function initializeControlOnly(address admin) external {
+        _initializeVaultFacetControl(admin);
+    }
+
+    function feeRecipient() external view returns (address) {
+        return LibERC4626VaultStorage.layout().fees.feeRecipient;
+    }
+
+    function controlPlaneInitialized() external view returns (bool) {
+        return LibERC4626VaultStorage.layout().controlPlaneInitialized;
+    }
+
+    function probeNonReentrant() external nonReentrant returns (bool) {
+        return true;
+    }
+
+    function transfer(address to, uint256 value) external returns (bool) {
+        _transferShares(msg.sender, to, value);
+        return true;
+    }
+
+    function approve(address spender, uint256 value) external returns (bool) {
+        _setAllowance(msg.sender, spender, value);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 value) external returns (bool) {
+        _spendAllowance(from, msg.sender, value);
+        _transferShares(from, to, value);
+        return true;
+    }
+
+    function supportsInterface(bytes4 interfaceId) public view override(VaultFacetControl) returns (bool) {
+        return
+            interfaceId == type(IERC4626VaultControlsFacet).interfaceId
+                || VaultFacetControl.supportsInterface(interfaceId);
+    }
+}
+
+abstract contract VaultFacetFoundationFixture is TestBase {
+    address internal admin = address(0xA11CE);
+    address internal bob = address(0xB0B);
+
+    MockAssetWithDecimals internal asset;
+    HostedVaultFacetFoundationHarness internal vault;
+
+    function setUp() public virtual {
+        asset = new MockAssetWithDecimals(6);
+        vault = new HostedVaultFacetFoundationHarness();
+    }
+
+    function _initializeVault() internal {
+        vault.initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function _newNoMetadataAsset() internal returns (NoMetadataAsset) {
+        return new NoMetadataAsset();
+    }
+}


### PR DESCRIPTION
## Summary
- add the shared vault facet foundation and constructor-free hosted init/control model
- add the ERC-4626 vault core, controls, and integration facets behind a single diamond host
- add the local diamond-hosted vault deployment and init flow with oracle adapter wiring
- add cross-facet hardening and diamond-routed invariant coverage for the hosted vault
- document hosted vault deployment, selector ownership, pause behavior, and upgrade assumptions

## Included Work
- #95 Shared vault facet foundation
- #96 Implement vault core facet
- #97 Implement vault controls facet
- #98 Implement vault oracle and strategy integration facet
- #99 Add diamond-hosted vault deployment and init integration
- #100 Add cross-facet routing, upgrade, and invariant coverage for the hosted vault
- #101 Document hosted vault usage and safety assumptions

## Validation
Validation across the milestone PRs included:
- `forge test --offline`
- `forge test --offline --match-path test/ERC4626VaultFacetCore.t.sol`
- `forge test --offline --match-path test/ERC4626VaultControlsFacetCore.t.sol`
- `forge test --offline --match-path test/ERC4626VaultIntegrationFacetCore.t.sol`
- `forge test --offline --match-path test/DiamondVaultDeploymentIntegration.t.sol`
- `forge test --offline --match-path test/DiamondVaultHostHardening.t.sol`
- `forge test --offline --match-path test/DiamondVaultHostInvariant.t.sol`
- `forge script script/DeployDiamondVaultHost.s.sol:DeployDiamondVaultHostScript --rpc-url http://127.0.0.1:8545 --broadcast`

## Notes
- the hosted vault model is one diamond with separate core, controls, and integration facets
- `initializeVault(...)` on the core facet remains the only hosted initializer
- strategy-reported assets remain advisory in this milestone and do not modify core ERC-4626 liquidity math