### PR TITLE
Add hosted vault cross-facet hardening

### DIFF
--- a/test/DiamondVaultHostHardening.t.sol
+++ b/test/DiamondVaultHostHardening.t.sol
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
+import {IERC165} from "../src/interfaces/IERC165.sol";
+import {IERC20Metadata} from "../src/interfaces/IERC20Metadata.sol";
+import {IERC4626} from "../src/interfaces/IERC4626.sol";
+import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol";
+import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControlsFacet.sol";
+import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
+import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
+import {IPausable} from "../src/interfaces/IPausable.sol";
+import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
+import {
+    DiamondVaultHostHardeningFixture,
+    IFacetVersionMarker
+} from "./helpers/DiamondVaultHostHardeningTestHarness.sol";
+
+contract DiamondVaultHostHardeningTest is DiamondVaultHostHardeningFixture {
+    function testCoreFacetReplaceRemoveReAddPreservesState() public {
+        _installAndSeedVaultHost();
+
+        _replaceCoreFacet(address(coreReplacement));
+        _addCoreReplacementMarker(address(coreReplacement));
+
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultCoreSelectors(), address(coreReplacement));
+        assertTrue(
+            IDiamondLoupe(address(diamond)).facetAddress(IFacetVersionMarker.facetVersion.selector)
+                == address(coreReplacement),
+            "core marker owner mismatch"
+        );
+        assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "core replacement marker mismatch");
+        assertTrue(coreFacetInterface().asset() == address(asset), "core asset mismatch after replace");
+        assertTrue(
+            keccak256(bytes(IERC20Metadata(address(diamond)).name())) == keccak256(bytes("Vault Share")),
+            "core name mismatch after replace"
+        );
+        assertTrue(
+            keccak256(bytes(IERC20Metadata(address(diamond)).symbol())) == keccak256(bytes("vSHARE")),
+            "core symbol mismatch after replace"
+        );
+        assertTrue(coreFacetInterface().totalManagedAssets() == BOB_DEPOSIT + CAROL_DEPOSIT, "managed assets mismatch");
+        assertTrue(coreFacetInterface().totalAssets() == BOB_DEPOSIT + CAROL_DEPOSIT, "total assets mismatch");
+        assertTrue(coreFacetInterface().totalSupply() == BOB_DEPOSIT + CAROL_DEPOSIT, "total supply mismatch");
+        assertTrue(coreFacetInterface().balanceOf(bob) == BOB_DEPOSIT, "bob balance mismatch");
+        assertTrue(coreFacetInterface().balanceOf(carol) == CAROL_DEPOSIT, "carol balance mismatch");
+        assertTrue(coreFacetInterface().allowance(bob, eve) == SHARE_ALLOWANCE, "share allowance mismatch");
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC4626VaultFacet).interfaceId),
+            "core interface missing after replace"
+        );
+
+        _removeCoreFacetWithMarker();
+
+        _assertMissingSelector(abi.encodeWithSelector(IERC4626.asset.selector), "core asset selector should be missing");
+        _assertMissingSelector(
+            abi.encodeWithSelector(IERC20Metadata.name.selector), "core metadata selector should be missing"
+        );
+        assertTrue(
+            !IERC165(address(diamond)).supportsInterface(type(IERC4626VaultFacet).interfaceId),
+            "core interface should be absent when selectors removed"
+        );
+        (,, address feeRecipient) = controlsFacetInterface().feeConfig();
+        assertTrue(feeRecipient == feeSink, "controls should still route after core removal");
+        assertTrue(
+            integrationFacetInterface().oracleAdapter() == address(adapter),
+            "integration should still route after core removal"
+        );
+
+        _reAddCoreFacetWithMarker(address(coreReplacement));
+
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultCoreSelectors(), address(coreReplacement));
+        assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "core marker mismatch after re-add");
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC4626VaultFacet).interfaceId),
+            "core interface missing after re-add"
+        );
+        assertTrue(coreFacetInterface().asset() == address(asset), "core asset mismatch after re-add");
+        assertTrue(
+            coreFacetInterface().totalSupply() == BOB_DEPOSIT + CAROL_DEPOSIT, "core supply mismatch after re-add"
+        );
+        assertTrue(coreFacetInterface().balanceOf(bob) == BOB_DEPOSIT, "bob balance mismatch after re-add");
+        assertTrue(coreFacetInterface().balanceOf(carol) == CAROL_DEPOSIT, "carol balance mismatch after re-add");
+        assertTrue(coreFacetInterface().allowance(bob, eve) == SHARE_ALLOWANCE, "allowance mismatch after re-add");
+    }
+
+    function testControlsFacetReplaceRemoveReAddPreservesControlState() public {
+        _installAndSeedVaultHost();
+        _pauseVault();
+
+        _replaceControlsFacet(address(controlsReplacement));
+        _addControlsReplacementMarker(address(controlsReplacement));
+
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultControlsSelectors(), address(controlsReplacement));
+        assertTrue(
+            IDiamondLoupe(address(diamond)).facetAddress(IERC165.supportsInterface.selector)
+                == address(controlsReplacement),
+            "supportsInterface owner mismatch after controls replace"
+        );
+        assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "controls replacement marker mismatch");
+        _assertControlsState();
+        assertTrue(controlsFacetInterface().paused(), "paused state should persist after replace");
+        assertFalse(controlsFacetInterface().reentrancyGuardEntered(), "reentrancy should not be entered");
+
+        _removeControlsFacetWithMarker();
+
+        _assertMissingSelector(
+            abi.encodeWithSelector(IERC4626VaultControls.feeConfig.selector),
+            "controls fee config selector should be missing"
+        );
+        _assertMissingSelector(
+            abi.encodeWithSelector(IERC165.supportsInterface.selector, type(IERC4626VaultFacet).interfaceId),
+            "supportsInterface selector should be missing"
+        );
+        assertTrue(coreFacetInterface().asset() == address(asset), "core should still route after controls removal");
+        assertTrue(
+            integrationFacetInterface().strategyReportedAssets() == STRATEGY_REPORTED_ASSETS,
+            "integration should still route after controls removal"
+        );
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+        coreFacetInterface().deposit(1, bob);
+
+        _reAddControlsFacetWithMarker(address(controlsReplacement));
+
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultControlsSelectors(), address(controlsReplacement));
+        assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "controls marker mismatch after re-add");
+        _assertControlsState();
+        assertTrue(controlsFacetInterface().paused(), "paused state should persist after re-add");
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC4626VaultFacet).interfaceId),
+            "core interface should be reported after controls re-add"
+        );
+        _unpauseVault();
+
+        VM.prank(dave);
+        coreFacetInterface().deposit(1, dave);
+        assertTrue(coreFacetInterface().balanceOf(dave) == 1, "dave should receive shares after unpause");
+    }
+
+    function testIntegrationFacetReplaceRemoveReAddPreservesIntegrationState() public {
+        _installAndSeedVaultHost();
+
+        _replaceIntegrationFacet(address(integrationReplacement));
+        _addIntegrationReplacementMarker(address(integrationReplacement));
+
+        _assertSelectorsOwnedByFacet(
+            LibVaultFacetSelectors.vaultIntegrationSelectors(), address(integrationReplacement)
+        );
+        assertTrue(
+            IDiamondLoupe(address(diamond)).facetAddress(IFacetVersionMarker.facetVersion.selector)
+                == address(integrationReplacement),
+            "integration marker owner mismatch"
+        );
+        assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "integration replacement marker mismatch");
+        _assertIntegrationState();
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC4626VaultIntegrationFacet).interfaceId),
+            "integration interface missing after replace"
+        );
+
+        _removeIntegrationFacetWithMarker();
+
+        _assertMissingSelector(
+            abi.encodeWithSelector(IERC4626VaultIntegrationFacet.oracleAdapter.selector),
+            "integration oracle selector should be missing"
+        );
+        assertTrue(coreFacetInterface().asset() == address(asset), "core should still route after integration removal");
+        assertTrue(
+            controlsFacetInterface().hasRole(controlsFacetInterface().VAULT_MANAGER_ROLE(), eve),
+            "controls should still route after integration removal"
+        );
+        assertTrue(
+            !IERC165(address(diamond)).supportsInterface(type(IERC4626VaultIntegrationFacet).interfaceId),
+            "integration interface should be absent when selectors removed"
+        );
+
+        _reAddIntegrationFacetWithMarker(address(integrationReplacement));
+
+        _assertSelectorsOwnedByFacet(
+            LibVaultFacetSelectors.vaultIntegrationSelectors(), address(integrationReplacement)
+        );
+        assertTrue(
+            IFacetVersionMarker(address(diamond)).facetVersion() == 2, "integration marker mismatch after re-add"
+        );
+        _assertIntegrationState();
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC4626VaultIntegrationFacet).interfaceId),
+            "integration interface missing after re-add"
+        );
+    }
+
+    function _assertSelectorsOwnedByFacet(bytes4[] memory selectors, address expectedFacet) internal view {
+        for (uint256 i = 0; i < selectors.length; i++) {
+            assertTrue(
+                IDiamondLoupe(address(diamond)).facetAddress(selectors[i]) == expectedFacet, "selector owner mismatch"
+            );
+        }
+    }
+
+    function _assertControlsState() internal view {
+        bytes32 managerRole = controlsFacetInterface().VAULT_MANAGER_ROLE();
+        (uint16 depositFeeBps, uint16 withdrawFeeBps, address feeRecipient) = controlsFacetInterface().feeConfig();
+        (uint128 maxTotalAssets, uint128 maxDeposit, uint128 maxMint, uint128 maxWithdraw, uint128 maxRedeem) =
+            controlsFacetInterface().limitConfig();
+        (uint64 start, uint64 end, bool exists) = controlsFacetInterface().getRoleWindow(managerRole, dave);
+
+        assertTrue(depositFeeBps == 100, "deposit fee mismatch");
+        assertTrue(withdrawFeeBps == 50, "withdraw fee mismatch");
+        assertTrue(feeRecipient == feeSink, "fee recipient mismatch");
+        assertTrue(maxTotalAssets == 900_000, "max total assets mismatch");
+        assertTrue(maxDeposit == 300_000, "max deposit mismatch");
+        assertTrue(maxMint == 300_000, "max mint mismatch");
+        assertTrue(maxWithdraw == 250_000, "max withdraw mismatch");
+        assertTrue(maxRedeem == 250_000, "max redeem mismatch");
+        assertTrue(controlsFacetInterface().hasRole(managerRole, eve), "eve manager role mismatch");
+        assertTrue(start == uint64(currentTime - 100), "role window start mismatch");
+        assertTrue(end == uint64(currentTime + 1_000), "role window end mismatch");
+        assertTrue(exists, "role window should exist");
+        assertTrue(controlsFacetInterface().hasActiveRole(managerRole, dave), "dave active manager role mismatch");
+    }
+
+    function _assertIntegrationState() internal view {
+        assertTrue(integrationFacetInterface().oracleAdapter() == address(adapter), "oracle adapter mismatch");
+        assertTrue(integrationFacetInterface().strategy() == strategyReporter, "strategy mismatch");
+        assertTrue(
+            integrationFacetInterface().strategyReportedAssets() == STRATEGY_REPORTED_ASSETS,
+            "strategy reported assets mismatch"
+        );
+        assertTrue(integrationFacetInterface().idleAssets() == BOB_DEPOSIT + CAROL_DEPOSIT, "idle assets mismatch");
+        assertTrue(
+            integrationFacetInterface().estimatedTotalManagedAssets()
+                == BOB_DEPOSIT + CAROL_DEPOSIT + STRATEGY_REPORTED_ASSETS,
+            "estimated managed assets mismatch"
+        );
+    }
+}

--- a/test/DiamondVaultHostInvariant.t.sol
+++ b/test/DiamondVaultHostInvariant.t.sol
@@ -1,0 +1,270 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol";
+import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
+import {IPausable} from "../src/interfaces/IPausable.sol";
+import {DiamondVaultHostHardeningFixture} from "./helpers/DiamondVaultHostHardeningTestHarness.sol";
+
+contract DiamondVaultHostInvariantTest is DiamondVaultHostHardeningFixture {
+    uint256 internal constant EXPECTED_INITIAL_ASSET_SUPPLY = INITIAL_ASSETS * ACTOR_COUNT;
+
+    function setUp() public override {
+        super.setUp();
+        _installVaultHostFacets();
+        _initializeVaultHost();
+        _wireOracleAdapter();
+
+        VM.prank(admin);
+        controlsFacetInterface().setFeeConfig(0, 0, feeSink);
+    }
+
+    function targetContracts() external view returns (address[] memory contracts) {
+        contracts = new address[](1);
+        contracts[0] = address(this);
+    }
+
+    function actionDeposit(uint8 actorSeed, uint96 assetsRaw) external {
+        address actor = _actor(actorSeed);
+        uint256 maxAssets = _min(coreFacetInterface().maxDeposit(actor), asset.balanceOf(actor));
+        uint256 assets_ = _boundAmount(assetsRaw, maxAssets);
+        if (assets_ == 0 || coreFacetInterface().previewDeposit(assets_) == 0) {
+            return;
+        }
+
+        if (controlsFacetInterface().paused()) {
+            VM.startPrank(actor);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+            coreFacetInterface().deposit(assets_, actor);
+            VM.stopPrank();
+            return;
+        }
+
+        VM.prank(actor);
+        coreFacetInterface().deposit(assets_, actor);
+    }
+
+    function actionMint(uint8 actorSeed, uint96 sharesRaw) external {
+        address actor = _actor(actorSeed);
+        uint256 feasibleShares = coreFacetInterface().previewDeposit(asset.balanceOf(actor));
+        uint256 maxShares = _min(coreFacetInterface().maxMint(actor), feasibleShares);
+        uint256 shares = _boundAmount(sharesRaw, maxShares);
+        if (shares == 0) {
+            return;
+        }
+
+        uint256 requiredAssets = coreFacetInterface().previewMint(shares);
+        if (requiredAssets == 0 || requiredAssets > asset.balanceOf(actor)) {
+            return;
+        }
+
+        if (controlsFacetInterface().paused()) {
+            VM.startPrank(actor);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+            coreFacetInterface().mint(shares, actor);
+            VM.stopPrank();
+            return;
+        }
+
+        VM.prank(actor);
+        coreFacetInterface().mint(shares, actor);
+    }
+
+    function actionWithdraw(uint8 actorSeed, uint96 assetsRaw) external {
+        address actor = _actor(actorSeed);
+        uint256 assets_ = _boundAmount(assetsRaw, coreFacetInterface().maxWithdraw(actor));
+        if (assets_ == 0) {
+            return;
+        }
+
+        if (controlsFacetInterface().paused()) {
+            VM.startPrank(actor);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+            coreFacetInterface().withdraw(assets_, actor, actor);
+            VM.stopPrank();
+            return;
+        }
+
+        VM.prank(actor);
+        coreFacetInterface().withdraw(assets_, actor, actor);
+    }
+
+    function actionRedeem(uint8 actorSeed, uint96 sharesRaw) external {
+        address actor = _actor(actorSeed);
+        uint256 shares = _boundAmount(sharesRaw, coreFacetInterface().maxRedeem(actor));
+        if (shares == 0 || coreFacetInterface().previewRedeem(shares) == 0) {
+            return;
+        }
+
+        if (controlsFacetInterface().paused()) {
+            VM.startPrank(actor);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+            coreFacetInterface().redeem(shares, actor, actor);
+            VM.stopPrank();
+            return;
+        }
+
+        VM.prank(actor);
+        coreFacetInterface().redeem(shares, actor, actor);
+    }
+
+    function actionApprove(uint8 ownerSeed, uint8 spenderSeed, uint96 sharesRaw) external {
+        address owner = _actor(ownerSeed);
+        address spender = _actorExcluding(owner, spenderSeed);
+
+        VM.prank(owner);
+        coreFacetInterface().approve(spender, uint256(sharesRaw));
+    }
+
+    function actionTransfer(uint8 fromSeed, uint8 toSeed, uint96 sharesRaw) external {
+        address from = _actor(fromSeed);
+        address to = _actorExcluding(from, toSeed);
+        uint256 shares = _boundAmount(sharesRaw, coreFacetInterface().balanceOf(from));
+        if (shares == 0) {
+            return;
+        }
+
+        VM.prank(from);
+        coreFacetInterface().transfer(to, shares);
+    }
+
+    function actionTransferFrom(uint8 spenderSeed, uint8 ownerSeed, uint8 toSeed, uint96 sharesRaw) external {
+        address spender = _actor(spenderSeed);
+        address owner = _actor(ownerSeed);
+        if (spender == owner) {
+            return;
+        }
+
+        address to = _actorExcluding(owner, toSeed);
+        uint256 allowance = coreFacetInterface().allowance(owner, spender);
+        uint256 balance = coreFacetInterface().balanceOf(owner);
+        uint256 shares = _boundAmount(sharesRaw, allowance < balance ? allowance : balance);
+        if (shares == 0) {
+            return;
+        }
+
+        VM.prank(spender);
+        coreFacetInterface().transferFrom(owner, to, shares);
+    }
+
+    function actionPauseToggle(bool shouldPause) external {
+        bool isPaused = controlsFacetInterface().paused();
+        if (shouldPause && !isPaused) {
+            _pauseVault();
+        } else if (!shouldPause && isPaused) {
+            _unpauseVault();
+        }
+    }
+
+    function actionSetFeeConfig(uint16 depositFeeRaw, uint16 withdrawFeeRaw) external {
+        AccountingSnapshot memory snapshot = _snapshotAccounting();
+        uint16 depositFeeBps = uint16(uint256(depositFeeRaw) % 2_001);
+        uint16 withdrawFeeBps = uint16(uint256(withdrawFeeRaw) % 2_001);
+
+        VM.prank(admin);
+        controlsFacetInterface().setFeeConfig(depositFeeBps, withdrawFeeBps, feeSink);
+
+        _assertAccountingUnchanged(snapshot, "fee config updates should not mutate core accounting");
+    }
+
+    function actionSetLimitConfig(
+        uint96 totalCapRaw,
+        uint96 depositRaw,
+        uint96 mintRaw,
+        uint96 withdrawRaw,
+        uint96 redeemRaw
+    ) external {
+        AccountingSnapshot memory snapshot = _snapshotAccounting();
+
+        uint256 currentAssets = coreFacetInterface().totalAssets();
+        uint128 maxTotalAssets = totalCapRaw % 4 == 0
+            ? 0
+            : uint128(currentAssets + (uint256(totalCapRaw) % EXPECTED_INITIAL_ASSET_SUPPLY) + 1);
+        uint128 maxDeposit = depositRaw % 4 == 0 ? 0 : uint128((uint256(depositRaw) % INITIAL_ASSETS) + 1);
+        uint128 maxMint = mintRaw % 4 == 0 ? 0 : uint128((uint256(mintRaw) % INITIAL_ASSETS) + 1);
+        uint128 maxWithdraw = withdrawRaw % 4 == 0 ? 0 : uint128((uint256(withdrawRaw) % INITIAL_ASSETS) + 1);
+        uint128 maxRedeem = redeemRaw % 4 == 0 ? 0 : uint128((uint256(redeemRaw) % INITIAL_ASSETS) + 1);
+
+        VM.prank(admin);
+        controlsFacetInterface().setLimitConfig(maxTotalAssets, maxDeposit, maxMint, maxWithdraw, maxRedeem);
+
+        _assertAccountingUnchanged(snapshot, "limit config updates should not mutate core accounting");
+    }
+
+    function actionSetOracleAdapter(bool configured) external {
+        AccountingSnapshot memory snapshot = _snapshotAccounting();
+
+        VM.prank(admin);
+        integrationFacetInterface().setOracleAdapter(configured ? address(adapter) : address(0));
+
+        _assertAccountingUnchanged(snapshot, "oracle adapter updates should not mutate core accounting");
+    }
+
+    function actionSetStrategy(bool configured) external {
+        AccountingSnapshot memory snapshot = _snapshotAccounting();
+
+        VM.prank(admin);
+        integrationFacetInterface().setStrategy(configured ? strategyReporter : address(0));
+
+        _assertAccountingUnchanged(snapshot, "strategy updates should not mutate core accounting");
+    }
+
+    function actionReportStrategyAssets(uint96 assetsRaw, bool asStrategyReporter) external {
+        AccountingSnapshot memory snapshot = _snapshotAccounting();
+        uint256 assets_ = uint256(assetsRaw);
+        address configuredStrategy = integrationFacetInterface().strategy();
+        address caller = asStrategyReporter && configuredStrategy != address(0) ? strategyReporter : admin;
+
+        VM.prank(caller);
+        integrationFacetInterface().reportStrategyAssets(assets_);
+
+        _assertAccountingUnchanged(snapshot, "strategy reports should not mutate core accounting");
+    }
+
+    function invariantManagedAssetsTrackUnderlyingBalance() public view {
+        assertTrue(
+            coreFacetInterface().totalAssets() == asset.balanceOf(address(diamond)),
+            "managed assets should match vault-held underlying"
+        );
+    }
+
+    function invariantShareSupplyMatchesTrackedActorBalances() public view {
+        assertTrue(
+            coreFacetInterface().totalSupply() == _sumTrackedShareBalances(),
+            "share supply should remain equal to tracked balances"
+        );
+    }
+
+    function invariantTrackedUnderlyingRemainsConserved() public view {
+        assertTrue(
+            _sumTrackedUnderlying() == EXPECTED_INITIAL_ASSET_SUPPLY,
+            "tracked underlying should remain conserved across actors, vault, and fee sink"
+        );
+    }
+
+    function invariantEstimatedManagedAssetsReflectIdlePlusReported() public view {
+        assertTrue(
+            integrationFacetInterface().estimatedTotalManagedAssets()
+                == integrationFacetInterface().idleAssets() + integrationFacetInterface().strategyReportedAssets(),
+            "estimated assets should equal idle plus reported strategy assets"
+        );
+        assertTrue(
+            integrationFacetInterface().estimatedTotalManagedAssets() >= coreFacetInterface().totalManagedAssets(),
+            "estimated managed assets should not be less than managed assets"
+        );
+    }
+
+    function invariantPausedStateZeroesMutatingMaxFunctions() public view {
+        if (!controlsFacetInterface().paused()) {
+            return;
+        }
+
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            address actor = actors[i];
+            assertTrue(coreFacetInterface().maxDeposit(actor) == 0, "paused vault should expose zero maxDeposit");
+            assertTrue(coreFacetInterface().maxMint(actor) == 0, "paused vault should expose zero maxMint");
+            assertTrue(coreFacetInterface().maxWithdraw(actor) == 0, "paused vault should expose zero maxWithdraw");
+            assertTrue(coreFacetInterface().maxRedeem(actor) == 0, "paused vault should expose zero maxRedeem");
+        }
+    }
+}

--- a/test/helpers/DiamondVaultHostHardeningTestHarness.sol
+++ b/test/helpers/DiamondVaultHostHardeningTestHarness.sol
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
+import {IERC4626VaultControls} from "../../src/interfaces/IERC4626VaultControls.sol";
+import {IERC4626VaultFacet} from "../../src/interfaces/IERC4626VaultFacet.sol";
+import {IERC4626VaultIntegrationFacet} from "../../src/interfaces/IERC4626VaultIntegrationFacet.sol";
+import {ERC4626VaultControlsFacet} from "../../src/vault/facets/ERC4626VaultControlsFacet.sol";
+import {ERC4626VaultFacet} from "../../src/vault/facets/ERC4626VaultFacet.sol";
+import {ERC4626VaultIntegrationFacet} from "../../src/vault/facets/ERC4626VaultIntegrationFacet.sol";
+import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
+import {DiamondVaultDeploymentFixture} from "./DiamondVaultDeploymentTestHarness.sol";
+
+interface IFacetVersionMarker {
+    function facetVersion() external view returns (uint256);
+}
+
+contract ERC4626VaultFacetReplacement is ERC4626VaultFacet {
+    function facetVersion() external pure returns (uint256) {
+        return 2;
+    }
+}
+
+contract ERC4626VaultControlsFacetReplacement is ERC4626VaultControlsFacet {
+    function facetVersion() external pure returns (uint256) {
+        return 2;
+    }
+}
+
+contract ERC4626VaultIntegrationFacetReplacement is ERC4626VaultIntegrationFacet {
+    function facetVersion() external pure returns (uint256) {
+        return 2;
+    }
+}
+
+abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixture {
+    struct AccountingSnapshot {
+        uint256 totalAssets;
+        uint256 totalSupply;
+        uint256 vaultUnderlyingBalance;
+        uint256 feeSinkBalance;
+        uint256 actorUnderlyingBalanceSum;
+        uint256 actorShareBalanceSum;
+    }
+
+    uint256 internal constant INITIAL_ASSETS = 1_000_000;
+    uint256 internal constant ACTOR_COUNT = 4;
+    uint256 internal constant BOB_DEPOSIT = 200_000;
+    uint256 internal constant CAROL_DEPOSIT = 150_000;
+    uint256 internal constant SHARE_ALLOWANCE = 25_000;
+    uint256 internal constant STRATEGY_REPORTED_ASSETS = 75_000;
+
+    address internal bob = address(0xB0B);
+    address internal carol = address(0xCA11);
+    address internal dave = address(0xD0D);
+    address internal eve = address(0xE11E);
+    address internal feeSink = address(0xFEE);
+    address internal strategyReporter = address(0x57A7);
+
+    address[ACTOR_COUNT] internal actors;
+
+    ERC4626VaultFacetReplacement internal coreReplacement;
+    ERC4626VaultControlsFacetReplacement internal controlsReplacement;
+    ERC4626VaultIntegrationFacetReplacement internal integrationReplacement;
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        coreReplacement = new ERC4626VaultFacetReplacement();
+        controlsReplacement = new ERC4626VaultControlsFacetReplacement();
+        integrationReplacement = new ERC4626VaultIntegrationFacetReplacement();
+
+        actors[0] = bob;
+        actors[1] = carol;
+        actors[2] = dave;
+        actors[3] = eve;
+
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            address actor = actors[i];
+            asset.mint(actor, INITIAL_ASSETS);
+            VM.prank(actor);
+            asset.approve(address(diamond), type(uint256).max);
+        }
+    }
+
+    function _installAndSeedVaultHost() internal {
+        _installVaultHostFacets();
+        _initializeVaultHost();
+        _wireOracleAdapter();
+        _seedCoreState();
+        _seedControlsState();
+        _seedIntegrationState();
+    }
+
+    function _seedCoreState() internal {
+        VM.prank(bob);
+        coreFacetInterface().deposit(BOB_DEPOSIT, bob);
+
+        VM.prank(carol);
+        coreFacetInterface().deposit(CAROL_DEPOSIT, carol);
+
+        VM.prank(bob);
+        coreFacetInterface().approve(eve, SHARE_ALLOWANCE);
+    }
+
+    function _seedControlsState() internal {
+        bytes32 managerRole = controlsFacetInterface().VAULT_MANAGER_ROLE();
+
+        VM.prank(admin);
+        controlsFacetInterface().setFeeConfig(100, 50, feeSink);
+
+        VM.prank(admin);
+        controlsFacetInterface().setLimitConfig(900_000, 300_000, 300_000, 250_000, 250_000);
+
+        VM.prank(admin);
+        controlsFacetInterface().grantRole(managerRole, eve);
+
+        VM.prank(admin);
+        controlsFacetInterface()
+            .grantRoleWithWindow(managerRole, dave, uint64(currentTime - 100), uint64(currentTime + 1_000));
+    }
+
+    function _seedIntegrationState() internal {
+        VM.prank(admin);
+        integrationFacetInterface().setStrategy(strategyReporter);
+
+        VM.prank(strategyReporter);
+        integrationFacetInterface().reportStrategyAssets(STRATEGY_REPORTED_ASSETS);
+    }
+
+    function _replaceCoreFacet(address facetAddress_) internal {
+        _replaceFacet(facetAddress_, LibVaultFacetSelectors.vaultCoreSelectors());
+    }
+
+    function _replaceControlsFacet(address facetAddress_) internal {
+        _replaceFacet(facetAddress_, LibVaultFacetSelectors.vaultControlsSelectors());
+    }
+
+    function _replaceIntegrationFacet(address facetAddress_) internal {
+        _replaceFacet(facetAddress_, LibVaultFacetSelectors.vaultIntegrationSelectors());
+    }
+
+    function _addCoreReplacementMarker(address facetAddress_) internal {
+        _addFacet(facetAddress_, _markerSelectors());
+    }
+
+    function _addControlsReplacementMarker(address facetAddress_) internal {
+        _addFacet(facetAddress_, _markerSelectors());
+    }
+
+    function _addIntegrationReplacementMarker(address facetAddress_) internal {
+        _addFacet(facetAddress_, _markerSelectors());
+    }
+
+    function _removeCoreFacetWithMarker() internal {
+        _removeSelectors(_concat(LibVaultFacetSelectors.vaultCoreSelectors(), _markerSelectors()));
+    }
+
+    function _removeControlsFacetWithMarker() internal {
+        _removeSelectors(_concat(LibVaultFacetSelectors.vaultControlsSelectors(), _markerSelectors()));
+    }
+
+    function _removeIntegrationFacetWithMarker() internal {
+        _removeSelectors(_concat(LibVaultFacetSelectors.vaultIntegrationSelectors(), _markerSelectors()));
+    }
+
+    function _reAddCoreFacetWithMarker(address facetAddress_) internal {
+        _addFacet(facetAddress_, _concat(LibVaultFacetSelectors.vaultCoreSelectors(), _markerSelectors()));
+    }
+
+    function _reAddControlsFacetWithMarker(address facetAddress_) internal {
+        _addFacet(facetAddress_, _concat(LibVaultFacetSelectors.vaultControlsSelectors(), _markerSelectors()));
+    }
+
+    function _reAddIntegrationFacetWithMarker(address facetAddress_) internal {
+        _addFacet(facetAddress_, _concat(LibVaultFacetSelectors.vaultIntegrationSelectors(), _markerSelectors()));
+    }
+
+    function _pauseVault() internal {
+        VM.prank(admin);
+        controlsFacetInterface().pause();
+    }
+
+    function _unpauseVault() internal {
+        VM.prank(admin);
+        controlsFacetInterface().unpause();
+    }
+
+    function _actor(uint8 seed) internal view returns (address) {
+        return actors[uint256(seed) % ACTOR_COUNT];
+    }
+
+    function _actorExcluding(address excluded, uint8 seed) internal view returns (address actor) {
+        actor = _actor(seed);
+        if (actor == excluded) {
+            actor = _actor(seed + 1);
+        }
+    }
+
+    function _boundAmount(uint256 raw, uint256 max) internal pure returns (uint256) {
+        if (max == 0) {
+            return 0;
+        }
+        return (raw % max) + 1;
+    }
+
+    function _min(uint256 x, uint256 y) internal pure returns (uint256) {
+        return x < y ? x : y;
+    }
+
+    function _sumTrackedShareBalances() internal view returns (uint256 sum) {
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            sum += coreFacetInterface().balanceOf(actors[i]);
+        }
+    }
+
+    function _sumTrackedUnderlying() internal view returns (uint256 sum) {
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            sum += asset.balanceOf(actors[i]);
+        }
+
+        sum += asset.balanceOf(address(diamond));
+        sum += asset.balanceOf(feeSink);
+    }
+
+    function _snapshotAccounting() internal view returns (AccountingSnapshot memory snapshot) {
+        snapshot.totalAssets = coreFacetInterface().totalAssets();
+        snapshot.totalSupply = coreFacetInterface().totalSupply();
+        snapshot.vaultUnderlyingBalance = asset.balanceOf(address(diamond));
+        snapshot.feeSinkBalance = asset.balanceOf(feeSink);
+
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            snapshot.actorUnderlyingBalanceSum += asset.balanceOf(actors[i]);
+            snapshot.actorShareBalanceSum += coreFacetInterface().balanceOf(actors[i]);
+        }
+    }
+
+    function _assertAccountingUnchanged(AccountingSnapshot memory snapshot, string memory reason) internal view {
+        AccountingSnapshot memory afterSnapshot = _snapshotAccounting();
+        assertTrue(afterSnapshot.totalAssets == snapshot.totalAssets, reason);
+        assertTrue(afterSnapshot.totalSupply == snapshot.totalSupply, reason);
+        assertTrue(afterSnapshot.vaultUnderlyingBalance == snapshot.vaultUnderlyingBalance, reason);
+        assertTrue(afterSnapshot.feeSinkBalance == snapshot.feeSinkBalance, reason);
+        assertTrue(afterSnapshot.actorUnderlyingBalanceSum == snapshot.actorUnderlyingBalanceSum, reason);
+        assertTrue(afterSnapshot.actorShareBalanceSum == snapshot.actorShareBalanceSum, reason);
+    }
+
+    function _addFacet(address facetAddress_, bytes4[] memory selectors) internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: facetAddress_, action: IDiamondCut.FacetCutAction.Add, functionSelectors: selectors
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _replaceFacet(address facetAddress_, bytes4[] memory selectors) internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: facetAddress_, action: IDiamondCut.FacetCutAction.Replace, functionSelectors: selectors
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _removeSelectors(bytes4[] memory selectors) internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(0), action: IDiamondCut.FacetCutAction.Remove, functionSelectors: selectors
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _assertMissingSelector(bytes memory callData, string memory reason) internal {
+        (bool success,) = address(diamond).call(callData);
+        assertFalse(success, reason);
+    }
+
+    function _markerSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](1);
+        selectors[0] = IFacetVersionMarker.facetVersion.selector;
+    }
+
+    function _concat(bytes4[] memory first, bytes4[] memory second) internal pure returns (bytes4[] memory combined) {
+        combined = new bytes4[](first.length + second.length);
+
+        uint256 i;
+        for (; i < first.length; i++) {
+            combined[i] = first[i];
+        }
+
+        for (uint256 j = 0; j < second.length; j++) {
+            combined[i + j] = second[j];
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add vault-host replace/remove/re-add hardening coverage for core, controls, and integration facets
- add a diamond-host invariant suite that drives vault, control, and integration actions through the hosted vault address
- validate selector ownership movement, state persistence, and cross-facet accounting assumptions

## Validation
- `git diff --check`
- `forge fmt --check test/helpers/DiamondVaultHostHardeningTestHarness.sol test/DiamondVaultHostHardening.t.sol test/DiamondVaultHostInvariant.t.sol`
- `forge test --offline --match-path test/DiamondVaultHostHardening.t.sol`
- `forge test --offline --match-path test/DiamondVaultHostInvariant.t.sol`
- `forge test --offline`

## Issue
- Closes #100