### PR TITLE
Add hosted vault controls facet

### DIFF
--- a/src/vault/ERC4626VaultControlLogic.sol
+++ b/src/vault/ERC4626VaultControlLogic.sol
@@ -1,0 +1,436 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC4626VaultControls} from "../interfaces/IERC4626VaultControls.sol";
+import {ERC4626Vault} from "./ERC4626Vault.sol";
+import {LibERC4626VaultStorage} from "./storage/LibERC4626VaultStorage.sol";
+import {VaultFacetControl} from "./VaultFacetControl.sol";
+
+/// @title LibERC4626VaultControlLogic
+/// @notice Shared fee and limit logic for standalone and hosted vault flows.
+library LibERC4626VaultControlLogic {
+    uint256 internal constant BPS_DENOMINATOR = 10_000;
+
+    enum FeeRounding {
+        Down,
+        Up
+    }
+
+    function feeConfig() internal view returns (uint16 depositFeeBps, uint16 withdrawFeeBps, address recipient) {
+        LibERC4626VaultStorage.FeeConfig storage fees = LibERC4626VaultStorage.layout().fees;
+        return (fees.depositFeeBps, fees.withdrawFeeBps, fees.feeRecipient);
+    }
+
+    function limitConfig()
+        internal
+        view
+        returns (uint128 maxTotalAssets, uint128 maxDeposit, uint128 maxMint, uint128 maxWithdraw, uint128 maxRedeem)
+    {
+        LibERC4626VaultStorage.LimitConfig storage limits = LibERC4626VaultStorage.layout().limits;
+        return (limits.maxTotalAssets, limits.maxDeposit, limits.maxMint, limits.maxWithdraw, limits.maxRedeem);
+    }
+
+    function feeRecipient() internal view returns (address) {
+        return LibERC4626VaultStorage.layout().fees.feeRecipient;
+    }
+
+    function validateFeeBps(uint16 feeBps) internal pure {
+        if (feeBps >= BPS_DENOMINATOR) {
+            revert IERC4626VaultControls.ERC4626VaultInvalidFeeBps(feeBps);
+        }
+    }
+
+    function netAfterDepositFee(uint256 assets) internal view returns (uint256 netAssets, uint256 feeAssets) {
+        uint16 depositFeeBps = LibERC4626VaultStorage.layout().fees.depositFeeBps;
+        feeAssets = feeOnRaw(assets, depositFeeBps, FeeRounding.Down);
+        netAssets = assets - feeAssets;
+    }
+
+    function grossUpForDepositFee(uint256 netAssets) internal view returns (uint256 grossAssets) {
+        uint16 depositFeeBps = LibERC4626VaultStorage.layout().fees.depositFeeBps;
+        if (depositFeeBps == 0 || netAssets == 0) {
+            return netAssets;
+        }
+
+        uint256 denominator = BPS_DENOMINATOR - depositFeeBps;
+        grossAssets = mulDiv(netAssets, BPS_DENOMINATOR, denominator, FeeRounding.Up);
+
+        (uint256 creditedAssets,) = netAfterDepositFee(grossAssets);
+        if (creditedAssets < netAssets) {
+            grossAssets += 1;
+        }
+    }
+
+    function withdrawGrossFromNet(uint256 assets) internal view returns (uint256 grossAssets, uint256 feeAssets) {
+        uint16 withdrawFeeBps = LibERC4626VaultStorage.layout().fees.withdrawFeeBps;
+        feeAssets = feeOnRaw(assets, withdrawFeeBps, FeeRounding.Up);
+        grossAssets = assets + feeAssets;
+    }
+
+    function withdrawNetFromGross(uint256 grossAssets) internal view returns (uint256 netAssets, uint256 feeAssets) {
+        uint16 withdrawFeeBps = LibERC4626VaultStorage.layout().fees.withdrawFeeBps;
+        feeAssets = feeOnRaw(grossAssets, withdrawFeeBps, FeeRounding.Down);
+        netAssets = grossAssets - feeAssets;
+    }
+
+    function feeOnRaw(uint256 assets, uint16 feeBps, FeeRounding rounding) internal pure returns (uint256) {
+        if (feeBps == 0 || assets == 0) {
+            return 0;
+        }
+
+        return mulDiv(assets, feeBps, BPS_DENOMINATOR, rounding);
+    }
+
+    function mulDiv(uint256 x, uint256 y, uint256 denominator, FeeRounding rounding)
+        internal
+        pure
+        returns (uint256 result)
+    {
+        uint256 product = x * y;
+        result = product / denominator;
+
+        if (rounding == FeeRounding.Up && product % denominator != 0) {
+            result += 1;
+        }
+    }
+}
+
+/// @title ERC4626VaultControlledCore
+/// @notice Shared fee-aware and limit-aware ERC-4626 core behavior.
+abstract contract ERC4626VaultControlledCore is ERC4626Vault {
+    function maxDeposit(address receiver) public view virtual override returns (uint256) {
+        if (receiver == address(0) || _vaultOperationsPaused()) {
+            return 0;
+        }
+
+        uint256 maxAssets = type(uint256).max;
+        (uint128 maxTotalAssets_, uint128 maxDeposit_,,,) = LibERC4626VaultControlLogic.limitConfig();
+
+        if (maxDeposit_ != 0) {
+            maxAssets = maxDeposit_;
+        }
+
+        if (maxTotalAssets_ != 0) {
+            uint256 currentAssets = totalAssets();
+            if (currentAssets >= maxTotalAssets_) {
+                return 0;
+            }
+
+            uint256 remainingAssets = maxTotalAssets_ - currentAssets;
+            uint256 capBasedMaxAssets = LibERC4626VaultControlLogic.grossUpForDepositFee(remainingAssets);
+            if (capBasedMaxAssets < maxAssets) {
+                maxAssets = capBasedMaxAssets;
+            }
+        }
+
+        return maxAssets;
+    }
+
+    function maxMint(address receiver) public view virtual override returns (uint256) {
+        if (receiver == address(0) || _vaultOperationsPaused()) {
+            return 0;
+        }
+
+        uint256 maxShares = type(uint256).max;
+        (uint128 maxTotalAssets_,, uint128 maxMint_,,) = LibERC4626VaultControlLogic.limitConfig();
+
+        if (maxMint_ != 0) {
+            maxShares = maxMint_;
+        }
+
+        if (maxTotalAssets_ != 0) {
+            uint256 currentAssets = totalAssets();
+            if (currentAssets >= maxTotalAssets_) {
+                return 0;
+            }
+
+            uint256 remainingAssets = maxTotalAssets_ - currentAssets;
+            uint256 capBasedMaxShares = _convertToShares(remainingAssets, Rounding.Down);
+            if (capBasedMaxShares < maxShares) {
+                maxShares = capBasedMaxShares;
+            }
+        }
+
+        return maxShares;
+    }
+
+    function maxWithdraw(address owner) public view virtual override returns (uint256) {
+        if (owner == address(0) || _vaultOperationsPaused()) {
+            return 0;
+        }
+
+        uint256 grossAssets = _convertToAssets(balanceOf(owner), Rounding.Down);
+        (uint256 netAssets,) = LibERC4626VaultControlLogic.withdrawNetFromGross(grossAssets);
+
+        (,,, uint128 maxWithdraw_,) = LibERC4626VaultControlLogic.limitConfig();
+        if (maxWithdraw_ != 0 && netAssets > maxWithdraw_) {
+            return maxWithdraw_;
+        }
+
+        return netAssets;
+    }
+
+    function maxRedeem(address owner) public view virtual override returns (uint256) {
+        if (owner == address(0) || _vaultOperationsPaused()) {
+            return 0;
+        }
+
+        uint256 redeemableShares = balanceOf(owner);
+        (,,,, uint128 maxRedeem_) = LibERC4626VaultControlLogic.limitConfig();
+        if (maxRedeem_ != 0 && redeemableShares > maxRedeem_) {
+            return maxRedeem_;
+        }
+
+        return redeemableShares;
+    }
+
+    function previewDeposit(uint256 assets) public view virtual override returns (uint256) {
+        (uint256 netAssets,) = LibERC4626VaultControlLogic.netAfterDepositFee(assets);
+        return _convertToShares(netAssets, Rounding.Down);
+    }
+
+    function previewMint(uint256 shares) public view virtual override returns (uint256) {
+        uint256 netAssets = _convertToAssets(shares, Rounding.Up);
+        return LibERC4626VaultControlLogic.grossUpForDepositFee(netAssets);
+    }
+
+    function previewWithdraw(uint256 assets) public view virtual override returns (uint256) {
+        (uint256 grossAssets,) = LibERC4626VaultControlLogic.withdrawGrossFromNet(assets);
+        return _convertToShares(grossAssets, Rounding.Up);
+    }
+
+    function previewRedeem(uint256 shares) public view virtual override returns (uint256) {
+        uint256 grossAssets = _convertToAssets(shares, Rounding.Down);
+        (uint256 netAssets,) = LibERC4626VaultControlLogic.withdrawNetFromGross(grossAssets);
+        return netAssets;
+    }
+
+    function _depositWithControls(uint256 assets, address receiver) internal returns (uint256 shares) {
+        _requireInitialized();
+        _requireNonZeroAddress(receiver);
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        uint256 maxAssets = maxDeposit(receiver);
+        if (assets > maxAssets) {
+            revert IERC4626VaultControls.ERC4626VaultDepositLimitExceeded(assets, maxAssets);
+        }
+
+        (uint256 netAssets, uint256 feeAssets) = LibERC4626VaultControlLogic.netAfterDepositFee(assets);
+        _enforceTotalAssetsCap(netAssets);
+
+        shares = _convertToShares(netAssets, Rounding.Down);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        _safeTransferFromAsset(msg.sender, address(this), assets);
+        _increaseManagedAssets(netAssets);
+        _mintShares(receiver, shares);
+        _payoutFee(feeAssets);
+
+        emit Deposit(msg.sender, receiver, assets, shares);
+    }
+
+    function _mintWithControls(uint256 shares, address receiver) internal returns (uint256 assets) {
+        _requireInitialized();
+        _requireNonZeroAddress(receiver);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        uint256 maxShares = maxMint(receiver);
+        if (shares > maxShares) {
+            revert IERC4626VaultControls.ERC4626VaultMintLimitExceeded(shares, maxShares);
+        }
+
+        uint256 netAssets = _convertToAssets(shares, Rounding.Up);
+        if (netAssets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        assets = LibERC4626VaultControlLogic.grossUpForDepositFee(netAssets);
+        uint256 feeAssets = assets - netAssets;
+
+        _enforceTotalAssetsCap(netAssets);
+        _safeTransferFromAsset(msg.sender, address(this), assets);
+        _increaseManagedAssets(netAssets);
+        _mintShares(receiver, shares);
+        _payoutFee(feeAssets);
+
+        emit Deposit(msg.sender, receiver, assets, shares);
+    }
+
+    function _withdrawWithControls(uint256 assets, address receiver, address owner) internal returns (uint256 shares) {
+        _requireInitialized();
+        _requireNonZeroAddress(receiver);
+        _requireNonZeroAddress(owner);
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        uint256 maxAssets = maxWithdraw(owner);
+        if (assets > maxAssets) {
+            revert IERC4626VaultControls.ERC4626VaultWithdrawLimitExceeded(assets, maxAssets);
+        }
+
+        (uint256 grossAssets, uint256 feeAssets) = LibERC4626VaultControlLogic.withdrawGrossFromNet(assets);
+        shares = _convertToShares(grossAssets, Rounding.Up);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        if (msg.sender != owner) {
+            _spendAllowance(owner, msg.sender, shares);
+        }
+
+        _burnShares(owner, shares);
+        _decreaseManagedAssets(grossAssets);
+        _safeTransferAsset(receiver, assets);
+        _payoutFee(feeAssets);
+
+        emit Withdraw(msg.sender, receiver, owner, assets, shares);
+    }
+
+    function _redeemWithControls(uint256 shares, address receiver, address owner) internal returns (uint256 assets) {
+        _requireInitialized();
+        _requireNonZeroAddress(receiver);
+        _requireNonZeroAddress(owner);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        uint256 maxShares = maxRedeem(owner);
+        if (shares > maxShares) {
+            revert IERC4626VaultControls.ERC4626VaultRedeemLimitExceeded(shares, maxShares);
+        }
+
+        uint256 grossAssets = _convertToAssets(shares, Rounding.Down);
+        uint256 feeAssets;
+        (assets, feeAssets) = LibERC4626VaultControlLogic.withdrawNetFromGross(grossAssets);
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        if (msg.sender != owner) {
+            _spendAllowance(owner, msg.sender, shares);
+        }
+
+        _burnShares(owner, shares);
+        _decreaseManagedAssets(grossAssets);
+        _safeTransferAsset(receiver, assets);
+        _payoutFee(feeAssets);
+
+        emit Withdraw(msg.sender, receiver, owner, assets, shares);
+    }
+
+    function _enforceTotalAssetsCap(uint256 additionalAssets) internal view {
+        (uint128 maxTotalAssets_,,,,) = LibERC4626VaultControlLogic.limitConfig();
+        if (maxTotalAssets_ == 0) {
+            return;
+        }
+
+        uint256 currentAssets = totalAssets();
+        uint256 nextAssets = currentAssets + additionalAssets;
+        if (nextAssets > maxTotalAssets_) {
+            revert IERC4626VaultControls.ERC4626VaultTotalAssetsCapExceeded(
+                currentAssets, additionalAssets, maxTotalAssets_
+            );
+        }
+    }
+
+    function _payoutFee(uint256 feeAssets) internal {
+        if (feeAssets == 0) {
+            return;
+        }
+
+        _safeTransferAsset(LibERC4626VaultControlLogic.feeRecipient(), feeAssets);
+    }
+
+    function _vaultOperationsPaused() internal view virtual returns (bool);
+}
+
+/// @title ERC4626VaultControlSurface
+/// @notice Shared hosted and standalone control-plane surface for vault config and governance.
+abstract contract ERC4626VaultControlSurface is VaultFacetControl, IERC4626VaultControls {
+    function VAULT_MANAGER_ROLE()
+        public
+        pure
+        virtual
+        override(VaultFacetControl, IERC4626VaultControls)
+        returns (bytes32)
+    {
+        return VaultFacetControl.VAULT_MANAGER_ROLE();
+    }
+
+    function feeConfig()
+        public
+        view
+        virtual
+        override
+        returns (uint16 depositFeeBps, uint16 withdrawFeeBps, address feeRecipient)
+    {
+        return LibERC4626VaultControlLogic.feeConfig();
+    }
+
+    function limitConfig()
+        public
+        view
+        virtual
+        override
+        returns (uint128 maxTotalAssets, uint128 maxDeposit, uint128 maxMint, uint128 maxWithdraw, uint128 maxRedeem)
+    {
+        return LibERC4626VaultControlLogic.limitConfig();
+    }
+
+    function setFeeConfig(uint16 depositFeeBps, uint16 withdrawFeeBps, address feeRecipient)
+        public
+        virtual
+        override
+        onlyRole(VAULT_MANAGER_ROLE())
+    {
+        LibERC4626VaultControlLogic.validateFeeBps(depositFeeBps);
+        LibERC4626VaultControlLogic.validateFeeBps(withdrawFeeBps);
+
+        if ((depositFeeBps != 0 || withdrawFeeBps != 0) && feeRecipient == address(0)) {
+            revert IERC4626VaultControls.ERC4626VaultInvalidFeeRecipient();
+        }
+
+        (uint16 previousDepositFeeBps, uint16 previousWithdrawFeeBps, address previousFeeRecipient) =
+            LibERC4626VaultControlLogic.feeConfig();
+        LibERC4626VaultStorage.FeeConfig storage fees = LibERC4626VaultStorage.layout().fees;
+
+        fees.depositFeeBps = depositFeeBps;
+        fees.withdrawFeeBps = withdrawFeeBps;
+        fees.feeRecipient = feeRecipient;
+
+        emit VaultFeeConfigUpdated(
+            previousDepositFeeBps,
+            previousWithdrawFeeBps,
+            previousFeeRecipient,
+            depositFeeBps,
+            withdrawFeeBps,
+            feeRecipient,
+            msg.sender
+        );
+    }
+
+    function setLimitConfig(
+        uint128 maxTotalAssets,
+        uint128 maxDeposit,
+        uint128 maxMint,
+        uint128 maxWithdraw,
+        uint128 maxRedeem
+    ) public virtual override onlyRole(VAULT_MANAGER_ROLE()) {
+        LibERC4626VaultStorage.LimitConfig storage limits = LibERC4626VaultStorage.layout().limits;
+
+        limits.maxTotalAssets = maxTotalAssets;
+        limits.maxDeposit = maxDeposit;
+        limits.maxMint = maxMint;
+        limits.maxWithdraw = maxWithdraw;
+        limits.maxRedeem = maxRedeem;
+
+        emit VaultLimitConfigUpdated(maxTotalAssets, maxDeposit, maxMint, maxWithdraw, maxRedeem, msg.sender);
+    }
+}

--- a/src/vault/ERC4626VaultControls.sol
+++ b/src/vault/ERC4626VaultControls.sol
@@ -2,17 +2,15 @@
 pragma solidity ^0.8.30;
 
 import {IERC165} from "../interfaces/IERC165.sol";
+import {IERC4626} from "../interfaces/IERC4626.sol";
 import {IERC4626VaultControls} from "../interfaces/IERC4626VaultControls.sol";
-import {LibERC4626VaultStorage} from "./storage/LibERC4626VaultStorage.sol";
 import {ERC4626Vault} from "./ERC4626Vault.sol";
+import {ERC4626VaultControlledCore, ERC4626VaultControlSurface} from "./ERC4626VaultControlLogic.sol";
 import {VaultFacetControl} from "./VaultFacetControl.sol";
 
 /// @title ERC4626VaultControls
-/// @notice ERC-4626 extension with role-gated fee/limit controls and safety hooks.
-abstract contract ERC4626VaultControls is ERC4626Vault, VaultFacetControl, IERC4626VaultControls {
-    /// @dev Basis points denominator.
-    uint256 internal constant BPS_DENOMINATOR = 10_000;
-
+/// @notice ERC-4626 extension with role-gated fee, limit, and safety controls.
+abstract contract ERC4626VaultControls is ERC4626VaultControlSurface, ERC4626VaultControlledCore {
     /// @param initialAdmin Account receiving admin, pauser, and manager roles.
     /// @param vaultAsset Underlying vault asset token.
     /// @param vaultName ERC-20 share token name.
@@ -20,18 +18,6 @@ abstract contract ERC4626VaultControls is ERC4626Vault, VaultFacetControl, IERC4
     constructor(address initialAdmin, address vaultAsset, string memory vaultName, string memory vaultSymbol) {
         _initializeVaultFacetControl(initialAdmin);
         _initializeErc4626Vault(vaultAsset, vaultName, vaultSymbol);
-    }
-
-    /// @notice Role that can manage vault fees and limits.
-    /// @return The vault manager role identifier.
-    function VAULT_MANAGER_ROLE()
-        public
-        pure
-        virtual
-        override(VaultFacetControl, IERC4626VaultControls)
-        returns (bytes32)
-    {
-        return VaultFacetControl.VAULT_MANAGER_ROLE();
     }
 
     /// @notice Returns true if this contract implements `interfaceId`.
@@ -48,230 +34,6 @@ abstract contract ERC4626VaultControls is ERC4626Vault, VaultFacetControl, IERC4
             || VaultFacetControl.supportsInterface(interfaceId);
     }
 
-    /// @notice Returns current fee configuration.
-    /// @return depositFeeBps Deposit fee in basis points.
-    /// @return withdrawFeeBps Withdraw fee in basis points.
-    /// @return feeRecipient Fee recipient account.
-    function feeConfig() public view returns (uint16 depositFeeBps, uint16 withdrawFeeBps, address feeRecipient) {
-        LibERC4626VaultStorage.FeeConfig storage fees = LibERC4626VaultStorage.layout().fees;
-        return (fees.depositFeeBps, fees.withdrawFeeBps, fees.feeRecipient);
-    }
-
-    /// @notice Returns current limit configuration.
-    /// @return limitMaxTotalAssets Cap for managed assets (`0` means unlimited).
-    /// @return limitMaxDeposit Per-call deposit limit (`0` means unlimited).
-    /// @return limitMaxMint Per-call mint limit (`0` means unlimited).
-    /// @return limitMaxWithdraw Per-call withdraw limit (`0` means unlimited).
-    /// @return limitMaxRedeem Per-call redeem limit (`0` means unlimited).
-    function limitConfig()
-        public
-        view
-        returns (
-            uint128 limitMaxTotalAssets,
-            uint128 limitMaxDeposit,
-            uint128 limitMaxMint,
-            uint128 limitMaxWithdraw,
-            uint128 limitMaxRedeem
-        )
-    {
-        LibERC4626VaultStorage.LimitConfig storage limits = LibERC4626VaultStorage.layout().limits;
-        return (limits.maxTotalAssets, limits.maxDeposit, limits.maxMint, limits.maxWithdraw, limits.maxRedeem);
-    }
-
-    /// @notice Sets fee configuration.
-    /// @dev Caller must have `VAULT_MANAGER_ROLE`.
-    /// @param depositFeeBps Deposit fee in basis points.
-    /// @param withdrawFeeBps Withdraw fee in basis points.
-    /// @param feeRecipient Fee recipient account.
-    function setFeeConfig(uint16 depositFeeBps, uint16 withdrawFeeBps, address feeRecipient)
-        public
-        onlyRole(VAULT_MANAGER_ROLE())
-    {
-        _validateFeeBps(depositFeeBps);
-        _validateFeeBps(withdrawFeeBps);
-
-        if ((depositFeeBps != 0 || withdrawFeeBps != 0) && feeRecipient == address(0)) {
-            revert ERC4626VaultInvalidFeeRecipient();
-        }
-
-        LibERC4626VaultStorage.FeeConfig storage fees = LibERC4626VaultStorage.layout().fees;
-        uint16 previousDepositFeeBps = fees.depositFeeBps;
-        uint16 previousWithdrawFeeBps = fees.withdrawFeeBps;
-        address previousFeeRecipient = fees.feeRecipient;
-
-        fees.depositFeeBps = depositFeeBps;
-        fees.withdrawFeeBps = withdrawFeeBps;
-        fees.feeRecipient = feeRecipient;
-
-        emit VaultFeeConfigUpdated(
-            previousDepositFeeBps,
-            previousWithdrawFeeBps,
-            previousFeeRecipient,
-            depositFeeBps,
-            withdrawFeeBps,
-            feeRecipient,
-            msg.sender
-        );
-    }
-
-    /// @notice Sets limit configuration.
-    /// @dev Caller must have `VAULT_MANAGER_ROLE`.
-    /// @param limitMaxTotalAssets Cap for managed assets (`0` means unlimited).
-    /// @param limitMaxDeposit Per-call deposit limit (`0` means unlimited).
-    /// @param limitMaxMint Per-call mint limit (`0` means unlimited).
-    /// @param limitMaxWithdraw Per-call withdraw limit (`0` means unlimited).
-    /// @param limitMaxRedeem Per-call redeem limit (`0` means unlimited).
-    function setLimitConfig(
-        uint128 limitMaxTotalAssets,
-        uint128 limitMaxDeposit,
-        uint128 limitMaxMint,
-        uint128 limitMaxWithdraw,
-        uint128 limitMaxRedeem
-    ) public onlyRole(VAULT_MANAGER_ROLE()) {
-        LibERC4626VaultStorage.LimitConfig storage limits = LibERC4626VaultStorage.layout().limits;
-
-        limits.maxTotalAssets = limitMaxTotalAssets;
-        limits.maxDeposit = limitMaxDeposit;
-        limits.maxMint = limitMaxMint;
-        limits.maxWithdraw = limitMaxWithdraw;
-        limits.maxRedeem = limitMaxRedeem;
-
-        emit VaultLimitConfigUpdated(
-            limitMaxTotalAssets, limitMaxDeposit, limitMaxMint, limitMaxWithdraw, limitMaxRedeem, msg.sender
-        );
-    }
-
-    /// @notice Returns max assets `receiver` can deposit.
-    /// @param receiver Target receiver.
-    /// @return Max asset amount accepted.
-    function maxDeposit(address receiver) public view virtual override returns (uint256) {
-        if (receiver == address(0) || paused()) {
-            return 0;
-        }
-
-        uint256 maxAssets = type(uint256).max;
-        LibERC4626VaultStorage.LimitConfig storage limits = LibERC4626VaultStorage.layout().limits;
-
-        if (limits.maxDeposit != 0) {
-            maxAssets = limits.maxDeposit;
-        }
-
-        if (limits.maxTotalAssets != 0) {
-            uint256 currentAssets = totalAssets();
-            if (currentAssets >= limits.maxTotalAssets) {
-                return 0;
-            }
-
-            uint256 remainingAssets = limits.maxTotalAssets - currentAssets;
-            uint256 capBasedMaxAssets = _grossUpForDepositFee(remainingAssets);
-            if (capBasedMaxAssets < maxAssets) {
-                maxAssets = capBasedMaxAssets;
-            }
-        }
-
-        return maxAssets;
-    }
-
-    /// @notice Returns max shares `receiver` can mint.
-    /// @param receiver Target receiver.
-    /// @return Max shares accepted.
-    function maxMint(address receiver) public view virtual override returns (uint256) {
-        if (receiver == address(0) || paused()) {
-            return 0;
-        }
-
-        uint256 maxShares = type(uint256).max;
-        LibERC4626VaultStorage.LimitConfig storage limits = LibERC4626VaultStorage.layout().limits;
-
-        if (limits.maxMint != 0) {
-            maxShares = limits.maxMint;
-        }
-
-        if (limits.maxTotalAssets != 0) {
-            uint256 currentAssets = totalAssets();
-            if (currentAssets >= limits.maxTotalAssets) {
-                return 0;
-            }
-
-            uint256 remainingAssets = limits.maxTotalAssets - currentAssets;
-            uint256 capBasedMaxShares = _convertToShares(remainingAssets, Rounding.Down);
-            if (capBasedMaxShares < maxShares) {
-                maxShares = capBasedMaxShares;
-            }
-        }
-
-        return maxShares;
-    }
-
-    /// @notice Returns max assets `owner` can withdraw.
-    /// @param owner Share owner.
-    /// @return Max withdrawable assets.
-    function maxWithdraw(address owner) public view virtual override returns (uint256) {
-        if (owner == address(0) || paused()) {
-            return 0;
-        }
-
-        uint256 grossAssets = _convertToAssets(balanceOf(owner), Rounding.Down);
-        (uint256 netAssets,) = _withdrawNetFromGross(grossAssets);
-
-        uint128 configuredMaxWithdraw = LibERC4626VaultStorage.layout().limits.maxWithdraw;
-        if (configuredMaxWithdraw != 0 && netAssets > configuredMaxWithdraw) {
-            return configuredMaxWithdraw;
-        }
-
-        return netAssets;
-    }
-
-    /// @notice Returns max shares `owner` can redeem.
-    /// @param owner Share owner.
-    /// @return Max redeemable shares.
-    function maxRedeem(address owner) public view virtual override returns (uint256) {
-        if (owner == address(0) || paused()) {
-            return 0;
-        }
-
-        uint256 redeemableShares = balanceOf(owner);
-        uint128 configuredMaxRedeem = LibERC4626VaultStorage.layout().limits.maxRedeem;
-        if (configuredMaxRedeem != 0 && redeemableShares > configuredMaxRedeem) {
-            return configuredMaxRedeem;
-        }
-
-        return redeemableShares;
-    }
-
-    /// @notice Returns shares minted by depositing `assets`.
-    /// @param assets Asset amount.
-    /// @return Estimated shares.
-    function previewDeposit(uint256 assets) public view virtual override returns (uint256) {
-        (uint256 netAssets,) = _netAfterDepositFee(assets);
-        return _convertToShares(netAssets, Rounding.Down);
-    }
-
-    /// @notice Returns assets required to mint `shares`.
-    /// @param shares Share amount.
-    /// @return Required assets.
-    function previewMint(uint256 shares) public view virtual override returns (uint256) {
-        uint256 netAssets = _convertToAssets(shares, Rounding.Up);
-        return _grossUpForDepositFee(netAssets);
-    }
-
-    /// @notice Returns shares burned by withdrawing `assets`.
-    /// @param assets Asset amount.
-    /// @return Estimated shares burned.
-    function previewWithdraw(uint256 assets) public view virtual override returns (uint256) {
-        (uint256 grossAssets,) = _withdrawGrossFromNet(assets);
-        return _convertToShares(grossAssets, Rounding.Up);
-    }
-
-    /// @notice Returns assets received by redeeming `shares`.
-    /// @param shares Share amount.
-    /// @return Estimated assets returned.
-    function previewRedeem(uint256 shares) public view virtual override returns (uint256) {
-        uint256 grossAssets = _convertToAssets(shares, Rounding.Down);
-        (uint256 netAssets,) = _withdrawNetFromGross(grossAssets);
-        return netAssets;
-    }
-
     /// @notice Deposits `assets` and mints shares to `receiver`.
     /// @param assets Asset amount.
     /// @param receiver Receiver of minted shares.
@@ -279,36 +41,12 @@ abstract contract ERC4626VaultControls is ERC4626Vault, VaultFacetControl, IERC4
     function deposit(uint256 assets, address receiver)
         public
         virtual
-        override
+        override(ERC4626Vault)
         whenNotPaused
         nonReentrant
         returns (uint256 shares)
     {
-        _requireInitialized();
-        _requireNonZeroAddress(receiver);
-        if (assets == 0) {
-            revert ERC4626VaultZeroAssets();
-        }
-
-        uint256 maxAssets = maxDeposit(receiver);
-        if (assets > maxAssets) {
-            revert ERC4626VaultDepositLimitExceeded(assets, maxAssets);
-        }
-
-        (uint256 netAssets, uint256 feeAssets) = _netAfterDepositFee(assets);
-        _enforceTotalAssetsCap(netAssets);
-
-        shares = _convertToShares(netAssets, Rounding.Down);
-        if (shares == 0) {
-            revert ERC4626VaultZeroShares();
-        }
-
-        _safeTransferFromAsset(msg.sender, address(this), assets);
-        _increaseManagedAssets(netAssets);
-        _mintShares(receiver, shares);
-        _payoutFee(feeAssets);
-
-        emit Deposit(msg.sender, receiver, assets, shares);
+        return _depositWithControls(assets, receiver);
     }
 
     /// @notice Mints `shares` to `receiver`.
@@ -318,37 +56,12 @@ abstract contract ERC4626VaultControls is ERC4626Vault, VaultFacetControl, IERC4
     function mint(uint256 shares, address receiver)
         public
         virtual
-        override
+        override(ERC4626Vault)
         whenNotPaused
         nonReentrant
         returns (uint256 assets)
     {
-        _requireInitialized();
-        _requireNonZeroAddress(receiver);
-        if (shares == 0) {
-            revert ERC4626VaultZeroShares();
-        }
-
-        uint256 maxShares = maxMint(receiver);
-        if (shares > maxShares) {
-            revert ERC4626VaultMintLimitExceeded(shares, maxShares);
-        }
-
-        uint256 netAssets = _convertToAssets(shares, Rounding.Up);
-        if (netAssets == 0) {
-            revert ERC4626VaultZeroAssets();
-        }
-
-        assets = _grossUpForDepositFee(netAssets);
-        uint256 feeAssets = assets - netAssets;
-
-        _enforceTotalAssetsCap(netAssets);
-        _safeTransferFromAsset(msg.sender, address(this), assets);
-        _increaseManagedAssets(netAssets);
-        _mintShares(receiver, shares);
-        _payoutFee(feeAssets);
-
-        emit Deposit(msg.sender, receiver, assets, shares);
+        return _mintWithControls(shares, receiver);
     }
 
     /// @notice Withdraws `assets` to `receiver` from `owner`.
@@ -359,39 +72,12 @@ abstract contract ERC4626VaultControls is ERC4626Vault, VaultFacetControl, IERC4
     function withdraw(uint256 assets, address receiver, address owner)
         public
         virtual
-        override
+        override(ERC4626Vault)
         whenNotPaused
         nonReentrant
         returns (uint256 shares)
     {
-        _requireInitialized();
-        _requireNonZeroAddress(receiver);
-        _requireNonZeroAddress(owner);
-        if (assets == 0) {
-            revert ERC4626VaultZeroAssets();
-        }
-
-        uint256 maxAssets = maxWithdraw(owner);
-        if (assets > maxAssets) {
-            revert ERC4626VaultWithdrawLimitExceeded(assets, maxAssets);
-        }
-
-        (uint256 grossAssets, uint256 feeAssets) = _withdrawGrossFromNet(assets);
-        shares = _convertToShares(grossAssets, Rounding.Up);
-        if (shares == 0) {
-            revert ERC4626VaultZeroShares();
-        }
-
-        if (msg.sender != owner) {
-            _spendAllowance(owner, msg.sender, shares);
-        }
-
-        _burnShares(owner, shares);
-        _decreaseManagedAssets(grossAssets);
-        _safeTransferAsset(receiver, assets);
-        _payoutFee(feeAssets);
-
-        emit Withdraw(msg.sender, receiver, owner, assets, shares);
+        return _withdrawWithControls(assets, receiver, owner);
     }
 
     /// @notice Redeems `shares` from `owner` to `receiver`.
@@ -402,134 +88,15 @@ abstract contract ERC4626VaultControls is ERC4626Vault, VaultFacetControl, IERC4
     function redeem(uint256 shares, address receiver, address owner)
         public
         virtual
-        override
+        override(ERC4626Vault)
         whenNotPaused
         nonReentrant
         returns (uint256 assets)
     {
-        _requireInitialized();
-        _requireNonZeroAddress(receiver);
-        _requireNonZeroAddress(owner);
-        if (shares == 0) {
-            revert ERC4626VaultZeroShares();
-        }
-
-        uint256 maxShares = maxRedeem(owner);
-        if (shares > maxShares) {
-            revert ERC4626VaultRedeemLimitExceeded(shares, maxShares);
-        }
-
-        uint256 grossAssets = _convertToAssets(shares, Rounding.Down);
-        uint256 feeAssets;
-        (assets, feeAssets) = _withdrawNetFromGross(grossAssets);
-        if (assets == 0) {
-            revert ERC4626VaultZeroAssets();
-        }
-
-        if (msg.sender != owner) {
-            _spendAllowance(owner, msg.sender, shares);
-        }
-
-        _burnShares(owner, shares);
-        _decreaseManagedAssets(grossAssets);
-        _safeTransferAsset(receiver, assets);
-        _payoutFee(feeAssets);
-
-        emit Withdraw(msg.sender, receiver, owner, assets, shares);
+        return _redeemWithControls(shares, receiver, owner);
     }
 
-    /// @dev Enforces configured total-assets cap.
-    /// @param additionalAssets Assets to be added to managed accounting.
-    function _enforceTotalAssetsCap(uint256 additionalAssets) internal view {
-        uint128 cap = LibERC4626VaultStorage.layout().limits.maxTotalAssets;
-        if (cap == 0) {
-            return;
-        }
-
-        uint256 currentAssets = totalAssets();
-        uint256 nextAssets = currentAssets + additionalAssets;
-        if (nextAssets > cap) {
-            revert ERC4626VaultTotalAssetsCapExceeded(currentAssets, additionalAssets, cap);
-        }
-    }
-
-    /// @dev Returns net deposit assets and fee amount from a gross input.
-    /// @param assets Gross deposit asset amount.
-    /// @return netAssets Net assets credited to vault accounting.
-    /// @return feeAssets Fee assets paid out.
-    function _netAfterDepositFee(uint256 assets) internal view returns (uint256 netAssets, uint256 feeAssets) {
-        uint16 depositFeeBps = LibERC4626VaultStorage.layout().fees.depositFeeBps;
-        feeAssets = _feeOnRaw(assets, depositFeeBps, Rounding.Down);
-        netAssets = assets - feeAssets;
-    }
-
-    /// @dev Returns gross deposit amount needed to credit `netAssets`.
-    /// @param netAssets Desired net assets credited to vault accounting.
-    /// @return grossAssets Gross assets that must be transferred in.
-    function _grossUpForDepositFee(uint256 netAssets) internal view returns (uint256 grossAssets) {
-        uint16 depositFeeBps = LibERC4626VaultStorage.layout().fees.depositFeeBps;
-        if (depositFeeBps == 0 || netAssets == 0) {
-            return netAssets;
-        }
-
-        uint256 denominator = BPS_DENOMINATOR - depositFeeBps;
-        grossAssets = _mulDiv(netAssets, BPS_DENOMINATOR, denominator, Rounding.Up);
-
-        (uint256 creditedAssets,) = _netAfterDepositFee(grossAssets);
-        if (creditedAssets < netAssets) {
-            grossAssets += 1;
-        }
-    }
-
-    /// @dev Returns gross withdraw assets and fee from a requested net output.
-    /// @param assets Requested receiver assets.
-    /// @return grossAssets Gross assets removed from managed accounting.
-    /// @return feeAssets Fee assets paid out.
-    function _withdrawGrossFromNet(uint256 assets) internal view returns (uint256 grossAssets, uint256 feeAssets) {
-        uint16 withdrawFeeBps = LibERC4626VaultStorage.layout().fees.withdrawFeeBps;
-        feeAssets = _feeOnRaw(assets, withdrawFeeBps, Rounding.Up);
-        grossAssets = assets + feeAssets;
-    }
-
-    /// @dev Returns receiver assets and fee from a gross redeemed amount.
-    /// @param grossAssets Gross assets removed from managed accounting.
-    /// @return netAssets Assets sent to receiver.
-    /// @return feeAssets Fee assets paid out.
-    function _withdrawNetFromGross(uint256 grossAssets) internal view returns (uint256 netAssets, uint256 feeAssets) {
-        uint16 withdrawFeeBps = LibERC4626VaultStorage.layout().fees.withdrawFeeBps;
-        feeAssets = _feeOnRaw(grossAssets, withdrawFeeBps, Rounding.Down);
-        netAssets = grossAssets - feeAssets;
-    }
-
-    /// @dev Pays `feeAssets` to configured fee recipient when non-zero.
-    /// @param feeAssets Fee amount to transfer.
-    function _payoutFee(uint256 feeAssets) internal {
-        if (feeAssets == 0) {
-            return;
-        }
-
-        address recipient = LibERC4626VaultStorage.layout().fees.feeRecipient;
-        _safeTransferAsset(recipient, feeAssets);
-    }
-
-    /// @dev Reverts when `feeBps` is invalid.
-    /// @param feeBps Fee basis points.
-    function _validateFeeBps(uint16 feeBps) internal pure {
-        if (feeBps >= BPS_DENOMINATOR) {
-            revert ERC4626VaultInvalidFeeBps(feeBps);
-        }
-    }
-
-    /// @dev Returns fee amount for `assets` and `feeBps` with controlled rounding.
-    /// @param assets Asset amount used for fee computation.
-    /// @param feeBps Fee basis points.
-    /// @param rounding Rounding direction.
-    /// @return Computed fee amount.
-    function _feeOnRaw(uint256 assets, uint16 feeBps, Rounding rounding) internal pure returns (uint256) {
-        if (feeBps == 0 || assets == 0) {
-            return 0;
-        }
-
-        return _mulDiv(assets, feeBps, BPS_DENOMINATOR, rounding);
+    function _vaultOperationsPaused() internal view virtual override returns (bool) {
+        return paused();
     }
 }

--- a/src/vault/facets/ERC4626VaultControlsFacet.sol
+++ b/src/vault/facets/ERC4626VaultControlsFacet.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "../../interfaces/IAccessControl.sol";
+import {IAccessControlTime} from "../../interfaces/IAccessControlTime.sol";
+import {IERC165} from "../../interfaces/IERC165.sol";
+import {IERC4626VaultControls} from "../../interfaces/IERC4626VaultControls.sol";
+import {IERC4626VaultControlsFacet} from "../../interfaces/IERC4626VaultControlsFacet.sol";
+import {IPausable} from "../../interfaces/IPausable.sol";
+import {IReentrancyGuard} from "../../interfaces/IReentrancyGuard.sol";
+import {ERC4626VaultControlSurface} from "../ERC4626VaultControlLogic.sol";
+import {VaultFacetControl} from "../VaultFacetControl.sol";
+
+/// @title ERC4626VaultControlsFacet
+/// @notice Hosted control-plane facet for vault fee, limit, and governance operations.
+contract ERC4626VaultControlsFacet is ERC4626VaultControlSurface {
+    /// @notice Returns true if this contract implements `interfaceId`.
+    /// @param interfaceId The interface identifier.
+    /// @return True if the interface is supported.
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(VaultFacetControl, IERC165)
+        returns (bool)
+    {
+        return interfaceId == type(IERC165).interfaceId || interfaceId == type(IERC4626VaultControls).interfaceId
+            || interfaceId == type(IERC4626VaultControlsFacet).interfaceId
+            || interfaceId == type(IAccessControl).interfaceId || interfaceId == type(IAccessControlTime).interfaceId
+            || interfaceId == type(IPausable).interfaceId || interfaceId == type(IReentrancyGuard).interfaceId
+            || VaultFacetControl.supportsInterface(interfaceId);
+    }
+}

--- a/src/vault/facets/ERC4626VaultFacet.sol
+++ b/src/vault/facets/ERC4626VaultFacet.sol
@@ -5,11 +5,12 @@ import {IERC4626} from "../../interfaces/IERC4626.sol";
 import {IERC4626VaultFacet} from "../../interfaces/IERC4626VaultFacet.sol";
 import {ERC4626Vault} from "../ERC4626Vault.sol";
 import {ERC4626VaultBase} from "../ERC4626VaultBase.sol";
+import {ERC4626VaultControlledCore} from "../ERC4626VaultControlLogic.sol";
 import {VaultFacetControl} from "../VaultFacetControl.sol";
 
 /// @title ERC4626VaultFacet
 /// @notice Hosted ERC-4626 core facet with constructor-free initialization.
-contract ERC4626VaultFacet is ERC4626Vault, VaultFacetControl, IERC4626VaultFacet {
+contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IERC4626VaultFacet {
     /// @notice Returns true when vault storage is initialized.
     /// @return True if initialized.
     function isVaultInitialized() public view virtual override(IERC4626VaultFacet, ERC4626VaultBase) returns (bool) {
@@ -60,7 +61,7 @@ contract ERC4626VaultFacet is ERC4626Vault, VaultFacetControl, IERC4626VaultFace
         nonReentrant
         returns (uint256 shares)
     {
-        return super.deposit(assets, receiver);
+        return _depositWithControls(assets, receiver);
     }
 
     /// @notice Mints `shares` to `receiver`.
@@ -75,7 +76,7 @@ contract ERC4626VaultFacet is ERC4626Vault, VaultFacetControl, IERC4626VaultFace
         nonReentrant
         returns (uint256 assets)
     {
-        return super.mint(shares, receiver);
+        return _mintWithControls(shares, receiver);
     }
 
     /// @notice Withdraws `assets` to `receiver` from `owner`.
@@ -91,7 +92,7 @@ contract ERC4626VaultFacet is ERC4626Vault, VaultFacetControl, IERC4626VaultFace
         nonReentrant
         returns (uint256 shares)
     {
-        return super.withdraw(assets, receiver, owner);
+        return _withdrawWithControls(assets, receiver, owner);
     }
 
     /// @notice Redeems `shares` from `owner` to `receiver`.
@@ -107,6 +108,10 @@ contract ERC4626VaultFacet is ERC4626Vault, VaultFacetControl, IERC4626VaultFace
         nonReentrant
         returns (uint256 assets)
     {
-        return super.redeem(shares, receiver, owner);
+        return _redeemWithControls(shares, receiver, owner);
+    }
+
+    function _vaultOperationsPaused() internal view virtual override returns (bool) {
+        return paused();
     }
 }

--- a/test/ERC4626VaultControlsFacetCore.t.sol
+++ b/test/ERC4626VaultControlsFacetCore.t.sol
@@ -1,0 +1,294 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
+import {IAccessControlTime} from "../src/interfaces/IAccessControlTime.sol";
+import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
+import {IERC165} from "../src/interfaces/IERC165.sol";
+import {IERC4626} from "../src/interfaces/IERC4626.sol";
+import {IERC4626VaultBase} from "../src/interfaces/IERC4626VaultBase.sol";
+import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol";
+import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControlsFacet.sol";
+import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
+import {IPausable} from "../src/interfaces/IPausable.sol";
+import {IReentrancyGuard} from "../src/interfaces/IReentrancyGuard.sol";
+import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
+import {ERC4626VaultControlsFacetFixture} from "./helpers/ERC4626VaultControlsFacetTestHarness.sol";
+
+contract ERC4626VaultControlsFacetCoreTest is ERC4626VaultControlsFacetFixture {
+    function testDirectControlsFacetReadWriteAndInterfaceSupportAfterTestInit() public {
+        _initializeDirectControlsFacet();
+
+        assertTrue(controlsFacet.hasRole(controlsFacet.DEFAULT_ADMIN_ROLE(), admin), "missing default admin role");
+        assertTrue(controlsFacet.hasRole(controlsFacet.PAUSER_ROLE(), admin), "missing pauser role");
+        assertTrue(controlsFacet.hasRole(controlsFacet.VAULT_MANAGER_ROLE(), admin), "missing vault manager role");
+        assertFalse(controlsFacet.reentrancyGuardEntered(), "reentrancy guard should be idle");
+
+        (uint16 depositFeeBps, uint16 withdrawFeeBps, address feeRecipient) = controlsFacet.feeConfig();
+        assertTrue(depositFeeBps == 0, "unexpected deposit fee");
+        assertTrue(withdrawFeeBps == 0, "unexpected withdraw fee");
+        assertTrue(feeRecipient == admin, "unexpected fee recipient");
+
+        (uint128 maxTotalAssets, uint128 maxDeposit, uint128 maxMint, uint128 maxWithdraw, uint128 maxRedeem) =
+            controlsFacet.limitConfig();
+        assertTrue(maxTotalAssets == 0, "unexpected max total assets");
+        assertTrue(maxDeposit == 0, "unexpected max deposit");
+        assertTrue(maxMint == 0, "unexpected max mint");
+        assertTrue(maxWithdraw == 0, "unexpected max withdraw");
+        assertTrue(maxRedeem == 0, "unexpected max redeem");
+
+        assertTrue(controlsFacet.supportsInterface(type(IERC165).interfaceId), "erc165 unsupported");
+        assertTrue(controlsFacet.supportsInterface(type(IERC4626VaultControls).interfaceId), "controls unsupported");
+        assertTrue(
+            controlsFacet.supportsInterface(type(IERC4626VaultControlsFacet).interfaceId), "controls facet unsupported"
+        );
+        assertTrue(controlsFacet.supportsInterface(type(IAccessControl).interfaceId), "access control unsupported");
+        assertTrue(
+            controlsFacet.supportsInterface(type(IAccessControlTime).interfaceId), "access control time unsupported"
+        );
+        assertTrue(controlsFacet.supportsInterface(type(IPausable).interfaceId), "pausable unsupported");
+        assertTrue(controlsFacet.supportsInterface(type(IReentrancyGuard).interfaceId), "reentrancy unsupported");
+        assertFalse(controlsFacet.supportsInterface(type(IERC4626).interfaceId), "erc4626 should not be reported");
+
+        VM.prank(admin);
+        controlsFacet.setFeeConfig(500, 250, eve);
+        VM.prank(admin);
+        controlsFacet.setLimitConfig(1_000, 500, 300, 200, 100);
+
+        (depositFeeBps, withdrawFeeBps, feeRecipient) = controlsFacet.feeConfig();
+        assertTrue(depositFeeBps == 500, "deposit fee not updated");
+        assertTrue(withdrawFeeBps == 250, "withdraw fee not updated");
+        assertTrue(feeRecipient == eve, "fee recipient not updated");
+
+        (maxTotalAssets, maxDeposit, maxMint, maxWithdraw, maxRedeem) = controlsFacet.limitConfig();
+        assertTrue(maxTotalAssets == 1_000, "max total assets not updated");
+        assertTrue(maxDeposit == 500, "max deposit not updated");
+        assertTrue(maxMint == 300, "max mint not updated");
+        assertTrue(maxWithdraw == 200, "max withdraw not updated");
+        assertTrue(maxRedeem == 100, "max redeem not updated");
+    }
+
+    function testDirectControlsFacetRejectsInvalidFeeConfigAndNonManagerCalls() public {
+        _initializeDirectControlsFacet();
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorized.selector, eve, controlsFacet.VAULT_MANAGER_ROLE()
+            )
+        );
+        VM.prank(eve);
+        controlsFacet.setFeeConfig(100, 0, eve);
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultControls.ERC4626VaultInvalidFeeBps.selector, 10_000));
+        controlsFacet.setFeeConfig(10_000, 0, admin);
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultControls.ERC4626VaultInvalidFeeRecipient.selector));
+        controlsFacet.setFeeConfig(100, 0, address(0));
+    }
+
+    function testDirectControlsFacetPauseAndRoleWindowSmoke() public {
+        _initializeDirectControlsFacet();
+        bytes32 scope = keccak256("ops");
+
+        VM.prank(admin);
+        controlsFacet.pauseScope(scope);
+        assertTrue(controlsFacet.scopePaused(scope), "scope should be paused");
+        assertTrue(controlsFacet.paused(scope), "effective scope pause mismatch");
+        assertFalse(controlsFacet.paused(), "global pause should remain unset");
+
+        VM.prank(admin);
+        controlsFacet.unpauseScope(scope);
+        assertFalse(controlsFacet.scopePaused(scope), "scope should be unpaused");
+
+        VM.prank(admin);
+        controlsFacet.pause();
+        assertTrue(controlsFacet.paused(), "global pause should be set");
+
+        VM.prank(admin);
+        controlsFacet.unpause();
+        assertFalse(controlsFacet.paused(), "global pause should clear");
+
+        bytes32 managerRole = controlsFacet.VAULT_MANAGER_ROLE();
+
+        VM.prank(admin);
+        controlsFacet.grantRoleWithWindow(managerRole, eve, 100, 200);
+        assertTrue(controlsFacet.hasRole(managerRole, eve), "manager role missing");
+
+        (uint64 start, uint64 end, bool exists) = controlsFacet.getRoleWindow(managerRole, eve);
+        assertTrue(exists, "window should exist");
+        assertTrue(start == 100, "window start mismatch");
+        assertTrue(end == 200, "window end mismatch");
+
+        VM.warp(99);
+        assertFalse(controlsFacet.hasActiveRole(managerRole, eve), "window should be inactive");
+        VM.warp(100);
+        assertTrue(controlsFacet.hasActiveRole(managerRole, eve), "window should be active");
+        VM.warp(200);
+        assertFalse(controlsFacet.hasActiveRole(managerRole, eve), "window should expire");
+    }
+
+    function testDiamondSelectorsSplitBetweenCoreAndControlsFacets() public {
+        _installHostedVaultFacetsToDiamond();
+        _initializeDiamondVault();
+
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultCoreSelectors(), address(coreFacet));
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultControlsSelectors(), address(controlsFacet));
+
+        assertTrue(
+            IDiamondLoupe(address(diamond)).facetFunctionSelectors(address(coreFacet)).length
+                == LibVaultFacetSelectors.vaultCoreSelectors().length,
+            "unexpected core selector count"
+        );
+        assertTrue(
+            IDiamondLoupe(address(diamond)).facetFunctionSelectors(address(controlsFacet)).length
+                == LibVaultFacetSelectors.vaultControlsSelectors().length,
+            "unexpected controls selector count"
+        );
+        assertTrue(
+            IDiamondLoupe(address(diamond)).facetAddress(IERC4626VaultFacet.initializeVault.selector)
+                == address(coreFacet),
+            "initializer owner mismatch"
+        );
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultAlreadyInitialized.selector));
+        IERC4626VaultFacet(address(diamond)).initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function testDiamondControlsConfigReshapesCoreRouting() public {
+        _installHostedVaultFacetsToDiamond();
+        _initializeDiamondVault();
+        _approveAsset(bob, address(diamond), 200);
+
+        VM.prank(admin);
+        IERC4626VaultControlsFacet(address(diamond)).setFeeConfig(1_000, 1_000, eve);
+        VM.prank(admin);
+        IERC4626VaultControlsFacet(address(diamond)).setLimitConfig(60, 50, 40, 25, 20);
+
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewDeposit(100) == 90, "previewDeposit mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewMint(50) == 56, "previewMint mismatch");
+
+        VM.prank(bob);
+        uint256 shares = IERC4626VaultFacet(address(diamond)).deposit(50, bob);
+        assertTrue(shares == 45, "deposit shares mismatch");
+        assertTrue(asset.balanceOf(eve) == INITIAL_ASSETS + 5, "fee recipient balance mismatch");
+
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxDeposit(bob) == 17, "maxDeposit mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxMint(bob) == 15, "maxMint mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxWithdraw(bob) == 25, "maxWithdraw mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxRedeem(bob) == 20, "maxRedeem mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewWithdraw(20) == 22, "previewWithdraw mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewRedeem(20) == 18, "previewRedeem mismatch");
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultControls.ERC4626VaultDepositLimitExceeded.selector, 18, 17));
+        IERC4626VaultFacet(address(diamond)).deposit(18, bob);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultControls.ERC4626VaultMintLimitExceeded.selector, 16, 15));
+        IERC4626VaultFacet(address(diamond)).mint(16, bob);
+
+        VM.prank(bob);
+        VM.expectRevert(
+            abi.encodeWithSelector(IERC4626VaultControls.ERC4626VaultWithdrawLimitExceeded.selector, 26, 25)
+        );
+        IERC4626VaultFacet(address(diamond)).withdraw(26, bob, bob);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultControls.ERC4626VaultRedeemLimitExceeded.selector, 21, 20));
+        IERC4626VaultFacet(address(diamond)).redeem(21, bob, bob);
+    }
+
+    function testDiamondGlobalPauseBlocksVaultEntrypointsButNotShareTokenFlows() public {
+        _installHostedVaultFacetsToDiamond();
+        _initializeDiamondVault();
+        _approveAsset(bob, address(diamond), 100);
+
+        VM.prank(bob);
+        IERC4626VaultFacet(address(diamond)).deposit(40, bob);
+
+        VM.prank(admin);
+        IERC4626VaultControlsFacet(address(diamond)).pause();
+
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxDeposit(bob) == 0, "maxDeposit should pause");
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxMint(bob) == 0, "maxMint should pause");
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxWithdraw(bob) == 0, "maxWithdraw should pause");
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxRedeem(bob) == 0, "maxRedeem should pause");
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+        IERC4626VaultFacet(address(diamond)).deposit(1, bob);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+        IERC4626VaultFacet(address(diamond)).mint(1, bob);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+        IERC4626VaultFacet(address(diamond)).withdraw(1, bob, bob);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+        IERC4626VaultFacet(address(diamond)).redeem(1, bob, bob);
+
+        VM.prank(bob);
+        IERC4626VaultFacet(address(diamond)).approve(eve, 15);
+        VM.prank(eve);
+        IERC4626VaultFacet(address(diamond)).transferFrom(bob, admin, 10);
+        VM.prank(bob);
+        IERC4626VaultFacet(address(diamond)).transfer(admin, 5);
+
+        assertTrue(IERC4626VaultFacet(address(diamond)).allowance(bob, eve) == 5, "allowance mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).balanceOf(bob) == 25, "bob balance mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).balanceOf(admin) == 15, "admin balance mismatch");
+    }
+
+    function testDiamondScopePauseRoutesButDoesNotBlockVaultEntrypoints() public {
+        _installHostedVaultFacetsToDiamond();
+        _initializeDiamondVault();
+        _approveAsset(bob, address(diamond), 100);
+        bytes32 scope = keccak256("vault-ops");
+
+        VM.prank(admin);
+        IERC4626VaultControlsFacet(address(diamond)).pauseScope(scope);
+
+        assertTrue(IERC4626VaultControlsFacet(address(diamond)).scopePaused(scope), "scope pause mismatch");
+        assertTrue(IERC4626VaultControlsFacet(address(diamond)).paused(scope), "effective scope pause mismatch");
+        assertFalse(IERC4626VaultControlsFacet(address(diamond)).paused(), "global pause should remain unset");
+
+        VM.prank(bob);
+        uint256 shares = IERC4626VaultFacet(address(diamond)).deposit(10, bob);
+        assertTrue(shares == 10, "scope pause should not block deposit");
+    }
+
+    function testDiamondTimeWindowSelectorsRouteForManagerDelegation() public {
+        _installHostedVaultFacetsToDiamond();
+        _initializeDiamondVault();
+
+        bytes32 managerRole = IERC4626VaultControlsFacet(address(diamond)).VAULT_MANAGER_ROLE();
+
+        VM.prank(admin);
+        IERC4626VaultControlsFacet(address(diamond)).grantRoleWithWindow(managerRole, eve, 100, 200);
+
+        (uint64 start, uint64 end, bool exists) =
+            IERC4626VaultControlsFacet(address(diamond)).getRoleWindow(managerRole, eve);
+        assertTrue(exists, "window should exist");
+        assertTrue(start == 100, "window start mismatch");
+        assertTrue(end == 200, "window end mismatch");
+
+        VM.warp(150);
+        assertTrue(
+            IERC4626VaultControlsFacet(address(diamond)).hasActiveRole(managerRole, eve), "window should be active"
+        );
+    }
+
+    function _assertSelectorsOwnedByFacet(bytes4[] memory selectors, address expectedFacet) internal view {
+        for (uint256 i = 0; i < selectors.length; i++) {
+            assertTrue(
+                IDiamondLoupe(address(diamond)).facetAddress(selectors[i]) == expectedFacet, "selector owner mismatch"
+            );
+        }
+    }
+}

--- a/test/ERC4626VaultFacetCore.t.sol
+++ b/test/ERC4626VaultFacetCore.t.sol
@@ -112,10 +112,10 @@ contract ERC4626VaultFacetCoreTest is ERC4626VaultFacetFixture {
         VM.prank(admin);
         facet.pause();
 
-        assertTrue(facet.maxDeposit(bob) == type(uint256).max, "maxDeposit should remain baseline");
-        assertTrue(facet.maxMint(bob) == type(uint256).max, "maxMint should remain baseline");
-        assertTrue(facet.maxWithdraw(bob) == 40, "maxWithdraw should remain baseline");
-        assertTrue(facet.maxRedeem(bob) == 40, "maxRedeem should remain baseline");
+        assertTrue(facet.maxDeposit(bob) == 0, "maxDeposit should pause");
+        assertTrue(facet.maxMint(bob) == 0, "maxMint should pause");
+        assertTrue(facet.maxWithdraw(bob) == 0, "maxWithdraw should pause");
+        assertTrue(facet.maxRedeem(bob) == 0, "maxRedeem should pause");
 
         VM.prank(bob);
         VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));

--- a/test/helpers/ERC4626VaultControlsFacetTestHarness.sol
+++ b/test/helpers/ERC4626VaultControlsFacetTestHarness.sol
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
+import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
+import {IERC4626VaultControlsFacet} from "../../src/interfaces/IERC4626VaultControlsFacet.sol";
+import {IERC4626VaultFacet} from "../../src/interfaces/IERC4626VaultFacet.sol";
+import {ERC4626Vault} from "../../src/vault/ERC4626Vault.sol";
+import {ERC4626VaultControlsFacet} from "../../src/vault/facets/ERC4626VaultControlsFacet.sol";
+import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
+import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
+import {ERC4626VaultFacetHarness} from "./ERC4626VaultFacetTestHarness.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+import {ReentrantMockVaultAsset} from "./ERC4626VaultControlsTestHarness.sol";
+
+contract ERC4626VaultControlsFacetHarness is ERC4626VaultControlsFacet, ERC4626Vault {
+    function initializeHostedVaultForTest(
+        address vaultAsset,
+        string memory vaultName,
+        string memory vaultSymbol,
+        address admin
+    ) external {
+        _initializeVaultFacetControl(admin);
+        _initializeErc4626Vault(vaultAsset, vaultName, vaultSymbol);
+    }
+}
+
+abstract contract ERC4626VaultControlsFacetFixture is TestBase {
+    uint256 internal constant INITIAL_ASSETS = 1_000_000;
+
+    address internal admin = address(0xA11CE);
+    address internal bob = address(0xB0B);
+    address internal eve = address(0xE11E);
+
+    ReentrantMockVaultAsset internal asset;
+    ERC4626VaultFacetHarness internal coreFacet;
+    ERC4626VaultControlsFacetHarness internal controlsFacet;
+    DiamondCutFacet internal cutFacet;
+    DiamondLoupeFacet internal loupeFacet;
+    DiamondProxyHarness internal diamond;
+
+    function setUp() public virtual {
+        asset = new ReentrantMockVaultAsset();
+        coreFacet = new ERC4626VaultFacetHarness();
+        controlsFacet = new ERC4626VaultControlsFacetHarness();
+        cutFacet = new DiamondCutFacet();
+        loupeFacet = new DiamondLoupeFacet();
+        diamond = new DiamondProxyHarness(admin, address(cutFacet));
+
+        asset.mint(bob, INITIAL_ASSETS);
+        asset.mint(eve, INITIAL_ASSETS);
+
+        _installLoupeFacet();
+    }
+
+    function _initializeDirectControlsFacet() internal {
+        controlsFacet.initializeHostedVaultForTest(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function _initializeDiamondVault() internal {
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond)).initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function _approveAsset(address owner, address spender, uint256 amount) internal {
+        VM.prank(owner);
+        asset.approve(spender, amount);
+    }
+
+    function _installLoupeFacet() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(loupeFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: _loupeSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installVaultCoreFacetToDiamond() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(coreFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultCoreSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installVaultControlsFacetToDiamond() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(controlsFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultControlsSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installHostedVaultFacetsToDiamond() internal {
+        _installVaultCoreFacetToDiamond();
+        _installVaultControlsFacetToDiamond();
+    }
+
+    function _loupeSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](6);
+        selectors[0] = DiamondLoupeFacet.facets.selector;
+        selectors[1] = DiamondLoupeFacet.facetFunctionSelectors.selector;
+        selectors[2] = DiamondLoupeFacet.facetAddresses.selector;
+        selectors[3] = DiamondLoupeFacet.facetAddress.selector;
+        selectors[4] = DiamondLoupeFacet.owner.selector;
+        selectors[5] = DiamondLoupeFacet.transferOwnership.selector;
+    }
+}


### PR DESCRIPTION
## Summary
- add shared fee and limit logic for standalone and hosted vault flows
- add the hosted vault controls facet and wire the hosted core facet to honor fee and limit storage
- add direct and diamond-routed coverage for selector ownership, config routing, pause behavior, and time-window ACL selectors

## Validation
- `git diff --check`
- `forge fmt --check`
- `forge test --offline --match-path test/ERC4626VaultControlsFacetCore.t.sol`
- `forge test --offline --match-path test/ERC4626VaultControlsCore.t.sol`
- `forge test --offline --match-path test/ERC4626VaultFacetCore.t.sol`
- `forge test --offline --match-path test/ERC4626VaultAccountingFuzz.t.sol`
- `forge test --offline --match-path test/ERC4626VaultAccountingInvariant.t.sol`
- `forge test --offline`

## Issue
- Closes #97