### PR TITLE
Document hosted vault architecture and safety assumptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ reviewable engineering system.
 - Hosted ERC20 and ERC721 token facets deployed behind separate diamond hosts,
   with init, selector ownership, Permit/metadata support, and host-level
   hardening coverage.
+- A hosted ERC-4626 vault platform deployed behind a diamond host, split across
+  core, controls, and integration facets with deployment-backed init, oracle
+  wiring, replace/remove/re-add hardening, and diamond-routed invariant
+  coverage.
 - Operational maturity through local bootstrap, smoke validation, upgrade
   rehearsal, system-hardening flows, and matching CI gates.
 
@@ -44,8 +48,9 @@ Implemented milestones so far:
 - Access Control + Upgrade Safety Kit
 - Oracle Adapter + Circuit Breaker
 - Diamond Core (EIP-2535)
-- Diamond Token Facets
 - System-Level Testing & Hardening
+- Diamond Token Facets
+- Diamond-Hosted Vault Platform
 
 ## Validation
 
@@ -61,8 +66,8 @@ bash script/run-local-system-hardening.sh
 ## Documentation
 
 Architecture and module docs live in `docs/diamond-core.md`,
-`docs/oracle-adapter.md`, `docs/erc4626-vault.md`, `docs/token-facets.md`, and
-`docs/threat-model.md`.
+`docs/oracle-adapter.md`, `docs/erc4626-vault.md`, `docs/vault-facets.md`,
+`docs/token-facets.md`, and `docs/threat-model.md`.
 
 Operational guidance lives in `docs/ops/README.md`, with the end-to-end
 execution order collected in `docs/ops/runbook-system-hardening.md`.
@@ -72,6 +77,10 @@ CI and local validation parity are documented in `docs/security-checks.md`.
 Token-host architecture and safety assumptions live in `docs/token-facets.md`,
 including the init model, selector ownership rules, separate-host deployment
 constraint, and token-host upgrade assumptions.
+
+Hosted-vault architecture and safety assumptions live in
+`docs/vault-facets.md`, including the init model, selector ownership split,
+pause behavior, deployment references, and hosted-vault upgrade assumptions.
 
 ## Tooling
 

--- a/docs/erc4626-vault.md
+++ b/docs/erc4626-vault.md
@@ -6,6 +6,9 @@ repository:
 - `ERC4626Vault`
 - `ERC4626VaultControls`
 
+It covers the standalone vault modules and their math/control behavior. For the
+diamond-hosted vault platform, see `docs/vault-facets.md`.
+
 ## Contract Roles
 
 - `ERC4626VaultBase`: initializer + share/asset accounting primitives.

--- a/docs/security-checks.md
+++ b/docs/security-checks.md
@@ -63,6 +63,20 @@ forge test --offline --match-path test/DiamondErc721HostInvariant.t.sol
 Use these to reproduce token-host deployment, selector ownership, replace and
 reinstall persistence, and diamond-routed invariant coverage locally.
 
+### Hosted Vault
+
+The hosted vault milestone has matching deployment, hardening, and invariant
+coverage for the supported three-facet vault host:
+
+```bash
+forge test --offline --match-path test/DiamondVaultDeploymentIntegration.t.sol
+forge test --offline --match-path test/DiamondVaultHostHardening.t.sol
+forge test --offline --match-path test/DiamondVaultHostInvariant.t.sol
+```
+
+Use these to reproduce hosted-vault deployment, selector ownership, facet
+replacement/reinstall persistence, and diamond-routed vault invariants locally.
+
 ### Slither
 
 Install and run the same high-severity gate locally:

--- a/docs/vault-facets.md
+++ b/docs/vault-facets.md
@@ -1,0 +1,204 @@
+# Diamond Vault Facets
+
+This document is the canonical guide for the hosted vault model implemented in
+the `Diamond-Hosted Vault Platform` milestone.
+
+It covers the supported diamond-hosted vault deployment:
+
+- one diamond
+- one `ERC4626VaultFacet`
+- one `ERC4626VaultControlsFacet`
+- one `ERC4626VaultIntegrationFacet`
+
+For the standalone ERC-4626 module behavior and math reference, see
+`docs/erc4626-vault.md`.
+
+## Supported Host Model
+
+The hosted vault diamond preserves a split between user-facing vault flows,
+control-plane selectors, and integration/config selectors.
+
+### Core Facet
+
+`ERC4626VaultFacet` owns the ERC-4626/share-token selector group:
+
+- vault initialization
+- share metadata and share-token flows
+- `deposit`, `mint`, `withdraw`, `redeem`
+- conversion, preview, and `max*` helpers
+- `asset()` and `totalManagedAssets()`
+
+### Controls Facet
+
+`ERC4626VaultControlsFacet` owns the control-plane selector group:
+
+- fee config and limit config
+- access control and time-window role selectors
+- global and scoped pause selectors
+- reentrancy introspection
+- `supportsInterface(bytes4)`
+
+### Integration Facet
+
+`ERC4626VaultIntegrationFacet` owns the integration/config selector group:
+
+- oracle adapter reference
+- strategy reference
+- strategy report hook
+- `idleAssets()`
+- `estimatedTotalManagedAssets()`
+- `oracleQuote()`
+
+## Initialization Model
+
+The hosted vault uses one initializer on the core facet only.
+
+Initialization sequence:
+
+1. Install loupe selectors.
+2. Install the core, controls, and integration selector groups.
+3. Call
+   `initializeVault(address vaultAsset, string vaultName, string vaultSymbol, address admin)`
+   through the diamond.
+4. Optionally call `setOracleAdapter(address newAdapter)` through the
+   integration facet.
+
+Initialization behavior:
+
+- `initializeVault(...)` initializes vault storage and shared control storage.
+- `DEFAULT_ADMIN_ROLE`, `PAUSER_ROLE`, and `VAULT_MANAGER_ROLE` are granted to
+  `admin`.
+- `feeRecipient` defaults to `admin` at initialization.
+- `ERC4626VaultControlsFacet` has no independent initializer.
+- `ERC4626VaultIntegrationFacet` has no independent initializer.
+- a second call to `initializeVault(...)` reverts.
+
+## Role Model And Pause Behavior
+
+Hosted vault facets reuse the shared control plane.
+
+### Roles
+
+- `DEFAULT_ADMIN_ROLE`
+- `PAUSER_ROLE`
+- `VAULT_MANAGER_ROLE`
+
+`VAULT_MANAGER_ROLE` is used for:
+
+- `setFeeConfig(...)`
+- `setLimitConfig(...)`
+- `setOracleAdapter(...)`
+- `setStrategy(...)`
+- manager-authorized `reportStrategyAssets(...)`
+
+If a strategy is configured, the strategy address may also call
+`reportStrategyAssets(...)`.
+
+### Pause Behavior
+
+The hosted vault currently uses a global pause model for vault entrypoints.
+
+Global pause blocks:
+
+- `deposit`
+- `mint`
+- `withdraw`
+- `redeem`
+
+Global pause does not block share-token flows:
+
+- `approve`
+- `transfer`
+- `transferFrom`
+
+Scoped pause selectors still route through the controls facet, but the hosted
+vault does not currently use per-scope pause behavior for ERC-4626 entrypoints.
+
+## Integration Behavior
+
+The integration facet is config/report infrastructure, not an active strategy
+engine.
+
+Oracle behavior:
+
+- the oracle adapter is an external contract reference
+- the reference host deployment wires it after vault initialization
+- `oracleQuote()` reads through the configured adapter
+
+Strategy behavior:
+
+- `setStrategy(...)` stores a configured strategy reference
+- `reportStrategyAssets(...)` updates an advisory reported amount
+- `strategyReportedAssets` does not mutate core ERC-4626 liquidity accounting
+
+Asset helpers:
+
+- `idleAssets()` returns the underlying balance held directly by the vault
+- `estimatedTotalManagedAssets()` returns
+  `idleAssets() + strategyReportedAssets()`
+- `totalManagedAssets()` and ERC-4626 preview/liquidity math continue to use the
+  vault's managed accounting only
+
+That means strategy reports are visible to operators and reviewers, but they do
+not automatically change `withdraw`, `redeem`, preview math, or live liquidity
+semantics in this milestone.
+
+## Selector Ownership Model
+
+For the supported hosted vault deployment:
+
+- `diamondCut` is owned by `DiamondCutFacet`
+- loupe and ownership-introspection selectors are owned by
+  `DiamondLoupeFacet`
+- core selectors are owned by `ERC4626VaultFacet`
+- controls selectors and `supportsInterface(bytes4)` are owned by
+  `ERC4626VaultControlsFacet`
+- integration selectors are owned by `ERC4626VaultIntegrationFacet`
+
+One important implication:
+
+- support for `IERC4626VaultFacet` and `IERC4626VaultIntegrationFacet` is
+  reported through the controls facet
+- those interface IDs are only reported when the corresponding core or
+  integration selectors are installed
+
+## Storage And Upgrade Assumptions
+
+Hosted vault state lives in the diamond, not in the facet bytecode.
+
+Supported replace/remove/re-add flows assume:
+
+- replacement facets preserve the same storage layout
+- selectors are restored before the corresponding surface is expected to route
+- no re-initialization is performed during upgrades
+
+Current hardening coverage explicitly validates persistence for:
+
+- vault metadata and ERC-4626/share-token state
+- fee config, limit config, roles, role windows, and pause state
+- oracle adapter, strategy reference, and reported strategy assets
+
+## Deployment References
+
+Reference local deployment flow:
+
+- `script/DeployDiamondVaultHost.s.sol`
+
+Reference local artifact:
+
+- `deployments/diamond-vault.local.json`
+
+The reference deployment:
+
+- installs loupe, core, controls, and integration selectors
+- initializes the vault through the core facet
+- wires the oracle adapter through the integration facet
+- leaves `strategy == address(0)` and `strategyReportedAssets == 0`
+
+## Validation References
+
+The hosted vault model is covered by:
+
+- `test/DiamondVaultDeploymentIntegration.t.sol`
+- `test/DiamondVaultHostHardening.t.sol`
+- `test/DiamondVaultHostInvariant.t.sol`


### PR DESCRIPTION
## Summary
- add a canonical hosted-vault architecture guide for the diamond-hosted vault platform
- update the README and security-check docs to point reviewers to the hosted-vault deployment, hardening, and invariant coverage
- keep the standalone ERC-4626 doc focused on the non-hosted vault modules and add a pointer to the hosted-vault guide

## Validation
- `git diff --check`
- verified referenced paths exist for the hosted-vault script, artifact, and validation suites

## Issue
- Closes #101