### PR TITLE
Add diamond-hosted vault deployment integration

### DIFF
--- a/script/DeployDiamondVaultHost.s.sol
+++ b/script/DeployDiamondVaultHost.s.sol
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {DiamondCutFacet} from "../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../src/diamond/facets/DiamondLoupeFacet.sol";
+import {IDiamondCut} from "../src/interfaces/IDiamondCut.sol";
+import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
+import {IERC165} from "../src/interfaces/IERC165.sol";
+import {IERC20Metadata} from "../src/interfaces/IERC20Metadata.sol";
+import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol";
+import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControlsFacet.sol";
+import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
+import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
+import {IOracleAdapter} from "../src/interfaces/IOracleAdapter.sol";
+import {ERC4626VaultControlsFacet} from "../src/vault/facets/ERC4626VaultControlsFacet.sol";
+import {ERC4626VaultFacet} from "../src/vault/facets/ERC4626VaultFacet.sol";
+import {ERC4626VaultIntegrationFacet} from "../src/vault/facets/ERC4626VaultIntegrationFacet.sol";
+import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
+import {DiamondVaultHostScriptBase} from "./common/DiamondVaultHostScriptBase.sol";
+import {
+    LocalMintableVaultAsset,
+    LocalMockOracleFeed,
+    LocalOracleAdapterHarness
+} from "./mocks/LocalVaultDeploymentMocks.sol";
+
+/// @title DeployDiamondVaultHostScript
+/// @notice Reference local deployment flow for the hosted vault diamond.
+contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
+    struct VaultHostDeploymentState {
+        address diamondAddress;
+        address cutFacetAddress;
+        address loupeFacetAddress;
+        address vaultCoreFacetAddress;
+        address vaultControlsFacetAddress;
+        address vaultIntegrationFacetAddress;
+        address vaultAssetAddress;
+        address oracleFeedAddress;
+        address oracleAdapterAddress;
+    }
+
+    string internal constant VAULT_OBJECT = "diamondVaultHost";
+    string internal constant VAULT_OUTPUT_RELATIVE_PATH = "/deployments/diamond-vault.local.json";
+    string internal constant VAULT_NAME = "Vault Share";
+    string internal constant VAULT_SYMBOL = "vSHARE";
+    uint64 internal constant MAX_STALENESS = 1 hours;
+    uint8 internal constant ORACLE_DECIMALS = 8;
+    int256 internal constant ORACLE_ANSWER = 100_000_000;
+
+    function run()
+        external
+        returns (
+            address diamondAddress,
+            address vaultCoreFacetAddress,
+            address vaultControlsFacetAddress,
+            address vaultIntegrationFacetAddress
+        )
+    {
+        uint256 deployerPrivateKey = VM.envUint("PRIVATE_KEY");
+        address owner = VM.addr(deployerPrivateKey);
+        VaultHostDeploymentState memory state;
+
+        VM.startBroadcast(deployerPrivateKey);
+
+        (state.diamondAddress, state.cutFacetAddress, state.loupeFacetAddress) = _deployDiamondCore(owner);
+        state = _deployVaultSupportContracts(state, owner);
+        _installVaultHostFacets(state);
+
+        IERC4626VaultFacet(state.diamondAddress)
+            .initializeVault(state.vaultAssetAddress, VAULT_NAME, VAULT_SYMBOL, owner);
+        IERC4626VaultIntegrationFacet(state.diamondAddress).setOracleAdapter(state.oracleAdapterAddress);
+
+        VM.stopBroadcast();
+
+        _validateVaultHost(state, owner);
+        _writeVaultDeploymentArtifact(
+            VAULT_OBJECT,
+            VAULT_OUTPUT_RELATIVE_PATH,
+            VaultHostDeploymentArtifact({
+                diamond: state.diamondAddress,
+                diamondCutFacet: state.cutFacetAddress,
+                diamondLoupeFacet: state.loupeFacetAddress,
+                vaultCoreFacet: state.vaultCoreFacetAddress,
+                vaultControlsFacet: state.vaultControlsFacetAddress,
+                vaultIntegrationFacet: state.vaultIntegrationFacetAddress,
+                vaultAsset: state.vaultAssetAddress,
+                oracleFeed: state.oracleFeedAddress,
+                oracleAdapter: state.oracleAdapterAddress,
+                strategy: address(0),
+                owner: owner,
+                chainId: block.chainid,
+                vaultName: VAULT_NAME,
+                vaultSymbol: VAULT_SYMBOL
+            })
+        );
+
+        diamondAddress = state.diamondAddress;
+        vaultCoreFacetAddress = state.vaultCoreFacetAddress;
+        vaultControlsFacetAddress = state.vaultControlsFacetAddress;
+        vaultIntegrationFacetAddress = state.vaultIntegrationFacetAddress;
+    }
+
+    function _deployVaultSupportContracts(VaultHostDeploymentState memory state, address owner)
+        internal
+        returns (VaultHostDeploymentState memory)
+    {
+        state.vaultCoreFacetAddress = address(new ERC4626VaultFacet());
+        state.vaultControlsFacetAddress = address(new ERC4626VaultControlsFacet());
+        state.vaultIntegrationFacetAddress = address(new ERC4626VaultIntegrationFacet());
+        state.vaultAssetAddress = address(new LocalMintableVaultAsset("Mock USD", "mUSD", 6));
+        state.oracleFeedAddress = address(new LocalMockOracleFeed(ORACLE_DECIMALS, ORACLE_ANSWER, block.timestamp - 1));
+        state.oracleAdapterAddress =
+            address(new LocalOracleAdapterHarness(owner, state.oracleFeedAddress, MAX_STALENESS));
+        return state;
+    }
+
+    function _installVaultHostFacets(VaultHostDeploymentState memory state) internal {
+        IDiamondCut.FacetCut[] memory vaultCut = new IDiamondCut.FacetCut[](3);
+        vaultCut[0] = IDiamondCut.FacetCut({
+            facetAddress: state.vaultCoreFacetAddress,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultCoreSelectors()
+        });
+        vaultCut[1] = IDiamondCut.FacetCut({
+            facetAddress: state.vaultControlsFacetAddress,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultControlsSelectors()
+        });
+        vaultCut[2] = IDiamondCut.FacetCut({
+            facetAddress: state.vaultIntegrationFacetAddress,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultIntegrationSelectors()
+        });
+        IDiamondCut(state.diamondAddress).diamondCut(vaultCut, address(0), "");
+    }
+
+    function _validateVaultHost(VaultHostDeploymentState memory state, address owner) internal view {
+        _validateDiamondCore(state.diamondAddress, owner, state.cutFacetAddress, state.loupeFacetAddress);
+
+        IDiamondLoupe loupe = IDiamondLoupe(state.diamondAddress);
+        IERC4626VaultFacet vaultCore = IERC4626VaultFacet(state.diamondAddress);
+        IERC4626VaultControlsFacet vaultControls = IERC4626VaultControlsFacet(state.diamondAddress);
+        IERC4626VaultIntegrationFacet vaultIntegration = IERC4626VaultIntegrationFacet(state.diamondAddress);
+        address[] memory facetAddresses = loupe.facetAddresses();
+
+        require(facetAddresses.length == 5, "vault host facet count mismatch");
+        require(_containsAddress(facetAddresses, state.cutFacetAddress), "vault host missing cut facet");
+        require(_containsAddress(facetAddresses, state.loupeFacetAddress), "vault host missing loupe facet");
+        require(_containsAddress(facetAddresses, state.vaultCoreFacetAddress), "vault host missing core facet");
+        require(_containsAddress(facetAddresses, state.vaultControlsFacetAddress), "vault host missing controls facet");
+        require(
+            _containsAddress(facetAddresses, state.vaultIntegrationFacetAddress), "vault host missing integration facet"
+        );
+
+        require(
+            loupe.facetFunctionSelectors(state.vaultCoreFacetAddress).length
+                == LibVaultFacetSelectors.vaultCoreSelectors().length,
+            "vault host core selector count mismatch"
+        );
+        require(
+            loupe.facetFunctionSelectors(state.vaultControlsFacetAddress).length
+                == LibVaultFacetSelectors.vaultControlsSelectors().length,
+            "vault host controls selector count mismatch"
+        );
+        require(
+            loupe.facetFunctionSelectors(state.vaultIntegrationFacetAddress).length
+                == LibVaultFacetSelectors.vaultIntegrationSelectors().length,
+            "vault host integration selector count mismatch"
+        );
+
+        require(vaultCore.isVaultInitialized(), "vault host not initialized");
+        require(vaultCore.asset() == state.vaultAssetAddress, "vault host asset mismatch");
+        require(
+            keccak256(bytes(IERC20Metadata(state.diamondAddress).name())) == keccak256(bytes(VAULT_NAME)),
+            "vault name mismatch"
+        );
+        require(
+            keccak256(bytes(IERC20Metadata(state.diamondAddress).symbol())) == keccak256(bytes(VAULT_SYMBOL)),
+            "vault symbol mismatch"
+        );
+        require(vaultControls.hasRole(vaultControls.DEFAULT_ADMIN_ROLE(), owner), "vault default admin missing");
+        require(vaultControls.hasRole(vaultControls.PAUSER_ROLE(), owner), "vault pauser missing");
+        require(vaultControls.hasRole(vaultControls.VAULT_MANAGER_ROLE(), owner), "vault manager missing");
+
+        (,, address feeRecipient) = vaultControls.feeConfig();
+        require(feeRecipient == owner, "vault fee recipient mismatch");
+
+        require(vaultIntegration.oracleAdapter() == state.oracleAdapterAddress, "vault oracle adapter mismatch");
+        require(vaultIntegration.strategy() == address(0), "vault strategy should be unset");
+        require(vaultIntegration.strategyReportedAssets() == 0, "vault reported assets should be zero");
+
+        IOracleAdapter.OracleQuote memory quotePayload = vaultIntegration.oracleQuote();
+        require(quotePayload.value == ORACLE_ANSWER, "vault quote value mismatch");
+        require(quotePayload.decimals == ORACLE_DECIMALS, "vault quote decimals mismatch");
+        require(quotePayload.updatedAt != 0, "vault quote timestamp missing");
+
+        require(
+            IERC165(state.diamondAddress).supportsInterface(type(IERC4626VaultFacet).interfaceId),
+            "vault host missing core interface"
+        );
+        require(
+            IERC165(state.diamondAddress).supportsInterface(type(IERC4626VaultControlsFacet).interfaceId),
+            "vault host missing controls interface"
+        );
+        require(
+            IERC165(state.diamondAddress).supportsInterface(type(IERC4626VaultIntegrationFacet).interfaceId),
+            "vault host missing integration interface"
+        );
+
+        _requireSelectorOwner(loupe, DiamondCutFacet.diamondCut.selector, state.cutFacetAddress, "vault cut owner");
+        _requireSelectorOwner(loupe, DiamondLoupeFacet.facets.selector, state.loupeFacetAddress, "vault loupe owner");
+        _requireSelectorOwner(
+            loupe, IERC4626VaultFacet.initializeVault.selector, state.vaultCoreFacetAddress, "vault init owner"
+        );
+        _requireSelectorOwner(
+            loupe,
+            IERC4626VaultControls.VAULT_MANAGER_ROLE.selector,
+            state.vaultControlsFacetAddress,
+            "vault manager owner"
+        );
+        _requireSelectorOwner(
+            loupe,
+            IERC4626VaultIntegrationFacet.oracleAdapter.selector,
+            state.vaultIntegrationFacetAddress,
+            "vault oracle owner"
+        );
+        _requireSelectorOwner(
+            loupe, IERC165.supportsInterface.selector, state.vaultControlsFacetAddress, "vault erc165 owner"
+        );
+    }
+
+    function _requireSelectorOwner(IDiamondLoupe loupe, bytes4 selector, address expected, string memory message)
+        internal
+        view
+    {
+        require(loupe.facetAddress(selector) == expected, message);
+    }
+}

--- a/script/common/DiamondVaultHostScriptBase.sol
+++ b/script/common/DiamondVaultHostScriptBase.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Diamond} from "../../src/diamond/Diamond.sol";
+import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
+import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
+import {IDiamondLoupe} from "../../src/interfaces/IDiamondLoupe.sol";
+import {IERC173} from "../../src/interfaces/IERC173.sol";
+import {DiamondCoreScriptBase} from "./DiamondCoreScriptBase.sol";
+
+/// @title DiamondVaultHostScriptBase
+/// @notice Shared deployment helpers for the reference hosted vault diamond.
+abstract contract DiamondVaultHostScriptBase is DiamondCoreScriptBase {
+    /// @notice Parsed addresses from a hosted vault deployment artifact.
+    struct VaultHostDeploymentArtifact {
+        address diamond;
+        address diamondCutFacet;
+        address diamondLoupeFacet;
+        address vaultCoreFacet;
+        address vaultControlsFacet;
+        address vaultIntegrationFacet;
+        address vaultAsset;
+        address oracleFeed;
+        address oracleAdapter;
+        address strategy;
+        address owner;
+        uint256 chainId;
+        string vaultName;
+        string vaultSymbol;
+    }
+
+    function _deployDiamondCore(address owner)
+        internal
+        returns (address diamondAddress, address cutFacetAddress, address loupeFacetAddress)
+    {
+        DiamondCutFacet cutFacet = new DiamondCutFacet();
+        Diamond diamond = new Diamond(owner, address(cutFacet));
+        DiamondLoupeFacet loupeFacet = new DiamondLoupeFacet();
+
+        IDiamondCut.FacetCut[] memory initialCut = new IDiamondCut.FacetCut[](1);
+        initialCut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(loupeFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: _loupeSelectors()
+        });
+        IDiamondCut(address(diamond)).diamondCut(initialCut, address(0), "");
+
+        diamondAddress = address(diamond);
+        cutFacetAddress = address(cutFacet);
+        loupeFacetAddress = address(loupeFacet);
+    }
+
+    function _validateDiamondCore(
+        address diamondAddress,
+        address owner,
+        address cutFacetAddress,
+        address loupeFacetAddress
+    ) internal view {
+        IERC173 ownership = IERC173(diamondAddress);
+        IDiamondLoupe loupe = IDiamondLoupe(diamondAddress);
+
+        require(ownership.owner() == owner, "vault host owner mismatch");
+        require(
+            loupe.facetAddress(DiamondCutFacet.diamondCut.selector) == cutFacetAddress,
+            "vault host cut selector mismatch"
+        );
+        require(
+            loupe.facetAddress(DiamondLoupeFacet.facets.selector) == loupeFacetAddress,
+            "vault host loupe selector mismatch"
+        );
+    }
+
+    function _writeVaultDeploymentArtifact(
+        string memory objectKey,
+        string memory outputRelativePath,
+        VaultHostDeploymentArtifact memory artifact
+    ) internal {
+        string memory json = VM.serializeString(objectKey, "network", "local-anvil");
+        json = VM.serializeUint(objectKey, "chainId", block.chainid);
+        json = VM.serializeAddress(objectKey, "owner", artifact.owner);
+        json = VM.serializeAddress(objectKey, "diamond", artifact.diamond);
+        json = VM.serializeAddress(objectKey, "diamondCutFacet", artifact.diamondCutFacet);
+        json = VM.serializeAddress(objectKey, "diamondLoupeFacet", artifact.diamondLoupeFacet);
+        json = VM.serializeAddress(objectKey, "vaultCoreFacet", artifact.vaultCoreFacet);
+        json = VM.serializeAddress(objectKey, "vaultControlsFacet", artifact.vaultControlsFacet);
+        json = VM.serializeAddress(objectKey, "vaultIntegrationFacet", artifact.vaultIntegrationFacet);
+        json = VM.serializeAddress(objectKey, "vaultAsset", artifact.vaultAsset);
+        json = VM.serializeAddress(objectKey, "oracleFeed", artifact.oracleFeed);
+        json = VM.serializeAddress(objectKey, "oracleAdapter", artifact.oracleAdapter);
+        json = VM.serializeAddress(objectKey, "strategy", artifact.strategy);
+        json = VM.serializeString(objectKey, "vaultName", artifact.vaultName);
+        json = VM.serializeString(objectKey, "vaultSymbol", artifact.vaultSymbol);
+        VM.writeJson(json, string.concat(VM.projectRoot(), outputRelativePath));
+    }
+
+    function _loupeSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](6);
+        selectors[0] = DiamondLoupeFacet.facets.selector;
+        selectors[1] = DiamondLoupeFacet.facetFunctionSelectors.selector;
+        selectors[2] = DiamondLoupeFacet.facetAddresses.selector;
+        selectors[3] = DiamondLoupeFacet.facetAddress.selector;
+        selectors[4] = DiamondLoupeFacet.owner.selector;
+        selectors[5] = DiamondLoupeFacet.transferOwnership.selector;
+    }
+
+    function _containsAddress(address[] memory addresses, address expected) internal pure returns (bool) {
+        for (uint256 i = 0; i < addresses.length; i++) {
+            if (addresses[i] == expected) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/script/mocks/LocalVaultDeploymentMocks.sol
+++ b/script/mocks/LocalVaultDeploymentMocks.sol
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC20Metadata} from "../../src/interfaces/IERC20Metadata.sol";
+import {IOracleFeed} from "../../src/interfaces/IOracleFeed.sol";
+import {OracleAdapter} from "../../src/oracle/OracleAdapter.sol";
+
+/// @title LocalMintableVaultAsset
+/// @notice Minimal mintable ERC20 used for local hosted-vault deployment rehearsal.
+contract LocalMintableVaultAsset is IERC20Metadata {
+    string internal _name;
+    string internal _symbol;
+    uint8 internal _decimals;
+    uint256 internal _totalSupply;
+
+    mapping(address => uint256) internal _balances;
+    mapping(address => mapping(address => uint256)) internal _allowances;
+
+    constructor(string memory name_, string memory symbol_, uint8 decimals_) {
+        _name = name_;
+        _symbol = symbol_;
+        _decimals = decimals_;
+    }
+
+    function name() external view returns (string memory) {
+        return _name;
+    }
+
+    function symbol() external view returns (string memory) {
+        return _symbol;
+    }
+
+    function decimals() external view returns (uint8) {
+        return _decimals;
+    }
+
+    function totalSupply() external view returns (uint256) {
+        return _totalSupply;
+    }
+
+    function balanceOf(address account) external view returns (uint256) {
+        return _balances[account];
+    }
+
+    function allowance(address owner, address spender) external view returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    function mint(address to, uint256 amount) external {
+        _balances[to] += amount;
+        _totalSupply += amount;
+        emit Transfer(address(0), to, amount);
+    }
+
+    function approve(address spender, uint256 value) external returns (bool) {
+        _allowances[msg.sender][spender] = value;
+        emit Approval(msg.sender, spender, value);
+        return true;
+    }
+
+    function transfer(address to, uint256 value) external returns (bool) {
+        _transfer(msg.sender, to, value);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 value) external returns (bool) {
+        uint256 currentAllowance = _allowances[from][msg.sender];
+        require(currentAllowance >= value, "INSUFFICIENT_ALLOWANCE");
+        if (currentAllowance != type(uint256).max) {
+            unchecked {
+                _allowances[from][msg.sender] = currentAllowance - value;
+            }
+            emit Approval(from, msg.sender, _allowances[from][msg.sender]);
+        }
+
+        _transfer(from, to, value);
+        return true;
+    }
+
+    function _transfer(address from, address to, uint256 value) internal {
+        require(to != address(0), "ZERO_TO");
+
+        uint256 fromBalance = _balances[from];
+        require(fromBalance >= value, "INSUFFICIENT_BALANCE");
+
+        unchecked {
+            _balances[from] = fromBalance - value;
+        }
+        _balances[to] += value;
+
+        emit Transfer(from, to, value);
+    }
+}
+
+/// @title LocalMockOracleFeed
+/// @notice Minimal oracle feed used for local hosted-vault deployment rehearsal.
+contract LocalMockOracleFeed is IOracleFeed {
+    uint8 internal immutable _decimals;
+    uint80 internal immutable _roundId;
+    int256 internal immutable _answer;
+    uint256 internal immutable _updatedAt;
+    uint80 internal immutable _answeredInRound;
+
+    constructor(uint8 decimals_, int256 answer_, uint256 updatedAt_) {
+        _decimals = decimals_;
+        _roundId = 1;
+        _answer = answer_;
+        _updatedAt = updatedAt_;
+        _answeredInRound = 1;
+    }
+
+    function decimals() external view returns (uint8) {
+        return _decimals;
+    }
+
+    function latestRoundData()
+        external
+        view
+        returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
+    {
+        return (_roundId, _answer, _updatedAt, _updatedAt, _answeredInRound);
+    }
+}
+
+/// @title LocalOracleAdapterHarness
+/// @notice Concrete oracle adapter used by the local hosted-vault deployment flow.
+contract LocalOracleAdapterHarness is OracleAdapter {
+    constructor(address initialAdmin, address initialSource, uint64 initialMaxStaleness)
+        OracleAdapter(initialAdmin, initialSource, initialMaxStaleness)
+    {}
+}

--- a/src/vault/facets/ERC4626VaultControlsFacet.sol
+++ b/src/vault/facets/ERC4626VaultControlsFacet.sol
@@ -6,6 +6,7 @@ import {IAccessControlTime} from "../../interfaces/IAccessControlTime.sol";
 import {IERC165} from "../../interfaces/IERC165.sol";
 import {IERC4626VaultControls} from "../../interfaces/IERC4626VaultControls.sol";
 import {IERC4626VaultControlsFacet} from "../../interfaces/IERC4626VaultControlsFacet.sol";
+import {IERC4626VaultFacet} from "../../interfaces/IERC4626VaultFacet.sol";
 import {IERC4626VaultIntegrationFacet} from "../../interfaces/IERC4626VaultIntegrationFacet.sol";
 import {IPausable} from "../../interfaces/IPausable.sol";
 import {IReentrancyGuard} from "../../interfaces/IReentrancyGuard.sol";
@@ -28,6 +29,8 @@ contract ERC4626VaultControlsFacet is ERC4626VaultControlSurface {
     {
         return interfaceId == type(IERC165).interfaceId || interfaceId == type(IERC4626VaultControls).interfaceId
             || interfaceId == type(IERC4626VaultControlsFacet).interfaceId
+            || (interfaceId == type(IERC4626VaultFacet).interfaceId
+                && LibDiamond.selectorExists(IERC4626VaultFacet.initializeVault.selector))
             || (interfaceId == type(IERC4626VaultIntegrationFacet).interfaceId
                 && LibDiamond.selectorExists(IERC4626VaultIntegrationFacet.oracleAdapter.selector))
             || interfaceId == type(IAccessControl).interfaceId || interfaceId == type(IAccessControlTime).interfaceId

--- a/test/DiamondVaultDeploymentIntegration.t.sol
+++ b/test/DiamondVaultDeploymentIntegration.t.sol
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {DiamondCutFacet} from "../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../src/diamond/facets/DiamondLoupeFacet.sol";
+import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
+import {IERC165} from "../src/interfaces/IERC165.sol";
+import {IERC20Metadata} from "../src/interfaces/IERC20Metadata.sol";
+import {IERC4626VaultBase} from "../src/interfaces/IERC4626VaultBase.sol";
+import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol";
+import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControlsFacet.sol";
+import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
+import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
+import {IOracleAdapter} from "../src/interfaces/IOracleAdapter.sol";
+import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
+import {DiamondVaultDeploymentFixture} from "./helpers/DiamondVaultDeploymentTestHarness.sol";
+
+contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture {
+    function testVaultHostDeployInstallInitAndOracleWiring() public {
+        _installVaultHostFacets();
+        _initializeVaultHost();
+        _wireOracleAdapter();
+
+        IDiamondLoupe loupe = IDiamondLoupe(address(diamond));
+        address[] memory facetAddresses = loupe.facetAddresses();
+        IOracleAdapter.OracleQuote memory quotePayload = integrationFacetInterface().oracleQuote();
+
+        assertTrue(facetAddresses.length == 5, "vault host facet count mismatch");
+        assertTrue(_containsAddress(facetAddresses, address(cutFacet)), "missing cut facet");
+        assertTrue(_containsAddress(facetAddresses, address(loupeFacet)), "missing loupe facet");
+        assertTrue(_containsAddress(facetAddresses, address(coreFacet)), "missing core facet");
+        assertTrue(_containsAddress(facetAddresses, address(controlsFacet)), "missing controls facet");
+        assertTrue(_containsAddress(facetAddresses, address(integrationFacet)), "missing integration facet");
+
+        assertTrue(
+            loupe.facetFunctionSelectors(address(coreFacet)).length
+                == LibVaultFacetSelectors.vaultCoreSelectors().length,
+            "unexpected core selector count"
+        );
+        assertTrue(
+            loupe.facetFunctionSelectors(address(controlsFacet)).length
+                == LibVaultFacetSelectors.vaultControlsSelectors().length,
+            "unexpected controls selector count"
+        );
+        assertTrue(
+            loupe.facetFunctionSelectors(address(integrationFacet)).length
+                == LibVaultFacetSelectors.vaultIntegrationSelectors().length,
+            "unexpected integration selector count"
+        );
+
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultCoreSelectors(), address(coreFacet));
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultControlsSelectors(), address(controlsFacet));
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultIntegrationSelectors(), address(integrationFacet));
+
+        assertTrue(loupe.facetAddress(DiamondCutFacet.diamondCut.selector) == address(cutFacet), "cut owner mismatch");
+        assertTrue(loupe.facetAddress(DiamondLoupeFacet.facets.selector) == address(loupeFacet), "loupe owner mismatch");
+        assertTrue(
+            loupe.facetAddress(IERC4626VaultFacet.initializeVault.selector) == address(coreFacet), "init owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC4626VaultControls.VAULT_MANAGER_ROLE.selector) == address(controlsFacet),
+            "vault manager owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC4626VaultIntegrationFacet.oracleAdapter.selector) == address(integrationFacet),
+            "oracle selector owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC165.supportsInterface.selector) == address(controlsFacet),
+            "supportsInterface owner mismatch"
+        );
+
+        assertTrue(coreFacetInterface().isVaultInitialized(), "vault should be initialized");
+        assertTrue(coreFacetInterface().asset() == address(asset), "asset mismatch");
+        assertTrue(
+            keccak256(bytes(IERC20Metadata(address(diamond)).name())) == keccak256(bytes("Vault Share")),
+            "name mismatch"
+        );
+        assertTrue(
+            keccak256(bytes(IERC20Metadata(address(diamond)).symbol())) == keccak256(bytes("vSHARE")), "symbol mismatch"
+        );
+
+        assertTrue(
+            controlsFacetInterface().hasRole(controlsFacetInterface().DEFAULT_ADMIN_ROLE(), admin),
+            "missing default admin"
+        );
+        assertTrue(controlsFacetInterface().hasRole(controlsFacetInterface().PAUSER_ROLE(), admin), "missing pauser");
+        assertTrue(
+            controlsFacetInterface().hasRole(controlsFacetInterface().VAULT_MANAGER_ROLE(), admin),
+            "missing vault manager"
+        );
+        (,, address feeRecipient) = controlsFacetInterface().feeConfig();
+        assertTrue(feeRecipient == admin, "fee recipient mismatch");
+
+        assertTrue(integrationFacetInterface().oracleAdapter() == address(adapter), "adapter mismatch");
+        assertTrue(integrationFacetInterface().strategy() == address(0), "strategy should be unset");
+        assertTrue(integrationFacetInterface().strategyReportedAssets() == 0, "reported assets should be zero");
+        assertTrue(quotePayload.value == 100_000_000, "quote value mismatch");
+        assertTrue(quotePayload.updatedAt == quoteUpdatedAt, "quote timestamp mismatch");
+        assertTrue(quotePayload.decimals == 8, "quote decimals mismatch");
+
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC4626VaultFacet).interfaceId), "missing core interface"
+        );
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC4626VaultControlsFacet).interfaceId),
+            "missing controls interface"
+        );
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC4626VaultIntegrationFacet).interfaceId),
+            "missing integration interface"
+        );
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultAlreadyInitialized.selector));
+        coreFacetInterface().initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function _assertSelectorsOwnedByFacet(bytes4[] memory selectors, address expectedFacet) internal view {
+        for (uint256 i = 0; i < selectors.length; i++) {
+            assertTrue(
+                IDiamondLoupe(address(diamond)).facetAddress(selectors[i]) == expectedFacet, "selector owner mismatch"
+            );
+        }
+    }
+}

--- a/test/helpers/DiamondVaultDeploymentTestHarness.sol
+++ b/test/helpers/DiamondVaultDeploymentTestHarness.sol
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
+import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
+import {ERC4626VaultControlsFacetHarness} from "./ERC4626VaultControlsFacetTestHarness.sol";
+import {ERC4626VaultFacetHarness} from "./ERC4626VaultFacetTestHarness.sol";
+import {ERC4626VaultIntegrationFacetHarness} from "./ERC4626VaultIntegrationFacetTestHarness.sol";
+import {MockVaultAsset} from "./ERC4626CoreTestHarness.sol";
+import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
+import {MockOracleFeed, OracleAdapterHarness} from "./OracleAdapterTestHarness.sol";
+import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+
+abstract contract DiamondVaultDeploymentFixture is TestBase {
+    address internal admin = address(0xA11CE);
+
+    uint64 internal maxStaleness = 1 hours;
+    uint64 internal currentTime = 1_000_000;
+    uint64 internal quoteUpdatedAt = 999_900;
+
+    DiamondCutFacet internal cutFacet;
+    DiamondLoupeFacet internal loupeFacet;
+    ERC4626VaultFacetHarness internal coreFacet;
+    ERC4626VaultControlsFacetHarness internal controlsFacet;
+    ERC4626VaultIntegrationFacetHarness internal integrationFacet;
+    DiamondProxyHarness internal diamond;
+    MockVaultAsset internal asset;
+    MockOracleFeed internal feed;
+    OracleAdapterHarness internal adapter;
+
+    function setUp() public virtual {
+        VM.warp(currentTime);
+
+        cutFacet = new DiamondCutFacet();
+        loupeFacet = new DiamondLoupeFacet();
+        coreFacet = new ERC4626VaultFacetHarness();
+        controlsFacet = new ERC4626VaultControlsFacetHarness();
+        integrationFacet = new ERC4626VaultIntegrationFacetHarness();
+        diamond = new DiamondProxyHarness(admin, address(cutFacet));
+        asset = new MockVaultAsset("Mock USD", "mUSD", 6);
+        feed = new MockOracleFeed(8);
+        feed.setLatestRoundData(1, 100_000_000, quoteUpdatedAt, quoteUpdatedAt, 1);
+        adapter = new OracleAdapterHarness(admin, address(feed), maxStaleness);
+
+        _installLoupeFacet();
+    }
+
+    function _installLoupeFacet() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(loupeFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: _loupeSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installVaultHostFacets() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](3);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(coreFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultCoreSelectors()
+        });
+        cut[1] = IDiamondCut.FacetCut({
+            facetAddress: address(controlsFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultControlsSelectors()
+        });
+        cut[2] = IDiamondCut.FacetCut({
+            facetAddress: address(integrationFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultIntegrationSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _initializeVaultHost() internal {
+        VM.prank(admin);
+        coreFacetInterface().initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function _wireOracleAdapter() internal {
+        VM.prank(admin);
+        integrationFacetInterface().setOracleAdapter(address(adapter));
+    }
+
+    function coreFacetInterface() internal view returns (ERC4626VaultFacetHarness) {
+        return ERC4626VaultFacetHarness(address(diamond));
+    }
+
+    function controlsFacetInterface() internal view returns (ERC4626VaultControlsFacetHarness) {
+        return ERC4626VaultControlsFacetHarness(address(diamond));
+    }
+
+    function integrationFacetInterface() internal view returns (ERC4626VaultIntegrationFacetHarness) {
+        return ERC4626VaultIntegrationFacetHarness(address(diamond));
+    }
+
+    function _containsAddress(address[] memory addresses, address expected) internal pure returns (bool) {
+        for (uint256 i = 0; i < addresses.length; i++) {
+            if (addresses[i] == expected) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    function _loupeSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](6);
+        selectors[0] = DiamondLoupeFacet.facets.selector;
+        selectors[1] = DiamondLoupeFacet.facetFunctionSelectors.selector;
+        selectors[2] = DiamondLoupeFacet.facetAddresses.selector;
+        selectors[3] = DiamondLoupeFacet.facetAddress.selector;
+        selectors[4] = DiamondLoupeFacet.owner.selector;
+        selectors[5] = DiamondLoupeFacet.transferOwnership.selector;
+    }
+}


### PR DESCRIPTION
## Summary
- add a reference hosted-vault diamond deployment script and shared script base
- add local script-only asset and oracle mocks for reproducible Anvil deployment
- add deployment integration coverage for hosted vault init, selector ownership, oracle wiring, and interface reporting

## Validation
- `git diff --check`
- `forge fmt --check`
- `forge test --offline --match-path test/DiamondVaultDeploymentIntegration.t.sol`
- `forge test --offline`
- `forge script script/DeployDiamondVaultHost.s.sol:DeployDiamondVaultHostScript --rpc-url http://127.0.0.1:8545 --broadcast`

## Issue
- Closes #99