### PR TITLE
Complete Auralis Launch Readiness spike

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -423,3 +423,6 @@ broadcast/
 
 # Local portfolio tracking
 PORTFOLIO_PROJECTS.md
+
+# Local Auralis workflow state
+.auralis/

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ reviewable engineering system.
   coverage.
 - Operational maturity through local bootstrap, smoke validation, upgrade
   rehearsal, system-hardening flows, and matching CI gates.
+- A local Auralis workflow for full-stack bootstrap, smoke checks, simulated
+  activity, reset flows, and unified deployment artifacts.
 
 ## Current Status
 
@@ -51,6 +53,7 @@ Implemented milestones so far:
 - System-Level Testing & Hardening
 - Diamond Token Facets
 - Diamond-Hosted Vault Platform
+- Auralis Launch Readiness
 
 ## Validation
 
@@ -61,6 +64,15 @@ forge test --offline
 bash script/run-local-diamond-smoke.sh
 bash script/run-local-diamond-upgrade-rehearsal.sh
 bash script/run-local-system-hardening.sh
+```
+
+For the local Auralis workflow:
+
+```shell
+bash scripts/auralis-up.sh
+bash scripts/auralis-smoke.sh
+bash scripts/auralis-activity.sh
+bash scripts/auralis-reset.sh
 ```
 
 ## Documentation
@@ -82,8 +94,19 @@ Hosted-vault architecture and safety assumptions live in
 `docs/vault-facets.md`, including the init model, selector ownership split,
 pause behavior, deployment references, and hosted-vault upgrade assumptions.
 
+Local Auralis bootstrap, smoke, simulated activity, reset flow, and artifact
+layout are documented in `docs/auralis-local.md`.
+
 ## Tooling
 
 Built with Foundry. CI workflows live under `.github/workflows/`.
 
 Foundry docs: [book.getfoundry.sh](https://book.getfoundry.sh/)
+
+## AI Usage
+
+AI assistance was used for tests, documentation, scripts, planning support,
+and some implementation acceleration.
+
+The protocol architecture, technical decisions, and final review/integration of
+changes were directed and owned by me.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 <p align="center">
-  <img src="docs/assets/keystone-logo.svg" alt="Keystone logo" width="140" />
+  <img src="docs/assets/auralis-logo.svg" alt="Auralis logo" width="140" />
 </p>
 
-# Keystone
+# Auralis
 
 ![Solidity](https://img.shields.io/badge/Solidity-0.8.30-363636?logo=solidity)
-[![Foundry CI](https://github.com/amshirif/smart-contracts/actions/workflows/ci.yml/badge.svg)](https://github.com/amshirif/smart-contracts/actions/workflows/ci.yml)
-![License](https://img.shields.io/github/license/amshirif/smart-contracts)
+[![Foundry CI](https://github.com/amshirif/Auralis/actions/workflows/ci.yml/badge.svg)](https://github.com/amshirif/Auralis/actions/workflows/ci.yml)
+![License](https://img.shields.io/github/license/amshirif/Auralis)
 
 Security-first, diamond-ready Solidity systems.
 
-`Keystone` is a portfolio-focused Solidity repository built to show
+`Auralis` is a portfolio-focused Solidity repository built to show
 security-first protocol engineering, dependency-light design, and
 deployment-backed validation. The codebase is intentionally diamond-ready, so
 core modules can evolve into facetized systems without rewriting storage or

--- a/README.md
+++ b/README.md
@@ -105,8 +105,7 @@ Foundry docs: [book.getfoundry.sh](https://book.getfoundry.sh/)
 
 ## AI Usage
 
-AI assistance was used for tests, documentation, scripts, planning support,
-and some implementation acceleration.
+AI assistance was used for tests, documentation, scripts, planning support.
 
 The protocol architecture, technical decisions, and final review/integration of
 changes were directed and owned by me.

--- a/docs/assets/auralis-logo.svg
+++ b/docs/assets/auralis-logo.svg
@@ -1,5 +1,5 @@
 <svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
-  <title id="title">Keystone logo</title>
+  <title id="title">Auralis logo</title>
   <desc id="desc">A geometric diamond mark with a highlighted central cut seam.</desc>
   <path d="M128 28L212 92V164L128 228L44 164V92L128 28Z" fill="#111827"/>
   <path d="M128 28L212 92L128 116L44 92L128 28Z" fill="#374151"/>

--- a/docs/auralis-local.md
+++ b/docs/auralis-local.md
@@ -1,0 +1,80 @@
+# Auralis Local Workflow
+
+`Auralis` ships with a local-first workflow for bootstrapping the token hosts,
+vault host, and a small amount of simulated protocol activity on Anvil.
+
+## Prerequisites
+
+- `anvil`
+- `forge`
+- `cast`
+- Python 3
+
+The scripts assume the default local Anvil account key unless overridden with
+`PRIVATE_KEY` and `ALICE_PRIVATE_KEY`.
+
+## Commands
+
+Bootstrap the full local environment:
+
+```shell
+bash scripts/auralis-up.sh
+```
+
+Smoke-check the deployed stack:
+
+```shell
+bash scripts/auralis-smoke.sh
+```
+
+Generate simulated local activity:
+
+```shell
+bash scripts/auralis-activity.sh
+```
+
+Reset local artifacts and stop the managed Anvil process:
+
+```shell
+bash scripts/auralis-reset.sh
+```
+
+## What The Scripts Do
+
+`auralis-up.sh`
+- starts Anvil if one is not already available
+- deploys the ERC20 host, ERC721 host, and vault host
+- writes `deployments/auralis.local.json`
+
+`auralis-smoke.sh`
+- checks deployed code is present
+- runs token, NFT, and vault happy-path transactions
+- verifies the vault oracle quote path is live
+
+`auralis-activity.sh`
+- generates deterministic demo traffic across the deployed hosts
+- mints and transfers ERC20 balances
+- mints and moves an ERC721 token
+- deposits into the vault, moves shares, redeems shares, updates the oracle, and reports strategy assets
+
+`auralis-reset.sh`
+- stops the managed Anvil process if `auralis-up.sh` started it
+- removes the Auralis deployment artifacts
+
+## Artifact Layout
+
+`deployments/auralis.local.json` combines the host-specific deployment outputs
+and records:
+
+- RPC URL
+- chain id
+- owner/alice actor addresses
+- ERC20 host addresses
+- ERC721 host addresses
+- vault host addresses
+
+## Simulated Activity
+
+The activity script is explicitly demo traffic for local development and review.
+It is meant to create realistic event history and state transitions, not to
+model production usage or strategy execution.

--- a/docs/token-facets.md
+++ b/docs/token-facets.md
@@ -146,8 +146,8 @@ transfer or approval pause scopes.
 
 The token facets use fixed storage slots:
 
-- ERC20: `keccak256("smart-contracts.token.erc20.storage")`
-- ERC721: `keccak256("smart-contracts.token.erc721.storage")`
+- ERC20: `keccak256("auralis.token.erc20.storage")`
+- ERC721: `keccak256("auralis.token.erc721.storage")`
 
 Those layouts are separate, so ERC20 and ERC721 state do not collide at the
 storage level. The repo still deploys them as separate hosts because the raw

--- a/script/helpers/DiamondUpgradeRehearsalFixtures.sol
+++ b/script/helpers/DiamondUpgradeRehearsalFixtures.sol
@@ -54,7 +54,7 @@ contract DiamondUpgradeFailureFacet {
 }
 
 library LibDiamondUpgradeRehearsalStorage {
-    bytes32 internal constant STORAGE_SLOT = keccak256("smart-contracts.script.diamond-upgrade-rehearsal.storage");
+    bytes32 internal constant STORAGE_SLOT = keccak256("auralis.script.diamond-upgrade-rehearsal.storage");
 
     struct Layout {
         uint256 value;

--- a/script/mocks/LocalVaultDeploymentMocks.sol
+++ b/script/mocks/LocalVaultDeploymentMocks.sol
@@ -95,11 +95,11 @@ contract LocalMintableVaultAsset is IERC20Metadata {
 /// @title LocalMockOracleFeed
 /// @notice Minimal oracle feed used for local hosted-vault deployment rehearsal.
 contract LocalMockOracleFeed is IOracleFeed {
-    uint8 internal immutable _decimals;
-    uint80 internal immutable _roundId;
-    int256 internal immutable _answer;
-    uint256 internal immutable _updatedAt;
-    uint80 internal immutable _answeredInRound;
+    uint8 internal _decimals;
+    uint80 internal _roundId;
+    int256 internal _answer;
+    uint256 internal _updatedAt;
+    uint80 internal _answeredInRound;
 
     constructor(uint8 decimals_, int256 answer_, uint256 updatedAt_) {
         _decimals = decimals_;
@@ -107,6 +107,13 @@ contract LocalMockOracleFeed is IOracleFeed {
         _answer = answer_;
         _updatedAt = updatedAt_;
         _answeredInRound = 1;
+    }
+
+    function setRoundData(int256 answer_, uint256 updatedAt_) external {
+        _roundId += 1;
+        _answer = answer_;
+        _updatedAt = updatedAt_;
+        _answeredInRound = _roundId;
     }
 
     function decimals() external view returns (uint8) {

--- a/scripts/auralis-activity.sh
+++ b/scripts/auralis-activity.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/auralis.sh"
+
+auralis_export_env
+auralis_require_artifact
+
+erc20_diamond="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" erc20Host.diamond)"
+erc721_diamond="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" erc721Host.diamond)"
+vault_diamond="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.diamond)"
+vault_asset="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.vaultAsset)"
+oracle_feed="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.oracleFeed)"
+
+now_ts="$(date +%s)"
+
+auralis_note "Minting additional ERC20 liquidity"
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${erc20_diamond}" "mint(address,uint256)" "${AURALIS_ALICE_ADDRESS}" 5000000000000000000000 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_ALICE_PRIVATE_KEY}" \
+  "${erc20_diamond}" "approve(address,uint256)" "${AURALIS_OWNER_ADDRESS}" 1000000000000000000000 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${erc20_diamond}" "transferFrom(address,address,uint256)" "${AURALIS_ALICE_ADDRESS}" "${AURALIS_OWNER_ADDRESS}" 300000000000000000000 >/dev/null
+
+auralis_note "Minting and moving an ERC721 collectible"
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${erc721_diamond}" "mint(address,uint256)" "${AURALIS_OWNER_ADDRESS}" 2 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${erc721_diamond}" "approve(address,uint256)" "${AURALIS_ALICE_ADDRESS}" 2 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_ALICE_PRIVATE_KEY}" \
+  "${erc721_diamond}" "transferFrom(address,address,uint256)" "${AURALIS_OWNER_ADDRESS}" "${AURALIS_ALICE_ADDRESS}" 2 >/dev/null
+
+auralis_note "Generating vault flow activity"
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${vault_asset}" "mint(address,uint256)" "${AURALIS_ALICE_ADDRESS}" 4000000000 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_ALICE_PRIVATE_KEY}" \
+  "${vault_asset}" "approve(address,uint256)" "${vault_diamond}" 4000000000 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_ALICE_PRIVATE_KEY}" \
+  "${vault_diamond}" "deposit(uint256,address)(uint256)" 1250000000 "${AURALIS_ALICE_ADDRESS}" >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_ALICE_PRIVATE_KEY}" \
+  "${vault_diamond}" "transfer(address,uint256)" "${AURALIS_OWNER_ADDRESS}" 250000000 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${vault_diamond}" "redeem(uint256,address,address)(uint256)" 100000000 "${AURALIS_OWNER_ADDRESS}" "${AURALIS_OWNER_ADDRESS}" >/dev/null
+
+auralis_note "Updating oracle and strategy reporting"
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${oracle_feed}" "setRoundData(int256,uint256)" 102000000 "${now_ts}" >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${vault_diamond}" "setStrategy(address)" "${AURALIS_ALICE_ADDRESS}" >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_ALICE_PRIVATE_KEY}" \
+  "${vault_diamond}" "reportStrategyAssets(uint256)" 275000000 >/dev/null
+
+auralis_note "Toggling global pause state"
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${vault_diamond}" "pause()" >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${vault_diamond}" "unpause()" >/dev/null
+
+estimated_assets="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "estimatedTotalManagedAssets()(uint256)" | awk '{print $1}')"
+quote_tuple="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "oracleQuote()((int256,uint64,uint8))")"
+
+cat <<MSG
+Auralis simulated activity complete.
+
+Estimated managed assets: ${estimated_assets}
+Oracle quote tuple: ${quote_tuple}
+
+The local chain now has representative token, NFT, vault, oracle, and strategy-report activity.
+MSG

--- a/scripts/auralis-reset.sh
+++ b/scripts/auralis-reset.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/auralis.sh"
+
+auralis_export_env
+auralis_note "Stopping managed Anvil if present"
+auralis_stop_managed_anvil
+
+auralis_note "Removing local Auralis artifacts"
+auralis_remove_artifacts
+rm -f "${AURALIS_ANVIL_LOG_PATH}"
+
+auralis_note "Auralis local environment reset complete"

--- a/scripts/auralis-smoke.sh
+++ b/scripts/auralis-smoke.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/auralis.sh"
+
+auralis_export_env
+auralis_require_artifact
+
+erc20_diamond="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" erc20Host.diamond)"
+erc721_diamond="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" erc721Host.diamond)"
+vault_diamond="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.diamond)"
+vault_asset="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.vaultAsset)"
+oracle_adapter="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.oracleAdapter)"
+
+for address in "${erc20_diamond}" "${erc721_diamond}" "${vault_diamond}" "${vault_asset}" "${oracle_adapter}"; do
+  code="$(cast code --rpc-url "${AURALIS_RPC_URL}" "${address}")"
+  if [[ "${code}" == "0x" ]]; then
+    echo "Expected deployed code at ${address}, found empty code." >&2
+    exit 1
+  fi
+done
+
+auralis_note "ERC20 host smoke: mint and transfer"
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${erc20_diamond}" "mint(address,uint256)" "${AURALIS_ALICE_ADDRESS}" 1000000000000000000000 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_ALICE_PRIVATE_KEY}" \
+  "${erc20_diamond}" "transfer(address,uint256)" "${AURALIS_OWNER_ADDRESS}" 250000000000000000000 >/dev/null
+alice_erc20_balance="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${erc20_diamond}" "balanceOf(address)(uint256)" "${AURALIS_ALICE_ADDRESS}" | awk '{print $1}')"
+if [[ "${alice_erc20_balance}" != "750000000000000000000" ]]; then
+  echo "Unexpected ERC20 balance after smoke flow: ${alice_erc20_balance}" >&2
+  exit 1
+fi
+
+auralis_note "ERC721 host smoke: mint and transfer"
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${erc721_diamond}" "mint(address,uint256)" "${AURALIS_ALICE_ADDRESS}" 1 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_ALICE_PRIVATE_KEY}" \
+  "${erc721_diamond}" "transferFrom(address,address,uint256)" "${AURALIS_ALICE_ADDRESS}" "${AURALIS_OWNER_ADDRESS}" 1 >/dev/null
+nft_owner="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${erc721_diamond}" "ownerOf(uint256)(address)" 1)"
+if [[ "${nft_owner,,}" != "${AURALIS_OWNER_ADDRESS,,}" ]]; then
+  echo "Unexpected ERC721 owner after smoke flow: ${nft_owner}" >&2
+  exit 1
+fi
+
+auralis_note "Vault host smoke: deposit, quote, and withdraw"
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${vault_asset}" "mint(address,uint256)" "${AURALIS_ALICE_ADDRESS}" 1500000000 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_ALICE_PRIVATE_KEY}" \
+  "${vault_asset}" "approve(address,uint256)" "${vault_diamond}" 1500000000 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_ALICE_PRIVATE_KEY}" \
+  "${vault_diamond}" "deposit(uint256,address)(uint256)" 1000000000 "${AURALIS_ALICE_ADDRESS}" >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_ALICE_PRIVATE_KEY}" \
+  "${vault_diamond}" "withdraw(uint256,address,address)(uint256)" 250000000 "${AURALIS_ALICE_ADDRESS}" "${AURALIS_ALICE_ADDRESS}" >/dev/null
+shares_after="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "balanceOf(address)(uint256)" "${AURALIS_ALICE_ADDRESS}" | awk '{print $1}')"
+if [[ "${shares_after}" != "750000000" ]]; then
+  echo "Unexpected vault share balance after smoke flow: ${shares_after}" >&2
+  exit 1
+fi
+quote_tuple="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "oracleQuote()((int256,uint64,uint8))")"
+if [[ -z "${quote_tuple}" ]]; then
+  echo "oracleQuote() returned empty output." >&2
+  exit 1
+fi
+
+auralis_note "Auralis smoke flow passed"

--- a/scripts/auralis-up.sh
+++ b/scripts/auralis-up.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/auralis.sh"
+
+auralis_export_env
+auralis_start_anvil_if_needed
+auralis_remove_artifacts
+
+auralis_note "Funding local actor accounts"
+auralis_fund_actor "${AURALIS_ALICE_ADDRESS}"
+
+auralis_note "Deploying ERC20 host"
+(
+  cd "${AURALIS_ROOT}"
+  forge script script/DeployDiamondErc20Host.s.sol:DeployDiamondErc20HostScript --rpc-url "${AURALIS_RPC_URL}" --broadcast
+)
+
+auralis_note "Deploying ERC721 host"
+(
+  cd "${AURALIS_ROOT}"
+  forge script script/DeployDiamondErc721Host.s.sol:DeployDiamondErc721HostScript --rpc-url "${AURALIS_RPC_URL}" --broadcast
+)
+
+auralis_note "Deploying vault host"
+(
+  cd "${AURALIS_ROOT}"
+  forge script script/DeployDiamondVaultHost.s.sol:DeployDiamondVaultHostScript --rpc-url "${AURALIS_RPC_URL}" --broadcast
+)
+
+auralis_note "Writing unified Auralis artifact"
+auralis_write_unified_artifact
+
+cat <<MSG
+Auralis local environment is ready.
+
+RPC: ${AURALIS_RPC_URL}
+Artifact: ${AURALIS_ARTIFACT_PATH}
+Owner: ${AURALIS_OWNER_ADDRESS}
+Alice: ${AURALIS_ALICE_ADDRESS}
+
+Next steps:
+- bash scripts/auralis-smoke.sh
+- bash scripts/auralis-activity.sh
+- bash scripts/auralis-reset.sh
+MSG

--- a/scripts/lib/auralis.sh
+++ b/scripts/lib/auralis.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+
+AURALIS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+AURALIS_STATE_DIR="${AURALIS_ROOT}/.auralis"
+AURALIS_DEPLOYMENTS_DIR="${AURALIS_ROOT}/deployments"
+AURALIS_ARTIFACT_PATH="${AURALIS_DEPLOYMENTS_DIR}/auralis.local.json"
+AURALIS_ERC20_ARTIFACT_PATH="${AURALIS_DEPLOYMENTS_DIR}/diamond-erc20.local.json"
+AURALIS_ERC721_ARTIFACT_PATH="${AURALIS_DEPLOYMENTS_DIR}/diamond-erc721.local.json"
+AURALIS_VAULT_ARTIFACT_PATH="${AURALIS_DEPLOYMENTS_DIR}/diamond-vault.local.json"
+AURALIS_ANVIL_PID_PATH="${AURALIS_STATE_DIR}/anvil.pid"
+AURALIS_ANVIL_LOG_PATH="${ANVIL_LOG_PATH:-${AURALIS_STATE_DIR}/anvil.log}"
+AURALIS_OWNER_PRIVATE_KEY="${PRIVATE_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}"
+AURALIS_ALICE_PRIVATE_KEY="${ALICE_PRIVATE_KEY:-0x59c6995e998f97a5a0044976f094538e0d7bafad8d4d49d7dc1f6c4b2f6e6d5f}"
+AURALIS_HOST="${ANVIL_HOST:-127.0.0.1}"
+AURALIS_PORT="${ANVIL_PORT:-8545}"
+AURALIS_CHAIN_ID="${ANVIL_CHAIN_ID:-31337}"
+AURALIS_RPC_URL="${RPC_URL:-http://${AURALIS_HOST}:${AURALIS_PORT}}"
+
+AURALIS_OWNER_ADDRESS=""
+AURALIS_ALICE_ADDRESS=""
+
+auralis_export_env() {
+  export PRIVATE_KEY="${AURALIS_OWNER_PRIVATE_KEY}"
+  export ALICE_PRIVATE_KEY="${AURALIS_ALICE_PRIVATE_KEY}"
+  export ANVIL_HOST="${AURALIS_HOST}"
+  export ANVIL_PORT="${AURALIS_PORT}"
+  export ANVIL_CHAIN_ID="${AURALIS_CHAIN_ID}"
+  export RPC_URL="${AURALIS_RPC_URL}"
+  export NO_PROXY="${NO_PROXY:-127.0.0.1,localhost}"
+  unset HTTP_PROXY HTTPS_PROXY ALL_PROXY http_proxy https_proxy all_proxy
+
+  mkdir -p "${AURALIS_STATE_DIR}" "${AURALIS_DEPLOYMENTS_DIR}"
+
+  if [[ -z "${AURALIS_OWNER_ADDRESS}" ]]; then
+    AURALIS_OWNER_ADDRESS="$(cast wallet address --private-key "${AURALIS_OWNER_PRIVATE_KEY}")"
+  fi
+  if [[ -z "${AURALIS_ALICE_ADDRESS}" ]]; then
+    AURALIS_ALICE_ADDRESS="$(cast wallet address --private-key "${AURALIS_ALICE_PRIVATE_KEY}")"
+  fi
+}
+
+auralis_note() {
+  printf '==> %s\n' "$1"
+}
+
+auralis_json_get() {
+  python3 - "$1" "$2" <<'PY'
+import json
+import sys
+
+path = sys.argv[2].split('.')
+value = json.load(open(sys.argv[1], 'r', encoding='utf-8'))
+for part in path:
+    value = value[part]
+if isinstance(value, bool):
+    print('true' if value else 'false')
+elif value is None:
+    print('null')
+else:
+    print(value)
+PY
+}
+
+auralis_rpc_ready() {
+  cast block-number --rpc-url "${AURALIS_RPC_URL}" >/dev/null 2>&1
+}
+
+auralis_wait_for_rpc() {
+  for _ in {1..30}; do
+    if auralis_rpc_ready; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  return 1
+}
+
+auralis_start_anvil_if_needed() {
+  if auralis_rpc_ready; then
+    auralis_note "Using existing Anvil at ${AURALIS_RPC_URL}"
+    return 0
+  fi
+
+  auralis_note "Starting Anvil at ${AURALIS_RPC_URL}"
+  nohup anvil --host "${AURALIS_HOST}" --port "${AURALIS_PORT}" --chain-id "${AURALIS_CHAIN_ID}" >"${AURALIS_ANVIL_LOG_PATH}" 2>&1 < /dev/null &
+  echo $! >"${AURALIS_ANVIL_PID_PATH}"
+
+  if ! auralis_wait_for_rpc; then
+    echo "Anvil did not become ready. See ${AURALIS_ANVIL_LOG_PATH}." >&2
+    return 1
+  fi
+}
+
+auralis_stop_managed_anvil() {
+  if [[ ! -f "${AURALIS_ANVIL_PID_PATH}" ]]; then
+    return 0
+  fi
+
+  local pid
+  pid="$(cat "${AURALIS_ANVIL_PID_PATH}")"
+  if [[ -n "${pid}" ]] && kill -0 "${pid}" >/dev/null 2>&1; then
+    kill "${pid}" >/dev/null 2>&1 || true
+    wait "${pid}" >/dev/null 2>&1 || true
+  fi
+  rm -f "${AURALIS_ANVIL_PID_PATH}"
+}
+
+auralis_require_artifact() {
+  if [[ ! -f "${AURALIS_ARTIFACT_PATH}" ]]; then
+    echo "Missing ${AURALIS_ARTIFACT_PATH}. Run scripts/auralis-up.sh first." >&2
+    return 1
+  fi
+  if ! auralis_rpc_ready; then
+    echo "RPC ${AURALIS_RPC_URL} is not reachable. Start Anvil or rerun scripts/auralis-up.sh." >&2
+    return 1
+  fi
+}
+
+auralis_remove_artifacts() {
+  rm -f \
+    "${AURALIS_ARTIFACT_PATH}" \
+    "${AURALIS_ERC20_ARTIFACT_PATH}" \
+    "${AURALIS_ERC721_ARTIFACT_PATH}" \
+    "${AURALIS_VAULT_ARTIFACT_PATH}"
+}
+
+auralis_write_unified_artifact() {
+  python3 - "${AURALIS_ERC20_ARTIFACT_PATH}" "${AURALIS_ERC721_ARTIFACT_PATH}" "${AURALIS_VAULT_ARTIFACT_PATH}" "${AURALIS_ARTIFACT_PATH}" "${AURALIS_RPC_URL}" "${AURALIS_OWNER_ADDRESS}" "${AURALIS_ALICE_ADDRESS}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+erc20 = json.load(open(sys.argv[1], 'r', encoding='utf-8'))
+erc721 = json.load(open(sys.argv[2], 'r', encoding='utf-8'))
+vault = json.load(open(sys.argv[3], 'r', encoding='utf-8'))
+out_path = Path(sys.argv[4])
+rpc_url = sys.argv[5]
+owner = sys.argv[6]
+alice = sys.argv[7]
+
+artifact = {
+    'project': 'Auralis',
+    'network': 'local-anvil',
+    'chainId': vault['chainId'],
+    'rpcUrl': rpc_url,
+    'actors': {
+        'owner': owner,
+        'alice': alice,
+    },
+    'erc20Host': {
+        **erc20,
+        'label': 'ERC20 host',
+    },
+    'erc721Host': {
+        **erc721,
+        'label': 'ERC721 host',
+    },
+    'vaultHost': {
+        **vault,
+        'label': 'Vault host',
+    },
+}
+
+out_path.write_text(json.dumps(artifact, indent=2) + '\n', encoding='utf-8')
+PY
+}
+
+auralis_fund_actor() {
+  local recipient="$1"
+  local value_wei="${2:-1000000000000000000}"
+  cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" --value "${value_wei}" "${recipient}" >/dev/null
+}
+

--- a/src/access/storage/LibAccessControlStorage.sol
+++ b/src/access/storage/LibAccessControlStorage.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.30;
 /// @notice Storage layout for AccessControl modules (diamond-ready).
 library LibAccessControlStorage {
     /// @dev Storage slot for the layout.
-    bytes32 internal constant STORAGE_SLOT = keccak256("smart-contracts.access-control.storage");
+    bytes32 internal constant STORAGE_SLOT = keccak256("auralis.access-control.storage");
 
     /// @notice Role membership and admin role data.
     struct RoleData {

--- a/src/access/storage/LibAccessControlTimeStorage.sol
+++ b/src/access/storage/LibAccessControlTimeStorage.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.30;
 /// @notice Time-window storage layout for AccessControl modules (diamond-ready).
 library LibAccessControlTimeStorage {
     /// @dev Storage slot for time-window layout.
-    bytes32 internal constant STORAGE_SLOT = keccak256("smart-contracts.access-control.time.storage");
+    bytes32 internal constant STORAGE_SLOT = keccak256("auralis.access-control.time.storage");
 
     /// @notice Per-account role activation window.
     struct RoleWindow {

--- a/src/access/storage/LibPausableStorage.sol
+++ b/src/access/storage/LibPausableStorage.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.30;
 /// @notice Storage layout for pausability modules (diamond-ready).
 library LibPausableStorage {
     /// @dev Storage slot for pausable layout.
-    bytes32 internal constant STORAGE_SLOT = keccak256("smart-contracts.pausable.storage");
+    bytes32 internal constant STORAGE_SLOT = keccak256("auralis.pausable.storage");
 
     /// @notice Pausable storage layout.
     struct Layout {

--- a/src/diamond/storage/LibDiamondStorage.sol
+++ b/src/diamond/storage/LibDiamondStorage.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.30;
 /// @notice Diamond storage layout for selector routing, facet metadata, and ownership.
 library LibDiamondStorage {
     /// @dev Storage slot for the diamond layout.
-    bytes32 internal constant STORAGE_SLOT = keccak256("smart-contracts.diamond.storage");
+    bytes32 internal constant STORAGE_SLOT = keccak256("auralis.diamond.storage");
 
     /// @notice Selector routing metadata.
     struct SelectorData {

--- a/src/oracle/storage/LibOracleAdapterStorage.sol
+++ b/src/oracle/storage/LibOracleAdapterStorage.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.30;
 /// @notice Storage layout for oracle adapter modules (diamond-ready).
 library LibOracleAdapterStorage {
     /// @dev Storage slot for oracle adapter layout.
-    bytes32 internal constant STORAGE_SLOT = keccak256("smart-contracts.oracle-adapter.storage");
+    bytes32 internal constant STORAGE_SLOT = keccak256("auralis.oracle-adapter.storage");
 
     /// @notice Oracle adapter storage layout.
     struct Layout {

--- a/src/security/storage/LibReentrancyGuardStorage.sol
+++ b/src/security/storage/LibReentrancyGuardStorage.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.30;
 /// @notice Storage layout for reentrancy guard modules (diamond-ready).
 library LibReentrancyGuardStorage {
     /// @dev Storage slot for reentrancy guard layout.
-    bytes32 internal constant STORAGE_SLOT = keccak256("smart-contracts.reentrancy-guard.storage");
+    bytes32 internal constant STORAGE_SLOT = keccak256("auralis.reentrancy-guard.storage");
 
     /// @notice Reentrancy guard storage layout.
     struct Layout {

--- a/src/token/storage/LibERC20TokenStorage.sol
+++ b/src/token/storage/LibERC20TokenStorage.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.30;
 /// @notice Diamond-safe storage layout for hosted ERC-20 facets.
 library LibERC20TokenStorage {
     /// @dev Storage slot for ERC-20 token layout.
-    bytes32 internal constant STORAGE_SLOT = keccak256("smart-contracts.token.erc20.storage");
+    bytes32 internal constant STORAGE_SLOT = keccak256("auralis.token.erc20.storage");
 
     /// @notice ERC-20 token storage layout.
     struct Layout {

--- a/src/token/storage/LibERC721TokenStorage.sol
+++ b/src/token/storage/LibERC721TokenStorage.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.30;
 /// @notice Diamond-safe storage layout for hosted ERC-721 facets.
 library LibERC721TokenStorage {
     /// @dev Storage slot for ERC-721 token layout.
-    bytes32 internal constant STORAGE_SLOT = keccak256("smart-contracts.token.erc721.storage");
+    bytes32 internal constant STORAGE_SLOT = keccak256("auralis.token.erc721.storage");
 
     /// @notice ERC-721 token storage layout.
     struct Layout {

--- a/src/upgrade/storage/LibUpgradeGuardrailsStorage.sol
+++ b/src/upgrade/storage/LibUpgradeGuardrailsStorage.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.30;
 /// @notice Storage layout for upgrade guardrails modules (diamond-ready).
 library LibUpgradeGuardrailsStorage {
     /// @dev Storage slot for upgrade guardrails layout.
-    bytes32 internal constant STORAGE_SLOT = keccak256("smart-contracts.upgrade-guardrails.storage");
+    bytes32 internal constant STORAGE_SLOT = keccak256("auralis.upgrade-guardrails.storage");
 
     /// @notice Queued upgrade metadata.
     struct UpgradeIntent {

--- a/src/vault/storage/LibERC4626VaultStorage.sol
+++ b/src/vault/storage/LibERC4626VaultStorage.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.30;
 /// @notice Storage layout for ERC-4626 vault modules (diamond-ready).
 library LibERC4626VaultStorage {
     /// @dev Storage slot for vault layout.
-    bytes32 internal constant STORAGE_SLOT = keccak256("smart-contracts.erc4626-vault.storage");
+    bytes32 internal constant STORAGE_SLOT = keccak256("auralis.erc4626-vault.storage");
 
     /// @notice Configurable fee settings for vault flows.
     struct FeeConfig {

--- a/test/helpers/DiamondTestHarness.sol
+++ b/test/helpers/DiamondTestHarness.sol
@@ -57,7 +57,7 @@ contract DiamondFacetTwo {
 }
 
 library LibDiamondInitTestStorage {
-    bytes32 internal constant STORAGE_SLOT = keccak256("smart-contracts.test.diamond-init.storage");
+    bytes32 internal constant STORAGE_SLOT = keccak256("auralis.test.diamond-init.storage");
 
     struct Layout {
         uint256 value;


### PR DESCRIPTION
## Summary
- finish the user-facing repo rename to Auralis in the README, logo asset, docs, local workflow scripts, and deployment artifacts
- add a local-first Auralis workflow with bootstrap, smoke, simulated activity, and reset scripts
- add a unified local artifact flow centered on `deployments/auralis.local.json`
- add local workflow documentation and a README AI-usage disclosure
- rename storage namespace strings from `smart-contracts.*` to `auralis.*` across source, tests, and matching docs
- extend the local vault oracle feed mock so simulated activity can update oracle rounds during demos

## Validation
- `git diff --check`
- `bash -n scripts/lib/auralis.sh scripts/auralis-up.sh scripts/auralis-smoke.sh scripts/auralis-activity.sh scripts/auralis-reset.sh`
- `forge test --offline`
- `bash scripts/auralis-reset.sh`
- `bash scripts/auralis-up.sh`
- `bash scripts/auralis-smoke.sh`
- `bash scripts/auralis-activity.sh`
- `bash scripts/auralis-reset.sh`

## Notes
- this is a repo maturity spike, not a new protocol architecture milestone
- simulated activity is explicitly demo traffic for local ecosystem feel, not production behavior
- backward compatibility for prior local storage roots is intentionally not preserved in this spike

## Issue
- Closes #110