### PR TITLE
Add vault integration facet

### DIFF
--- a/src/interfaces/IERC4626VaultIntegrationFacet.sol
+++ b/src/interfaces/IERC4626VaultIntegrationFacet.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC165} from "./IERC165.sol";
+import {IOracleAdapter} from "./IOracleAdapter.sol";
+
+/// @title IERC4626VaultIntegrationFacet
+/// @notice Hosted integration/config surface for vault oracle and strategy wiring.
+interface IERC4626VaultIntegrationFacet is IERC165 {
+    /// @notice Emitted when the configured oracle adapter is updated.
+    event VaultOracleAdapterUpdated(
+        address indexed previousAdapter, address indexed newAdapter, address indexed sender
+    );
+
+    /// @notice Emitted when the configured strategy address is updated.
+    event VaultStrategyUpdated(address indexed previousStrategy, address indexed newStrategy, address indexed sender);
+
+    /// @notice Emitted when reported strategy assets are updated.
+    event VaultStrategyAssetsReported(uint256 previousAssets, uint256 newAssets, address indexed sender);
+
+    /// @notice Thrown when `oracleQuote()` is called without a configured adapter.
+    error ERC4626VaultOracleAdapterNotConfigured();
+
+    /// @notice Thrown when `reportStrategyAssets()` is called by an unauthorized account.
+    /// @param caller The unauthorized caller.
+    /// @param strategy The currently configured strategy address.
+    error ERC4626VaultStrategyReporterUnauthorized(address caller, address strategy);
+
+    /// @notice Returns the configured external oracle adapter address.
+    /// @return The adapter address, or zero when unset.
+    function oracleAdapter() external view returns (address);
+
+    /// @notice Returns the configured strategy address.
+    /// @return The strategy address, or zero when unset.
+    function strategy() external view returns (address);
+
+    /// @notice Returns the latest reported strategy-held asset amount.
+    /// @return The reported asset amount.
+    function strategyReportedAssets() external view returns (uint256);
+
+    /// @notice Returns the vault's idle underlying asset balance.
+    /// @return The idle asset amount held directly by the vault.
+    function idleAssets() external view returns (uint256);
+
+    /// @notice Returns idle assets plus the latest reported strategy assets.
+    /// @return The estimated total assets across idle vault balance and strategy reports.
+    function estimatedTotalManagedAssets() external view returns (uint256);
+
+    /// @notice Returns the latest normalized quote from the configured oracle adapter.
+    /// @return quotePayload The latest quote payload.
+    function oracleQuote() external view returns (IOracleAdapter.OracleQuote memory quotePayload);
+
+    /// @notice Sets the external oracle adapter reference.
+    /// @param newAdapter The new adapter address, or zero to clear.
+    function setOracleAdapter(address newAdapter) external;
+
+    /// @notice Sets the configured strategy reference.
+    /// @param newStrategy The new strategy address, or zero to clear.
+    function setStrategy(address newStrategy) external;
+
+    /// @notice Updates the latest reported strategy-held asset amount.
+    /// @param assets The latest reported asset amount.
+    function reportStrategyAssets(uint256 assets) external;
+}

--- a/src/vault/facets/ERC4626VaultControlsFacet.sol
+++ b/src/vault/facets/ERC4626VaultControlsFacet.sol
@@ -6,8 +6,10 @@ import {IAccessControlTime} from "../../interfaces/IAccessControlTime.sol";
 import {IERC165} from "../../interfaces/IERC165.sol";
 import {IERC4626VaultControls} from "../../interfaces/IERC4626VaultControls.sol";
 import {IERC4626VaultControlsFacet} from "../../interfaces/IERC4626VaultControlsFacet.sol";
+import {IERC4626VaultIntegrationFacet} from "../../interfaces/IERC4626VaultIntegrationFacet.sol";
 import {IPausable} from "../../interfaces/IPausable.sol";
 import {IReentrancyGuard} from "../../interfaces/IReentrancyGuard.sol";
+import {LibDiamond} from "../../diamond/libraries/LibDiamond.sol";
 import {ERC4626VaultControlSurface} from "../ERC4626VaultControlLogic.sol";
 import {VaultFacetControl} from "../VaultFacetControl.sol";
 
@@ -26,6 +28,8 @@ contract ERC4626VaultControlsFacet is ERC4626VaultControlSurface {
     {
         return interfaceId == type(IERC165).interfaceId || interfaceId == type(IERC4626VaultControls).interfaceId
             || interfaceId == type(IERC4626VaultControlsFacet).interfaceId
+            || (interfaceId == type(IERC4626VaultIntegrationFacet).interfaceId
+                && LibDiamond.selectorExists(IERC4626VaultIntegrationFacet.oracleAdapter.selector))
             || interfaceId == type(IAccessControl).interfaceId || interfaceId == type(IAccessControlTime).interfaceId
             || interfaceId == type(IPausable).interfaceId || interfaceId == type(IReentrancyGuard).interfaceId
             || VaultFacetControl.supportsInterface(interfaceId);

--- a/src/vault/facets/ERC4626VaultIntegrationFacet.sol
+++ b/src/vault/facets/ERC4626VaultIntegrationFacet.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC20} from "../../interfaces/IERC20.sol";
+import {IERC4626VaultIntegrationFacet} from "../../interfaces/IERC4626VaultIntegrationFacet.sol";
+import {IOracleAdapter} from "../../interfaces/IOracleAdapter.sol";
+import {ERC4626Vault} from "../ERC4626Vault.sol";
+import {VaultFacetControl} from "../VaultFacetControl.sol";
+import {LibERC4626VaultStorage} from "../storage/LibERC4626VaultStorage.sol";
+
+/// @title ERC4626VaultIntegrationFacet
+/// @notice Hosted integration/config facet for oracle references and strategy reports.
+contract ERC4626VaultIntegrationFacet is ERC4626Vault, VaultFacetControl, IERC4626VaultIntegrationFacet {
+    /// @notice Returns the configured external oracle adapter address.
+    /// @return The adapter address, or zero when unset.
+    function oracleAdapter() public view returns (address) {
+        return LibERC4626VaultStorage.layout().oracleAdapter;
+    }
+
+    /// @notice Returns the configured strategy address.
+    /// @return The strategy address, or zero when unset.
+    function strategy() public view returns (address) {
+        return LibERC4626VaultStorage.layout().strategy;
+    }
+
+    /// @notice Returns the latest reported strategy-held asset amount.
+    /// @return The reported asset amount.
+    function strategyReportedAssets() public view returns (uint256) {
+        return LibERC4626VaultStorage.layout().strategyReportedAssets;
+    }
+
+    /// @notice Returns the vault's idle underlying asset balance.
+    /// @return The idle asset amount held directly by the vault.
+    function idleAssets() public view returns (uint256) {
+        _requireInitialized();
+        return IERC20(asset()).balanceOf(address(this));
+    }
+
+    /// @notice Returns idle assets plus the latest reported strategy assets.
+    /// @return The estimated total assets across idle vault balance and strategy reports.
+    function estimatedTotalManagedAssets() public view returns (uint256) {
+        return idleAssets() + strategyReportedAssets();
+    }
+
+    /// @notice Returns the latest normalized quote from the configured oracle adapter.
+    /// @return quotePayload The latest quote payload.
+    function oracleQuote() public view returns (IOracleAdapter.OracleQuote memory quotePayload) {
+        _requireInitialized();
+        address adapter = oracleAdapter();
+        if (adapter == address(0)) {
+            revert ERC4626VaultOracleAdapterNotConfigured();
+        }
+
+        return IOracleAdapter(adapter).quote();
+    }
+
+    /// @notice Sets the external oracle adapter reference.
+    /// @param newAdapter The new adapter address, or zero to clear.
+    function setOracleAdapter(address newAdapter) public {
+        _requireInitialized();
+        _checkRole(VAULT_MANAGER_ROLE(), msg.sender);
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        address previousAdapter = layout.oracleAdapter;
+        layout.oracleAdapter = newAdapter;
+
+        emit VaultOracleAdapterUpdated(previousAdapter, newAdapter, msg.sender);
+    }
+
+    /// @notice Sets the configured strategy reference.
+    /// @param newStrategy The new strategy address, or zero to clear.
+    function setStrategy(address newStrategy) public {
+        _requireInitialized();
+        _checkRole(VAULT_MANAGER_ROLE(), msg.sender);
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        address previousStrategy = layout.strategy;
+        layout.strategy = newStrategy;
+        layout.strategyReportedAssets = 0;
+
+        emit VaultStrategyUpdated(previousStrategy, newStrategy, msg.sender);
+    }
+
+    /// @notice Updates the latest reported strategy-held asset amount.
+    /// @param assets The latest reported asset amount.
+    function reportStrategyAssets(uint256 assets) public {
+        _requireInitialized();
+        address configuredStrategy = strategy();
+        if (msg.sender != configuredStrategy || configuredStrategy == address(0)) {
+            if (!hasRole(VAULT_MANAGER_ROLE(), msg.sender)) {
+                revert ERC4626VaultStrategyReporterUnauthorized(msg.sender, configuredStrategy);
+            }
+        }
+
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        uint256 previousAssets = layout.strategyReportedAssets;
+        layout.strategyReportedAssets = assets;
+
+        emit VaultStrategyAssetsReported(previousAssets, assets, msg.sender);
+    }
+}

--- a/src/vault/libraries/LibVaultFacetSelectors.sol
+++ b/src/vault/libraries/LibVaultFacetSelectors.sol
@@ -10,6 +10,7 @@ import {IERC4626} from "../../interfaces/IERC4626.sol";
 import {IERC4626VaultBase} from "../../interfaces/IERC4626VaultBase.sol";
 import {IERC4626VaultControls} from "../../interfaces/IERC4626VaultControls.sol";
 import {IERC4626VaultFacet} from "../../interfaces/IERC4626VaultFacet.sol";
+import {IERC4626VaultIntegrationFacet} from "../../interfaces/IERC4626VaultIntegrationFacet.sol";
 import {IPausable} from "../../interfaces/IPausable.sol";
 import {IReentrancyGuard} from "../../interfaces/IReentrancyGuard.sol";
 
@@ -80,5 +81,19 @@ library LibVaultFacetSelectors {
         selectors[25] = IPausable.unpauseScope.selector;
         selectors[26] = IReentrancyGuard.reentrancyGuardEntered.selector;
         selectors[27] = IERC165.supportsInterface.selector;
+    }
+
+    /// @notice Returns the hosted vault integration selector group.
+    function vaultIntegrationSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](9);
+        selectors[0] = IERC4626VaultIntegrationFacet.oracleAdapter.selector;
+        selectors[1] = IERC4626VaultIntegrationFacet.strategy.selector;
+        selectors[2] = IERC4626VaultIntegrationFacet.strategyReportedAssets.selector;
+        selectors[3] = IERC4626VaultIntegrationFacet.idleAssets.selector;
+        selectors[4] = IERC4626VaultIntegrationFacet.estimatedTotalManagedAssets.selector;
+        selectors[5] = IERC4626VaultIntegrationFacet.oracleQuote.selector;
+        selectors[6] = IERC4626VaultIntegrationFacet.setOracleAdapter.selector;
+        selectors[7] = IERC4626VaultIntegrationFacet.setStrategy.selector;
+        selectors[8] = IERC4626VaultIntegrationFacet.reportStrategyAssets.selector;
     }
 }

--- a/src/vault/storage/LibERC4626VaultStorage.sol
+++ b/src/vault/storage/LibERC4626VaultStorage.sol
@@ -37,6 +37,9 @@ library LibERC4626VaultStorage {
         uint256 totalManagedAssets;
         FeeConfig fees;
         LimitConfig limits;
+        address oracleAdapter;
+        address strategy;
+        uint256 strategyReportedAssets;
     }
 
     /// @notice Returns the storage layout for vault state.

--- a/test/ERC4626VaultIntegrationFacetCore.t.sol
+++ b/test/ERC4626VaultIntegrationFacetCore.t.sol
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
+import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
+import {IERC165} from "../src/interfaces/IERC165.sol";
+import {IERC4626VaultBase} from "../src/interfaces/IERC4626VaultBase.sol";
+import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
+import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
+import {IOracleAdapter} from "../src/interfaces/IOracleAdapter.sol";
+import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
+import {ERC4626VaultIntegrationFacetFixture} from "./helpers/ERC4626VaultIntegrationFacetTestHarness.sol";
+
+contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFixture {
+    function testDirectIntegrationFacetRequiresManagerForConfigAndReporterAuth() public {
+        _initializeDirectIntegrationFacet();
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorized.selector, bob, integrationFacet.VAULT_MANAGER_ROLE()
+            )
+        );
+        VM.prank(bob);
+        integrationFacet.setOracleAdapter(address(adapter));
+
+        VM.prank(admin);
+        integrationFacet.setOracleAdapter(address(adapter));
+        assertTrue(integrationFacet.oracleAdapter() == address(adapter), "adapter mismatch");
+
+        VM.prank(admin);
+        integrationFacet.setStrategy(bob);
+        assertTrue(integrationFacet.strategy() == bob, "strategy mismatch");
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IERC4626VaultIntegrationFacet.ERC4626VaultStrategyReporterUnauthorized.selector, eve, bob
+            )
+        );
+        VM.prank(eve);
+        integrationFacet.reportStrategyAssets(25);
+
+        VM.prank(bob);
+        integrationFacet.reportStrategyAssets(25);
+        assertTrue(integrationFacet.strategyReportedAssets() == 25, "reported assets mismatch");
+    }
+
+    function testDirectIntegrationFacetChangingStrategyClearsReportedAssets() public {
+        _initializeDirectIntegrationFacet();
+
+        VM.prank(admin);
+        integrationFacet.setStrategy(bob);
+        VM.prank(bob);
+        integrationFacet.reportStrategyAssets(75);
+
+        VM.prank(admin);
+        integrationFacet.setStrategy(eve);
+
+        assertTrue(integrationFacet.strategy() == eve, "strategy should update");
+        assertTrue(integrationFacet.strategyReportedAssets() == 0, "reported assets should reset");
+
+        VM.prank(admin);
+        integrationFacet.setStrategy(address(0));
+        assertTrue(integrationFacet.strategy() == address(0), "strategy should clear");
+        assertTrue(integrationFacet.strategyReportedAssets() == 0, "reported assets should stay cleared");
+    }
+
+    function testDirectIntegrationFacetOracleQuoteAndEstimatedAssets() public {
+        _initializeDirectIntegrationFacet();
+
+        VM.expectRevert(
+            abi.encodeWithSelector(IERC4626VaultIntegrationFacet.ERC4626VaultOracleAdapterNotConfigured.selector)
+        );
+        integrationFacet.oracleQuote();
+
+        VM.prank(admin);
+        integrationFacet.setOracleAdapter(address(adapter));
+
+        asset.mint(address(integrationFacet), 40);
+
+        VM.prank(admin);
+        integrationFacet.reportStrategyAssets(25);
+
+        IOracleAdapter.OracleQuote memory quotePayload = integrationFacet.oracleQuote();
+
+        assertTrue(quotePayload.value == 100_000_000, "quote value mismatch");
+        assertTrue(quotePayload.updatedAt == quoteUpdatedAt, "quote timestamp mismatch");
+        assertTrue(quotePayload.decimals == 8, "quote decimals mismatch");
+        assertTrue(integrationFacet.idleAssets() == 40, "idle assets mismatch");
+        assertTrue(integrationFacet.estimatedTotalManagedAssets() == 65, "estimated assets mismatch");
+        assertTrue(integrationFacet.totalManagedAssets() == 0, "managed assets should remain unchanged");
+    }
+
+    function testDirectIntegrationFacetHelpersRevertBeforeVaultInit() public {
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultNotInitialized.selector));
+        integrationFacet.idleAssets();
+
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultNotInitialized.selector));
+        integrationFacet.estimatedTotalManagedAssets();
+
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultNotInitialized.selector));
+        VM.prank(admin);
+        integrationFacet.setOracleAdapter(address(adapter));
+    }
+
+    function testDiamondIntegrationFacetRoutesAndComposesWithCoreAndControls() public {
+        _installHostedVaultFacetsToDiamond();
+        _initializeDiamondVault();
+
+        _approveAsset(bob, address(diamond), 100);
+
+        VM.prank(bob);
+        uint256 mintedShares = IERC4626VaultFacet(address(diamond)).deposit(40, bob);
+
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).setOracleAdapter(address(adapter));
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(eve);
+
+        VM.prank(eve);
+        IERC4626VaultIntegrationFacet(address(diamond)).reportStrategyAssets(25);
+
+        IOracleAdapter.OracleQuote memory quotePayload = IERC4626VaultIntegrationFacet(address(diamond)).oracleQuote();
+
+        assertTrue(mintedShares == 40, "deposit shares mismatch");
+        assertTrue(
+            IERC4626VaultIntegrationFacet(address(diamond)).oracleAdapter() == address(adapter), "adapter mismatch"
+        );
+        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).strategy() == eve, "strategy mismatch");
+        assertTrue(
+            IERC4626VaultIntegrationFacet(address(diamond)).strategyReportedAssets() == 25, "reported assets mismatch"
+        );
+        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).idleAssets() == 40, "idle assets mismatch");
+        assertTrue(
+            IERC4626VaultIntegrationFacet(address(diamond)).estimatedTotalManagedAssets() == 65,
+            "estimated assets mismatch"
+        );
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 40, "managed assets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewDeposit(10) == 10, "preview should remain core-based");
+        assertTrue(quotePayload.value == 100_000_000, "quote value mismatch");
+        assertTrue(quotePayload.updatedAt == quoteUpdatedAt, "quote timestamp mismatch");
+        assertTrue(quotePayload.decimals == 8, "quote decimals mismatch");
+
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultCoreSelectors(), address(coreFacet));
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultControlsSelectors(), address(controlsFacet));
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultIntegrationSelectors(), address(integrationFacet));
+
+        assertTrue(
+            IDiamondLoupe(address(diamond)).facetAddress(IERC4626VaultFacet.initializeVault.selector)
+                == address(coreFacet),
+            "initializer selector should stay on core facet"
+        );
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC4626VaultIntegrationFacet).interfaceId),
+            "diamond should report integration interface support"
+        );
+    }
+
+    function testDiamondIntegrationFacetHasNoInitializerSelector() public {
+        _installHostedVaultFacetsToDiamond();
+
+        bytes4[] memory selectors = LibVaultFacetSelectors.vaultIntegrationSelectors();
+        for (uint256 i = 0; i < selectors.length; i++) {
+            assertTrue(
+                selectors[i] != IERC4626VaultFacet.initializeVault.selector,
+                "integration facet should not own initializer selector"
+            );
+        }
+    }
+
+    function _assertSelectorsOwnedByFacet(bytes4[] memory selectors, address expectedFacet) internal view {
+        for (uint256 i = 0; i < selectors.length; i++) {
+            assertTrue(
+                IDiamondLoupe(address(diamond)).facetAddress(selectors[i]) == expectedFacet, "selector owner mismatch"
+            );
+        }
+    }
+}

--- a/test/helpers/ERC4626VaultIntegrationFacetTestHarness.sol
+++ b/test/helpers/ERC4626VaultIntegrationFacetTestHarness.sol
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
+import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
+import {IERC4626VaultFacet} from "../../src/interfaces/IERC4626VaultFacet.sol";
+import {ERC4626VaultIntegrationFacet} from "../../src/vault/facets/ERC4626VaultIntegrationFacet.sol";
+import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
+import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+import {ERC4626VaultControlsFacetHarness} from "./ERC4626VaultControlsFacetTestHarness.sol";
+import {ReentrantMockVaultAsset} from "./ERC4626VaultControlsTestHarness.sol";
+import {ERC4626VaultFacetHarness} from "./ERC4626VaultFacetTestHarness.sol";
+import {MockOracleFeed, OracleAdapterHarness} from "./OracleAdapterTestHarness.sol";
+
+contract ERC4626VaultIntegrationFacetHarness is ERC4626VaultIntegrationFacet {
+    function initializeHostedVaultForTest(
+        address vaultAsset,
+        string memory vaultName,
+        string memory vaultSymbol,
+        address admin
+    ) external {
+        _initializeVaultFacetControl(admin);
+        _initializeErc4626Vault(vaultAsset, vaultName, vaultSymbol);
+    }
+}
+
+abstract contract ERC4626VaultIntegrationFacetFixture is TestBase {
+    uint256 internal constant INITIAL_ASSETS = 1_000_000;
+
+    address internal admin = address(0xA11CE);
+    address internal bob = address(0xB0B);
+    address internal eve = address(0xE11E);
+
+    uint64 internal maxStaleness = 1 hours;
+    uint64 internal currentTime = 1_000_000;
+    uint64 internal quoteUpdatedAt = 999_900;
+
+    ReentrantMockVaultAsset internal asset;
+    ERC4626VaultFacetHarness internal coreFacet;
+    ERC4626VaultControlsFacetHarness internal controlsFacet;
+    ERC4626VaultIntegrationFacetHarness internal integrationFacet;
+    DiamondCutFacet internal cutFacet;
+    DiamondLoupeFacet internal loupeFacet;
+    DiamondProxyHarness internal diamond;
+    MockOracleFeed internal feed;
+    OracleAdapterHarness internal adapter;
+
+    function setUp() public virtual {
+        VM.warp(currentTime);
+
+        asset = new ReentrantMockVaultAsset();
+        coreFacet = new ERC4626VaultFacetHarness();
+        controlsFacet = new ERC4626VaultControlsFacetHarness();
+        integrationFacet = new ERC4626VaultIntegrationFacetHarness();
+        cutFacet = new DiamondCutFacet();
+        loupeFacet = new DiamondLoupeFacet();
+        diamond = new DiamondProxyHarness(admin, address(cutFacet));
+        feed = new MockOracleFeed(8);
+        feed.setLatestRoundData(1, 100_000_000, quoteUpdatedAt, quoteUpdatedAt, 1);
+        adapter = new OracleAdapterHarness(admin, address(feed), maxStaleness);
+
+        asset.mint(bob, INITIAL_ASSETS);
+        asset.mint(eve, INITIAL_ASSETS);
+
+        _installLoupeFacet();
+    }
+
+    function _initializeDirectIntegrationFacet() internal {
+        integrationFacet.initializeHostedVaultForTest(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function _initializeDiamondVault() internal {
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond)).initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function _approveAsset(address owner, address spender, uint256 amount) internal {
+        VM.prank(owner);
+        asset.approve(spender, amount);
+    }
+
+    function _installLoupeFacet() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(loupeFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: _loupeSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installVaultCoreFacetToDiamond() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(coreFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultCoreSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installVaultControlsFacetToDiamond() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(controlsFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultControlsSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installVaultIntegrationFacetToDiamond() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(integrationFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultIntegrationSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installHostedVaultFacetsToDiamond() internal {
+        _installVaultCoreFacetToDiamond();
+        _installVaultControlsFacetToDiamond();
+        _installVaultIntegrationFacetToDiamond();
+    }
+
+    function _loupeSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](6);
+        selectors[0] = DiamondLoupeFacet.facets.selector;
+        selectors[1] = DiamondLoupeFacet.facetFunctionSelectors.selector;
+        selectors[2] = DiamondLoupeFacet.facetAddresses.selector;
+        selectors[3] = DiamondLoupeFacet.facetAddress.selector;
+        selectors[4] = DiamondLoupeFacet.owner.selector;
+        selectors[5] = DiamondLoupeFacet.transferOwnership.selector;
+    }
+}


### PR DESCRIPTION
## Summary
- add the hosted vault integration facet for oracle adapter wiring and strategy reporting
- add read-only estimated asset helpers without changing core ERC-4626 managed-asset accounting
- add direct and diamond-routed coverage for selector ownership, strategy report auth, and diamond interface support

## Validation
- `git diff --check`
- `forge fmt --check`
- `forge test --offline --match-path test/ERC4626VaultIntegrationFacetCore.t.sol`
- `forge test --offline --match-path test/ERC4626VaultControlsFacetCore.t.sol`
- `forge test --offline`

## Issue
- Closes #98