### PR TITLE
Make hosted vault accounting strategy-aware

### DIFF
--- a/src/vault/ERC4626Vault.sol
+++ b/src/vault/ERC4626Vault.sol
@@ -26,7 +26,7 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
     /// @notice Returns total assets managed by the vault.
     /// @return The total managed asset amount.
     function totalAssets() public view virtual returns (uint256) {
-        return totalManagedAssets();
+        return _managedAssetsForPricing();
     }
 
     /// @notice Converts `assets` to shares, rounding down.

--- a/src/vault/ERC4626VaultBase.sol
+++ b/src/vault/ERC4626VaultBase.sol
@@ -212,7 +212,7 @@ abstract contract ERC4626VaultBase is IERC4626VaultBase {
     /// @return Share amount.
     function _convertToShares(uint256 assets, Rounding rounding) internal view returns (uint256) {
         LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
-        return _convertToShares(assets, layout.totalSupply, layout.totalManagedAssets, rounding);
+        return _convertToShares(assets, layout.totalSupply, _managedAssetsForPricing(), rounding);
     }
 
     /// @dev Converts `shares` to assets using current vault totals.
@@ -221,7 +221,13 @@ abstract contract ERC4626VaultBase is IERC4626VaultBase {
     /// @return Asset amount.
     function _convertToAssets(uint256 shares, Rounding rounding) internal view returns (uint256) {
         LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
-        return _convertToAssets(shares, layout.totalSupply, layout.totalManagedAssets, rounding);
+        return _convertToAssets(shares, layout.totalSupply, _managedAssetsForPricing(), rounding);
+    }
+
+    /// @dev Returns the managed assets amount used for ERC-4626 pricing views.
+    /// @return managedAssets The pricing asset amount.
+    function _managedAssetsForPricing() internal view virtual returns (uint256 managedAssets) {
+        return LibERC4626VaultStorage.layout().totalManagedAssets;
     }
 
     /// @dev Converts `assets` to shares using explicit totals.

--- a/src/vault/ERC4626VaultControlLogic.sol
+++ b/src/vault/ERC4626VaultControlLogic.sol
@@ -160,6 +160,11 @@ abstract contract ERC4626VaultControlledCore is ERC4626Vault {
         }
 
         uint256 grossAssets = _convertToAssets(balanceOf(owner), Rounding.Down);
+        uint256 liquidityCapAssets = _withdrawLiquidityCapAssets();
+        if (grossAssets > liquidityCapAssets) {
+            grossAssets = liquidityCapAssets;
+        }
+
         (uint256 netAssets,) = LibERC4626VaultControlLogic.withdrawNetFromGross(grossAssets);
 
         (,,, uint128 maxWithdraw_,) = LibERC4626VaultControlLogic.limitConfig();
@@ -176,6 +181,14 @@ abstract contract ERC4626VaultControlledCore is ERC4626Vault {
         }
 
         uint256 redeemableShares = balanceOf(owner);
+        uint256 liquidityCapAssets = _withdrawLiquidityCapAssets();
+        if (liquidityCapAssets != type(uint256).max) {
+            uint256 liquidityCappedShares = _convertToShares(liquidityCapAssets, Rounding.Down);
+            if (liquidityCappedShares < redeemableShares) {
+                redeemableShares = liquidityCappedShares;
+            }
+        }
+
         (,,,, uint128 maxRedeem_) = LibERC4626VaultControlLogic.limitConfig();
         if (maxRedeem_ != 0 && redeemableShares > maxRedeem_) {
             return maxRedeem_;
@@ -346,6 +359,10 @@ abstract contract ERC4626VaultControlledCore is ERC4626Vault {
         }
 
         _safeTransferAsset(LibERC4626VaultControlLogic.feeRecipient(), feeAssets);
+    }
+
+    function _withdrawLiquidityCapAssets() internal view virtual returns (uint256) {
+        return type(uint256).max;
     }
 
     function _vaultOperationsPaused() internal view virtual returns (bool);

--- a/src/vault/facets/ERC4626VaultFacet.sol
+++ b/src/vault/facets/ERC4626VaultFacet.sol
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
+import {IERC20} from "../../interfaces/IERC20.sol";
 import {IERC4626} from "../../interfaces/IERC4626.sol";
 import {IERC4626VaultFacet} from "../../interfaces/IERC4626VaultFacet.sol";
+import {IERC4626VaultStrategy} from "../../interfaces/IERC4626VaultStrategy.sol";
 import {ERC4626Vault} from "../ERC4626Vault.sol";
 import {ERC4626VaultBase} from "../ERC4626VaultBase.sol";
 import {ERC4626VaultControlledCore} from "../ERC4626VaultControlLogic.sol";
 import {VaultFacetControl} from "../VaultFacetControl.sol";
+import {LibERC4626VaultStorage} from "../storage/LibERC4626VaultStorage.sol";
 
 /// @title ERC4626VaultFacet
 /// @notice Hosted ERC-4626 core facet with constructor-free initialization.
@@ -109,6 +112,28 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
         returns (uint256 assets)
     {
         return _redeemWithControls(shares, receiver, owner);
+    }
+
+    function _managedAssetsForPricing() internal view virtual override returns (uint256) {
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        if (layout.strategy == address(0) || layout.strategyDebt == 0) {
+            return layout.totalManagedAssets;
+        }
+
+        uint256 idleBookAssets = layout.totalManagedAssets - layout.strategyDebt;
+        uint256 liveStrategyAssets = IERC4626VaultStrategy(layout.strategy).totalAssets();
+        return idleBookAssets + liveStrategyAssets;
+    }
+
+    function _withdrawLiquidityCapAssets() internal view virtual override returns (uint256) {
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        if (layout.strategy == address(0) || layout.strategyDebt == 0) {
+            return type(uint256).max;
+        }
+
+        uint256 idleBookAssets = layout.totalManagedAssets - layout.strategyDebt;
+        uint256 idleVaultAssets = IERC20(asset()).balanceOf(address(this));
+        return idleVaultAssets < idleBookAssets ? idleVaultAssets : idleBookAssets;
     }
 
     function _vaultOperationsPaused() internal view virtual override returns (bool) {

--- a/test/ERC4626VaultStrategyAccountingCore.t.sol
+++ b/test/ERC4626VaultStrategyAccountingCore.t.sol
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControlsFacet.sol";
+import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
+import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
+import {ERC4626VaultStrategyAccountingFixture} from "./helpers/ERC4626VaultStrategyAccountingTestHarness.sol";
+
+contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountingFixture {
+    function testDirectHostedVaultWithoutStrategyMatchesBaselineAccounting() public {
+        _initializeDirectVault();
+        _approveAsset(bob, address(facet), DEPOSIT_ASSETS);
+
+        VM.prank(bob);
+        uint256 mintedShares = facet.deposit(DEPOSIT_ASSETS, bob);
+
+        assertTrue(mintedShares == DEPOSIT_ASSETS, "deposit shares mismatch");
+        assertTrue(facet.totalManagedAssets() == DEPOSIT_ASSETS, "book value mismatch");
+        assertTrue(facet.totalAssets() == DEPOSIT_ASSETS, "total assets mismatch");
+        assertTrue(facet.previewDeposit(10) == 10, "previewDeposit baseline mismatch");
+        assertTrue(facet.previewMint(10) == 10, "previewMint baseline mismatch");
+        assertTrue(facet.previewWithdraw(10) == 10, "previewWithdraw baseline mismatch");
+        assertTrue(facet.previewRedeem(10) == 10, "previewRedeem baseline mismatch");
+        assertTrue(facet.maxWithdraw(bob) == DEPOSIT_ASSETS, "maxWithdraw baseline mismatch");
+        assertTrue(facet.maxRedeem(bob) == DEPOSIT_ASSETS, "maxRedeem baseline mismatch");
+    }
+
+    function testDirectStrategyProfitMakesPricingMarkToMarketAndCapsLiquidity() public {
+        _initializeDirectVault();
+        _approveAsset(bob, address(facet), DEPOSIT_ASSETS);
+
+        VM.prank(bob);
+        facet.deposit(DEPOSIT_ASSETS, bob);
+
+        facet.setStrategyStateForTest(address(directProfitStrategy), STRATEGY_DEBT);
+        _simulateStrategyDeployment(address(facet), directProfitStrategy, STRATEGY_DEBT);
+        directProfitStrategy.injectProfit(20);
+
+        assertTrue(facet.strategyDebtForTest() == STRATEGY_DEBT, "strategy debt mismatch");
+        assertTrue(facet.totalManagedAssets() == DEPOSIT_ASSETS, "book value should remain unchanged");
+        assertTrue(facet.totalAssets() == 120, "mark-to-market assets mismatch");
+        assertTrue(facet.convertToShares(12) == 10, "convertToShares profit mismatch");
+        assertTrue(facet.convertToAssets(10) == 12, "convertToAssets profit mismatch");
+        assertTrue(facet.previewDeposit(12) == 10, "previewDeposit profit mismatch");
+        assertTrue(facet.previewMint(10) == 12, "previewMint profit mismatch");
+        assertTrue(facet.previewWithdraw(12) == 10, "previewWithdraw profit mismatch");
+        assertTrue(facet.previewRedeem(10) == 12, "previewRedeem profit mismatch");
+        assertTrue(facet.maxWithdraw(bob) == 40, "maxWithdraw should cap to idle liquidity");
+        assertTrue(facet.maxRedeem(bob) == 33, "maxRedeem should cap to idle liquidity");
+    }
+
+    function testDirectStrategyLossMovesPricingDownward() public {
+        _initializeDirectVault();
+        _approveAsset(bob, address(facet), DEPOSIT_ASSETS);
+
+        VM.prank(bob);
+        facet.deposit(DEPOSIT_ASSETS, bob);
+
+        facet.setStrategyStateForTest(address(directLossStrategy), STRATEGY_DEBT);
+        _simulateStrategyDeployment(address(facet), directLossStrategy, STRATEGY_DEBT);
+        directLossStrategy.applyLoss(30, 30);
+
+        assertTrue(facet.totalManagedAssets() == DEPOSIT_ASSETS, "book value should remain unchanged");
+        assertTrue(facet.totalAssets() == 70, "loss should reduce mark-to-market assets");
+        assertTrue(facet.convertToShares(12) == 17, "convertToShares loss mismatch");
+        assertTrue(facet.convertToAssets(10) == 7, "convertToAssets loss mismatch");
+        assertTrue(facet.previewDeposit(12) == 17, "previewDeposit loss mismatch");
+        assertTrue(facet.previewMint(10) == 7, "previewMint loss mismatch");
+        assertTrue(facet.previewWithdraw(12) == 18, "previewWithdraw loss mismatch");
+        assertTrue(facet.previewRedeem(10) == 7, "previewRedeem loss mismatch");
+        assertTrue(facet.maxWithdraw(bob) == 40, "maxWithdraw should remain idle-capped");
+        assertTrue(facet.maxRedeem(bob) == 57, "maxRedeem loss cap mismatch");
+    }
+
+    function testConfiguredStrategyWithZeroDebtKeepsHostedPricingBaseline() public {
+        _initializeDirectVault();
+        _approveAsset(bob, address(facet), DEPOSIT_ASSETS);
+
+        VM.prank(bob);
+        facet.deposit(DEPOSIT_ASSETS, bob);
+
+        facet.setStrategyStateForTest(address(directProfitStrategy), 0);
+        directProfitStrategy.injectProfit(20);
+
+        assertTrue(facet.totalManagedAssets() == DEPOSIT_ASSETS, "book value mismatch");
+        assertTrue(facet.totalAssets() == DEPOSIT_ASSETS, "zero debt strategy should not affect pricing");
+        assertTrue(facet.previewDeposit(10) == 10, "previewDeposit should ignore zero-debt strategy");
+        assertTrue(facet.maxWithdraw(bob) == DEPOSIT_ASSETS, "maxWithdraw should ignore zero-debt strategy");
+    }
+
+    function testDiamondHostedVaultStrategyAccountingUsesLiveStrategyAssetsAndKeepsAdvisoryReportsSeparate() public {
+        _installHostedVaultFacetsToDiamond();
+        _initializeDiamondVault();
+        _approveAsset(bob, address(diamond), DEPOSIT_ASSETS);
+
+        VM.prank(bob);
+        IERC4626VaultFacet(address(diamond)).deposit(DEPOSIT_ASSETS, bob);
+
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(address(diamondProfitStrategy));
+        _seedDiamondStrategyState(address(diamondProfitStrategy), STRATEGY_DEBT);
+        _simulateStrategyDeployment(address(diamond), diamondProfitStrategy, STRATEGY_DEBT);
+        diamondProfitStrategy.injectProfit(20);
+
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).reportStrategyAssets(25);
+        VM.prank(admin);
+        IERC4626VaultControlsFacet(address(diamond)).setLimitConfig(125, 0, 0, 0, 0);
+
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == DEPOSIT_ASSETS, "book value mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 120, "diamond totalAssets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewDeposit(12) == 10, "diamond previewDeposit mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewMint(10) == 12, "diamond previewMint mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewWithdraw(12) == 10, "diamond previewWithdraw mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewRedeem(10) == 12, "diamond previewRedeem mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxDeposit(bob) == 5, "maxDeposit should use live totalAssets");
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxMint(bob) == 4, "maxMint should use live totalAssets");
+        assertTrue(
+            IERC4626VaultFacet(address(diamond)).maxWithdraw(bob) == 40, "maxWithdraw should cap to idle liquidity"
+        );
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxRedeem(bob) == 33, "maxRedeem should cap to idle liquidity");
+        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).idleAssets() == 40, "idle assets mismatch");
+        assertTrue(
+            IERC4626VaultIntegrationFacet(address(diamond)).strategyReportedAssets() == 25, "reported assets mismatch"
+        );
+        assertTrue(
+            IERC4626VaultIntegrationFacet(address(diamond)).estimatedTotalManagedAssets() == 65,
+            "estimated assets should remain advisory"
+        );
+    }
+}

--- a/test/helpers/ERC4626VaultStrategyAccountingTestHarness.sol
+++ b/test/helpers/ERC4626VaultStrategyAccountingTestHarness.sol
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
+import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
+import {IERC4626VaultFacet} from "../../src/interfaces/IERC4626VaultFacet.sol";
+import {IERC4626VaultIntegrationFacet} from "../../src/interfaces/IERC4626VaultIntegrationFacet.sol";
+import {IERC4626VaultStrategy} from "../../src/interfaces/IERC4626VaultStrategy.sol";
+import {ERC4626VaultFacet} from "../../src/vault/facets/ERC4626VaultFacet.sol";
+import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
+import {LibERC4626VaultStorage} from "../../src/vault/storage/LibERC4626VaultStorage.sol";
+import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+import {ERC4626VaultControlsFacetHarness} from "./ERC4626VaultControlsFacetTestHarness.sol";
+import {ReentrantMockVaultAsset} from "./ERC4626VaultControlsTestHarness.sol";
+import {ERC4626VaultIntegrationFacetHarness} from "./ERC4626VaultIntegrationFacetTestHarness.sol";
+import {LossShortfallMockVaultStrategy, ProfitMockVaultStrategy} from "./ERC4626VaultStrategyTestHarness.sol";
+
+contract ERC4626VaultStrategyAccountingFacetHarness is ERC4626VaultFacet {
+    function setStrategyStateForTest(address strategy_, uint256 strategyDebt_) external {
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        layout.strategy = strategy_;
+        layout.strategyDebt = strategyDebt_;
+    }
+
+    function strategyDebtForTest() external view returns (uint256) {
+        return LibERC4626VaultStorage.layout().strategyDebt;
+    }
+}
+
+contract ERC4626VaultStrategyAccountingInitMock {
+    function seedStrategyState(address strategy_, uint256 strategyDebt_) external {
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        layout.strategy = strategy_;
+        layout.strategyDebt = strategyDebt_;
+    }
+}
+
+abstract contract ERC4626VaultStrategyAccountingFixture is TestBase {
+    uint256 internal constant INITIAL_ASSETS = 1_000_000;
+    uint256 internal constant DEPOSIT_ASSETS = 100;
+    uint256 internal constant STRATEGY_DEBT = 60;
+
+    address internal admin = address(0xA11CE);
+    address internal bob = address(0xB0B);
+    address internal eve = address(0xE11E);
+    address internal sink = address(0x515E);
+
+    ReentrantMockVaultAsset internal asset;
+    ERC4626VaultStrategyAccountingFacetHarness internal facet;
+    ERC4626VaultControlsFacetHarness internal controlsFacet;
+    ERC4626VaultIntegrationFacetHarness internal integrationFacet;
+    DiamondCutFacet internal cutFacet;
+    DiamondLoupeFacet internal loupeFacet;
+    DiamondProxyHarness internal diamond;
+    ERC4626VaultStrategyAccountingInitMock internal accountingInit;
+    ProfitMockVaultStrategy internal directProfitStrategy;
+    LossShortfallMockVaultStrategy internal directLossStrategy;
+    ProfitMockVaultStrategy internal diamondProfitStrategy;
+
+    function setUp() public virtual {
+        asset = new ReentrantMockVaultAsset();
+        facet = new ERC4626VaultStrategyAccountingFacetHarness();
+        controlsFacet = new ERC4626VaultControlsFacetHarness();
+        integrationFacet = new ERC4626VaultIntegrationFacetHarness();
+        cutFacet = new DiamondCutFacet();
+        loupeFacet = new DiamondLoupeFacet();
+        diamond = new DiamondProxyHarness(admin, address(cutFacet));
+        accountingInit = new ERC4626VaultStrategyAccountingInitMock();
+        directProfitStrategy = new ProfitMockVaultStrategy(address(facet), address(asset));
+        directLossStrategy = new LossShortfallMockVaultStrategy(address(facet), address(asset));
+        diamondProfitStrategy = new ProfitMockVaultStrategy(address(diamond), address(asset));
+
+        asset.mint(bob, INITIAL_ASSETS);
+        asset.mint(eve, INITIAL_ASSETS);
+
+        _installLoupeFacet();
+    }
+
+    function _initializeDirectVault() internal {
+        facet.initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function _initializeDiamondVault() internal {
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond)).initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function _approveAsset(address owner, address spender, uint256 amount) internal {
+        VM.prank(owner);
+        asset.approve(spender, amount);
+    }
+
+    function _seedDiamondStrategyState(address strategy_, uint256 strategyDebt_) internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](0);
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond))
+            .diamondCut(
+                cut,
+                address(accountingInit),
+                abi.encodeCall(ERC4626VaultStrategyAccountingInitMock.seedStrategyState, (strategy_, strategyDebt_))
+            );
+    }
+
+    function _simulateStrategyDeployment(address vaultAccount, IERC4626VaultStrategy strategy_, uint256 assets_)
+        internal
+    {
+        VM.prank(vaultAccount);
+        asset.transfer(sink, assets_);
+
+        VM.prank(vaultAccount);
+        strategy_.deployFunds(assets_);
+    }
+
+    function _installLoupeFacet() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(loupeFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: _loupeSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installVaultCoreFacetToDiamond() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(facet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultCoreSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installVaultControlsFacetToDiamond() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(controlsFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultControlsSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installVaultIntegrationFacetToDiamond() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(integrationFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultIntegrationSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installHostedVaultFacetsToDiamond() internal {
+        _installVaultCoreFacetToDiamond();
+        _installVaultControlsFacetToDiamond();
+        _installVaultIntegrationFacetToDiamond();
+    }
+
+    function _loupeSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](6);
+        selectors[0] = DiamondLoupeFacet.facets.selector;
+        selectors[1] = DiamondLoupeFacet.facetFunctionSelectors.selector;
+        selectors[2] = DiamondLoupeFacet.facetAddresses.selector;
+        selectors[3] = DiamondLoupeFacet.facetAddress.selector;
+        selectors[4] = DiamondLoupeFacet.owner.selector;
+        selectors[5] = DiamondLoupeFacet.transferOwnership.selector;
+    }
+}


### PR DESCRIPTION
## Summary
- make hosted vault pricing mark-to-market when a configured strategy has nonzero strategy debt
- keep `totalManagedAssets()` as stored book value and leave advisory integration reporting unchanged
- cap hosted `maxWithdraw()` and `maxRedeem()` by immediate idle liquidity until strategy pull wiring lands
- add direct and diamond-routed tests for strategy-aware accounting profit/loss cases

## Validation
- git diff --check
- forge test --offline --match-path test/ERC4626VaultStrategyAccountingCore.t.sol
- forge test --offline --match-path test/ERC4626VaultFacetCore.t.sol
- forge test --offline --match-path test/ERC4626VaultControlsFacetCore.t.sol
- forge test --offline --match-path test/ERC4626VaultIntegrationFacetCore.t.sol
- forge test --offline --match-path test/VaultStrategyFoundationCore.t.sol
- forge test --offline

Closes #113