### PR TITLE
Implement active strategy lifecycle on the integration facet

### DIFF
--- a/script/DeployDiamondVaultHost.s.sol
+++ b/script/DeployDiamondVaultHost.s.sol
@@ -186,7 +186,8 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
 
         require(vaultIntegration.oracleAdapter() == state.oracleAdapterAddress, "vault oracle adapter mismatch");
         require(vaultIntegration.strategy() == address(0), "vault strategy should be unset");
-        require(vaultIntegration.strategyReportedAssets() == 0, "vault reported assets should be zero");
+        require(vaultIntegration.strategyDebt() == 0, "vault strategy debt should be zero");
+        require(vaultIntegration.liveStrategyAssets() == 0, "vault live strategy assets should be zero");
 
         IOracleAdapter.OracleQuote memory quotePayload = vaultIntegration.oracleQuote();
         require(quotePayload.value == ORACLE_ANSWER, "vault quote value mismatch");

--- a/src/interfaces/IERC4626VaultIntegrationFacet.sol
+++ b/src/interfaces/IERC4626VaultIntegrationFacet.sol
@@ -5,7 +5,7 @@ import {IERC165} from "./IERC165.sol";
 import {IOracleAdapter} from "./IOracleAdapter.sol";
 
 /// @title IERC4626VaultIntegrationFacet
-/// @notice Hosted integration/config surface for vault oracle and strategy wiring.
+/// @notice Hosted integration/config surface for vault oracle wiring and active strategy lifecycle management.
 interface IERC4626VaultIntegrationFacet is IERC165 {
     /// @notice Emitted when the configured oracle adapter is updated.
     event VaultOracleAdapterUpdated(
@@ -15,16 +15,46 @@ interface IERC4626VaultIntegrationFacet is IERC165 {
     /// @notice Emitted when the configured strategy address is updated.
     event VaultStrategyUpdated(address indexed previousStrategy, address indexed newStrategy, address indexed sender);
 
-    /// @notice Emitted when reported strategy assets are updated.
-    event VaultStrategyAssetsReported(uint256 previousAssets, uint256 newAssets, address indexed sender);
+    /// @notice Emitted when assets are deployed from the vault into the configured strategy.
+    event VaultStrategyDeployed(uint256 assets, uint256 newStrategyDebt, address indexed sender);
+
+    /// @notice Emitted when assets are withdrawn from the configured strategy back to the vault.
+    event VaultStrategyWithdrawn(uint256 assets, uint256 newStrategyDebt, address indexed sender);
+
+    /// @notice Emitted when live strategy assets are synced into vault book accounting.
+    event VaultStrategySynced(uint256 previousDebt, uint256 liveAssets, address indexed sender);
 
     /// @notice Thrown when `oracleQuote()` is called without a configured adapter.
     error ERC4626VaultOracleAdapterNotConfigured();
 
-    /// @notice Thrown when `reportStrategyAssets()` is called by an unauthorized account.
-    /// @param caller The unauthorized caller.
-    /// @param strategy The currently configured strategy address.
-    error ERC4626VaultStrategyReporterUnauthorized(address caller, address strategy);
+    /// @notice Thrown when a strategy lifecycle action is attempted without a configured strategy.
+    error ERC4626VaultStrategyNotConfigured();
+
+    /// @notice Thrown when a strategy clear/swap is attempted while debt is still outstanding.
+    /// @param strategyDebt The current outstanding strategy debt.
+    error ERC4626VaultStrategyDebtOutstanding(uint256 strategyDebt);
+
+    /// @notice Thrown when a configured strategy is bound to a different vault.
+    /// @param strategy The invalid strategy address.
+    /// @param expectedVault The expected vault address.
+    /// @param actualVault The strategy-reported bound vault address.
+    error ERC4626VaultStrategyInvalidVault(address strategy, address expectedVault, address actualVault);
+
+    /// @notice Thrown when a configured strategy is bound to a different asset.
+    /// @param strategy The invalid strategy address.
+    /// @param expectedAsset The expected asset address.
+    /// @param actualAsset The strategy-reported bound asset address.
+    error ERC4626VaultStrategyInvalidAsset(address strategy, address expectedAsset, address actualAsset);
+
+    /// @notice Thrown when a deploy attempt exceeds the vault's immediately idle assets.
+    /// @param requestedAssets The requested deployment amount.
+    /// @param idleAssets The vault's immediately available idle asset amount.
+    error ERC4626VaultStrategyInsufficientIdleAssets(uint256 requestedAssets, uint256 idleAssets);
+
+    /// @notice Thrown when a strategy withdrawal returns less than requested in the happy-path lifecycle surface.
+    /// @param requestedAssets The requested withdrawal amount.
+    /// @param returnedAssets The actual returned amount.
+    error ERC4626VaultStrategyUnexpectedWithdrawResult(uint256 requestedAssets, uint256 returnedAssets);
 
     /// @notice Returns the configured external oracle adapter address.
     /// @return The adapter address, or zero when unset.
@@ -34,17 +64,17 @@ interface IERC4626VaultIntegrationFacet is IERC165 {
     /// @return The strategy address, or zero when unset.
     function strategy() external view returns (address);
 
-    /// @notice Returns the latest reported strategy-held asset amount.
-    /// @return The reported asset amount.
-    function strategyReportedAssets() external view returns (uint256);
+    /// @notice Returns the vault's current stored book debt allocated to the configured strategy.
+    /// @return The strategy debt amount.
+    function strategyDebt() external view returns (uint256);
 
     /// @notice Returns the vault's idle underlying asset balance.
     /// @return The idle asset amount held directly by the vault.
     function idleAssets() external view returns (uint256);
 
-    /// @notice Returns idle assets plus the latest reported strategy assets.
-    /// @return The estimated total assets across idle vault balance and strategy reports.
-    function estimatedTotalManagedAssets() external view returns (uint256);
+    /// @notice Returns the configured strategy's live reported assets.
+    /// @return The live strategy asset amount, or zero when no strategy is configured.
+    function liveStrategyAssets() external view returns (uint256);
 
     /// @notice Returns the latest normalized quote from the configured oracle adapter.
     /// @return quotePayload The latest quote payload.
@@ -58,7 +88,14 @@ interface IERC4626VaultIntegrationFacet is IERC165 {
     /// @param newStrategy The new strategy address, or zero to clear.
     function setStrategy(address newStrategy) external;
 
-    /// @notice Updates the latest reported strategy-held asset amount.
-    /// @param assets The latest reported asset amount.
-    function reportStrategyAssets(uint256 assets) external;
+    /// @notice Deploys idle vault assets into the configured strategy.
+    /// @param assets The asset amount to deploy.
+    function deployToStrategy(uint256 assets) external;
+
+    /// @notice Withdraws assets from the configured strategy back to the vault.
+    /// @param assets The asset amount to withdraw.
+    function withdrawFromStrategy(uint256 assets) external;
+
+    /// @notice Syncs live strategy assets into vault book accounting.
+    function syncStrategyAssets() external;
 }

--- a/src/vault/facets/ERC4626VaultIntegrationFacet.sol
+++ b/src/vault/facets/ERC4626VaultIntegrationFacet.sol
@@ -3,13 +3,14 @@ pragma solidity ^0.8.30;
 
 import {IERC20} from "../../interfaces/IERC20.sol";
 import {IERC4626VaultIntegrationFacet} from "../../interfaces/IERC4626VaultIntegrationFacet.sol";
+import {IERC4626VaultStrategy} from "../../interfaces/IERC4626VaultStrategy.sol";
 import {IOracleAdapter} from "../../interfaces/IOracleAdapter.sol";
 import {ERC4626Vault} from "../ERC4626Vault.sol";
 import {VaultFacetControl} from "../VaultFacetControl.sol";
 import {LibERC4626VaultStorage} from "../storage/LibERC4626VaultStorage.sol";
 
 /// @title ERC4626VaultIntegrationFacet
-/// @notice Hosted integration/config facet for oracle references and strategy reports.
+/// @notice Hosted integration/config facet for oracle references and active strategy lifecycle operations.
 contract ERC4626VaultIntegrationFacet is ERC4626Vault, VaultFacetControl, IERC4626VaultIntegrationFacet {
     /// @notice Returns the configured external oracle adapter address.
     /// @return The adapter address, or zero when unset.
@@ -23,10 +24,10 @@ contract ERC4626VaultIntegrationFacet is ERC4626Vault, VaultFacetControl, IERC46
         return LibERC4626VaultStorage.layout().strategy;
     }
 
-    /// @notice Returns the latest reported strategy-held asset amount.
-    /// @return The reported asset amount.
-    function strategyReportedAssets() public view returns (uint256) {
-        return LibERC4626VaultStorage.layout().strategyReportedAssets;
+    /// @notice Returns the vault's current stored book debt allocated to the configured strategy.
+    /// @return The strategy debt amount.
+    function strategyDebt() public view returns (uint256) {
+        return LibERC4626VaultStorage.layout().strategyDebt;
     }
 
     /// @notice Returns the vault's idle underlying asset balance.
@@ -36,10 +37,16 @@ contract ERC4626VaultIntegrationFacet is ERC4626Vault, VaultFacetControl, IERC46
         return IERC20(asset()).balanceOf(address(this));
     }
 
-    /// @notice Returns idle assets plus the latest reported strategy assets.
-    /// @return The estimated total assets across idle vault balance and strategy reports.
-    function estimatedTotalManagedAssets() public view returns (uint256) {
-        return idleAssets() + strategyReportedAssets();
+    /// @notice Returns the configured strategy's live reported assets.
+    /// @return The live strategy asset amount, or zero when no strategy is configured.
+    function liveStrategyAssets() public view returns (uint256) {
+        _requireInitialized();
+        address configuredStrategy = strategy();
+        if (configuredStrategy == address(0)) {
+            return 0;
+        }
+
+        return IERC4626VaultStrategy(configuredStrategy).totalAssets();
     }
 
     /// @notice Returns the latest normalized quote from the configured oracle adapter.
@@ -71,29 +78,126 @@ contract ERC4626VaultIntegrationFacet is ERC4626Vault, VaultFacetControl, IERC46
     function setStrategy(address newStrategy) public {
         _requireInitialized();
         _checkRole(VAULT_MANAGER_ROLE(), msg.sender);
+
         LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        uint256 currentStrategyDebt = layout.strategyDebt;
+        if (currentStrategyDebt != 0) {
+            revert ERC4626VaultStrategyDebtOutstanding(currentStrategyDebt);
+        }
+
+        if (newStrategy != address(0)) {
+            _validateStrategyBinding(newStrategy);
+        }
+
         address previousStrategy = layout.strategy;
         layout.strategy = newStrategy;
         layout.strategyReportedAssets = 0;
+        layout.strategyEmergencyExit = false;
 
         emit VaultStrategyUpdated(previousStrategy, newStrategy, msg.sender);
     }
 
-    /// @notice Updates the latest reported strategy-held asset amount.
-    /// @param assets The latest reported asset amount.
-    function reportStrategyAssets(uint256 assets) public {
+    /// @notice Deploys idle vault assets into the configured strategy.
+    /// @param assets The asset amount to deploy.
+    function deployToStrategy(uint256 assets) public {
         _requireInitialized();
-        address configuredStrategy = strategy();
-        if (msg.sender != configuredStrategy || configuredStrategy == address(0)) {
-            if (!hasRole(VAULT_MANAGER_ROLE(), msg.sender)) {
-                revert ERC4626VaultStrategyReporterUnauthorized(msg.sender, configuredStrategy);
-            }
+        _checkRole(VAULT_MANAGER_ROLE(), msg.sender);
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
         }
 
-        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
-        uint256 previousAssets = layout.strategyReportedAssets;
-        layout.strategyReportedAssets = assets;
+        IERC4626VaultStrategy configuredStrategy = _configuredStrategy();
+        uint256 availableIdleAssets = _availableIdleAssetsForStrategy();
+        if (assets > availableIdleAssets) {
+            revert ERC4626VaultStrategyInsufficientIdleAssets(assets, availableIdleAssets);
+        }
 
-        emit VaultStrategyAssetsReported(previousAssets, assets, msg.sender);
+        _safeTransferAsset(address(configuredStrategy), assets);
+        configuredStrategy.deployFunds(assets);
+
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        layout.strategyDebt += assets;
+        layout.strategyReportedAssets = 0;
+
+        emit VaultStrategyDeployed(assets, layout.strategyDebt, msg.sender);
+    }
+
+    /// @notice Withdraws assets from the configured strategy back to the vault.
+    /// @param assets The asset amount to withdraw.
+    function withdrawFromStrategy(uint256 assets) public {
+        _requireInitialized();
+        _checkRole(VAULT_MANAGER_ROLE(), msg.sender);
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        IERC4626VaultStrategy configuredStrategy = _configuredStrategy();
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        uint256 currentStrategyDebt = layout.strategyDebt;
+        if (assets > currentStrategyDebt) {
+            revert ERC4626VaultStrategyDebtOutstanding(currentStrategyDebt);
+        }
+
+        uint256 returnedAssets = configuredStrategy.withdrawToVault(assets);
+        if (returnedAssets != assets) {
+            revert ERC4626VaultStrategyUnexpectedWithdrawResult(assets, returnedAssets);
+        }
+
+        layout.strategyDebt = currentStrategyDebt - assets;
+        layout.strategyReportedAssets = 0;
+
+        emit VaultStrategyWithdrawn(assets, layout.strategyDebt, msg.sender);
+    }
+
+    /// @notice Syncs live strategy assets into vault book accounting.
+    function syncStrategyAssets() public {
+        _requireInitialized();
+        _checkRole(VAULT_MANAGER_ROLE(), msg.sender);
+
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        uint256 previousDebt = layout.strategyDebt;
+        uint256 liveAssets = _configuredStrategy().totalAssets();
+
+        if (liveAssets > previousDebt) {
+            _increaseManagedAssets(liveAssets - previousDebt);
+        } else if (previousDebt > liveAssets) {
+            _decreaseManagedAssets(previousDebt - liveAssets);
+        }
+
+        layout.strategyDebt = liveAssets;
+        layout.strategyReportedAssets = 0;
+
+        emit VaultStrategySynced(previousDebt, liveAssets, msg.sender);
+    }
+
+    function _configuredStrategy() internal view returns (IERC4626VaultStrategy configuredStrategy) {
+        address configuredStrategyAddress = strategy();
+        if (configuredStrategyAddress == address(0)) {
+            revert ERC4626VaultStrategyNotConfigured();
+        }
+
+        configuredStrategy = IERC4626VaultStrategy(configuredStrategyAddress);
+    }
+
+    function _validateStrategyBinding(address newStrategy) internal view {
+        IERC4626VaultStrategy candidateStrategy = IERC4626VaultStrategy(newStrategy);
+        address expectedVault = address(this);
+        address actualVault = candidateStrategy.vault();
+        if (actualVault != expectedVault) {
+            revert ERC4626VaultStrategyInvalidVault(newStrategy, expectedVault, actualVault);
+        }
+
+        address expectedAsset = asset();
+        address actualAsset = candidateStrategy.asset();
+        if (actualAsset != expectedAsset) {
+            revert ERC4626VaultStrategyInvalidAsset(newStrategy, expectedAsset, actualAsset);
+        }
+    }
+
+    function _availableIdleAssetsForStrategy() internal view returns (uint256) {
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        uint256 actualIdleAssets = IERC20(asset()).balanceOf(address(this));
+        uint256 idleBookAssets = layout.totalManagedAssets - layout.strategyDebt;
+        return actualIdleAssets < idleBookAssets ? actualIdleAssets : idleBookAssets;
     }
 }

--- a/src/vault/libraries/LibVaultFacetSelectors.sol
+++ b/src/vault/libraries/LibVaultFacetSelectors.sol
@@ -85,15 +85,17 @@ library LibVaultFacetSelectors {
 
     /// @notice Returns the hosted vault integration selector group.
     function vaultIntegrationSelectors() internal pure returns (bytes4[] memory selectors) {
-        selectors = new bytes4[](9);
+        selectors = new bytes4[](11);
         selectors[0] = IERC4626VaultIntegrationFacet.oracleAdapter.selector;
         selectors[1] = IERC4626VaultIntegrationFacet.strategy.selector;
-        selectors[2] = IERC4626VaultIntegrationFacet.strategyReportedAssets.selector;
+        selectors[2] = IERC4626VaultIntegrationFacet.strategyDebt.selector;
         selectors[3] = IERC4626VaultIntegrationFacet.idleAssets.selector;
-        selectors[4] = IERC4626VaultIntegrationFacet.estimatedTotalManagedAssets.selector;
+        selectors[4] = IERC4626VaultIntegrationFacet.liveStrategyAssets.selector;
         selectors[5] = IERC4626VaultIntegrationFacet.oracleQuote.selector;
         selectors[6] = IERC4626VaultIntegrationFacet.setOracleAdapter.selector;
         selectors[7] = IERC4626VaultIntegrationFacet.setStrategy.selector;
-        selectors[8] = IERC4626VaultIntegrationFacet.reportStrategyAssets.selector;
+        selectors[8] = IERC4626VaultIntegrationFacet.deployToStrategy.selector;
+        selectors[9] = IERC4626VaultIntegrationFacet.withdrawFromStrategy.selector;
+        selectors[10] = IERC4626VaultIntegrationFacet.syncStrategyAssets.selector;
     }
 }

--- a/test/DiamondVaultDeploymentIntegration.t.sol
+++ b/test/DiamondVaultDeploymentIntegration.t.sol
@@ -94,7 +94,8 @@ contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture 
 
         assertTrue(integrationFacetInterface().oracleAdapter() == address(adapter), "adapter mismatch");
         assertTrue(integrationFacetInterface().strategy() == address(0), "strategy should be unset");
-        assertTrue(integrationFacetInterface().strategyReportedAssets() == 0, "reported assets should be zero");
+        assertTrue(integrationFacetInterface().strategyDebt() == 0, "strategy debt should be zero");
+        assertTrue(integrationFacetInterface().liveStrategyAssets() == 0, "live strategy assets should be zero");
         assertTrue(quotePayload.value == 100_000_000, "quote value mismatch");
         assertTrue(quotePayload.updatedAt == quoteUpdatedAt, "quote timestamp mismatch");
         assertTrue(quotePayload.decimals == 8, "quote decimals mismatch");

--- a/test/DiamondVaultHostHardening.t.sol
+++ b/test/DiamondVaultHostHardening.t.sol
@@ -114,7 +114,7 @@ contract DiamondVaultHostHardeningTest is DiamondVaultHostHardeningFixture {
         );
         assertTrue(coreFacetInterface().asset() == address(asset), "core should still route after controls removal");
         assertTrue(
-            integrationFacetInterface().strategyReportedAssets() == STRATEGY_REPORTED_ASSETS,
+            integrationFacetInterface().strategyDebt() == STRATEGY_DEPLOYED_ASSETS,
             "integration should still route after controls removal"
         );
 
@@ -223,16 +223,15 @@ contract DiamondVaultHostHardeningTest is DiamondVaultHostHardeningFixture {
 
     function _assertIntegrationState() internal view {
         assertTrue(integrationFacetInterface().oracleAdapter() == address(adapter), "oracle adapter mismatch");
-        assertTrue(integrationFacetInterface().strategy() == strategyReporter, "strategy mismatch");
+        assertTrue(integrationFacetInterface().strategy() == address(strategyContract), "strategy mismatch");
+        assertTrue(integrationFacetInterface().strategyDebt() == STRATEGY_DEPLOYED_ASSETS, "strategy debt mismatch");
         assertTrue(
-            integrationFacetInterface().strategyReportedAssets() == STRATEGY_REPORTED_ASSETS,
-            "strategy reported assets mismatch"
+            integrationFacetInterface().liveStrategyAssets() == STRATEGY_DEPLOYED_ASSETS,
+            "live strategy assets mismatch"
         );
-        assertTrue(integrationFacetInterface().idleAssets() == BOB_DEPOSIT + CAROL_DEPOSIT, "idle assets mismatch");
         assertTrue(
-            integrationFacetInterface().estimatedTotalManagedAssets()
-                == BOB_DEPOSIT + CAROL_DEPOSIT + STRATEGY_REPORTED_ASSETS,
-            "estimated managed assets mismatch"
+            integrationFacetInterface().idleAssets() == BOB_DEPOSIT + CAROL_DEPOSIT - STRATEGY_DEPLOYED_ASSETS,
+            "idle assets mismatch"
         );
     }
 }

--- a/test/DiamondVaultHostInvariant.t.sol
+++ b/test/DiamondVaultHostInvariant.t.sol
@@ -204,21 +204,22 @@ contract DiamondVaultHostInvariantTest is DiamondVaultHostHardeningFixture {
         AccountingSnapshot memory snapshot = _snapshotAccounting();
 
         VM.prank(admin);
-        integrationFacetInterface().setStrategy(configured ? strategyReporter : address(0));
+        integrationFacetInterface().setStrategy(configured ? address(strategyContract) : address(0));
 
         _assertAccountingUnchanged(snapshot, "strategy updates should not mutate core accounting");
     }
 
-    function actionReportStrategyAssets(uint96 assetsRaw, bool asStrategyReporter) external {
+    function actionSyncStrategyAssets() external {
         AccountingSnapshot memory snapshot = _snapshotAccounting();
-        uint256 assets_ = uint256(assetsRaw);
-        address configuredStrategy = integrationFacetInterface().strategy();
-        address caller = asStrategyReporter && configuredStrategy != address(0) ? strategyReporter : admin;
 
-        VM.prank(caller);
-        integrationFacetInterface().reportStrategyAssets(assets_);
+        if (integrationFacetInterface().strategy() == address(0)) {
+            return;
+        }
 
-        _assertAccountingUnchanged(snapshot, "strategy reports should not mutate core accounting");
+        VM.prank(admin);
+        integrationFacetInterface().syncStrategyAssets();
+
+        _assertAccountingUnchanged(snapshot, "strategy sync should not mutate core accounting without deployed assets");
     }
 
     function invariantManagedAssetsTrackUnderlyingBalance() public view {
@@ -242,15 +243,11 @@ contract DiamondVaultHostInvariantTest is DiamondVaultHostHardeningFixture {
         );
     }
 
-    function invariantEstimatedManagedAssetsReflectIdlePlusReported() public view {
+    function invariantStrategyLifecycleStateRemainsZeroWithoutDeploy() public view {
+        assertTrue(integrationFacetInterface().strategyDebt() == 0, "strategy debt should remain zero without deploy");
         assertTrue(
-            integrationFacetInterface().estimatedTotalManagedAssets()
-                == integrationFacetInterface().idleAssets() + integrationFacetInterface().strategyReportedAssets(),
-            "estimated assets should equal idle plus reported strategy assets"
-        );
-        assertTrue(
-            integrationFacetInterface().estimatedTotalManagedAssets() >= coreFacetInterface().totalManagedAssets(),
-            "estimated managed assets should not be less than managed assets"
+            integrationFacetInterface().liveStrategyAssets() == 0,
+            "live strategy assets should remain zero without deploy"
         );
     }
 

--- a/test/ERC4626VaultIntegrationFacetCore.t.sol
+++ b/test/ERC4626VaultIntegrationFacetCore.t.sol
@@ -12,8 +12,12 @@ import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelect
 import {ERC4626VaultIntegrationFacetFixture} from "./helpers/ERC4626VaultIntegrationFacetTestHarness.sol";
 
 contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFixture {
-    function testDirectIntegrationFacetRequiresManagerForConfigAndReporterAuth() public {
+    function testDirectIntegrationFacetRequiresManagerForConfigAndLifecycle() public {
         _initializeDirectIntegrationFacet();
+        _approveAsset(bob, address(integrationFacet), 100);
+
+        VM.prank(bob);
+        integrationFacet.deposit(100, bob);
 
         VM.expectRevert(
             abi.encodeWithSelector(
@@ -27,67 +31,158 @@ contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFix
         integrationFacet.setOracleAdapter(address(adapter));
         assertTrue(integrationFacet.oracleAdapter() == address(adapter), "adapter mismatch");
 
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorized.selector, bob, integrationFacet.VAULT_MANAGER_ROLE()
+            )
+        );
+        VM.prank(bob);
+        integrationFacet.setStrategy(address(directProfitStrategy));
+
         VM.prank(admin);
-        integrationFacet.setStrategy(bob);
-        assertTrue(integrationFacet.strategy() == bob, "strategy mismatch");
+        integrationFacet.setStrategy(address(directProfitStrategy));
+        assertTrue(integrationFacet.strategy() == address(directProfitStrategy), "strategy mismatch");
 
         VM.expectRevert(
             abi.encodeWithSelector(
-                IERC4626VaultIntegrationFacet.ERC4626VaultStrategyReporterUnauthorized.selector, eve, bob
+                IAccessControl.AccessControlUnauthorized.selector, bob, integrationFacet.VAULT_MANAGER_ROLE()
             )
         );
-        VM.prank(eve);
-        integrationFacet.reportStrategyAssets(25);
-
         VM.prank(bob);
-        integrationFacet.reportStrategyAssets(25);
-        assertTrue(integrationFacet.strategyReportedAssets() == 25, "reported assets mismatch");
+        integrationFacet.deployToStrategy(40);
+
+        VM.prank(admin);
+        integrationFacet.deployToStrategy(40);
+
+        assertTrue(integrationFacet.strategyDebt() == 40, "strategy debt mismatch");
+        assertTrue(integrationFacet.idleAssets() == 60, "idle assets mismatch");
+        assertTrue(integrationFacet.liveStrategyAssets() == 40, "live strategy assets mismatch");
     }
 
-    function testDirectIntegrationFacetChangingStrategyClearsReportedAssets() public {
+    function testDirectIntegrationFacetRejectsInvalidBindingAndOutstandingDebtOnStrategySwap() public {
         _initializeDirectIntegrationFacet();
+        _approveAsset(bob, address(integrationFacet), 100);
 
-        VM.prank(admin);
-        integrationFacet.setStrategy(bob);
         VM.prank(bob);
-        integrationFacet.reportStrategyAssets(75);
-
-        VM.prank(admin);
-        integrationFacet.setStrategy(eve);
-
-        assertTrue(integrationFacet.strategy() == eve, "strategy should update");
-        assertTrue(integrationFacet.strategyReportedAssets() == 0, "reported assets should reset");
-
-        VM.prank(admin);
-        integrationFacet.setStrategy(address(0));
-        assertTrue(integrationFacet.strategy() == address(0), "strategy should clear");
-        assertTrue(integrationFacet.strategyReportedAssets() == 0, "reported assets should stay cleared");
-    }
-
-    function testDirectIntegrationFacetOracleQuoteAndEstimatedAssets() public {
-        _initializeDirectIntegrationFacet();
+        integrationFacet.deposit(100, bob);
 
         VM.expectRevert(
-            abi.encodeWithSelector(IERC4626VaultIntegrationFacet.ERC4626VaultOracleAdapterNotConfigured.selector)
+            abi.encodeWithSelector(
+                IERC4626VaultIntegrationFacet.ERC4626VaultStrategyInvalidVault.selector,
+                address(wrongVaultStrategy),
+                address(integrationFacet),
+                address(0xBAD)
+            )
         );
-        integrationFacet.oracleQuote();
+        VM.prank(admin);
+        integrationFacet.setStrategy(address(wrongVaultStrategy));
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IERC4626VaultIntegrationFacet.ERC4626VaultStrategyInvalidAsset.selector,
+                address(directWrongAssetStrategy),
+                address(asset),
+                address(otherAsset)
+            )
+        );
+        VM.prank(admin);
+        integrationFacet.setStrategy(address(directWrongAssetStrategy));
 
         VM.prank(admin);
-        integrationFacet.setOracleAdapter(address(adapter));
+        integrationFacet.setStrategy(address(directProfitStrategy));
+        VM.prank(admin);
+        integrationFacet.deployToStrategy(40);
 
-        asset.mint(address(integrationFacet), 40);
+        VM.expectRevert(
+            abi.encodeWithSelector(IERC4626VaultIntegrationFacet.ERC4626VaultStrategyDebtOutstanding.selector, 40)
+        );
+        VM.prank(admin);
+        integrationFacet.setStrategy(address(0));
 
         VM.prank(admin);
-        integrationFacet.reportStrategyAssets(25);
+        integrationFacet.withdrawFromStrategy(40);
+        VM.prank(admin);
+        integrationFacet.setStrategy(address(0));
 
-        IOracleAdapter.OracleQuote memory quotePayload = integrationFacet.oracleQuote();
+        assertTrue(integrationFacet.strategy() == address(0), "strategy should clear after debt reaches zero");
+        assertTrue(integrationFacet.strategyDebt() == 0, "strategy debt should clear after full withdraw");
+    }
 
-        assertTrue(quotePayload.value == 100_000_000, "quote value mismatch");
-        assertTrue(quotePayload.updatedAt == quoteUpdatedAt, "quote timestamp mismatch");
-        assertTrue(quotePayload.decimals == 8, "quote decimals mismatch");
-        assertTrue(integrationFacet.idleAssets() == 40, "idle assets mismatch");
-        assertTrue(integrationFacet.estimatedTotalManagedAssets() == 65, "estimated assets mismatch");
-        assertTrue(integrationFacet.totalManagedAssets() == 0, "managed assets should remain unchanged");
+    function testDirectIntegrationFacetSyncRealizesProfitAndPartialWithdrawPreservesBookValue() public {
+        _initializeDirectIntegrationFacet();
+        _approveAsset(bob, address(integrationFacet), 100);
+
+        VM.prank(bob);
+        integrationFacet.deposit(100, bob);
+
+        VM.prank(admin);
+        integrationFacet.setStrategy(address(directProfitStrategy));
+        VM.prank(admin);
+        integrationFacet.deployToStrategy(60);
+        directProfitStrategy.injectProfit(20);
+
+        assertTrue(integrationFacet.totalManagedAssets() == 100, "book value should remain unchanged before sync");
+        assertTrue(integrationFacet.liveStrategyAssets() == 80, "live strategy assets should reflect unsynced profit");
+
+        VM.prank(admin);
+        integrationFacet.syncStrategyAssets();
+
+        assertTrue(integrationFacet.strategyDebt() == 80, "strategy debt should sync to live assets");
+        assertTrue(integrationFacet.liveStrategyAssets() == 80, "live strategy assets mismatch after profit sync");
+        assertTrue(integrationFacet.totalManagedAssets() == 120, "book value should realize profit on sync");
+        assertTrue(integrationFacet.totalAssets() == 120, "total assets should remain mark-to-market after sync");
+
+        VM.prank(admin);
+        integrationFacet.withdrawFromStrategy(30);
+
+        assertTrue(integrationFacet.strategyDebt() == 50, "strategy debt should decrease after withdraw");
+        assertTrue(integrationFacet.liveStrategyAssets() == 50, "live strategy assets should decrease after withdraw");
+        assertTrue(integrationFacet.idleAssets() == 70, "idle assets should increase after withdraw");
+        assertTrue(integrationFacet.totalManagedAssets() == 120, "book value should stay unchanged after pull");
+    }
+
+    function testDirectIntegrationFacetSyncRealizesLoss() public {
+        _initializeDirectIntegrationFacet();
+        _approveAsset(bob, address(integrationFacet), 100);
+
+        VM.prank(bob);
+        integrationFacet.deposit(100, bob);
+
+        VM.prank(admin);
+        integrationFacet.setStrategy(address(directLossStrategy));
+        VM.prank(admin);
+        integrationFacet.deployToStrategy(60);
+        directLossStrategy.applyLoss(15, 35);
+
+        VM.prank(admin);
+        integrationFacet.syncStrategyAssets();
+
+        assertTrue(integrationFacet.strategyDebt() == 45, "strategy debt should sync to loss-adjusted live assets");
+        assertTrue(integrationFacet.liveStrategyAssets() == 45, "live strategy assets mismatch after loss sync");
+        assertTrue(integrationFacet.totalManagedAssets() == 85, "book value should realize loss on sync");
+        assertTrue(integrationFacet.totalAssets() == 85, "total assets should reflect realized loss");
+    }
+
+    function testDirectIntegrationFacetRejectsUnexpectedPartialWithdrawResult() public {
+        _initializeDirectIntegrationFacet();
+        _approveAsset(bob, address(integrationFacet), 100);
+
+        VM.prank(bob);
+        integrationFacet.deposit(100, bob);
+
+        VM.prank(admin);
+        integrationFacet.setStrategy(address(directLossStrategy));
+        VM.prank(admin);
+        integrationFacet.deployToStrategy(60);
+        directLossStrategy.applyLoss(0, 30);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IERC4626VaultIntegrationFacet.ERC4626VaultStrategyUnexpectedWithdrawResult.selector, 40, 30
+            )
+        );
+        VM.prank(admin);
+        integrationFacet.withdrawFromStrategy(40);
     }
 
     function testDirectIntegrationFacetHelpersRevertBeforeVaultInit() public {
@@ -95,7 +190,7 @@ contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFix
         integrationFacet.idleAssets();
 
         VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultNotInitialized.selector));
-        integrationFacet.estimatedTotalManagedAssets();
+        integrationFacet.liveStrategyAssets();
 
         VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultNotInitialized.selector));
         VM.prank(admin);
@@ -109,33 +204,37 @@ contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFix
         _approveAsset(bob, address(diamond), 100);
 
         VM.prank(bob);
-        uint256 mintedShares = IERC4626VaultFacet(address(diamond)).deposit(40, bob);
+        uint256 mintedShares = IERC4626VaultFacet(address(diamond)).deposit(100, bob);
 
         VM.prank(admin);
         IERC4626VaultIntegrationFacet(address(diamond)).setOracleAdapter(address(adapter));
         VM.prank(admin);
-        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(eve);
-
-        VM.prank(eve);
-        IERC4626VaultIntegrationFacet(address(diamond)).reportStrategyAssets(25);
+        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(address(diamondProfitStrategy));
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).deployToStrategy(60);
+        diamondProfitStrategy.injectProfit(20);
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).syncStrategyAssets();
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).withdrawFromStrategy(30);
 
         IOracleAdapter.OracleQuote memory quotePayload = IERC4626VaultIntegrationFacet(address(diamond)).oracleQuote();
 
-        assertTrue(mintedShares == 40, "deposit shares mismatch");
+        assertTrue(mintedShares == 100, "deposit shares mismatch");
         assertTrue(
             IERC4626VaultIntegrationFacet(address(diamond)).oracleAdapter() == address(adapter), "adapter mismatch"
         );
-        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).strategy() == eve, "strategy mismatch");
         assertTrue(
-            IERC4626VaultIntegrationFacet(address(diamond)).strategyReportedAssets() == 25, "reported assets mismatch"
+            IERC4626VaultIntegrationFacet(address(diamond)).strategy() == address(diamondProfitStrategy),
+            "strategy mismatch"
         );
-        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).idleAssets() == 40, "idle assets mismatch");
+        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).strategyDebt() == 50, "strategy debt mismatch");
         assertTrue(
-            IERC4626VaultIntegrationFacet(address(diamond)).estimatedTotalManagedAssets() == 65,
-            "estimated assets mismatch"
+            IERC4626VaultIntegrationFacet(address(diamond)).liveStrategyAssets() == 50, "live strategy assets mismatch"
         );
-        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 40, "managed assets mismatch");
-        assertTrue(IERC4626VaultFacet(address(diamond)).previewDeposit(10) == 10, "preview should remain core-based");
+        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).idleAssets() == 70, "idle assets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 120, "managed assets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 120, "total assets mismatch");
         assertTrue(quotePayload.value == 100_000_000, "quote value mismatch");
         assertTrue(quotePayload.updatedAt == quoteUpdatedAt, "quote timestamp mismatch");
         assertTrue(quotePayload.decimals == 8, "quote decimals mismatch");

--- a/test/ERC4626VaultStrategyAccountingCore.t.sol
+++ b/test/ERC4626VaultStrategyAccountingCore.t.sol
@@ -88,7 +88,7 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
         assertTrue(facet.maxWithdraw(bob) == DEPOSIT_ASSETS, "maxWithdraw should ignore zero-debt strategy");
     }
 
-    function testDiamondHostedVaultStrategyAccountingUsesLiveStrategyAssetsAndKeepsAdvisoryReportsSeparate() public {
+    function testDiamondHostedVaultStrategyAccountingUsesLiveStrategyAssets() public {
         _installHostedVaultFacetsToDiamond();
         _initializeDiamondVault();
         _approveAsset(bob, address(diamond), DEPOSIT_ASSETS);
@@ -102,8 +102,6 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
         _simulateStrategyDeployment(address(diamond), diamondProfitStrategy, STRATEGY_DEBT);
         diamondProfitStrategy.injectProfit(20);
 
-        VM.prank(admin);
-        IERC4626VaultIntegrationFacet(address(diamond)).reportStrategyAssets(25);
         VM.prank(admin);
         IERC4626VaultControlsFacet(address(diamond)).setLimitConfig(125, 0, 0, 0, 0);
 
@@ -120,12 +118,9 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
         );
         assertTrue(IERC4626VaultFacet(address(diamond)).maxRedeem(bob) == 33, "maxRedeem should cap to idle liquidity");
         assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).idleAssets() == 40, "idle assets mismatch");
+        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).strategyDebt() == 60, "strategy debt mismatch");
         assertTrue(
-            IERC4626VaultIntegrationFacet(address(diamond)).strategyReportedAssets() == 25, "reported assets mismatch"
-        );
-        assertTrue(
-            IERC4626VaultIntegrationFacet(address(diamond)).estimatedTotalManagedAssets() == 65,
-            "estimated assets should remain advisory"
+            IERC4626VaultIntegrationFacet(address(diamond)).liveStrategyAssets() == 80, "live strategy assets mismatch"
         );
     }
 }

--- a/test/VaultStrategyFoundationCore.t.sol
+++ b/test/VaultStrategyFoundationCore.t.sol
@@ -10,7 +10,7 @@ import {
 contract VaultStrategyFoundationCoreTest is ERC4626VaultStrategyFixture {
     function testStorageDefaultsAfterHostedVaultInit() public view {
         assertTrue(storageHarness.strategy() == address(0), "strategy should default to zero");
-        assertTrue(storageHarness.strategyReportedAssets() == 0, "reported assets should default to zero");
+        assertTrue(storageHarness.liveStrategyAssets() == 0, "live strategy assets should default to zero");
         assertTrue(storageHarness.strategyDebtForTest() == 0, "strategy debt should default to zero");
         assertFalse(storageHarness.strategyEmergencyExitForTest(), "emergency exit should default to false");
     }
@@ -30,6 +30,7 @@ contract VaultStrategyFoundationCoreTest is ERC4626VaultStrategyFixture {
     }
 
     function testProfitMockReportsHigherAssetsAfterProfitInjection() public {
+        asset.mint(address(profitStrategy), 100);
         VM.prank(vault);
         profitStrategy.deployFunds(100);
 
@@ -37,9 +38,11 @@ contract VaultStrategyFoundationCoreTest is ERC4626VaultStrategyFixture {
 
         assertTrue(profitStrategy.totalAssets() == 125, "profit should increase tracked assets");
         assertTrue(profitStrategy.maxWithdrawableAssets() == 125, "profit should increase withdrawable assets");
+        assertTrue(asset.balanceOf(address(profitStrategy)) == 125, "strategy balance should reflect profit");
     }
 
     function testLossShortfallMockReturnsLessThanRequestedAndShrinksAssets() public {
+        asset.mint(address(lossStrategy), 100);
         VM.prank(vault);
         lossStrategy.deployFunds(100);
 
@@ -47,6 +50,7 @@ contract VaultStrategyFoundationCoreTest is ERC4626VaultStrategyFixture {
 
         assertTrue(lossStrategy.totalAssets() == 60, "loss should reduce tracked assets");
         assertTrue(lossStrategy.maxWithdrawableAssets() == 35, "shortfall should cap withdrawable assets");
+        assertTrue(asset.balanceOf(address(lossStrategy)) == 60, "strategy balance should reflect realized loss");
 
         VM.prank(vault);
         uint256 returnedAssets = lossStrategy.withdrawToVault(50);
@@ -54,6 +58,7 @@ contract VaultStrategyFoundationCoreTest is ERC4626VaultStrategyFixture {
         assertTrue(returnedAssets == 35, "withdraw should return available assets only");
         assertTrue(lossStrategy.totalAssets() == 25, "tracked assets should reduce by returned amount");
         assertTrue(lossStrategy.maxWithdrawableAssets() == 0, "withdrawable assets should be depleted");
+        assertTrue(asset.balanceOf(vault) == 35, "vault should receive returned assets");
     }
 
     function testRevertingMockRevertsOnConfiguredCalls() public {
@@ -63,6 +68,8 @@ contract VaultStrategyFoundationCoreTest is ERC4626VaultStrategyFixture {
             abi.encodeWithSelector(MockVaultStrategyForcedRevert.selector, revertingStrategy.totalAssets.selector)
         );
         revertingStrategy.totalAssets();
+
+        asset.mint(address(revertingStrategy), 100);
 
         VM.expectRevert(
             abi.encodeWithSelector(MockVaultStrategyForcedRevert.selector, revertingStrategy.deployFunds.selector)
@@ -86,6 +93,7 @@ contract VaultStrategyFoundationCoreTest is ERC4626VaultStrategyFixture {
     }
 
     function testEmergencyUnwindMockReturnsAllAssetsAndClearsState() public {
+        asset.mint(address(unwindStrategy), 100);
         VM.prank(vault);
         unwindStrategy.deployFunds(100);
 
@@ -97,6 +105,7 @@ contract VaultStrategyFoundationCoreTest is ERC4626VaultStrategyFixture {
         assertTrue(returnedAssets == 100, "emergency unwind should return all tracked assets");
         assertTrue(unwindStrategy.totalAssets() == 0, "tracked assets should clear on unwind");
         assertTrue(unwindStrategy.maxWithdrawableAssets() == 0, "withdrawable assets should clear on unwind");
+        assertTrue(asset.balanceOf(vault) == 100, "vault should receive unwound assets");
     }
 
     function _assertBinding(IERC4626VaultStrategy strategy_) internal view {

--- a/test/helpers/DiamondVaultHostHardeningTestHarness.sol
+++ b/test/helpers/DiamondVaultHostHardeningTestHarness.sol
@@ -10,6 +10,7 @@ import {ERC4626VaultFacet} from "../../src/vault/facets/ERC4626VaultFacet.sol";
 import {ERC4626VaultIntegrationFacet} from "../../src/vault/facets/ERC4626VaultIntegrationFacet.sol";
 import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {DiamondVaultDeploymentFixture} from "./DiamondVaultDeploymentTestHarness.sol";
+import {ProfitMockVaultStrategy} from "./ERC4626VaultStrategyTestHarness.sol";
 
 interface IFacetVersionMarker {
     function facetVersion() external view returns (uint256);
@@ -48,16 +49,17 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
     uint256 internal constant BOB_DEPOSIT = 200_000;
     uint256 internal constant CAROL_DEPOSIT = 150_000;
     uint256 internal constant SHARE_ALLOWANCE = 25_000;
-    uint256 internal constant STRATEGY_REPORTED_ASSETS = 75_000;
+    uint256 internal constant STRATEGY_DEPLOYED_ASSETS = 75_000;
 
     address internal bob = address(0xB0B);
     address internal carol = address(0xCA11);
     address internal dave = address(0xD0D);
     address internal eve = address(0xE11E);
     address internal feeSink = address(0xFEE);
-    address internal strategyReporter = address(0x57A7);
 
     address[ACTOR_COUNT] internal actors;
+
+    ProfitMockVaultStrategy internal strategyContract;
 
     ERC4626VaultFacetReplacement internal coreReplacement;
     ERC4626VaultControlsFacetReplacement internal controlsReplacement;
@@ -74,6 +76,8 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
         actors[1] = carol;
         actors[2] = dave;
         actors[3] = eve;
+
+        strategyContract = new ProfitMockVaultStrategy(address(diamond), address(asset));
 
         for (uint256 i = 0; i < ACTOR_COUNT; i++) {
             address actor = actors[i];
@@ -122,10 +126,10 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
 
     function _seedIntegrationState() internal {
         VM.prank(admin);
-        integrationFacetInterface().setStrategy(strategyReporter);
+        integrationFacetInterface().setStrategy(address(strategyContract));
 
-        VM.prank(strategyReporter);
-        integrationFacetInterface().reportStrategyAssets(STRATEGY_REPORTED_ASSETS);
+        VM.prank(admin);
+        integrationFacetInterface().deployToStrategy(STRATEGY_DEPLOYED_ASSETS);
     }
 
     function _replaceCoreFacet(address facetAddress_) internal {

--- a/test/helpers/ERC4626VaultIntegrationFacetTestHarness.sol
+++ b/test/helpers/ERC4626VaultIntegrationFacetTestHarness.sol
@@ -13,6 +13,8 @@ import {ERC4626VaultControlsFacetHarness} from "./ERC4626VaultControlsFacetTestH
 import {ReentrantMockVaultAsset} from "./ERC4626VaultControlsTestHarness.sol";
 import {ERC4626VaultFacetHarness} from "./ERC4626VaultFacetTestHarness.sol";
 import {MockOracleFeed, OracleAdapterHarness} from "./OracleAdapterTestHarness.sol";
+import {MockVaultAsset} from "./ERC4626CoreTestHarness.sol";
+import {LossShortfallMockVaultStrategy, ProfitMockVaultStrategy} from "./ERC4626VaultStrategyTestHarness.sol";
 
 contract ERC4626VaultIntegrationFacetHarness is ERC4626VaultIntegrationFacet {
     function initializeHostedVaultForTest(
@@ -38,6 +40,7 @@ abstract contract ERC4626VaultIntegrationFacetFixture is TestBase {
     uint64 internal quoteUpdatedAt = 999_900;
 
     ReentrantMockVaultAsset internal asset;
+    MockVaultAsset internal otherAsset;
     ERC4626VaultFacetHarness internal coreFacet;
     ERC4626VaultControlsFacetHarness internal controlsFacet;
     ERC4626VaultIntegrationFacetHarness internal integrationFacet;
@@ -46,11 +49,17 @@ abstract contract ERC4626VaultIntegrationFacetFixture is TestBase {
     DiamondProxyHarness internal diamond;
     MockOracleFeed internal feed;
     OracleAdapterHarness internal adapter;
+    ProfitMockVaultStrategy internal directProfitStrategy;
+    LossShortfallMockVaultStrategy internal directLossStrategy;
+    ProfitMockVaultStrategy internal diamondProfitStrategy;
+    ProfitMockVaultStrategy internal wrongVaultStrategy;
+    ProfitMockVaultStrategy internal directWrongAssetStrategy;
 
     function setUp() public virtual {
         VM.warp(currentTime);
 
         asset = new ReentrantMockVaultAsset();
+        otherAsset = new MockVaultAsset("Other USD", "oUSD", 6);
         coreFacet = new ERC4626VaultFacetHarness();
         controlsFacet = new ERC4626VaultControlsFacetHarness();
         integrationFacet = new ERC4626VaultIntegrationFacetHarness();
@@ -60,6 +69,11 @@ abstract contract ERC4626VaultIntegrationFacetFixture is TestBase {
         feed = new MockOracleFeed(8);
         feed.setLatestRoundData(1, 100_000_000, quoteUpdatedAt, quoteUpdatedAt, 1);
         adapter = new OracleAdapterHarness(admin, address(feed), maxStaleness);
+        directProfitStrategy = new ProfitMockVaultStrategy(address(integrationFacet), address(asset));
+        directLossStrategy = new LossShortfallMockVaultStrategy(address(integrationFacet), address(asset));
+        diamondProfitStrategy = new ProfitMockVaultStrategy(address(diamond), address(asset));
+        wrongVaultStrategy = new ProfitMockVaultStrategy(address(0xBAD), address(asset));
+        directWrongAssetStrategy = new ProfitMockVaultStrategy(address(integrationFacet), address(otherAsset));
 
         asset.mint(bob, INITIAL_ASSETS);
         asset.mint(eve, INITIAL_ASSETS);

--- a/test/helpers/ERC4626VaultStrategyAccountingTestHarness.sol
+++ b/test/helpers/ERC4626VaultStrategyAccountingTestHarness.sol
@@ -45,7 +45,6 @@ abstract contract ERC4626VaultStrategyAccountingFixture is TestBase {
     address internal admin = address(0xA11CE);
     address internal bob = address(0xB0B);
     address internal eve = address(0xE11E);
-    address internal sink = address(0x515E);
 
     ReentrantMockVaultAsset internal asset;
     ERC4626VaultStrategyAccountingFacetHarness internal facet;
@@ -108,7 +107,7 @@ abstract contract ERC4626VaultStrategyAccountingFixture is TestBase {
         internal
     {
         VM.prank(vaultAccount);
-        asset.transfer(sink, assets_);
+        asset.transfer(address(strategy_), assets_);
 
         VM.prank(vaultAccount);
         strategy_.deployFunds(assets_);

--- a/test/helpers/ERC4626VaultStrategyTestHarness.sol
+++ b/test/helpers/ERC4626VaultStrategyTestHarness.sol
@@ -30,6 +30,8 @@ contract ERC4626VaultStrategyStorageHarness is ERC4626VaultIntegrationFacet {
 error MockVaultStrategyForcedRevert(bytes4 selector);
 
 abstract contract MockVaultStrategyBase is IERC4626VaultStrategy {
+    address internal constant LOSS_SINK = address(0x1055);
+
     address internal immutable _vault;
     address internal immutable _asset;
 
@@ -67,18 +69,25 @@ abstract contract MockVaultStrategyBase is IERC4626VaultStrategy {
     function deployFunds(uint256 assets) external virtual override onlyVault {
         _trackedAssets += assets;
         _withdrawableAssets += assets;
+        require(MockVaultAsset(_asset).balanceOf(address(this)) >= _trackedAssets, "STRATEGY_BALANCE_UNDERFUNDED");
     }
 
     function withdrawToVault(uint256 assets) external virtual override onlyVault returns (uint256 assetsReturned) {
         assetsReturned = _min(assets, maxWithdrawableAssets());
         _trackedAssets -= assetsReturned;
         _withdrawableAssets -= assetsReturned;
+        if (assetsReturned != 0) {
+            MockVaultAsset(_asset).transfer(_vault, assetsReturned);
+        }
     }
 
     function withdrawAllToVault() external virtual override onlyVault returns (uint256 assetsReturned) {
         assetsReturned = maxWithdrawableAssets();
         _trackedAssets -= assetsReturned;
         _withdrawableAssets -= assetsReturned;
+        if (assetsReturned != 0) {
+            MockVaultAsset(_asset).transfer(_vault, assetsReturned);
+        }
     }
 
     function setWithdrawableAssets(uint256 assets) external {
@@ -94,6 +103,11 @@ contract ProfitMockVaultStrategy is MockVaultStrategyBase {
     constructor(address vault_, address asset_) MockVaultStrategyBase(vault_, asset_) {}
 
     function injectProfit(uint256 assets) external {
+        if (assets == 0) {
+            return;
+        }
+
+        MockVaultAsset(_asset).mint(address(this), assets);
         _trackedAssets += assets;
         _withdrawableAssets += assets;
     }
@@ -103,7 +117,11 @@ contract LossShortfallMockVaultStrategy is MockVaultStrategyBase {
     constructor(address vault_, address asset_) MockVaultStrategyBase(vault_, asset_) {}
 
     function applyLoss(uint256 lossAssets, uint256 withdrawableAssets_) external {
-        _trackedAssets = lossAssets >= _trackedAssets ? 0 : _trackedAssets - lossAssets;
+        uint256 realizedLoss = _min(lossAssets, _trackedAssets);
+        if (realizedLoss != 0) {
+            MockVaultAsset(_asset).transfer(LOSS_SINK, realizedLoss);
+            _trackedAssets -= realizedLoss;
+        }
         _withdrawableAssets = _min(withdrawableAssets_, _trackedAssets);
     }
 }
@@ -138,6 +156,7 @@ contract RevertingMockVaultStrategy is MockVaultStrategyBase {
         }
         _trackedAssets += assets;
         _withdrawableAssets += assets;
+        require(MockVaultAsset(_asset).balanceOf(address(this)) >= _trackedAssets, "STRATEGY_BALANCE_UNDERFUNDED");
     }
 
     function withdrawToVault(uint256 assets) external override onlyVault returns (uint256 assetsReturned) {
@@ -147,6 +166,9 @@ contract RevertingMockVaultStrategy is MockVaultStrategyBase {
         assetsReturned = _min(assets, maxWithdrawableAssets());
         _trackedAssets -= assetsReturned;
         _withdrawableAssets -= assetsReturned;
+        if (assetsReturned != 0) {
+            MockVaultAsset(_asset).transfer(_vault, assetsReturned);
+        }
     }
 
     function withdrawAllToVault() external override onlyVault returns (uint256 assetsReturned) {
@@ -156,6 +178,9 @@ contract RevertingMockVaultStrategy is MockVaultStrategyBase {
         assetsReturned = maxWithdrawableAssets();
         _trackedAssets -= assetsReturned;
         _withdrawableAssets -= assetsReturned;
+        if (assetsReturned != 0) {
+            MockVaultAsset(_asset).transfer(_vault, assetsReturned);
+        }
     }
 }
 
@@ -166,6 +191,9 @@ contract EmergencyUnwindMockVaultStrategy is MockVaultStrategyBase {
         assetsReturned = _trackedAssets;
         _trackedAssets = 0;
         _withdrawableAssets = 0;
+        if (assetsReturned != 0) {
+            MockVaultAsset(_asset).transfer(_vault, assetsReturned);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- replace the advisory integration surface with active single-strategy lifecycle methods
- add manager-controlled strategy deploy, withdraw, and sync flows on the hosted integration facet
- update selector wiring, deployment checks, and hosted vault tests for the new lifecycle model

## Validation
- `git diff --check`
- `forge test --offline --match-path test/ERC4626VaultIntegrationFacetCore.t.sol`
- `forge test --offline --match-path test/VaultStrategyFoundationCore.t.sol`
- `forge test --offline --match-path test/ERC4626VaultStrategyAccountingCore.t.sol`
- `forge test --offline --match-path test/DiamondVaultDeploymentIntegration.t.sol`
- `forge test --offline --match-path test/DiamondVaultHostHardening.t.sol`
- `forge test --offline --match-path test/DiamondVaultHostInvariant.t.sol`
- `forge test --offline`

Closes #114