### PR TITLE
Define strategy interface and mock strategy foundation

### DIFF
--- a/src/interfaces/IERC4626VaultStrategy.sol
+++ b/src/interfaces/IERC4626VaultStrategy.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title IERC4626VaultStrategy
+/// @notice Canonical single-vault, single-asset strategy interface for hosted vaults.
+interface IERC4626VaultStrategy {
+    /// @notice Thrown when a non-vault caller invokes a vault-only strategy action.
+    /// @param caller The unauthorized caller.
+    /// @param vault The bound vault address.
+    error ERC4626VaultStrategyOnlyVault(address caller, address vault);
+
+    /// @notice Returns the vault this strategy is bound to.
+    /// @return The vault address.
+    function vault() external view returns (address);
+
+    /// @notice Returns the underlying asset this strategy manages.
+    /// @return The asset address.
+    function asset() external view returns (address);
+
+    /// @notice Returns the strategy's total tracked assets.
+    /// @return The total tracked asset amount.
+    function totalAssets() external view returns (uint256);
+
+    /// @notice Returns the strategy's currently withdrawable asset amount.
+    /// @return The maximum assets that can be returned immediately.
+    function maxWithdrawableAssets() external view returns (uint256);
+
+    /// @notice Deploys `assets` from the bound vault into the strategy.
+    /// @param assets The asset amount to deploy.
+    function deployFunds(uint256 assets) external;
+
+    /// @notice Returns up to `assets` back to the bound vault.
+    /// @param assets The requested asset amount.
+    /// @return assetsReturned The actual returned asset amount.
+    function withdrawToVault(uint256 assets) external returns (uint256 assetsReturned);
+
+    /// @notice Fully unwinds strategy assets back to the bound vault.
+    /// @return assetsReturned The actual returned asset amount.
+    function withdrawAllToVault() external returns (uint256 assetsReturned);
+}

--- a/src/vault/storage/LibERC4626VaultStorage.sol
+++ b/src/vault/storage/LibERC4626VaultStorage.sol
@@ -40,6 +40,8 @@ library LibERC4626VaultStorage {
         address oracleAdapter;
         address strategy;
         uint256 strategyReportedAssets;
+        uint256 strategyDebt;
+        bool strategyEmergencyExit;
     }
 
     /// @notice Returns the storage layout for vault state.

--- a/test/VaultStrategyFoundationCore.t.sol
+++ b/test/VaultStrategyFoundationCore.t.sol
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC4626VaultStrategy} from "../src/interfaces/IERC4626VaultStrategy.sol";
+import {
+    ERC4626VaultStrategyFixture,
+    MockVaultStrategyForcedRevert
+} from "./helpers/ERC4626VaultStrategyTestHarness.sol";
+
+contract VaultStrategyFoundationCoreTest is ERC4626VaultStrategyFixture {
+    function testStorageDefaultsAfterHostedVaultInit() public view {
+        assertTrue(storageHarness.strategy() == address(0), "strategy should default to zero");
+        assertTrue(storageHarness.strategyReportedAssets() == 0, "reported assets should default to zero");
+        assertTrue(storageHarness.strategyDebtForTest() == 0, "strategy debt should default to zero");
+        assertFalse(storageHarness.strategyEmergencyExitForTest(), "emergency exit should default to false");
+    }
+
+    function testMockStrategiesBindVaultAndAsset() public view {
+        _assertBinding(profitStrategy);
+        _assertBinding(lossStrategy);
+        _assertBinding(revertingStrategy);
+        _assertBinding(unwindStrategy);
+    }
+
+    function testOnlyVaultCanOperateStrategyLifecycle() public {
+        _assertOnlyVault(profitStrategy);
+        _assertOnlyVault(lossStrategy);
+        _assertOnlyVault(revertingStrategy);
+        _assertOnlyVault(unwindStrategy);
+    }
+
+    function testProfitMockReportsHigherAssetsAfterProfitInjection() public {
+        VM.prank(vault);
+        profitStrategy.deployFunds(100);
+
+        profitStrategy.injectProfit(25);
+
+        assertTrue(profitStrategy.totalAssets() == 125, "profit should increase tracked assets");
+        assertTrue(profitStrategy.maxWithdrawableAssets() == 125, "profit should increase withdrawable assets");
+    }
+
+    function testLossShortfallMockReturnsLessThanRequestedAndShrinksAssets() public {
+        VM.prank(vault);
+        lossStrategy.deployFunds(100);
+
+        lossStrategy.applyLoss(40, 35);
+
+        assertTrue(lossStrategy.totalAssets() == 60, "loss should reduce tracked assets");
+        assertTrue(lossStrategy.maxWithdrawableAssets() == 35, "shortfall should cap withdrawable assets");
+
+        VM.prank(vault);
+        uint256 returnedAssets = lossStrategy.withdrawToVault(50);
+
+        assertTrue(returnedAssets == 35, "withdraw should return available assets only");
+        assertTrue(lossStrategy.totalAssets() == 25, "tracked assets should reduce by returned amount");
+        assertTrue(lossStrategy.maxWithdrawableAssets() == 0, "withdrawable assets should be depleted");
+    }
+
+    function testRevertingMockRevertsOnConfiguredCalls() public {
+        revertingStrategy.setRevertModes(true, true, true, true);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(MockVaultStrategyForcedRevert.selector, revertingStrategy.totalAssets.selector)
+        );
+        revertingStrategy.totalAssets();
+
+        VM.expectRevert(
+            abi.encodeWithSelector(MockVaultStrategyForcedRevert.selector, revertingStrategy.deployFunds.selector)
+        );
+        VM.prank(vault);
+        revertingStrategy.deployFunds(100);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(MockVaultStrategyForcedRevert.selector, revertingStrategy.withdrawToVault.selector)
+        );
+        VM.prank(vault);
+        revertingStrategy.withdrawToVault(100);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                MockVaultStrategyForcedRevert.selector, revertingStrategy.withdrawAllToVault.selector
+            )
+        );
+        VM.prank(vault);
+        revertingStrategy.withdrawAllToVault();
+    }
+
+    function testEmergencyUnwindMockReturnsAllAssetsAndClearsState() public {
+        VM.prank(vault);
+        unwindStrategy.deployFunds(100);
+
+        unwindStrategy.setWithdrawableAssets(40);
+
+        VM.prank(vault);
+        uint256 returnedAssets = unwindStrategy.withdrawAllToVault();
+
+        assertTrue(returnedAssets == 100, "emergency unwind should return all tracked assets");
+        assertTrue(unwindStrategy.totalAssets() == 0, "tracked assets should clear on unwind");
+        assertTrue(unwindStrategy.maxWithdrawableAssets() == 0, "withdrawable assets should clear on unwind");
+    }
+
+    function _assertBinding(IERC4626VaultStrategy strategy_) internal view {
+        assertTrue(strategy_.vault() == vault, "vault binding mismatch");
+        assertTrue(strategy_.asset() == address(asset), "asset binding mismatch");
+    }
+
+    function _assertOnlyVault(IERC4626VaultStrategy strategy_) internal {
+        VM.expectRevert(
+            abi.encodeWithSelector(IERC4626VaultStrategy.ERC4626VaultStrategyOnlyVault.selector, outsider, vault)
+        );
+        VM.prank(outsider);
+        strategy_.deployFunds(1);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(IERC4626VaultStrategy.ERC4626VaultStrategyOnlyVault.selector, outsider, vault)
+        );
+        VM.prank(outsider);
+        strategy_.withdrawToVault(1);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(IERC4626VaultStrategy.ERC4626VaultStrategyOnlyVault.selector, outsider, vault)
+        );
+        VM.prank(outsider);
+        strategy_.withdrawAllToVault();
+    }
+}

--- a/test/helpers/ERC4626VaultStrategyTestHarness.sol
+++ b/test/helpers/ERC4626VaultStrategyTestHarness.sol
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC4626VaultStrategy} from "../../src/interfaces/IERC4626VaultStrategy.sol";
+import {ERC4626VaultIntegrationFacet} from "../../src/vault/facets/ERC4626VaultIntegrationFacet.sol";
+import {LibERC4626VaultStorage} from "../../src/vault/storage/LibERC4626VaultStorage.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+import {MockVaultAsset} from "./ERC4626CoreTestHarness.sol";
+
+contract ERC4626VaultStrategyStorageHarness is ERC4626VaultIntegrationFacet {
+    function initializeHostedVaultForStrategyTest(
+        address vaultAsset,
+        string memory vaultName,
+        string memory vaultSymbol,
+        address admin
+    ) external {
+        _initializeVaultFacetControl(admin);
+        _initializeErc4626Vault(vaultAsset, vaultName, vaultSymbol);
+    }
+
+    function strategyDebtForTest() external view returns (uint256) {
+        return LibERC4626VaultStorage.layout().strategyDebt;
+    }
+
+    function strategyEmergencyExitForTest() external view returns (bool) {
+        return LibERC4626VaultStorage.layout().strategyEmergencyExit;
+    }
+}
+
+error MockVaultStrategyForcedRevert(bytes4 selector);
+
+abstract contract MockVaultStrategyBase is IERC4626VaultStrategy {
+    address internal immutable _vault;
+    address internal immutable _asset;
+
+    uint256 internal _trackedAssets;
+    uint256 internal _withdrawableAssets;
+
+    constructor(address vault_, address asset_) {
+        _vault = vault_;
+        _asset = asset_;
+    }
+
+    modifier onlyVault() {
+        if (msg.sender != _vault) {
+            revert ERC4626VaultStrategyOnlyVault(msg.sender, _vault);
+        }
+        _;
+    }
+
+    function vault() external view override returns (address) {
+        return _vault;
+    }
+
+    function asset() external view override returns (address) {
+        return _asset;
+    }
+
+    function totalAssets() public view virtual override returns (uint256) {
+        return _trackedAssets;
+    }
+
+    function maxWithdrawableAssets() public view virtual override returns (uint256) {
+        return _min(_trackedAssets, _withdrawableAssets);
+    }
+
+    function deployFunds(uint256 assets) external virtual override onlyVault {
+        _trackedAssets += assets;
+        _withdrawableAssets += assets;
+    }
+
+    function withdrawToVault(uint256 assets) external virtual override onlyVault returns (uint256 assetsReturned) {
+        assetsReturned = _min(assets, maxWithdrawableAssets());
+        _trackedAssets -= assetsReturned;
+        _withdrawableAssets -= assetsReturned;
+    }
+
+    function withdrawAllToVault() external virtual override onlyVault returns (uint256 assetsReturned) {
+        assetsReturned = maxWithdrawableAssets();
+        _trackedAssets -= assetsReturned;
+        _withdrawableAssets -= assetsReturned;
+    }
+
+    function setWithdrawableAssets(uint256 assets) external {
+        _withdrawableAssets = _min(assets, _trackedAssets);
+    }
+
+    function _min(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a < b ? a : b;
+    }
+}
+
+contract ProfitMockVaultStrategy is MockVaultStrategyBase {
+    constructor(address vault_, address asset_) MockVaultStrategyBase(vault_, asset_) {}
+
+    function injectProfit(uint256 assets) external {
+        _trackedAssets += assets;
+        _withdrawableAssets += assets;
+    }
+}
+
+contract LossShortfallMockVaultStrategy is MockVaultStrategyBase {
+    constructor(address vault_, address asset_) MockVaultStrategyBase(vault_, asset_) {}
+
+    function applyLoss(uint256 lossAssets, uint256 withdrawableAssets_) external {
+        _trackedAssets = lossAssets >= _trackedAssets ? 0 : _trackedAssets - lossAssets;
+        _withdrawableAssets = _min(withdrawableAssets_, _trackedAssets);
+    }
+}
+
+contract RevertingMockVaultStrategy is MockVaultStrategyBase {
+    bool internal _revertTotalAssets;
+    bool internal _revertDeployFunds;
+    bool internal _revertWithdrawToVault;
+    bool internal _revertWithdrawAllToVault;
+
+    constructor(address vault_, address asset_) MockVaultStrategyBase(vault_, asset_) {}
+
+    function setRevertModes(bool totalAssets_, bool deployFunds_, bool withdrawToVault_, bool withdrawAllToVault_)
+        external
+    {
+        _revertTotalAssets = totalAssets_;
+        _revertDeployFunds = deployFunds_;
+        _revertWithdrawToVault = withdrawToVault_;
+        _revertWithdrawAllToVault = withdrawAllToVault_;
+    }
+
+    function totalAssets() public view override returns (uint256) {
+        if (_revertTotalAssets) {
+            revert MockVaultStrategyForcedRevert(this.totalAssets.selector);
+        }
+        return super.totalAssets();
+    }
+
+    function deployFunds(uint256 assets) external override onlyVault {
+        if (_revertDeployFunds) {
+            revert MockVaultStrategyForcedRevert(this.deployFunds.selector);
+        }
+        _trackedAssets += assets;
+        _withdrawableAssets += assets;
+    }
+
+    function withdrawToVault(uint256 assets) external override onlyVault returns (uint256 assetsReturned) {
+        if (_revertWithdrawToVault) {
+            revert MockVaultStrategyForcedRevert(this.withdrawToVault.selector);
+        }
+        assetsReturned = _min(assets, maxWithdrawableAssets());
+        _trackedAssets -= assetsReturned;
+        _withdrawableAssets -= assetsReturned;
+    }
+
+    function withdrawAllToVault() external override onlyVault returns (uint256 assetsReturned) {
+        if (_revertWithdrawAllToVault) {
+            revert MockVaultStrategyForcedRevert(this.withdrawAllToVault.selector);
+        }
+        assetsReturned = maxWithdrawableAssets();
+        _trackedAssets -= assetsReturned;
+        _withdrawableAssets -= assetsReturned;
+    }
+}
+
+contract EmergencyUnwindMockVaultStrategy is MockVaultStrategyBase {
+    constructor(address vault_, address asset_) MockVaultStrategyBase(vault_, asset_) {}
+
+    function withdrawAllToVault() external override onlyVault returns (uint256 assetsReturned) {
+        assetsReturned = _trackedAssets;
+        _trackedAssets = 0;
+        _withdrawableAssets = 0;
+    }
+}
+
+abstract contract ERC4626VaultStrategyFixture is TestBase {
+    address internal admin = address(0xA11CE);
+    address internal vault = address(0xA417);
+    address internal outsider = address(0x0B5E1D3);
+
+    MockVaultAsset internal asset;
+    ERC4626VaultStrategyStorageHarness internal storageHarness;
+    ProfitMockVaultStrategy internal profitStrategy;
+    LossShortfallMockVaultStrategy internal lossStrategy;
+    RevertingMockVaultStrategy internal revertingStrategy;
+    EmergencyUnwindMockVaultStrategy internal unwindStrategy;
+
+    function setUp() public virtual {
+        asset = new MockVaultAsset("Mock USD", "mUSD", 6);
+        storageHarness = new ERC4626VaultStrategyStorageHarness();
+        storageHarness.initializeHostedVaultForStrategyTest(address(asset), "Vault Share", "vSHARE", admin);
+
+        profitStrategy = new ProfitMockVaultStrategy(vault, address(asset));
+        lossStrategy = new LossShortfallMockVaultStrategy(vault, address(asset));
+        revertingStrategy = new RevertingMockVaultStrategy(vault, address(asset));
+        unwindStrategy = new EmergencyUnwindMockVaultStrategy(vault, address(asset));
+    }
+}


### PR DESCRIPTION
## Summary
- add the canonical single-vault, single-asset `IERC4626VaultStrategy` interface
- extend vault storage with foundation-only strategy fields for later lifecycle work
- add reusable mock strategy contracts and a dedicated strategy foundation test suite
- keep the current integration facet API and selector ownership unchanged in this issue

## Validation
- `git diff --check`
- `forge test --offline --match-path test/VaultStrategyFoundationCore.t.sol`
- `forge test --offline --match-path test/ERC4626VaultIntegrationFacetCore.t.sol`
- `forge test --offline --match-path test/DiamondVaultHostHardening.t.sol`
- `forge test --offline --match-path test/DiamondVaultHostInvariant.t.sol`
- `forge test --offline`

## Notes
- `strategyDebt` and `strategyEmergencyExit` are storage-only foundation fields in this issue
- the live strategy lifecycle remains deferred to later issues in milestone #21
