### PR TITLE
Milestone/strategy yield abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,10 @@ reviewable engineering system.
   with init, selector ownership, Permit/metadata support, and host-level
   hardening coverage.
 - A hosted ERC-4626 vault platform deployed behind a diamond host, split across
-  core, controls, and integration facets with deployment-backed init, oracle
-  wiring, replace/remove/re-add hardening, and diamond-routed invariant
-  coverage.
+  core, controls, and integration facets with active strategy lifecycle
+  management, live strategy-aware accounting, loss-aware withdrawals,
+  emergency-exit safety, deployment-backed init, and diamond-routed hardening
+  plus invariant coverage.
 - Operational maturity through local bootstrap, smoke validation, upgrade
   rehearsal, system-hardening flows, and matching CI gates.
 - A local Auralis workflow for full-stack bootstrap, smoke checks, simulated
@@ -54,6 +55,7 @@ Implemented milestones so far:
 - Diamond Token Facets
 - Diamond-Hosted Vault Platform
 - Auralis Launch Readiness
+- Strategy / Yield Abstraction
 
 ## Validation
 
@@ -92,7 +94,8 @@ constraint, and token-host upgrade assumptions.
 
 Hosted-vault architecture and safety assumptions live in
 `docs/vault-facets.md`, including the init model, selector ownership split,
-pause behavior, deployment references, and hosted-vault upgrade assumptions.
+live strategy lifecycle, accounting model, emergency-exit behavior, deployment
+references, and hosted-vault upgrade assumptions.
 
 Local Auralis bootstrap, smoke, simulated activity, reset flow, and artifact
 layout are documented in `docs/auralis-local.md`.

--- a/docs/auralis-local.md
+++ b/docs/auralis-local.md
@@ -43,19 +43,21 @@ bash scripts/auralis-reset.sh
 
 `auralis-up.sh`
 - starts Anvil if one is not already available
-- deploys the ERC20 host, ERC721 host, and vault host
+- deploys the ERC20 host, ERC721 host, and strategy-enabled vault host
 - writes `deployments/auralis.local.json`
 
 `auralis-smoke.sh`
 - checks deployed code is present
-- runs token, NFT, and vault happy-path transactions
+- runs token and NFT happy-path transactions
+- runs vault deposit, strategy deploy, profit sync, manager pull, user auto-pull, and emergency-exit flows
+- restores the local vault to a ready state by re-binding the configured strategy after the emergency-exit smoke
 - verifies the vault oracle quote path is live
 
 `auralis-activity.sh`
 - generates deterministic demo traffic across the deployed hosts
 - mints and transfers ERC20 balances
 - mints and moves an ERC721 token
-- deposits into the vault, moves shares, redeems shares, updates the oracle, and reports strategy assets
+- deposits into the vault, deploys capital to strategy, syncs profit, pulls funds back, moves shares, redeems shares, updates the oracle, and toggles pause state
 
 `auralis-reset.sh`
 - stops the managed Anvil process if `auralis-up.sh` started it
@@ -72,6 +74,7 @@ and records:
 - ERC20 host addresses
 - ERC721 host addresses
 - vault host addresses
+- configured vault strategy address and zeroed initial strategy state
 
 ## Simulated Activity
 

--- a/docs/security-checks.md
+++ b/docs/security-checks.md
@@ -65,17 +65,23 @@ reinstall persistence, and diamond-routed invariant coverage locally.
 
 ### Hosted Vault
 
-The hosted vault milestone has matching deployment, hardening, and invariant
-coverage for the supported three-facet vault host:
+The hosted vault now has matching deployment, strategy lifecycle, hardening,
+and invariant coverage for the supported three-facet vault host with one active
+strategy per vault:
 
 ```bash
 forge test --offline --match-path test/DiamondVaultDeploymentIntegration.t.sol
+forge test --offline --match-path test/ERC4626VaultIntegrationFacetCore.t.sol
+forge test --offline --match-path test/ERC4626VaultStrategyAccountingCore.t.sol
+forge test --offline --match-path test/VaultStrategyFoundationCore.t.sol
 forge test --offline --match-path test/DiamondVaultHostHardening.t.sol
 forge test --offline --match-path test/DiamondVaultHostInvariant.t.sol
 ```
 
-Use these to reproduce hosted-vault deployment, selector ownership, facet
-replacement/reinstall persistence, and diamond-routed vault invariants locally.
+Use these to reproduce hosted-vault deployment, strategy binding, live
+strategy-aware accounting, loss and emergency-exit behavior, selector
+ownership, facet replacement persistence, and diamond-routed vault invariants
+locally.
 
 ### Slither
 

--- a/docs/vault-facets.md
+++ b/docs/vault-facets.md
@@ -1,7 +1,7 @@
 # Diamond Vault Facets
 
 This document is the canonical guide for the hosted vault model implemented in
-the `Diamond-Hosted Vault Platform` milestone.
+Auralis.
 
 It covers the supported diamond-hosted vault deployment:
 
@@ -9,6 +9,7 @@ It covers the supported diamond-hosted vault deployment:
 - one `ERC4626VaultFacet`
 - one `ERC4626VaultControlsFacet`
 - one `ERC4626VaultIntegrationFacet`
+- one active strategy per vault
 
 For the standalone ERC-4626 module behavior and math reference, see
 `docs/erc4626-vault.md`.
@@ -28,6 +29,11 @@ control-plane selectors, and integration/config selectors.
 - conversion, preview, and `max*` helpers
 - `asset()` and `totalManagedAssets()`
 
+The core facet also owns runtime liquidity sourcing for user withdrawals and
+redemptions. When idle vault liquidity is insufficient, it will pull
+immediately withdrawable assets from the configured strategy before finishing
+`withdraw` or `redeem`.
+
 ### Controls Facet
 
 `ERC4626VaultControlsFacet` owns the control-plane selector group:
@@ -43,13 +49,17 @@ control-plane selectors, and integration/config selectors.
 `ERC4626VaultIntegrationFacet` owns the integration/config selector group:
 
 - oracle adapter reference
-- strategy reference
-- strategy report hook
+- strategy reference and emergency-exit state
+- strategy lifecycle methods
 - `idleAssets()`
-- `estimatedTotalManagedAssets()`
+- `liveStrategyAssets()`
+- `strategyDebt()`
 - `oracleQuote()`
 
-## Initialization Model
+The integration facet is the manager-facing strategy surface. It does not own
+vault initialization and it does not own user ERC-4626 entrypoints.
+
+## Initialization And Deployment Model
 
 The hosted vault uses one initializer on the core facet only.
 
@@ -60,8 +70,8 @@ Initialization sequence:
 3. Call
    `initializeVault(address vaultAsset, string vaultName, string vaultSymbol, address admin)`
    through the diamond.
-4. Optionally call `setOracleAdapter(address newAdapter)` through the
-   integration facet.
+4. Call `setOracleAdapter(address newAdapter)` through the integration facet.
+5. Call `setStrategy(address newStrategy)` through the integration facet.
 
 Initialization behavior:
 
@@ -72,6 +82,17 @@ Initialization behavior:
 - `ERC4626VaultControlsFacet` has no independent initializer.
 - `ERC4626VaultIntegrationFacet` has no independent initializer.
 - a second call to `initializeVault(...)` reverts.
+
+The local reference deployment in `script/DeployDiamondVaultHost.s.sol` wires a
+vault-bound, asset-bound strategy by default. It leaves the vault in a ready
+state with:
+
+- `strategy()` configured
+- `strategyDebt() == 0`
+- `liveStrategyAssets() == 0`
+- `strategyEmergencyExit() == false`
+
+No funds are deployed to strategy during deployment.
 
 ## Role Model And Pause Behavior
 
@@ -89,10 +110,10 @@ Hosted vault facets reuse the shared control plane.
 - `setLimitConfig(...)`
 - `setOracleAdapter(...)`
 - `setStrategy(...)`
-- manager-authorized `reportStrategyAssets(...)`
-
-If a strategy is configured, the strategy address may also call
-`reportStrategyAssets(...)`.
+- `deployToStrategy(...)`
+- `withdrawFromStrategy(...)`
+- `syncStrategyAssets()`
+- `emergencyExitStrategy()`
 
 ### Pause Behavior
 
@@ -114,42 +135,119 @@ Global pause does not block share-token flows:
 Scoped pause selectors still route through the controls facet, but the hosted
 vault does not currently use per-scope pause behavior for ERC-4626 entrypoints.
 
-## Integration Behavior
+## Strategy Model
 
-The integration facet is config/report infrastructure, not an active strategy
-engine.
+The hosted vault strategy model is intentionally narrow:
 
-Oracle behavior:
+- one active strategy per vault
+- single-asset only
+- strategy instance is vault-bound and asset-bound
+- no allocator or multi-strategy routing
+- no async withdrawal queue
+- no automatic harvest or keeper loop
 
-- the oracle adapter is an external contract reference
-- the reference host deployment wires it after vault initialization
-- `oracleQuote()` reads through the configured adapter
+A strategy must satisfy `IERC4626VaultStrategy` and report:
 
-Strategy behavior:
+- `vault() == address(diamond)`
+- `asset() == asset()`
 
-- `setStrategy(...)` stores a configured strategy reference
-- `reportStrategyAssets(...)` updates an advisory reported amount
-- `strategyReportedAssets` does not mutate core ERC-4626 liquidity accounting
+`setStrategy(...)` validates those bindings and requires `strategyDebt() == 0`
+before a strategy can be cleared or replaced.
 
-Asset helpers:
+### Lifecycle Surface
 
-- `idleAssets()` returns the underlying balance held directly by the vault
-- `estimatedTotalManagedAssets()` returns
-  `idleAssets() + strategyReportedAssets()`
-- `totalManagedAssets()` and ERC-4626 preview/liquidity math continue to use the
-  vault's managed accounting only
+Manager lifecycle methods live on the integration facet:
 
-That means strategy reports are visible to operators and reviewers, but they do
-not automatically change `withdraw`, `redeem`, preview math, or live liquidity
-semantics in this milestone.
+- `setStrategy(address)`
+- `deployToStrategy(uint256)`
+- `withdrawFromStrategy(uint256)`
+- `syncStrategyAssets()`
+- `emergencyExitStrategy()`
+
+Behavior:
+
+- `deployToStrategy(...)` moves idle assets from the vault into strategy and
+  increases `strategyDebt()` by the deployed amount.
+- `withdrawFromStrategy(...)` pulls assets back from strategy, may return less
+  than requested, and realizes any gain or loss into book value.
+- `syncStrategyAssets()` realizes mark-to-market strategy profit or loss into
+  book value without moving idle assets.
+- `emergencyExitStrategy()` sets the sticky emergency-exit flag before trying a
+  full unwind.
+
+Emergency exit is one-way for the current strategy instance:
+
+- once emergency exit is active, new deploys are blocked
+- if unwind succeeds, debt is reconciled down to the remaining live strategy
+  assets
+- if unwind reverts, emergency exit stays active and the call does not revert
+- to resume deploying, the manager must get debt to zero and then clear or
+  replace the strategy
+
+## Accounting Model
+
+The hosted vault separates book accounting from live pricing.
+
+Book accounting:
+
+- `totalManagedAssets()` is the vault's stored book value
+- `strategyDebt()` is the book debt allocated to the configured strategy
+- `idleAssets()` is the underlying currently held by the vault
+
+Live pricing:
+
+- `liveStrategyAssets()` is the strategy's current mark-to-market value
+- hosted `totalAssets()` is priced as:
+  `idleAssets() + liveStrategyAssets()`
+
+Operationally:
+
+- after deploys, book value stays constant and debt increases
+- after manager pulls, syncs, or emergency exit, realized profit or loss is
+  written into `totalManagedAssets()` and `strategyDebt()` is updated to the
+  post-operation live strategy assets
+- when no strategy is configured or debt is zero, hosted pricing collapses back
+  to idle vault assets
+
+This means the hosted vault uses live strategy pricing for ERC-4626 conversions
+while still keeping explicit book accounting for deployed debt.
+
+## User-Facing Withdraw And Redeem Semantics
+
+`withdraw(assets)` and `redeem(shares)` remain core-facet entrypoints, but they
+are strategy-aware.
+
+### `withdraw(assets)`
+
+- exact-assets semantics are preserved
+- if idle vault assets are insufficient, the core facet automatically pulls
+  immediately withdrawable strategy liquidity
+- if the requested assets still cannot be sourced after realizing any loss, the
+  call reverts
+
+### `redeem(shares)`
+
+- exact-shares semantics are preserved
+- the vault burns the requested shares and returns the current post-loss asset
+  value of those shares
+- if strategy liquidity must be sourced first, the vault pulls it before final
+  asset calculation and transfer
+
+### `max*` Helpers
+
+- `maxDeposit()` and `maxMint()` remain strategy-aware through live `totalAssets()`
+  pricing and limit shaping
+- `maxWithdraw()` and `maxRedeem()` are bounded by immediate liquidity, not by
+  total mark-to-market assets alone
+- `maxWithdraw()` and `maxRedeem()` are zero when `totalAssets() == 0`, even if
+  residual dust shares still exist after a full loss event
 
 ## Selector Ownership Model
 
 For the supported hosted vault deployment:
 
 - `diamondCut` is owned by `DiamondCutFacet`
-- loupe and ownership-introspection selectors are owned by
-  `DiamondLoupeFacet`
+- loupe and ownership-introspection selectors are owned by `DiamondLoupeFacet`
 - core selectors are owned by `ERC4626VaultFacet`
 - controls selectors and `supportsInterface(bytes4)` are owned by
   `ERC4626VaultControlsFacet`
@@ -164,7 +262,7 @@ One important implication:
 
 ## Storage And Upgrade Assumptions
 
-Hosted vault state lives in the diamond, not in the facet bytecode.
+Hosted vault state lives in the diamond, not in facet bytecode.
 
 Supported replace/remove/re-add flows assume:
 
@@ -176,7 +274,8 @@ Current hardening coverage explicitly validates persistence for:
 
 - vault metadata and ERC-4626/share-token state
 - fee config, limit config, roles, role windows, and pause state
-- oracle adapter, strategy reference, and reported strategy assets
+- oracle adapter, strategy address, strategy debt, live strategy assets, and
+  emergency-exit state
 
 ## Deployment References
 
@@ -184,21 +283,20 @@ Reference local deployment flow:
 
 - `script/DeployDiamondVaultHost.s.sol`
 
-Reference local artifact:
-
-- `deployments/diamond-vault.local.json`
-
-The reference deployment:
-
-- installs loupe, core, controls, and integration selectors
-- initializes the vault through the core facet
-- wires the oracle adapter through the integration facet
-- leaves `strategy == address(0)` and `strategyReportedAssets == 0`
-
-## Validation References
-
-The hosted vault model is covered by:
+Reference deployment-backed validation:
 
 - `test/DiamondVaultDeploymentIntegration.t.sol`
+- `test/ERC4626VaultIntegrationFacetCore.t.sol`
+- `test/ERC4626VaultStrategyAccountingCore.t.sol`
+- `test/VaultStrategyFoundationCore.t.sol`
 - `test/DiamondVaultHostHardening.t.sol`
 - `test/DiamondVaultHostInvariant.t.sol`
+
+## Out Of Scope
+
+The current hosted strategy model does not include:
+
+- multi-strategy allocation
+- async or queued withdrawals
+- automatic harvest or keeper-driven execution
+- extension-standard work deferred to `#24 Advanced Extensions`

--- a/script/DeployDiamondVaultHost.s.sol
+++ b/script/DeployDiamondVaultHost.s.sol
@@ -11,6 +11,7 @@ import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol
 import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControlsFacet.sol";
 import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
 import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
+import {IERC4626VaultStrategy} from "../src/interfaces/IERC4626VaultStrategy.sol";
 import {IOracleAdapter} from "../src/interfaces/IOracleAdapter.sol";
 import {ERC4626VaultControlsFacet} from "../src/vault/facets/ERC4626VaultControlsFacet.sol";
 import {ERC4626VaultFacet} from "../src/vault/facets/ERC4626VaultFacet.sol";
@@ -18,6 +19,7 @@ import {ERC4626VaultIntegrationFacet} from "../src/vault/facets/ERC4626VaultInte
 import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {DiamondVaultHostScriptBase} from "./common/DiamondVaultHostScriptBase.sol";
 import {
+    LocalHappyPathVaultStrategy,
     LocalMintableVaultAsset,
     LocalMockOracleFeed,
     LocalOracleAdapterHarness
@@ -36,6 +38,7 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
         address vaultAssetAddress;
         address oracleFeedAddress;
         address oracleAdapterAddress;
+        address strategyAddress;
     }
 
     string internal constant VAULT_OBJECT = "diamondVaultHost";
@@ -68,6 +71,7 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
         IERC4626VaultFacet(state.diamondAddress)
             .initializeVault(state.vaultAssetAddress, VAULT_NAME, VAULT_SYMBOL, owner);
         IERC4626VaultIntegrationFacet(state.diamondAddress).setOracleAdapter(state.oracleAdapterAddress);
+        IERC4626VaultIntegrationFacet(state.diamondAddress).setStrategy(state.strategyAddress);
 
         VM.stopBroadcast();
 
@@ -85,9 +89,12 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
                 vaultAsset: state.vaultAssetAddress,
                 oracleFeed: state.oracleFeedAddress,
                 oracleAdapter: state.oracleAdapterAddress,
-                strategy: address(0),
+                strategy: state.strategyAddress,
                 owner: owner,
                 chainId: block.chainid,
+                strategyDebt: 0,
+                liveStrategyAssets: 0,
+                strategyEmergencyExit: false,
                 vaultName: VAULT_NAME,
                 vaultSymbol: VAULT_SYMBOL
             })
@@ -110,6 +117,7 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
         state.oracleFeedAddress = address(new LocalMockOracleFeed(ORACLE_DECIMALS, ORACLE_ANSWER, block.timestamp - 1));
         state.oracleAdapterAddress =
             address(new LocalOracleAdapterHarness(owner, state.oracleFeedAddress, MAX_STALENESS));
+        state.strategyAddress = address(new LocalHappyPathVaultStrategy(state.diamondAddress, state.vaultAssetAddress));
         return state;
     }
 
@@ -140,6 +148,7 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
         IERC4626VaultFacet vaultCore = IERC4626VaultFacet(state.diamondAddress);
         IERC4626VaultControlsFacet vaultControls = IERC4626VaultControlsFacet(state.diamondAddress);
         IERC4626VaultIntegrationFacet vaultIntegration = IERC4626VaultIntegrationFacet(state.diamondAddress);
+        IERC4626VaultStrategy strategy = IERC4626VaultStrategy(state.strategyAddress);
         address[] memory facetAddresses = loupe.facetAddresses();
 
         require(facetAddresses.length == 5, "vault host facet count mismatch");
@@ -185,9 +194,12 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
         require(feeRecipient == owner, "vault fee recipient mismatch");
 
         require(vaultIntegration.oracleAdapter() == state.oracleAdapterAddress, "vault oracle adapter mismatch");
-        require(vaultIntegration.strategy() == address(0), "vault strategy should be unset");
+        require(vaultIntegration.strategy() == state.strategyAddress, "vault strategy mismatch");
         require(vaultIntegration.strategyDebt() == 0, "vault strategy debt should be zero");
+        require(!vaultIntegration.strategyEmergencyExit(), "vault emergency exit should be inactive");
         require(vaultIntegration.liveStrategyAssets() == 0, "vault live strategy assets should be zero");
+        require(strategy.vault() == state.diamondAddress, "strategy vault binding mismatch");
+        require(strategy.asset() == state.vaultAssetAddress, "strategy asset binding mismatch");
 
         IOracleAdapter.OracleQuote memory quotePayload = vaultIntegration.oracleQuote();
         require(quotePayload.value == ORACLE_ANSWER, "vault quote value mismatch");
@@ -223,6 +235,12 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
             IERC4626VaultIntegrationFacet.oracleAdapter.selector,
             state.vaultIntegrationFacetAddress,
             "vault oracle owner"
+        );
+        _requireSelectorOwner(
+            loupe,
+            IERC4626VaultIntegrationFacet.deployToStrategy.selector,
+            state.vaultIntegrationFacetAddress,
+            "vault deploy strategy owner"
         );
         _requireSelectorOwner(
             loupe, IERC165.supportsInterface.selector, state.vaultControlsFacetAddress, "vault erc165 owner"

--- a/script/DeployDiamondVaultHost.s.sol
+++ b/script/DeployDiamondVaultHost.s.sol
@@ -186,7 +186,8 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
 
         require(vaultIntegration.oracleAdapter() == state.oracleAdapterAddress, "vault oracle adapter mismatch");
         require(vaultIntegration.strategy() == address(0), "vault strategy should be unset");
-        require(vaultIntegration.strategyReportedAssets() == 0, "vault reported assets should be zero");
+        require(vaultIntegration.strategyDebt() == 0, "vault strategy debt should be zero");
+        require(vaultIntegration.liveStrategyAssets() == 0, "vault live strategy assets should be zero");
 
         IOracleAdapter.OracleQuote memory quotePayload = vaultIntegration.oracleQuote();
         require(quotePayload.value == ORACLE_ANSWER, "vault quote value mismatch");

--- a/script/common/DiamondVaultHostScriptBase.sol
+++ b/script/common/DiamondVaultHostScriptBase.sol
@@ -26,6 +26,9 @@ abstract contract DiamondVaultHostScriptBase is DiamondCoreScriptBase {
         address strategy;
         address owner;
         uint256 chainId;
+        uint256 strategyDebt;
+        uint256 liveStrategyAssets;
+        bool strategyEmergencyExit;
         string vaultName;
         string vaultSymbol;
     }
@@ -89,6 +92,9 @@ abstract contract DiamondVaultHostScriptBase is DiamondCoreScriptBase {
         json = VM.serializeAddress(objectKey, "oracleFeed", artifact.oracleFeed);
         json = VM.serializeAddress(objectKey, "oracleAdapter", artifact.oracleAdapter);
         json = VM.serializeAddress(objectKey, "strategy", artifact.strategy);
+        json = VM.serializeUint(objectKey, "strategyDebt", artifact.strategyDebt);
+        json = VM.serializeUint(objectKey, "liveStrategyAssets", artifact.liveStrategyAssets);
+        json = VM.serializeBool(objectKey, "strategyEmergencyExit", artifact.strategyEmergencyExit);
         json = VM.serializeString(objectKey, "vaultName", artifact.vaultName);
         json = VM.serializeString(objectKey, "vaultSymbol", artifact.vaultSymbol);
         VM.writeJson(json, string.concat(VM.projectRoot(), outputRelativePath));

--- a/script/common/Vm.sol
+++ b/script/common/Vm.sol
@@ -18,6 +18,9 @@ interface Vm {
     function serializeUint(string calldata objectKey, string calldata valueKey, uint256 value)
         external
         returns (string memory);
+    function serializeBool(string calldata objectKey, string calldata valueKey, bool value)
+        external
+        returns (string memory);
     function startBroadcast(uint256 privateKey) external;
     function stopBroadcast() external;
     function writeJson(string calldata json, string calldata path) external;

--- a/script/mocks/LocalVaultDeploymentMocks.sol
+++ b/script/mocks/LocalVaultDeploymentMocks.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.30;
 
 import {IERC20Metadata} from "../../src/interfaces/IERC20Metadata.sol";
 import {IOracleFeed} from "../../src/interfaces/IOracleFeed.sol";
+import {IERC4626VaultStrategy} from "../../src/interfaces/IERC4626VaultStrategy.sol";
 import {OracleAdapter} from "../../src/oracle/OracleAdapter.sol";
 
 /// @title LocalMintableVaultAsset
@@ -126,6 +127,72 @@ contract LocalMockOracleFeed is IOracleFeed {
         returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
     {
         return (_roundId, _answer, _updatedAt, _updatedAt, _answeredInRound);
+    }
+}
+
+/// @title LocalHappyPathVaultStrategy
+/// @notice Simple vault-bound, asset-bound strategy used for local hosted-vault deployment and smoke flows.
+contract LocalHappyPathVaultStrategy is IERC4626VaultStrategy {
+    address internal immutable VAULT;
+    address internal immutable ASSET;
+    uint256 internal _trackedAssets;
+
+    constructor(address vault_, address asset_) {
+        VAULT = vault_;
+        ASSET = asset_;
+    }
+
+    modifier onlyVault() {
+        if (msg.sender != VAULT) {
+            revert ERC4626VaultStrategyOnlyVault(msg.sender, VAULT);
+        }
+        _;
+    }
+
+    function vault() external view returns (address) {
+        return VAULT;
+    }
+
+    function asset() external view returns (address) {
+        return ASSET;
+    }
+
+    function totalAssets() external view returns (uint256) {
+        return _trackedAssets;
+    }
+
+    function maxWithdrawableAssets() external view returns (uint256) {
+        return _trackedAssets;
+    }
+
+    function deployFunds(uint256 assets) external onlyVault {
+        _trackedAssets += assets;
+        require(LocalMintableVaultAsset(ASSET).balanceOf(address(this)) >= _trackedAssets, "STRATEGY_UNDERFUNDED");
+    }
+
+    function withdrawToVault(uint256 assets) external onlyVault returns (uint256 assetsReturned) {
+        assetsReturned = assets > _trackedAssets ? _trackedAssets : assets;
+        _trackedAssets -= assetsReturned;
+        if (assetsReturned != 0) {
+            require(LocalMintableVaultAsset(ASSET).transfer(VAULT, assetsReturned), "STRATEGY_TRANSFER_FAILED");
+        }
+    }
+
+    function withdrawAllToVault() external onlyVault returns (uint256 assetsReturned) {
+        assetsReturned = _trackedAssets;
+        _trackedAssets = 0;
+        if (assetsReturned != 0) {
+            require(LocalMintableVaultAsset(ASSET).transfer(VAULT, assetsReturned), "STRATEGY_TRANSFER_FAILED");
+        }
+    }
+
+    function injectProfit(uint256 assets) external {
+        if (assets == 0) {
+            return;
+        }
+
+        LocalMintableVaultAsset(ASSET).mint(address(this), assets);
+        _trackedAssets += assets;
     }
 }
 

--- a/scripts/auralis-activity.sh
+++ b/scripts/auralis-activity.sh
@@ -11,6 +11,7 @@ erc721_diamond="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" erc721Host.diamond
 vault_diamond="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.diamond)"
 vault_asset="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.vaultAsset)"
 oracle_feed="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.oracleFeed)"
+strategy="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.strategy)"
 
 now_ts="$(date +%s)"
 
@@ -30,40 +31,48 @@ cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_
 cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_ALICE_PRIVATE_KEY}" \
   "${erc721_diamond}" "transferFrom(address,address,uint256)" "${AURALIS_OWNER_ADDRESS}" "${AURALIS_ALICE_ADDRESS}" 2 >/dev/null
 
-auralis_note "Generating vault flow activity"
+auralis_note "Generating vault and strategy activity"
 cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
   "${vault_asset}" "mint(address,uint256)" "${AURALIS_ALICE_ADDRESS}" 4000000000 >/dev/null
 cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_ALICE_PRIVATE_KEY}" \
   "${vault_asset}" "approve(address,uint256)" "${vault_diamond}" 4000000000 >/dev/null
 cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_ALICE_PRIVATE_KEY}" \
   "${vault_diamond}" "deposit(uint256,address)(uint256)" 1250000000 "${AURALIS_ALICE_ADDRESS}" >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${vault_diamond}" "deployToStrategy(uint256)" 750000000 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${strategy}" "injectProfit(uint256)" 125000000 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${vault_diamond}" "syncStrategyAssets()" >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${vault_diamond}" "withdrawFromStrategy(uint256)(uint256)" 200000000 >/dev/null
 cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_ALICE_PRIVATE_KEY}" \
   "${vault_diamond}" "transfer(address,uint256)" "${AURALIS_OWNER_ADDRESS}" 250000000 >/dev/null
 cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
   "${vault_diamond}" "redeem(uint256,address,address)(uint256)" 100000000 "${AURALIS_OWNER_ADDRESS}" "${AURALIS_OWNER_ADDRESS}" >/dev/null
 
-auralis_note "Updating oracle and strategy reporting"
+auralis_note "Updating oracle and pause state"
 cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
   "${oracle_feed}" "setRoundData(int256,uint256)" 102000000 "${now_ts}" >/dev/null
-cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
-  "${vault_diamond}" "setStrategy(address)" "${AURALIS_ALICE_ADDRESS}" >/dev/null
-cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_ALICE_PRIVATE_KEY}" \
-  "${vault_diamond}" "reportStrategyAssets(uint256)" 275000000 >/dev/null
-
-auralis_note "Toggling global pause state"
 cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
   "${vault_diamond}" "pause()" >/dev/null
 cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
   "${vault_diamond}" "unpause()" >/dev/null
 
-estimated_assets="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "estimatedTotalManagedAssets()(uint256)" | awk '{print $1}')"
+idle_assets="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "idleAssets()(uint256)" | awk '{print $1}')"
+strategy_debt="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "strategyDebt()(uint256)" | awk '{print $1}')"
+live_strategy_assets="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "liveStrategyAssets()(uint256)" | awk '{print $1}')"
+total_assets="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "totalAssets()(uint256)" | awk '{print $1}')"
 quote_tuple="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "oracleQuote()((int256,uint64,uint8))")"
 
 cat <<MSG
 Auralis simulated activity complete.
 
-Estimated managed assets: ${estimated_assets}
+Idle assets: ${idle_assets}
+Strategy debt: ${strategy_debt}
+Live strategy assets: ${live_strategy_assets}
+Total assets: ${total_assets}
 Oracle quote tuple: ${quote_tuple}
 
-The local chain now has representative token, NFT, vault, oracle, and strategy-report activity.
+The local chain now has representative token, NFT, vault, oracle, and live strategy lifecycle activity.
 MSG

--- a/scripts/auralis-smoke.sh
+++ b/scripts/auralis-smoke.sh
@@ -11,8 +11,9 @@ erc721_diamond="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" erc721Host.diamond
 vault_diamond="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.diamond)"
 vault_asset="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.vaultAsset)"
 oracle_adapter="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.oracleAdapter)"
+strategy="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.strategy)"
 
-for address in "${erc20_diamond}" "${erc721_diamond}" "${vault_diamond}" "${vault_asset}" "${oracle_adapter}"; do
+for address in "${erc20_diamond}" "${erc721_diamond}" "${vault_diamond}" "${vault_asset}" "${oracle_adapter}" "${strategy}"; do
   code="$(cast code --rpc-url "${AURALIS_RPC_URL}" "${address}")"
   if [[ "${code}" == "0x" ]]; then
     echo "Expected deployed code at ${address}, found empty code." >&2
@@ -42,20 +43,45 @@ if [[ "${nft_owner,,}" != "${AURALIS_OWNER_ADDRESS,,}" ]]; then
   exit 1
 fi
 
-auralis_note "Vault host smoke: deposit, quote, and withdraw"
+auralis_note "Vault host smoke: strategy-enabled lifecycle"
 cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
   "${vault_asset}" "mint(address,uint256)" "${AURALIS_ALICE_ADDRESS}" 1500000000 >/dev/null
 cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_ALICE_PRIVATE_KEY}" \
   "${vault_asset}" "approve(address,uint256)" "${vault_diamond}" 1500000000 >/dev/null
 cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_ALICE_PRIVATE_KEY}" \
   "${vault_diamond}" "deposit(uint256,address)(uint256)" 1000000000 "${AURALIS_ALICE_ADDRESS}" >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${vault_diamond}" "deployToStrategy(uint256)" 600000000 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${strategy}" "injectProfit(uint256)" 100000000 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${vault_diamond}" "syncStrategyAssets()" >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${vault_diamond}" "withdrawFromStrategy(uint256)(uint256)" 150000000 >/dev/null
 cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_ALICE_PRIVATE_KEY}" \
-  "${vault_diamond}" "withdraw(uint256,address,address)(uint256)" 250000000 "${AURALIS_ALICE_ADDRESS}" "${AURALIS_ALICE_ADDRESS}" >/dev/null
-shares_after="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "balanceOf(address)(uint256)" "${AURALIS_ALICE_ADDRESS}" | awk '{print $1}')"
-if [[ "${shares_after}" != "750000000" ]]; then
-  echo "Unexpected vault share balance after smoke flow: ${shares_after}" >&2
+  "${vault_diamond}" "withdraw(uint256,address,address)(uint256)" 700000000 "${AURALIS_ALICE_ADDRESS}" "${AURALIS_ALICE_ADDRESS}" >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${vault_diamond}" "emergencyExitStrategy()(uint256)" >/dev/null
+
+strategy_debt="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "strategyDebt()(uint256)" | awk '{print $1}')"
+strategy_exit="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "strategyEmergencyExit()(bool)")"
+if [[ "${strategy_debt}" != "0" || "${strategy_exit}" != "true" ]]; then
+  echo "Unexpected strategy state after emergency exit: debt=${strategy_debt}, emergency=${strategy_exit}" >&2
   exit 1
 fi
+
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${vault_diamond}" "setStrategy(address)" 0x0000000000000000000000000000000000000000 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${vault_diamond}" "setStrategy(address)" "${strategy}" >/dev/null
+
+strategy_rebound="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "strategy()(address)")"
+strategy_exit="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "strategyEmergencyExit()(bool)")"
+if [[ "${strategy_rebound,,}" != "${strategy,,}" || "${strategy_exit}" != "false" ]]; then
+  echo "Strategy was not rebound cleanly after smoke flow." >&2
+  exit 1
+fi
+
 quote_tuple="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "oracleQuote()((int256,uint64,uint8))")"
 if [[ -z "${quote_tuple}" ]]; then
   echo "oracleQuote() returned empty output." >&2

--- a/scripts/auralis-up.sh
+++ b/scripts/auralis-up.sh
@@ -22,7 +22,7 @@ auralis_note "Deploying ERC721 host"
   forge script script/DeployDiamondErc721Host.s.sol:DeployDiamondErc721HostScript --rpc-url "${AURALIS_RPC_URL}" --broadcast
 )
 
-auralis_note "Deploying vault host"
+auralis_note "Deploying strategy-enabled vault host"
 (
   cd "${AURALIS_ROOT}"
   forge script script/DeployDiamondVaultHost.s.sol:DeployDiamondVaultHostScript --rpc-url "${AURALIS_RPC_URL}" --broadcast
@@ -31,6 +31,8 @@ auralis_note "Deploying vault host"
 auralis_note "Writing unified Auralis artifact"
 auralis_write_unified_artifact
 
+vault_strategy="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.strategy)"
+
 cat <<MSG
 Auralis local environment is ready.
 
@@ -38,6 +40,7 @@ RPC: ${AURALIS_RPC_URL}
 Artifact: ${AURALIS_ARTIFACT_PATH}
 Owner: ${AURALIS_OWNER_ADDRESS}
 Alice: ${AURALIS_ALICE_ADDRESS}
+Vault strategy: ${vault_strategy}
 
 Next steps:
 - bash scripts/auralis-smoke.sh

--- a/src/interfaces/IERC4626VaultIntegrationFacet.sol
+++ b/src/interfaces/IERC4626VaultIntegrationFacet.sol
@@ -5,7 +5,7 @@ import {IERC165} from "./IERC165.sol";
 import {IOracleAdapter} from "./IOracleAdapter.sol";
 
 /// @title IERC4626VaultIntegrationFacet
-/// @notice Hosted integration/config surface for vault oracle and strategy wiring.
+/// @notice Hosted integration/config surface for vault oracle wiring and active strategy lifecycle management.
 interface IERC4626VaultIntegrationFacet is IERC165 {
     /// @notice Emitted when the configured oracle adapter is updated.
     event VaultOracleAdapterUpdated(
@@ -15,16 +15,46 @@ interface IERC4626VaultIntegrationFacet is IERC165 {
     /// @notice Emitted when the configured strategy address is updated.
     event VaultStrategyUpdated(address indexed previousStrategy, address indexed newStrategy, address indexed sender);
 
-    /// @notice Emitted when reported strategy assets are updated.
-    event VaultStrategyAssetsReported(uint256 previousAssets, uint256 newAssets, address indexed sender);
+    /// @notice Emitted when assets are deployed from the vault into the configured strategy.
+    event VaultStrategyDeployed(uint256 assets, uint256 newStrategyDebt, address indexed sender);
+
+    /// @notice Emitted when assets are withdrawn from the configured strategy back to the vault.
+    event VaultStrategyWithdrawn(uint256 assets, uint256 newStrategyDebt, address indexed sender);
+
+    /// @notice Emitted when live strategy assets are synced into vault book accounting.
+    event VaultStrategySynced(uint256 previousDebt, uint256 liveAssets, address indexed sender);
 
     /// @notice Thrown when `oracleQuote()` is called without a configured adapter.
     error ERC4626VaultOracleAdapterNotConfigured();
 
-    /// @notice Thrown when `reportStrategyAssets()` is called by an unauthorized account.
-    /// @param caller The unauthorized caller.
-    /// @param strategy The currently configured strategy address.
-    error ERC4626VaultStrategyReporterUnauthorized(address caller, address strategy);
+    /// @notice Thrown when a strategy lifecycle action is attempted without a configured strategy.
+    error ERC4626VaultStrategyNotConfigured();
+
+    /// @notice Thrown when a strategy clear/swap is attempted while debt is still outstanding.
+    /// @param strategyDebt The current outstanding strategy debt.
+    error ERC4626VaultStrategyDebtOutstanding(uint256 strategyDebt);
+
+    /// @notice Thrown when a configured strategy is bound to a different vault.
+    /// @param strategy The invalid strategy address.
+    /// @param expectedVault The expected vault address.
+    /// @param actualVault The strategy-reported bound vault address.
+    error ERC4626VaultStrategyInvalidVault(address strategy, address expectedVault, address actualVault);
+
+    /// @notice Thrown when a configured strategy is bound to a different asset.
+    /// @param strategy The invalid strategy address.
+    /// @param expectedAsset The expected asset address.
+    /// @param actualAsset The strategy-reported bound asset address.
+    error ERC4626VaultStrategyInvalidAsset(address strategy, address expectedAsset, address actualAsset);
+
+    /// @notice Thrown when a deploy attempt exceeds the vault's immediately idle assets.
+    /// @param requestedAssets The requested deployment amount.
+    /// @param idleAssets The vault's immediately available idle asset amount.
+    error ERC4626VaultStrategyInsufficientIdleAssets(uint256 requestedAssets, uint256 idleAssets);
+
+    /// @notice Thrown when a strategy withdrawal returns less than requested in the happy-path lifecycle surface.
+    /// @param requestedAssets The requested withdrawal amount.
+    /// @param returnedAssets The actual returned amount.
+    error ERC4626VaultStrategyUnexpectedWithdrawResult(uint256 requestedAssets, uint256 returnedAssets);
 
     /// @notice Returns the configured external oracle adapter address.
     /// @return The adapter address, or zero when unset.
@@ -34,17 +64,17 @@ interface IERC4626VaultIntegrationFacet is IERC165 {
     /// @return The strategy address, or zero when unset.
     function strategy() external view returns (address);
 
-    /// @notice Returns the latest reported strategy-held asset amount.
-    /// @return The reported asset amount.
-    function strategyReportedAssets() external view returns (uint256);
+    /// @notice Returns the vault's current stored book debt allocated to the configured strategy.
+    /// @return The strategy debt amount.
+    function strategyDebt() external view returns (uint256);
 
     /// @notice Returns the vault's idle underlying asset balance.
     /// @return The idle asset amount held directly by the vault.
     function idleAssets() external view returns (uint256);
 
-    /// @notice Returns idle assets plus the latest reported strategy assets.
-    /// @return The estimated total assets across idle vault balance and strategy reports.
-    function estimatedTotalManagedAssets() external view returns (uint256);
+    /// @notice Returns the configured strategy's live reported assets.
+    /// @return The live strategy asset amount, or zero when no strategy is configured.
+    function liveStrategyAssets() external view returns (uint256);
 
     /// @notice Returns the latest normalized quote from the configured oracle adapter.
     /// @return quotePayload The latest quote payload.
@@ -58,7 +88,14 @@ interface IERC4626VaultIntegrationFacet is IERC165 {
     /// @param newStrategy The new strategy address, or zero to clear.
     function setStrategy(address newStrategy) external;
 
-    /// @notice Updates the latest reported strategy-held asset amount.
-    /// @param assets The latest reported asset amount.
-    function reportStrategyAssets(uint256 assets) external;
+    /// @notice Deploys idle vault assets into the configured strategy.
+    /// @param assets The asset amount to deploy.
+    function deployToStrategy(uint256 assets) external;
+
+    /// @notice Withdraws assets from the configured strategy back to the vault.
+    /// @param assets The asset amount to withdraw.
+    function withdrawFromStrategy(uint256 assets) external;
+
+    /// @notice Syncs live strategy assets into vault book accounting.
+    function syncStrategyAssets() external;
 }

--- a/src/interfaces/IERC4626VaultIntegrationFacet.sol
+++ b/src/interfaces/IERC4626VaultIntegrationFacet.sol
@@ -19,10 +19,18 @@ interface IERC4626VaultIntegrationFacet is IERC165 {
     event VaultStrategyDeployed(uint256 assets, uint256 newStrategyDebt, address indexed sender);
 
     /// @notice Emitted when assets are withdrawn from the configured strategy back to the vault.
-    event VaultStrategyWithdrawn(uint256 assets, uint256 newStrategyDebt, address indexed sender);
+    event VaultStrategyWithdrawn(
+        uint256 requestedAssets, uint256 returnedAssets, uint256 newStrategyDebt, address indexed sender
+    );
 
     /// @notice Emitted when live strategy assets are synced into vault book accounting.
     event VaultStrategySynced(uint256 previousDebt, uint256 liveAssets, address indexed sender);
+
+    /// @notice Emitted when emergency exit is triggered and the strategy is unwound as far as possible.
+    event VaultStrategyEmergencyExitTriggered(uint256 returnedAssets, uint256 newStrategyDebt, address indexed sender);
+
+    /// @notice Emitted when emergency exit is activated but the unwind attempt reverts.
+    event VaultStrategyEmergencyExitFailed(address indexed strategy, address indexed sender, bytes revertData);
 
     /// @notice Thrown when `oracleQuote()` is called without a configured adapter.
     error ERC4626VaultOracleAdapterNotConfigured();
@@ -51,10 +59,8 @@ interface IERC4626VaultIntegrationFacet is IERC165 {
     /// @param idleAssets The vault's immediately available idle asset amount.
     error ERC4626VaultStrategyInsufficientIdleAssets(uint256 requestedAssets, uint256 idleAssets);
 
-    /// @notice Thrown when a strategy withdrawal returns less than requested in the happy-path lifecycle surface.
-    /// @param requestedAssets The requested withdrawal amount.
-    /// @param returnedAssets The actual returned amount.
-    error ERC4626VaultStrategyUnexpectedWithdrawResult(uint256 requestedAssets, uint256 returnedAssets);
+    /// @notice Thrown when a strategy deploy is attempted after emergency exit has been activated.
+    error ERC4626VaultStrategyEmergencyExitActive();
 
     /// @notice Returns the configured external oracle adapter address.
     /// @return The adapter address, or zero when unset.
@@ -63,6 +69,10 @@ interface IERC4626VaultIntegrationFacet is IERC165 {
     /// @notice Returns the configured strategy address.
     /// @return The strategy address, or zero when unset.
     function strategy() external view returns (address);
+
+    /// @notice Returns true when the current strategy is in emergency-exit mode.
+    /// @return True when emergency exit is active.
+    function strategyEmergencyExit() external view returns (bool);
 
     /// @notice Returns the vault's current stored book debt allocated to the configured strategy.
     /// @return The strategy debt amount.
@@ -93,9 +103,14 @@ interface IERC4626VaultIntegrationFacet is IERC165 {
     function deployToStrategy(uint256 assets) external;
 
     /// @notice Withdraws assets from the configured strategy back to the vault.
-    /// @param assets The asset amount to withdraw.
-    function withdrawFromStrategy(uint256 assets) external;
+    /// @param assets The requested asset amount to withdraw.
+    /// @return assetsReturned The actual returned asset amount.
+    function withdrawFromStrategy(uint256 assets) external returns (uint256 assetsReturned);
 
     /// @notice Syncs live strategy assets into vault book accounting.
     function syncStrategyAssets() external;
+
+    /// @notice Activates emergency-exit mode and attempts to unwind the configured strategy.
+    /// @return assetsReturned The actual returned asset amount from the unwind attempt.
+    function emergencyExitStrategy() external returns (uint256 assetsReturned);
 }

--- a/src/interfaces/IERC4626VaultStrategy.sol
+++ b/src/interfaces/IERC4626VaultStrategy.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title IERC4626VaultStrategy
+/// @notice Canonical single-vault, single-asset strategy interface for hosted vaults.
+interface IERC4626VaultStrategy {
+    /// @notice Thrown when a non-vault caller invokes a vault-only strategy action.
+    /// @param caller The unauthorized caller.
+    /// @param vault The bound vault address.
+    error ERC4626VaultStrategyOnlyVault(address caller, address vault);
+
+    /// @notice Returns the vault this strategy is bound to.
+    /// @return The vault address.
+    function vault() external view returns (address);
+
+    /// @notice Returns the underlying asset this strategy manages.
+    /// @return The asset address.
+    function asset() external view returns (address);
+
+    /// @notice Returns the strategy's total tracked assets.
+    /// @return The total tracked asset amount.
+    function totalAssets() external view returns (uint256);
+
+    /// @notice Returns the strategy's currently withdrawable asset amount.
+    /// @return The maximum assets that can be returned immediately.
+    function maxWithdrawableAssets() external view returns (uint256);
+
+    /// @notice Deploys `assets` from the bound vault into the strategy.
+    /// @param assets The asset amount to deploy.
+    function deployFunds(uint256 assets) external;
+
+    /// @notice Returns up to `assets` back to the bound vault.
+    /// @param assets The requested asset amount.
+    /// @return assetsReturned The actual returned asset amount.
+    function withdrawToVault(uint256 assets) external returns (uint256 assetsReturned);
+
+    /// @notice Fully unwinds strategy assets back to the bound vault.
+    /// @return assetsReturned The actual returned asset amount.
+    function withdrawAllToVault() external returns (uint256 assetsReturned);
+}

--- a/src/vault/ERC4626Vault.sol
+++ b/src/vault/ERC4626Vault.sol
@@ -26,7 +26,7 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
     /// @notice Returns total assets managed by the vault.
     /// @return The total managed asset amount.
     function totalAssets() public view virtual returns (uint256) {
-        return totalManagedAssets();
+        return _managedAssetsForPricing();
     }
 
     /// @notice Converts `assets` to shares, rounding down.

--- a/src/vault/ERC4626Vault.sol
+++ b/src/vault/ERC4626Vault.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.30;
 
 import {IERC20} from "../interfaces/IERC20.sol";
 import {IERC4626} from "../interfaces/IERC4626.sol";
+import {IERC4626VaultStrategy} from "../interfaces/IERC4626VaultStrategy.sol";
+import {LibERC4626VaultStorage} from "./storage/LibERC4626VaultStorage.sol";
 import {ERC4626VaultBase} from "./ERC4626VaultBase.sol";
 
 /// @title ERC4626Vault
@@ -16,6 +18,10 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
     error ERC4626VaultAssetTransferFailed();
     /// @notice Thrown when asset transferFrom fails.
     error ERC4626VaultAssetTransferFromFailed();
+    /// @notice Thrown when the vault cannot source enough immediate liquidity for a withdrawal flow.
+    /// @param requiredAssets The gross asset amount required.
+    /// @param availableAssets The currently sourced idle asset amount.
+    error ERC4626VaultInsufficientLiquidity(uint256 requiredAssets, uint256 availableAssets);
 
     /// @notice Returns vault underlying asset token address.
     /// @return The underlying asset token.
@@ -257,5 +263,76 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
         if (!success || (data.length != 0 && !abi.decode(data, (bool)))) {
             revert ERC4626VaultAssetTransferFromFailed();
         }
+    }
+
+    /// @dev Returns the vault's immediately idle asset balance.
+    function _idleAssetBalance() internal view returns (uint256) {
+        return IERC20(asset()).balanceOf(address(this));
+    }
+
+    /// @dev Returns the configured strategy's immediately withdrawable assets.
+    function _strategyWithdrawableAssets() internal view returns (uint256) {
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        if (layout.strategy == address(0) || layout.strategyDebt == 0) {
+            return 0;
+        }
+
+        IERC4626VaultStrategy configuredStrategy = IERC4626VaultStrategy(layout.strategy);
+        uint256 liveAssets = configuredStrategy.totalAssets();
+        uint256 withdrawableAssets = configuredStrategy.maxWithdrawableAssets();
+        return liveAssets < withdrawableAssets ? liveAssets : withdrawableAssets;
+    }
+
+    /// @dev Pulls assets from the configured strategy back to the vault.
+    function _withdrawStrategyAssets(uint256 assets)
+        internal
+        returns (uint256 returnedAssets, uint256 postCallLiveAssets)
+    {
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        IERC4626VaultStrategy configuredStrategy = IERC4626VaultStrategy(layout.strategy);
+        returnedAssets = configuredStrategy.withdrawToVault(assets);
+        postCallLiveAssets = configuredStrategy.totalAssets();
+    }
+
+    /// @dev Fully unwinds assets from the configured strategy back to the vault.
+    function _withdrawAllStrategyAssets() internal returns (uint256 returnedAssets, uint256 postCallLiveAssets) {
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        IERC4626VaultStrategy configuredStrategy = IERC4626VaultStrategy(layout.strategy);
+        returnedAssets = configuredStrategy.withdrawAllToVault();
+        postCallLiveAssets = configuredStrategy.totalAssets();
+    }
+
+    /// @dev Realizes strategy mark-to-market changes into book accounting without moving idle vault assets.
+    function _syncStrategyDebtToLiveAssets(uint256 liveAssets) internal returns (uint256 previousDebt) {
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        previousDebt = layout.strategyDebt;
+
+        if (liveAssets > previousDebt) {
+            _increaseManagedAssets(liveAssets - previousDebt);
+        } else if (previousDebt > liveAssets) {
+            _decreaseManagedAssets(previousDebt - liveAssets);
+        }
+
+        layout.strategyDebt = liveAssets;
+        layout.strategyReportedAssets = 0;
+    }
+
+    /// @dev Reconciles book accounting after a strategy withdrawal-like call that returned assets to the vault.
+    function _reconcileStrategyWithdrawalAccounting(uint256 returnedAssets, uint256 postCallLiveAssets)
+        internal
+        returns (uint256 previousDebt)
+    {
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        previousDebt = layout.strategyDebt;
+        uint256 combinedAssets = returnedAssets + postCallLiveAssets;
+
+        if (combinedAssets > previousDebt) {
+            _increaseManagedAssets(combinedAssets - previousDebt);
+        } else if (previousDebt > combinedAssets) {
+            _decreaseManagedAssets(previousDebt - combinedAssets);
+        }
+
+        layout.strategyDebt = postCallLiveAssets;
+        layout.strategyReportedAssets = 0;
     }
 }

--- a/src/vault/ERC4626Vault.sol
+++ b/src/vault/ERC4626Vault.sol
@@ -127,7 +127,7 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
     /// @param owner Share owner.
     /// @return Max withdrawable assets.
     function maxWithdraw(address owner) public view virtual returns (uint256) {
-        if (owner == address(0)) {
+        if (owner == address(0) || totalAssets() == 0) {
             return 0;
         }
         return _convertToAssets(balanceOf(owner), Rounding.Down);
@@ -173,7 +173,7 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
     /// @param owner Share owner.
     /// @return Max redeemable shares.
     function maxRedeem(address owner) public view virtual returns (uint256) {
-        if (owner == address(0)) {
+        if (owner == address(0) || totalAssets() == 0) {
             return 0;
         }
         return balanceOf(owner);

--- a/src/vault/ERC4626VaultBase.sol
+++ b/src/vault/ERC4626VaultBase.sol
@@ -212,7 +212,7 @@ abstract contract ERC4626VaultBase is IERC4626VaultBase {
     /// @return Share amount.
     function _convertToShares(uint256 assets, Rounding rounding) internal view returns (uint256) {
         LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
-        return _convertToShares(assets, layout.totalSupply, layout.totalManagedAssets, rounding);
+        return _convertToShares(assets, layout.totalSupply, _managedAssetsForPricing(), rounding);
     }
 
     /// @dev Converts `shares` to assets using current vault totals.
@@ -221,7 +221,13 @@ abstract contract ERC4626VaultBase is IERC4626VaultBase {
     /// @return Asset amount.
     function _convertToAssets(uint256 shares, Rounding rounding) internal view returns (uint256) {
         LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
-        return _convertToAssets(shares, layout.totalSupply, layout.totalManagedAssets, rounding);
+        return _convertToAssets(shares, layout.totalSupply, _managedAssetsForPricing(), rounding);
+    }
+
+    /// @dev Returns the managed assets amount used for ERC-4626 pricing views.
+    /// @return managedAssets The pricing asset amount.
+    function _managedAssetsForPricing() internal view virtual returns (uint256 managedAssets) {
+        return LibERC4626VaultStorage.layout().totalManagedAssets;
     }
 
     /// @dev Converts `assets` to shares using explicit totals.

--- a/src/vault/ERC4626VaultControlLogic.sol
+++ b/src/vault/ERC4626VaultControlLogic.sol
@@ -160,6 +160,11 @@ abstract contract ERC4626VaultControlledCore is ERC4626Vault {
         }
 
         uint256 grossAssets = _convertToAssets(balanceOf(owner), Rounding.Down);
+        uint256 liquidityCapAssets = _withdrawLiquidityCapAssets();
+        if (grossAssets > liquidityCapAssets) {
+            grossAssets = liquidityCapAssets;
+        }
+
         (uint256 netAssets,) = LibERC4626VaultControlLogic.withdrawNetFromGross(grossAssets);
 
         (,,, uint128 maxWithdraw_,) = LibERC4626VaultControlLogic.limitConfig();
@@ -176,6 +181,14 @@ abstract contract ERC4626VaultControlledCore is ERC4626Vault {
         }
 
         uint256 redeemableShares = balanceOf(owner);
+        uint256 liquidityCapAssets = _withdrawLiquidityCapAssets();
+        if (liquidityCapAssets != type(uint256).max) {
+            uint256 liquidityCappedShares = _convertToShares(liquidityCapAssets, Rounding.Down);
+            if (liquidityCappedShares < redeemableShares) {
+                redeemableShares = liquidityCappedShares;
+            }
+        }
+
         (,,,, uint128 maxRedeem_) = LibERC4626VaultControlLogic.limitConfig();
         if (maxRedeem_ != 0 && redeemableShares > maxRedeem_) {
             return maxRedeem_;
@@ -346,6 +359,10 @@ abstract contract ERC4626VaultControlledCore is ERC4626Vault {
         }
 
         _safeTransferAsset(LibERC4626VaultControlLogic.feeRecipient(), feeAssets);
+    }
+
+    function _withdrawLiquidityCapAssets() internal view virtual returns (uint256) {
+        return type(uint256).max;
     }
 
     function _vaultOperationsPaused() internal view virtual returns (bool);

--- a/src/vault/ERC4626VaultControlLogic.sol
+++ b/src/vault/ERC4626VaultControlLogic.sol
@@ -155,7 +155,7 @@ abstract contract ERC4626VaultControlledCore is ERC4626Vault {
     }
 
     function maxWithdraw(address owner) public view virtual override returns (uint256) {
-        if (owner == address(0) || _vaultOperationsPaused()) {
+        if (owner == address(0) || _vaultOperationsPaused() || totalAssets() == 0) {
             return 0;
         }
 
@@ -176,7 +176,7 @@ abstract contract ERC4626VaultControlledCore is ERC4626Vault {
     }
 
     function maxRedeem(address owner) public view virtual override returns (uint256) {
-        if (owner == address(0) || _vaultOperationsPaused()) {
+        if (owner == address(0) || _vaultOperationsPaused() || totalAssets() == 0) {
             return 0;
         }
 

--- a/src/vault/facets/ERC4626VaultFacet.sol
+++ b/src/vault/facets/ERC4626VaultFacet.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
-import {IERC20} from "../../interfaces/IERC20.sol";
 import {IERC4626} from "../../interfaces/IERC4626.sol";
+import {IERC4626VaultControls} from "../../interfaces/IERC4626VaultControls.sol";
 import {IERC4626VaultFacet} from "../../interfaces/IERC4626VaultFacet.sol";
 import {IERC4626VaultStrategy} from "../../interfaces/IERC4626VaultStrategy.sol";
 import {ERC4626Vault} from "../ERC4626Vault.sol";
 import {ERC4626VaultBase} from "../ERC4626VaultBase.sol";
-import {ERC4626VaultControlledCore} from "../ERC4626VaultControlLogic.sol";
+import {ERC4626VaultControlledCore, LibERC4626VaultControlLogic} from "../ERC4626VaultControlLogic.sol";
 import {VaultFacetControl} from "../VaultFacetControl.sol";
 import {LibERC4626VaultStorage} from "../storage/LibERC4626VaultStorage.sol";
 
@@ -95,7 +95,41 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
         nonReentrant
         returns (uint256 shares)
     {
-        return _withdrawWithControls(assets, receiver, owner);
+        _requireInitialized();
+        _requireNonZeroAddress(receiver);
+        _requireNonZeroAddress(owner);
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        (uint256 grossAssets, uint256 feeAssets) = LibERC4626VaultControlLogic.withdrawGrossFromNet(assets);
+        _sourceStrategyLiquidity(grossAssets);
+
+        uint256 maxAssets = maxWithdraw(owner);
+        if (assets > maxAssets) {
+            revert IERC4626VaultControls.ERC4626VaultWithdrawLimitExceeded(assets, maxAssets);
+        }
+
+        uint256 availableIdleAssets = _idleAssetBalance();
+        if (grossAssets > availableIdleAssets) {
+            revert ERC4626VaultInsufficientLiquidity(grossAssets, availableIdleAssets);
+        }
+
+        shares = _convertToShares(grossAssets, Rounding.Up);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        if (msg.sender != owner) {
+            _spendAllowance(owner, msg.sender, shares);
+        }
+
+        _burnShares(owner, shares);
+        _decreaseManagedAssets(grossAssets);
+        _safeTransferAsset(receiver, assets);
+        _payoutFee(feeAssets);
+
+        emit Withdraw(msg.sender, receiver, owner, assets, shares);
     }
 
     /// @notice Redeems `shares` from `owner` to `receiver`.
@@ -111,7 +145,45 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
         nonReentrant
         returns (uint256 assets)
     {
-        return _redeemWithControls(shares, receiver, owner);
+        _requireInitialized();
+        _requireNonZeroAddress(receiver);
+        _requireNonZeroAddress(owner);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        uint256 maxShares = maxRedeem(owner);
+        if (shares > maxShares) {
+            revert IERC4626VaultControls.ERC4626VaultRedeemLimitExceeded(shares, maxShares);
+        }
+
+        uint256 grossAssets = _convertToAssets(shares, Rounding.Down);
+        _sourceStrategyLiquidity(grossAssets);
+
+        grossAssets = _convertToAssets(shares, Rounding.Down);
+        _sourceStrategyLiquidity(grossAssets);
+
+        uint256 availableIdleAssets = _idleAssetBalance();
+        if (grossAssets > availableIdleAssets) {
+            revert ERC4626VaultInsufficientLiquidity(grossAssets, availableIdleAssets);
+        }
+
+        uint256 feeAssets;
+        (assets, feeAssets) = LibERC4626VaultControlLogic.withdrawNetFromGross(grossAssets);
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        if (msg.sender != owner) {
+            _spendAllowance(owner, msg.sender, shares);
+        }
+
+        _burnShares(owner, shares);
+        _decreaseManagedAssets(grossAssets);
+        _safeTransferAsset(receiver, assets);
+        _payoutFee(feeAssets);
+
+        emit Withdraw(msg.sender, receiver, owner, assets, shares);
     }
 
     function _managedAssetsForPricing() internal view virtual override returns (uint256) {
@@ -131,12 +203,44 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
             return type(uint256).max;
         }
 
-        uint256 idleBookAssets = layout.totalManagedAssets - layout.strategyDebt;
-        uint256 idleVaultAssets = IERC20(asset()).balanceOf(address(this));
-        return idleVaultAssets < idleBookAssets ? idleVaultAssets : idleBookAssets;
+        return _idleAssetBalance() + _strategyWithdrawableAssets();
     }
 
     function _vaultOperationsPaused() internal view virtual override returns (bool) {
         return paused();
+    }
+
+    function _sourceStrategyLiquidity(uint256 requiredGrossAssets) internal {
+        if (requiredGrossAssets == 0) {
+            return;
+        }
+
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        if (layout.strategy == address(0) || layout.strategyDebt == 0) {
+            return;
+        }
+
+        uint256 idleAssets = _idleAssetBalance();
+        while (idleAssets < requiredGrossAssets) {
+            uint256 strategyLiquidity = _strategyWithdrawableAssets();
+            if (strategyLiquidity == 0) {
+                break;
+            }
+
+            uint256 requestedAssets = requiredGrossAssets - idleAssets;
+            if (requestedAssets > strategyLiquidity) {
+                requestedAssets = strategyLiquidity;
+            }
+
+            (uint256 returnedAssets, uint256 postCallLiveAssets) = _withdrawStrategyAssets(requestedAssets);
+            _reconcileStrategyWithdrawalAccounting(returnedAssets, postCallLiveAssets);
+
+            uint256 nextIdleAssets = _idleAssetBalance();
+            if (nextIdleAssets <= idleAssets) {
+                break;
+            }
+
+            idleAssets = nextIdleAssets;
+        }
     }
 }

--- a/src/vault/facets/ERC4626VaultFacet.sol
+++ b/src/vault/facets/ERC4626VaultFacet.sol
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
+import {IERC20} from "../../interfaces/IERC20.sol";
 import {IERC4626} from "../../interfaces/IERC4626.sol";
 import {IERC4626VaultFacet} from "../../interfaces/IERC4626VaultFacet.sol";
+import {IERC4626VaultStrategy} from "../../interfaces/IERC4626VaultStrategy.sol";
 import {ERC4626Vault} from "../ERC4626Vault.sol";
 import {ERC4626VaultBase} from "../ERC4626VaultBase.sol";
 import {ERC4626VaultControlledCore} from "../ERC4626VaultControlLogic.sol";
 import {VaultFacetControl} from "../VaultFacetControl.sol";
+import {LibERC4626VaultStorage} from "../storage/LibERC4626VaultStorage.sol";
 
 /// @title ERC4626VaultFacet
 /// @notice Hosted ERC-4626 core facet with constructor-free initialization.
@@ -109,6 +112,28 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
         returns (uint256 assets)
     {
         return _redeemWithControls(shares, receiver, owner);
+    }
+
+    function _managedAssetsForPricing() internal view virtual override returns (uint256) {
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        if (layout.strategy == address(0) || layout.strategyDebt == 0) {
+            return layout.totalManagedAssets;
+        }
+
+        uint256 idleBookAssets = layout.totalManagedAssets - layout.strategyDebt;
+        uint256 liveStrategyAssets = IERC4626VaultStrategy(layout.strategy).totalAssets();
+        return idleBookAssets + liveStrategyAssets;
+    }
+
+    function _withdrawLiquidityCapAssets() internal view virtual override returns (uint256) {
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        if (layout.strategy == address(0) || layout.strategyDebt == 0) {
+            return type(uint256).max;
+        }
+
+        uint256 idleBookAssets = layout.totalManagedAssets - layout.strategyDebt;
+        uint256 idleVaultAssets = IERC20(asset()).balanceOf(address(this));
+        return idleVaultAssets < idleBookAssets ? idleVaultAssets : idleBookAssets;
     }
 
     function _vaultOperationsPaused() internal view virtual override returns (bool) {

--- a/src/vault/facets/ERC4626VaultIntegrationFacet.sol
+++ b/src/vault/facets/ERC4626VaultIntegrationFacet.sol
@@ -3,13 +3,14 @@ pragma solidity ^0.8.30;
 
 import {IERC20} from "../../interfaces/IERC20.sol";
 import {IERC4626VaultIntegrationFacet} from "../../interfaces/IERC4626VaultIntegrationFacet.sol";
+import {IERC4626VaultStrategy} from "../../interfaces/IERC4626VaultStrategy.sol";
 import {IOracleAdapter} from "../../interfaces/IOracleAdapter.sol";
 import {ERC4626Vault} from "../ERC4626Vault.sol";
 import {VaultFacetControl} from "../VaultFacetControl.sol";
 import {LibERC4626VaultStorage} from "../storage/LibERC4626VaultStorage.sol";
 
 /// @title ERC4626VaultIntegrationFacet
-/// @notice Hosted integration/config facet for oracle references and strategy reports.
+/// @notice Hosted integration/config facet for oracle references and active strategy lifecycle operations.
 contract ERC4626VaultIntegrationFacet is ERC4626Vault, VaultFacetControl, IERC4626VaultIntegrationFacet {
     /// @notice Returns the configured external oracle adapter address.
     /// @return The adapter address, or zero when unset.
@@ -23,10 +24,10 @@ contract ERC4626VaultIntegrationFacet is ERC4626Vault, VaultFacetControl, IERC46
         return LibERC4626VaultStorage.layout().strategy;
     }
 
-    /// @notice Returns the latest reported strategy-held asset amount.
-    /// @return The reported asset amount.
-    function strategyReportedAssets() public view returns (uint256) {
-        return LibERC4626VaultStorage.layout().strategyReportedAssets;
+    /// @notice Returns the vault's current stored book debt allocated to the configured strategy.
+    /// @return The strategy debt amount.
+    function strategyDebt() public view returns (uint256) {
+        return LibERC4626VaultStorage.layout().strategyDebt;
     }
 
     /// @notice Returns the vault's idle underlying asset balance.
@@ -36,10 +37,16 @@ contract ERC4626VaultIntegrationFacet is ERC4626Vault, VaultFacetControl, IERC46
         return IERC20(asset()).balanceOf(address(this));
     }
 
-    /// @notice Returns idle assets plus the latest reported strategy assets.
-    /// @return The estimated total assets across idle vault balance and strategy reports.
-    function estimatedTotalManagedAssets() public view returns (uint256) {
-        return idleAssets() + strategyReportedAssets();
+    /// @notice Returns the configured strategy's live reported assets.
+    /// @return The live strategy asset amount, or zero when no strategy is configured.
+    function liveStrategyAssets() public view returns (uint256) {
+        _requireInitialized();
+        address configuredStrategy = strategy();
+        if (configuredStrategy == address(0)) {
+            return 0;
+        }
+
+        return IERC4626VaultStrategy(configuredStrategy).totalAssets();
     }
 
     /// @notice Returns the latest normalized quote from the configured oracle adapter.
@@ -71,29 +78,126 @@ contract ERC4626VaultIntegrationFacet is ERC4626Vault, VaultFacetControl, IERC46
     function setStrategy(address newStrategy) public {
         _requireInitialized();
         _checkRole(VAULT_MANAGER_ROLE(), msg.sender);
+
         LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        uint256 currentStrategyDebt = layout.strategyDebt;
+        if (currentStrategyDebt != 0) {
+            revert ERC4626VaultStrategyDebtOutstanding(currentStrategyDebt);
+        }
+
+        if (newStrategy != address(0)) {
+            _validateStrategyBinding(newStrategy);
+        }
+
         address previousStrategy = layout.strategy;
         layout.strategy = newStrategy;
         layout.strategyReportedAssets = 0;
+        layout.strategyEmergencyExit = false;
 
         emit VaultStrategyUpdated(previousStrategy, newStrategy, msg.sender);
     }
 
-    /// @notice Updates the latest reported strategy-held asset amount.
-    /// @param assets The latest reported asset amount.
-    function reportStrategyAssets(uint256 assets) public {
+    /// @notice Deploys idle vault assets into the configured strategy.
+    /// @param assets The asset amount to deploy.
+    function deployToStrategy(uint256 assets) public {
         _requireInitialized();
-        address configuredStrategy = strategy();
-        if (msg.sender != configuredStrategy || configuredStrategy == address(0)) {
-            if (!hasRole(VAULT_MANAGER_ROLE(), msg.sender)) {
-                revert ERC4626VaultStrategyReporterUnauthorized(msg.sender, configuredStrategy);
-            }
+        _checkRole(VAULT_MANAGER_ROLE(), msg.sender);
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
         }
 
-        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
-        uint256 previousAssets = layout.strategyReportedAssets;
-        layout.strategyReportedAssets = assets;
+        IERC4626VaultStrategy configuredStrategy = _configuredStrategy();
+        uint256 availableIdleAssets = _availableIdleAssetsForStrategy();
+        if (assets > availableIdleAssets) {
+            revert ERC4626VaultStrategyInsufficientIdleAssets(assets, availableIdleAssets);
+        }
 
-        emit VaultStrategyAssetsReported(previousAssets, assets, msg.sender);
+        _safeTransferAsset(address(configuredStrategy), assets);
+        configuredStrategy.deployFunds(assets);
+
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        layout.strategyDebt += assets;
+        layout.strategyReportedAssets = 0;
+
+        emit VaultStrategyDeployed(assets, layout.strategyDebt, msg.sender);
+    }
+
+    /// @notice Withdraws assets from the configured strategy back to the vault.
+    /// @param assets The asset amount to withdraw.
+    function withdrawFromStrategy(uint256 assets) public {
+        _requireInitialized();
+        _checkRole(VAULT_MANAGER_ROLE(), msg.sender);
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        IERC4626VaultStrategy configuredStrategy = _configuredStrategy();
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        uint256 currentStrategyDebt = layout.strategyDebt;
+        if (assets > currentStrategyDebt) {
+            revert ERC4626VaultStrategyDebtOutstanding(currentStrategyDebt);
+        }
+
+        uint256 returnedAssets = configuredStrategy.withdrawToVault(assets);
+        if (returnedAssets != assets) {
+            revert ERC4626VaultStrategyUnexpectedWithdrawResult(assets, returnedAssets);
+        }
+
+        layout.strategyDebt = currentStrategyDebt - assets;
+        layout.strategyReportedAssets = 0;
+
+        emit VaultStrategyWithdrawn(assets, layout.strategyDebt, msg.sender);
+    }
+
+    /// @notice Syncs live strategy assets into vault book accounting.
+    function syncStrategyAssets() public {
+        _requireInitialized();
+        _checkRole(VAULT_MANAGER_ROLE(), msg.sender);
+
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        uint256 previousDebt = layout.strategyDebt;
+        uint256 liveAssets = _configuredStrategy().totalAssets();
+
+        if (liveAssets > previousDebt) {
+            _increaseManagedAssets(liveAssets - previousDebt);
+        } else if (previousDebt > liveAssets) {
+            _decreaseManagedAssets(previousDebt - liveAssets);
+        }
+
+        layout.strategyDebt = liveAssets;
+        layout.strategyReportedAssets = 0;
+
+        emit VaultStrategySynced(previousDebt, liveAssets, msg.sender);
+    }
+
+    function _configuredStrategy() internal view returns (IERC4626VaultStrategy configuredStrategy) {
+        address configuredStrategyAddress = strategy();
+        if (configuredStrategyAddress == address(0)) {
+            revert ERC4626VaultStrategyNotConfigured();
+        }
+
+        configuredStrategy = IERC4626VaultStrategy(configuredStrategyAddress);
+    }
+
+    function _validateStrategyBinding(address newStrategy) internal view {
+        IERC4626VaultStrategy candidateStrategy = IERC4626VaultStrategy(newStrategy);
+        address expectedVault = address(this);
+        address actualVault = candidateStrategy.vault();
+        if (actualVault != expectedVault) {
+            revert ERC4626VaultStrategyInvalidVault(newStrategy, expectedVault, actualVault);
+        }
+
+        address expectedAsset = asset();
+        address actualAsset = candidateStrategy.asset();
+        if (actualAsset != expectedAsset) {
+            revert ERC4626VaultStrategyInvalidAsset(newStrategy, expectedAsset, actualAsset);
+        }
+    }
+
+    function _availableIdleAssetsForStrategy() internal view returns (uint256) {
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        uint256 actualIdleAssets = IERC20(asset()).balanceOf(address(this));
+        uint256 idleBookAssets = layout.totalManagedAssets - layout.strategyDebt;
+        return actualIdleAssets < idleBookAssets ? actualIdleAssets : idleBookAssets;
     }
 }

--- a/src/vault/facets/ERC4626VaultIntegrationFacet.sol
+++ b/src/vault/facets/ERC4626VaultIntegrationFacet.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
-import {IERC20} from "../../interfaces/IERC20.sol";
 import {IERC4626VaultIntegrationFacet} from "../../interfaces/IERC4626VaultIntegrationFacet.sol";
 import {IERC4626VaultStrategy} from "../../interfaces/IERC4626VaultStrategy.sol";
 import {IOracleAdapter} from "../../interfaces/IOracleAdapter.sol";
@@ -24,6 +23,12 @@ contract ERC4626VaultIntegrationFacet is ERC4626Vault, VaultFacetControl, IERC46
         return LibERC4626VaultStorage.layout().strategy;
     }
 
+    /// @notice Returns true when the current strategy is in emergency-exit mode.
+    /// @return True when emergency exit is active.
+    function strategyEmergencyExit() public view returns (bool) {
+        return LibERC4626VaultStorage.layout().strategyEmergencyExit;
+    }
+
     /// @notice Returns the vault's current stored book debt allocated to the configured strategy.
     /// @return The strategy debt amount.
     function strategyDebt() public view returns (uint256) {
@@ -34,7 +39,7 @@ contract ERC4626VaultIntegrationFacet is ERC4626Vault, VaultFacetControl, IERC46
     /// @return The idle asset amount held directly by the vault.
     function idleAssets() public view returns (uint256) {
         _requireInitialized();
-        return IERC20(asset()).balanceOf(address(this));
+        return _idleAssetBalance();
     }
 
     /// @notice Returns the configured strategy's live reported assets.
@@ -75,7 +80,7 @@ contract ERC4626VaultIntegrationFacet is ERC4626Vault, VaultFacetControl, IERC46
 
     /// @notice Sets the configured strategy reference.
     /// @param newStrategy The new strategy address, or zero to clear.
-    function setStrategy(address newStrategy) public {
+    function setStrategy(address newStrategy) public nonReentrant {
         _requireInitialized();
         _checkRole(VAULT_MANAGER_ROLE(), msg.sender);
 
@@ -99,15 +104,20 @@ contract ERC4626VaultIntegrationFacet is ERC4626Vault, VaultFacetControl, IERC46
 
     /// @notice Deploys idle vault assets into the configured strategy.
     /// @param assets The asset amount to deploy.
-    function deployToStrategy(uint256 assets) public {
+    function deployToStrategy(uint256 assets) public nonReentrant {
         _requireInitialized();
         _checkRole(VAULT_MANAGER_ROLE(), msg.sender);
         if (assets == 0) {
             revert ERC4626VaultZeroAssets();
         }
 
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        if (layout.strategyEmergencyExit) {
+            revert ERC4626VaultStrategyEmergencyExitActive();
+        }
+
         IERC4626VaultStrategy configuredStrategy = _configuredStrategy();
-        uint256 availableIdleAssets = _availableIdleAssetsForStrategy();
+        uint256 availableIdleAssets = _availableIdleAssetsForStrategyDeploy();
         if (assets > availableIdleAssets) {
             revert ERC4626VaultStrategyInsufficientIdleAssets(assets, availableIdleAssets);
         }
@@ -115,7 +125,6 @@ contract ERC4626VaultIntegrationFacet is ERC4626Vault, VaultFacetControl, IERC46
         _safeTransferAsset(address(configuredStrategy), assets);
         configuredStrategy.deployFunds(assets);
 
-        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
         layout.strategyDebt += assets;
         layout.strategyReportedAssets = 0;
 
@@ -123,51 +132,52 @@ contract ERC4626VaultIntegrationFacet is ERC4626Vault, VaultFacetControl, IERC46
     }
 
     /// @notice Withdraws assets from the configured strategy back to the vault.
-    /// @param assets The asset amount to withdraw.
-    function withdrawFromStrategy(uint256 assets) public {
+    /// @param assets The requested asset amount to withdraw.
+    /// @return returnedAssets The actual returned asset amount.
+    function withdrawFromStrategy(uint256 assets) public nonReentrant returns (uint256 returnedAssets) {
         _requireInitialized();
         _checkRole(VAULT_MANAGER_ROLE(), msg.sender);
         if (assets == 0) {
             revert ERC4626VaultZeroAssets();
         }
 
-        IERC4626VaultStrategy configuredStrategy = _configuredStrategy();
-        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
-        uint256 currentStrategyDebt = layout.strategyDebt;
-        if (assets > currentStrategyDebt) {
-            revert ERC4626VaultStrategyDebtOutstanding(currentStrategyDebt);
-        }
+        _configuredStrategy();
+        uint256 postCallLiveAssets;
+        (returnedAssets, postCallLiveAssets) = _withdrawStrategyAssets(assets);
+        _reconcileStrategyWithdrawalAccounting(returnedAssets, postCallLiveAssets);
 
-        uint256 returnedAssets = configuredStrategy.withdrawToVault(assets);
-        if (returnedAssets != assets) {
-            revert ERC4626VaultStrategyUnexpectedWithdrawResult(assets, returnedAssets);
-        }
-
-        layout.strategyDebt = currentStrategyDebt - assets;
-        layout.strategyReportedAssets = 0;
-
-        emit VaultStrategyWithdrawn(assets, layout.strategyDebt, msg.sender);
+        emit VaultStrategyWithdrawn(assets, returnedAssets, LibERC4626VaultStorage.layout().strategyDebt, msg.sender);
     }
 
     /// @notice Syncs live strategy assets into vault book accounting.
-    function syncStrategyAssets() public {
+    function syncStrategyAssets() public nonReentrant {
+        _requireInitialized();
+        _checkRole(VAULT_MANAGER_ROLE(), msg.sender);
+
+        uint256 liveAssets = _configuredStrategy().totalAssets();
+        uint256 previousDebt = _syncStrategyDebtToLiveAssets(liveAssets);
+
+        emit VaultStrategySynced(previousDebt, liveAssets, msg.sender);
+    }
+
+    /// @notice Activates emergency-exit mode and attempts to unwind the configured strategy.
+    /// @return assetsReturned The actual returned asset amount from the unwind attempt.
+    function emergencyExitStrategy() public nonReentrant returns (uint256 assetsReturned) {
         _requireInitialized();
         _checkRole(VAULT_MANAGER_ROLE(), msg.sender);
 
         LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
-        uint256 previousDebt = layout.strategyDebt;
-        uint256 liveAssets = _configuredStrategy().totalAssets();
+        IERC4626VaultStrategy configuredStrategy = _configuredStrategy();
+        layout.strategyEmergencyExit = true;
 
-        if (liveAssets > previousDebt) {
-            _increaseManagedAssets(liveAssets - previousDebt);
-        } else if (previousDebt > liveAssets) {
-            _decreaseManagedAssets(previousDebt - liveAssets);
+        try configuredStrategy.withdrawAllToVault() returns (uint256 returnedAssets) {
+            uint256 postCallLiveAssets = configuredStrategy.totalAssets();
+            assetsReturned = returnedAssets;
+            _reconcileStrategyWithdrawalAccounting(assetsReturned, postCallLiveAssets);
+            emit VaultStrategyEmergencyExitTriggered(assetsReturned, layout.strategyDebt, msg.sender);
+        } catch (bytes memory revertData) {
+            emit VaultStrategyEmergencyExitFailed(address(configuredStrategy), msg.sender, revertData);
         }
-
-        layout.strategyDebt = liveAssets;
-        layout.strategyReportedAssets = 0;
-
-        emit VaultStrategySynced(previousDebt, liveAssets, msg.sender);
     }
 
     function _configuredStrategy() internal view returns (IERC4626VaultStrategy configuredStrategy) {
@@ -194,9 +204,9 @@ contract ERC4626VaultIntegrationFacet is ERC4626Vault, VaultFacetControl, IERC46
         }
     }
 
-    function _availableIdleAssetsForStrategy() internal view returns (uint256) {
+    function _availableIdleAssetsForStrategyDeploy() internal view returns (uint256) {
         LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
-        uint256 actualIdleAssets = IERC20(asset()).balanceOf(address(this));
+        uint256 actualIdleAssets = _idleAssetBalance();
         uint256 idleBookAssets = layout.totalManagedAssets - layout.strategyDebt;
         return actualIdleAssets < idleBookAssets ? actualIdleAssets : idleBookAssets;
     }

--- a/src/vault/libraries/LibVaultFacetSelectors.sol
+++ b/src/vault/libraries/LibVaultFacetSelectors.sol
@@ -85,15 +85,17 @@ library LibVaultFacetSelectors {
 
     /// @notice Returns the hosted vault integration selector group.
     function vaultIntegrationSelectors() internal pure returns (bytes4[] memory selectors) {
-        selectors = new bytes4[](9);
+        selectors = new bytes4[](11);
         selectors[0] = IERC4626VaultIntegrationFacet.oracleAdapter.selector;
         selectors[1] = IERC4626VaultIntegrationFacet.strategy.selector;
-        selectors[2] = IERC4626VaultIntegrationFacet.strategyReportedAssets.selector;
+        selectors[2] = IERC4626VaultIntegrationFacet.strategyDebt.selector;
         selectors[3] = IERC4626VaultIntegrationFacet.idleAssets.selector;
-        selectors[4] = IERC4626VaultIntegrationFacet.estimatedTotalManagedAssets.selector;
+        selectors[4] = IERC4626VaultIntegrationFacet.liveStrategyAssets.selector;
         selectors[5] = IERC4626VaultIntegrationFacet.oracleQuote.selector;
         selectors[6] = IERC4626VaultIntegrationFacet.setOracleAdapter.selector;
         selectors[7] = IERC4626VaultIntegrationFacet.setStrategy.selector;
-        selectors[8] = IERC4626VaultIntegrationFacet.reportStrategyAssets.selector;
+        selectors[8] = IERC4626VaultIntegrationFacet.deployToStrategy.selector;
+        selectors[9] = IERC4626VaultIntegrationFacet.withdrawFromStrategy.selector;
+        selectors[10] = IERC4626VaultIntegrationFacet.syncStrategyAssets.selector;
     }
 }

--- a/src/vault/libraries/LibVaultFacetSelectors.sol
+++ b/src/vault/libraries/LibVaultFacetSelectors.sol
@@ -85,17 +85,19 @@ library LibVaultFacetSelectors {
 
     /// @notice Returns the hosted vault integration selector group.
     function vaultIntegrationSelectors() internal pure returns (bytes4[] memory selectors) {
-        selectors = new bytes4[](11);
+        selectors = new bytes4[](13);
         selectors[0] = IERC4626VaultIntegrationFacet.oracleAdapter.selector;
         selectors[1] = IERC4626VaultIntegrationFacet.strategy.selector;
-        selectors[2] = IERC4626VaultIntegrationFacet.strategyDebt.selector;
-        selectors[3] = IERC4626VaultIntegrationFacet.idleAssets.selector;
-        selectors[4] = IERC4626VaultIntegrationFacet.liveStrategyAssets.selector;
-        selectors[5] = IERC4626VaultIntegrationFacet.oracleQuote.selector;
-        selectors[6] = IERC4626VaultIntegrationFacet.setOracleAdapter.selector;
-        selectors[7] = IERC4626VaultIntegrationFacet.setStrategy.selector;
-        selectors[8] = IERC4626VaultIntegrationFacet.deployToStrategy.selector;
-        selectors[9] = IERC4626VaultIntegrationFacet.withdrawFromStrategy.selector;
-        selectors[10] = IERC4626VaultIntegrationFacet.syncStrategyAssets.selector;
+        selectors[2] = IERC4626VaultIntegrationFacet.strategyEmergencyExit.selector;
+        selectors[3] = IERC4626VaultIntegrationFacet.strategyDebt.selector;
+        selectors[4] = IERC4626VaultIntegrationFacet.idleAssets.selector;
+        selectors[5] = IERC4626VaultIntegrationFacet.liveStrategyAssets.selector;
+        selectors[6] = IERC4626VaultIntegrationFacet.oracleQuote.selector;
+        selectors[7] = IERC4626VaultIntegrationFacet.setOracleAdapter.selector;
+        selectors[8] = IERC4626VaultIntegrationFacet.setStrategy.selector;
+        selectors[9] = IERC4626VaultIntegrationFacet.deployToStrategy.selector;
+        selectors[10] = IERC4626VaultIntegrationFacet.withdrawFromStrategy.selector;
+        selectors[11] = IERC4626VaultIntegrationFacet.syncStrategyAssets.selector;
+        selectors[12] = IERC4626VaultIntegrationFacet.emergencyExitStrategy.selector;
     }
 }

--- a/src/vault/storage/LibERC4626VaultStorage.sol
+++ b/src/vault/storage/LibERC4626VaultStorage.sol
@@ -40,6 +40,8 @@ library LibERC4626VaultStorage {
         address oracleAdapter;
         address strategy;
         uint256 strategyReportedAssets;
+        uint256 strategyDebt;
+        bool strategyEmergencyExit;
     }
 
     /// @notice Returns the storage layout for vault state.

--- a/test/DiamondVaultDeploymentIntegration.t.sol
+++ b/test/DiamondVaultDeploymentIntegration.t.sol
@@ -94,7 +94,8 @@ contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture 
 
         assertTrue(integrationFacetInterface().oracleAdapter() == address(adapter), "adapter mismatch");
         assertTrue(integrationFacetInterface().strategy() == address(0), "strategy should be unset");
-        assertTrue(integrationFacetInterface().strategyReportedAssets() == 0, "reported assets should be zero");
+        assertTrue(integrationFacetInterface().strategyDebt() == 0, "strategy debt should be zero");
+        assertTrue(integrationFacetInterface().liveStrategyAssets() == 0, "live strategy assets should be zero");
         assertTrue(quotePayload.value == 100_000_000, "quote value mismatch");
         assertTrue(quotePayload.updatedAt == quoteUpdatedAt, "quote timestamp mismatch");
         assertTrue(quotePayload.decimals == 8, "quote decimals mismatch");

--- a/test/DiamondVaultDeploymentIntegration.t.sol
+++ b/test/DiamondVaultDeploymentIntegration.t.sol
@@ -11,15 +11,17 @@ import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol
 import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControlsFacet.sol";
 import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
 import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
+import {IERC4626VaultStrategy} from "../src/interfaces/IERC4626VaultStrategy.sol";
 import {IOracleAdapter} from "../src/interfaces/IOracleAdapter.sol";
 import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {DiamondVaultDeploymentFixture} from "./helpers/DiamondVaultDeploymentTestHarness.sol";
 
 contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture {
-    function testVaultHostDeployInstallInitAndOracleWiring() public {
+    function testVaultHostDeployInstallInitOracleAndStrategyWiring() public {
         _installVaultHostFacets();
         _initializeVaultHost();
         _wireOracleAdapter();
+        _wireStrategy();
 
         IDiamondLoupe loupe = IDiamondLoupe(address(diamond));
         address[] memory facetAddresses = loupe.facetAddresses();
@@ -66,6 +68,10 @@ contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture 
             "oracle selector owner mismatch"
         );
         assertTrue(
+            loupe.facetAddress(IERC4626VaultIntegrationFacet.deployToStrategy.selector) == address(integrationFacet),
+            "deploy strategy selector owner mismatch"
+        );
+        assertTrue(
             loupe.facetAddress(IERC165.supportsInterface.selector) == address(controlsFacet),
             "supportsInterface owner mismatch"
         );
@@ -93,9 +99,12 @@ contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture 
         assertTrue(feeRecipient == admin, "fee recipient mismatch");
 
         assertTrue(integrationFacetInterface().oracleAdapter() == address(adapter), "adapter mismatch");
-        assertTrue(integrationFacetInterface().strategy() == address(0), "strategy should be unset");
+        assertTrue(integrationFacetInterface().strategy() == address(strategy), "strategy should be configured");
         assertTrue(integrationFacetInterface().strategyDebt() == 0, "strategy debt should be zero");
+        assertFalse(integrationFacetInterface().strategyEmergencyExit(), "emergency exit should be inactive");
         assertTrue(integrationFacetInterface().liveStrategyAssets() == 0, "live strategy assets should be zero");
+        assertTrue(IERC4626VaultStrategy(address(strategy)).vault() == address(diamond), "strategy vault mismatch");
+        assertTrue(IERC4626VaultStrategy(address(strategy)).asset() == address(asset), "strategy asset mismatch");
         assertTrue(quotePayload.value == 100_000_000, "quote value mismatch");
         assertTrue(quotePayload.updatedAt == quoteUpdatedAt, "quote timestamp mismatch");
         assertTrue(quotePayload.decimals == 8, "quote decimals mismatch");
@@ -115,6 +124,63 @@ contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture 
         VM.prank(admin);
         VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultAlreadyInitialized.selector));
         coreFacetInterface().initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function testVaultHostSmokeCoversStrategyLifecycle() public {
+        _installVaultHostFacets();
+        _initializeVaultHost();
+        _wireOracleAdapter();
+        _wireStrategy();
+
+        asset.mint(admin, 1_500_000_000);
+        VM.prank(admin);
+        asset.approve(address(diamond), 1_500_000_000);
+        VM.prank(admin);
+        coreFacetInterface().deposit(1_000_000_000, admin);
+
+        VM.prank(admin);
+        integrationFacetInterface().deployToStrategy(600_000_000);
+        strategy.injectProfit(100_000_000);
+        VM.prank(admin);
+        integrationFacetInterface().syncStrategyAssets();
+
+        assertTrue(integrationFacetInterface().strategyDebt() == 700_000_000, "strategy debt mismatch after sync");
+        assertTrue(coreFacetInterface().totalManagedAssets() == 1_100_000_000, "book value mismatch after sync");
+        assertTrue(coreFacetInterface().totalAssets() == 1_100_000_000, "total assets mismatch after sync");
+
+        VM.prank(admin);
+        uint256 managerReturned = integrationFacetInterface().withdrawFromStrategy(150_000_000);
+        assertTrue(managerReturned == 150_000_000, "manager withdraw should return requested assets");
+        assertTrue(
+            integrationFacetInterface().strategyDebt() == 550_000_000, "strategy debt mismatch after manager withdraw"
+        );
+
+        VM.prank(admin);
+        coreFacetInterface().withdraw(700_000_000, admin, admin);
+
+        assertTrue(
+            integrationFacetInterface().strategyDebt() == 400_000_000, "strategy debt mismatch after user withdraw"
+        );
+        assertTrue(integrationFacetInterface().liveStrategyAssets() == 400_000_000, "live strategy assets mismatch");
+        assertTrue(integrationFacetInterface().idleAssets() == 0, "idle assets should be exhausted after auto-pull");
+        assertTrue(coreFacetInterface().totalManagedAssets() == 400_000_000, "book value mismatch after user withdraw");
+
+        VM.prank(admin);
+        uint256 emergencyAssets = integrationFacetInterface().emergencyExitStrategy();
+
+        assertTrue(emergencyAssets == 400_000_000, "emergency exit should unwind remaining assets");
+        assertTrue(integrationFacetInterface().strategyEmergencyExit(), "emergency exit should be active");
+        assertTrue(integrationFacetInterface().strategyDebt() == 0, "strategy debt should be zero after unwind");
+        assertTrue(integrationFacetInterface().idleAssets() == 400_000_000, "idle assets should contain unwound funds");
+
+        VM.prank(admin);
+        integrationFacetInterface().setStrategy(address(0));
+        VM.prank(admin);
+        integrationFacetInterface().setStrategy(address(strategy));
+
+        assertFalse(integrationFacetInterface().strategyEmergencyExit(), "emergency exit should clear on rebind");
+        assertTrue(integrationFacetInterface().strategy() == address(strategy), "strategy should be rebound");
+        assertTrue(integrationFacetInterface().strategyDebt() == 0, "strategy debt should reset to zero");
     }
 
     function _assertSelectorsOwnedByFacet(bytes4[] memory selectors, address expectedFacet) internal view {

--- a/test/DiamondVaultHostHardening.t.sol
+++ b/test/DiamondVaultHostHardening.t.sol
@@ -114,7 +114,7 @@ contract DiamondVaultHostHardeningTest is DiamondVaultHostHardeningFixture {
         );
         assertTrue(coreFacetInterface().asset() == address(asset), "core should still route after controls removal");
         assertTrue(
-            integrationFacetInterface().strategyReportedAssets() == STRATEGY_REPORTED_ASSETS,
+            integrationFacetInterface().strategyDebt() == STRATEGY_DEPLOYED_ASSETS,
             "integration should still route after controls removal"
         );
 
@@ -223,16 +223,15 @@ contract DiamondVaultHostHardeningTest is DiamondVaultHostHardeningFixture {
 
     function _assertIntegrationState() internal view {
         assertTrue(integrationFacetInterface().oracleAdapter() == address(adapter), "oracle adapter mismatch");
-        assertTrue(integrationFacetInterface().strategy() == strategyReporter, "strategy mismatch");
+        assertTrue(integrationFacetInterface().strategy() == address(strategyContract), "strategy mismatch");
+        assertTrue(integrationFacetInterface().strategyDebt() == STRATEGY_DEPLOYED_ASSETS, "strategy debt mismatch");
         assertTrue(
-            integrationFacetInterface().strategyReportedAssets() == STRATEGY_REPORTED_ASSETS,
-            "strategy reported assets mismatch"
+            integrationFacetInterface().liveStrategyAssets() == STRATEGY_DEPLOYED_ASSETS,
+            "live strategy assets mismatch"
         );
-        assertTrue(integrationFacetInterface().idleAssets() == BOB_DEPOSIT + CAROL_DEPOSIT, "idle assets mismatch");
         assertTrue(
-            integrationFacetInterface().estimatedTotalManagedAssets()
-                == BOB_DEPOSIT + CAROL_DEPOSIT + STRATEGY_REPORTED_ASSETS,
-            "estimated managed assets mismatch"
+            integrationFacetInterface().idleAssets() == BOB_DEPOSIT + CAROL_DEPOSIT - STRATEGY_DEPLOYED_ASSETS,
+            "idle assets mismatch"
         );
     }
 }

--- a/test/DiamondVaultHostHardening.t.sol
+++ b/test/DiamondVaultHostHardening.t.sol
@@ -19,6 +19,9 @@ import {
 contract DiamondVaultHostHardeningTest is DiamondVaultHostHardeningFixture {
     function testCoreFacetReplaceRemoveReAddPreservesState() public {
         _installAndSeedVaultHost();
+        _injectStrategyProfit(STRATEGY_PROFIT_ASSETS);
+
+        StrategyStateSnapshot memory initialState = _snapshotStrategyState();
 
         _replaceCoreFacet(address(coreReplacement));
         _addCoreReplacementMarker(address(coreReplacement));
@@ -39,12 +42,10 @@ contract DiamondVaultHostHardeningTest is DiamondVaultHostHardeningFixture {
             keccak256(bytes(IERC20Metadata(address(diamond)).symbol())) == keccak256(bytes("vSHARE")),
             "core symbol mismatch after replace"
         );
-        assertTrue(coreFacetInterface().totalManagedAssets() == BOB_DEPOSIT + CAROL_DEPOSIT, "managed assets mismatch");
-        assertTrue(coreFacetInterface().totalAssets() == BOB_DEPOSIT + CAROL_DEPOSIT, "total assets mismatch");
-        assertTrue(coreFacetInterface().totalSupply() == BOB_DEPOSIT + CAROL_DEPOSIT, "total supply mismatch");
         assertTrue(coreFacetInterface().balanceOf(bob) == BOB_DEPOSIT, "bob balance mismatch");
         assertTrue(coreFacetInterface().balanceOf(carol) == CAROL_DEPOSIT, "carol balance mismatch");
         assertTrue(coreFacetInterface().allowance(bob, eve) == SHARE_ALLOWANCE, "share allowance mismatch");
+        _assertStrategyState(initialState);
         assertTrue(
             IERC165(address(diamond)).supportsInterface(type(IERC4626VaultFacet).interfaceId),
             "core interface missing after replace"
@@ -76,17 +77,17 @@ contract DiamondVaultHostHardeningTest is DiamondVaultHostHardeningFixture {
             "core interface missing after re-add"
         );
         assertTrue(coreFacetInterface().asset() == address(asset), "core asset mismatch after re-add");
-        assertTrue(
-            coreFacetInterface().totalSupply() == BOB_DEPOSIT + CAROL_DEPOSIT, "core supply mismatch after re-add"
-        );
         assertTrue(coreFacetInterface().balanceOf(bob) == BOB_DEPOSIT, "bob balance mismatch after re-add");
         assertTrue(coreFacetInterface().balanceOf(carol) == CAROL_DEPOSIT, "carol balance mismatch after re-add");
         assertTrue(coreFacetInterface().allowance(bob, eve) == SHARE_ALLOWANCE, "allowance mismatch after re-add");
+        _assertStrategyState(initialState);
     }
 
     function testControlsFacetReplaceRemoveReAddPreservesControlState() public {
         _installAndSeedVaultHost();
         _pauseVault();
+
+        StrategyStateSnapshot memory initialState = _snapshotStrategyState();
 
         _replaceControlsFacet(address(controlsReplacement));
         _addControlsReplacementMarker(address(controlsReplacement));
@@ -99,6 +100,7 @@ contract DiamondVaultHostHardeningTest is DiamondVaultHostHardeningFixture {
         );
         assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "controls replacement marker mismatch");
         _assertControlsState();
+        _assertStrategyState(initialState);
         assertTrue(controlsFacetInterface().paused(), "paused state should persist after replace");
         assertFalse(controlsFacetInterface().reentrancyGuardEntered(), "reentrancy should not be entered");
 
@@ -114,7 +116,7 @@ contract DiamondVaultHostHardeningTest is DiamondVaultHostHardeningFixture {
         );
         assertTrue(coreFacetInterface().asset() == address(asset), "core should still route after controls removal");
         assertTrue(
-            integrationFacetInterface().strategyDebt() == STRATEGY_DEPLOYED_ASSETS,
+            integrationFacetInterface().strategyDebt() == initialState.strategyDebt,
             "integration should still route after controls removal"
         );
 
@@ -127,6 +129,7 @@ contract DiamondVaultHostHardeningTest is DiamondVaultHostHardeningFixture {
         _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultControlsSelectors(), address(controlsReplacement));
         assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "controls marker mismatch after re-add");
         _assertControlsState();
+        _assertStrategyState(initialState);
         assertTrue(controlsFacetInterface().paused(), "paused state should persist after re-add");
         assertTrue(
             IERC165(address(diamond)).supportsInterface(type(IERC4626VaultFacet).interfaceId),
@@ -142,6 +145,8 @@ contract DiamondVaultHostHardeningTest is DiamondVaultHostHardeningFixture {
     function testIntegrationFacetReplaceRemoveReAddPreservesIntegrationState() public {
         _installAndSeedVaultHost();
 
+        StrategyStateSnapshot memory initialState = _snapshotStrategyState();
+
         _replaceIntegrationFacet(address(integrationReplacement));
         _addIntegrationReplacementMarker(address(integrationReplacement));
 
@@ -154,7 +159,7 @@ contract DiamondVaultHostHardeningTest is DiamondVaultHostHardeningFixture {
             "integration marker owner mismatch"
         );
         assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "integration replacement marker mismatch");
-        _assertIntegrationState();
+        _assertStrategyState(initialState);
         assertTrue(
             IERC165(address(diamond)).supportsInterface(type(IERC4626VaultIntegrationFacet).interfaceId),
             "integration interface missing after replace"
@@ -176,6 +181,27 @@ contract DiamondVaultHostHardeningTest is DiamondVaultHostHardeningFixture {
             "integration interface should be absent when selectors removed"
         );
 
+        uint256 expectedBobSharesBurned = coreFacetInterface().previewWithdraw(BOB_AUTO_PULL_WITHDRAW_ASSETS);
+        VM.prank(bob);
+        uint256 burnedShares = coreFacetInterface().withdraw(BOB_AUTO_PULL_WITHDRAW_ASSETS, bob, bob);
+        assertTrue(
+            burnedShares == expectedBobSharesBurned, "withdraw should use previewWithdraw semantics while removed"
+        );
+
+        uint256 expectedCarolAssetsReturned = coreFacetInterface().previewRedeem(CAROL_AUTO_PULL_REDEEM_SHARES);
+        VM.prank(carol);
+        uint256 returnedAssets = coreFacetInterface().redeem(CAROL_AUTO_PULL_REDEEM_SHARES, carol, carol);
+        assertTrue(
+            returnedAssets == expectedCarolAssetsReturned, "redeem should use previewRedeem semantics while removed"
+        );
+
+        uint256 expectedIdleAssets = asset.balanceOf(address(diamond));
+        uint256 expectedLiveStrategyAssets = strategyContract.totalAssets();
+        uint256 expectedTotalManagedAssets = coreFacetInterface().totalManagedAssets();
+        uint256 expectedTotalAssets = coreFacetInterface().totalAssets();
+        uint256 expectedBobBalance = coreFacetInterface().balanceOf(bob);
+        uint256 expectedCarolBalance = coreFacetInterface().balanceOf(carol);
+
         _reAddIntegrationFacetWithMarker(address(integrationReplacement));
 
         _assertSelectorsOwnedByFacet(
@@ -184,11 +210,67 @@ contract DiamondVaultHostHardeningTest is DiamondVaultHostHardeningFixture {
         assertTrue(
             IFacetVersionMarker(address(diamond)).facetVersion() == 2, "integration marker mismatch after re-add"
         );
-        _assertIntegrationState();
         assertTrue(
             IERC165(address(diamond)).supportsInterface(type(IERC4626VaultIntegrationFacet).interfaceId),
             "integration interface missing after re-add"
         );
+        assertTrue(
+            integrationFacetInterface().strategy() == address(strategyContract), "strategy mismatch after re-add"
+        );
+        assertTrue(
+            integrationFacetInterface().strategyDebt() == expectedTotalManagedAssets - expectedIdleAssets,
+            "strategy debt mismatch after re-add"
+        );
+        assertTrue(
+            integrationFacetInterface().liveStrategyAssets() == expectedLiveStrategyAssets,
+            "live strategy assets mismatch after re-add"
+        );
+        assertTrue(integrationFacetInterface().idleAssets() == expectedIdleAssets, "idle assets mismatch after re-add");
+        assertFalse(integrationFacetInterface().strategyEmergencyExit(), "emergency exit should stay inactive");
+        assertTrue(
+            coreFacetInterface().totalManagedAssets() == expectedTotalManagedAssets, "book value mismatch after re-add"
+        );
+        assertTrue(coreFacetInterface().totalAssets() == expectedTotalAssets, "total assets mismatch after re-add");
+        assertTrue(coreFacetInterface().balanceOf(bob) == expectedBobBalance, "bob balance mismatch after re-add");
+        assertTrue(coreFacetInterface().balanceOf(carol) == expectedCarolBalance, "carol balance mismatch after re-add");
+    }
+
+    function testIntegrationEmergencyExitStatePersistsAcrossFacetChurn() public {
+        _installAndSeedVaultHost();
+
+        VM.prank(admin);
+        uint256 emergencyAssets = integrationFacetInterface().emergencyExitStrategy();
+        assertTrue(emergencyAssets == STRATEGY_DEPLOYED_ASSETS, "emergency exit should unwind deployed assets");
+
+        _replaceIntegrationFacet(address(integrationReplacement));
+        _addIntegrationReplacementMarker(address(integrationReplacement));
+        _removeIntegrationFacetWithMarker();
+        _reAddIntegrationFacetWithMarker(address(integrationReplacement));
+
+        assertTrue(
+            IFacetVersionMarker(address(diamond)).facetVersion() == 2,
+            "integration marker mismatch after emergency re-add"
+        );
+        assertTrue(integrationFacetInterface().strategy() == address(strategyContract), "strategy mismatch after churn");
+        assertTrue(integrationFacetInterface().strategyEmergencyExit(), "emergency exit should persist after churn");
+        assertTrue(integrationFacetInterface().strategyDebt() == 0, "strategy debt should remain zero after churn");
+        assertTrue(integrationFacetInterface().liveStrategyAssets() == 0, "live strategy assets should remain zero");
+        assertTrue(integrationFacetInterface().idleAssets() == BOB_DEPOSIT + CAROL_DEPOSIT, "idle assets mismatch");
+
+        VM.expectRevert(IERC4626VaultIntegrationFacet.ERC4626VaultStrategyEmergencyExitActive.selector);
+        VM.prank(admin);
+        integrationFacetInterface().deployToStrategy(1);
+
+        VM.prank(admin);
+        integrationFacetInterface().setStrategy(address(0));
+        VM.prank(admin);
+        integrationFacetInterface().setStrategy(address(strategyContract));
+
+        assertFalse(integrationFacetInterface().strategyEmergencyExit(), "emergency exit should clear on rebind");
+
+        VM.prank(admin);
+        integrationFacetInterface().deployToStrategy(1);
+        assertTrue(integrationFacetInterface().strategyDebt() == 1, "deploy should work after strategy rebind");
     }
 
     function _assertSelectorsOwnedByFacet(bytes4[] memory selectors, address expectedFacet) internal view {
@@ -219,19 +301,5 @@ contract DiamondVaultHostHardeningTest is DiamondVaultHostHardeningFixture {
         assertTrue(end == uint64(currentTime + 1_000), "role window end mismatch");
         assertTrue(exists, "role window should exist");
         assertTrue(controlsFacetInterface().hasActiveRole(managerRole, dave), "dave active manager role mismatch");
-    }
-
-    function _assertIntegrationState() internal view {
-        assertTrue(integrationFacetInterface().oracleAdapter() == address(adapter), "oracle adapter mismatch");
-        assertTrue(integrationFacetInterface().strategy() == address(strategyContract), "strategy mismatch");
-        assertTrue(integrationFacetInterface().strategyDebt() == STRATEGY_DEPLOYED_ASSETS, "strategy debt mismatch");
-        assertTrue(
-            integrationFacetInterface().liveStrategyAssets() == STRATEGY_DEPLOYED_ASSETS,
-            "live strategy assets mismatch"
-        );
-        assertTrue(
-            integrationFacetInterface().idleAssets() == BOB_DEPOSIT + CAROL_DEPOSIT - STRATEGY_DEPLOYED_ASSETS,
-            "idle assets mismatch"
-        );
     }
 }

--- a/test/DiamondVaultHostInvariant.t.sol
+++ b/test/DiamondVaultHostInvariant.t.sol
@@ -204,21 +204,22 @@ contract DiamondVaultHostInvariantTest is DiamondVaultHostHardeningFixture {
         AccountingSnapshot memory snapshot = _snapshotAccounting();
 
         VM.prank(admin);
-        integrationFacetInterface().setStrategy(configured ? strategyReporter : address(0));
+        integrationFacetInterface().setStrategy(configured ? address(strategyContract) : address(0));
 
         _assertAccountingUnchanged(snapshot, "strategy updates should not mutate core accounting");
     }
 
-    function actionReportStrategyAssets(uint96 assetsRaw, bool asStrategyReporter) external {
+    function actionSyncStrategyAssets() external {
         AccountingSnapshot memory snapshot = _snapshotAccounting();
-        uint256 assets_ = uint256(assetsRaw);
-        address configuredStrategy = integrationFacetInterface().strategy();
-        address caller = asStrategyReporter && configuredStrategy != address(0) ? strategyReporter : admin;
 
-        VM.prank(caller);
-        integrationFacetInterface().reportStrategyAssets(assets_);
+        if (integrationFacetInterface().strategy() == address(0)) {
+            return;
+        }
 
-        _assertAccountingUnchanged(snapshot, "strategy reports should not mutate core accounting");
+        VM.prank(admin);
+        integrationFacetInterface().syncStrategyAssets();
+
+        _assertAccountingUnchanged(snapshot, "strategy sync should not mutate core accounting without deployed assets");
     }
 
     function invariantManagedAssetsTrackUnderlyingBalance() public view {
@@ -242,15 +243,11 @@ contract DiamondVaultHostInvariantTest is DiamondVaultHostHardeningFixture {
         );
     }
 
-    function invariantEstimatedManagedAssetsReflectIdlePlusReported() public view {
+    function invariantStrategyLifecycleStateRemainsZeroWithoutDeploy() public view {
+        assertTrue(integrationFacetInterface().strategyDebt() == 0, "strategy debt should remain zero without deploy");
         assertTrue(
-            integrationFacetInterface().estimatedTotalManagedAssets()
-                == integrationFacetInterface().idleAssets() + integrationFacetInterface().strategyReportedAssets(),
-            "estimated assets should equal idle plus reported strategy assets"
-        );
-        assertTrue(
-            integrationFacetInterface().estimatedTotalManagedAssets() >= coreFacetInterface().totalManagedAssets(),
-            "estimated managed assets should not be less than managed assets"
+            integrationFacetInterface().liveStrategyAssets() == 0,
+            "live strategy assets should remain zero without deploy"
         );
     }
 

--- a/test/DiamondVaultHostInvariant.t.sol
+++ b/test/DiamondVaultHostInvariant.t.sol
@@ -434,6 +434,4 @@ contract DiamondVaultHostInvariantTest is DiamondVaultHostHardeningFixture {
         }
         return liquidity;
     }
-
-
 }

--- a/test/DiamondVaultHostInvariant.t.sol
+++ b/test/DiamondVaultHostInvariant.t.sol
@@ -7,13 +7,14 @@ import {IPausable} from "../src/interfaces/IPausable.sol";
 import {DiamondVaultHostHardeningFixture} from "./helpers/DiamondVaultHostHardeningTestHarness.sol";
 
 contract DiamondVaultHostInvariantTest is DiamondVaultHostHardeningFixture {
-    uint256 internal constant EXPECTED_INITIAL_ASSET_SUPPLY = INITIAL_ASSETS * ACTOR_COUNT;
+    uint256 internal constant EXPECTED_INITIAL_ASSET_SUPPLY = INITIAL_ASSETS * ACTOR_COUNT + STRATEGY_PROFIT_RESERVE;
 
     function setUp() public override {
         super.setUp();
         _installVaultHostFacets();
         _initializeVaultHost();
         _wireOracleAdapter();
+        _wireStrategy();
 
         VM.prank(admin);
         controlsFacetInterface().setFeeConfig(0, 0, feeSink);
@@ -164,7 +165,7 @@ contract DiamondVaultHostInvariantTest is DiamondVaultHostHardeningFixture {
         VM.prank(admin);
         controlsFacetInterface().setFeeConfig(depositFeeBps, withdrawFeeBps, feeSink);
 
-        _assertAccountingUnchanged(snapshot, "fee config updates should not mutate core accounting");
+        _assertAccountingUnchanged(snapshot, "fee config updates should not mutate accounting");
     }
 
     function actionSetLimitConfig(
@@ -188,7 +189,7 @@ contract DiamondVaultHostInvariantTest is DiamondVaultHostHardeningFixture {
         VM.prank(admin);
         controlsFacetInterface().setLimitConfig(maxTotalAssets, maxDeposit, maxMint, maxWithdraw, maxRedeem);
 
-        _assertAccountingUnchanged(snapshot, "limit config updates should not mutate core accounting");
+        _assertAccountingUnchanged(snapshot, "limit config updates should not mutate accounting");
     }
 
     function actionSetOracleAdapter(bool configured) external {
@@ -197,35 +198,173 @@ contract DiamondVaultHostInvariantTest is DiamondVaultHostHardeningFixture {
         VM.prank(admin);
         integrationFacetInterface().setOracleAdapter(configured ? address(adapter) : address(0));
 
-        _assertAccountingUnchanged(snapshot, "oracle adapter updates should not mutate core accounting");
+        _assertAccountingUnchanged(snapshot, "oracle adapter updates should not mutate accounting");
     }
 
     function actionSetStrategy(bool configured) external {
+        if (integrationFacetInterface().strategyDebt() != 0) {
+            return;
+        }
+
         AccountingSnapshot memory snapshot = _snapshotAccounting();
 
-        VM.prank(admin);
-        integrationFacetInterface().setStrategy(configured ? address(strategyContract) : address(0));
+        if (!configured && integrationFacetInterface().strategy() != address(0)) {
+            VM.prank(admin);
+            integrationFacetInterface().setStrategy(address(0));
+            _assertAccountingUnchanged(snapshot, "strategy clear should not mutate accounting");
+            return;
+        }
 
-        _assertAccountingUnchanged(snapshot, "strategy updates should not mutate core accounting");
+        if (configured && integrationFacetInterface().strategy() == address(0)) {
+            strategyContract.setWithdrawAllReverts(false);
+            VM.prank(admin);
+            integrationFacetInterface().setStrategy(address(strategyContract));
+            _assertAccountingUnchanged(snapshot, "strategy rebind should not mutate accounting");
+        }
+    }
+
+    function actionDeployToStrategy(uint96 assetsRaw) external {
+        if (integrationFacetInterface().strategy() != address(strategyContract)) {
+            return;
+        }
+
+        uint256 assets_ = _boundAmount(assetsRaw, integrationFacetInterface().idleAssets());
+        if (assets_ == 0) {
+            return;
+        }
+
+        if (integrationFacetInterface().strategyEmergencyExit()) {
+            VM.expectRevert(IERC4626VaultIntegrationFacet.ERC4626VaultStrategyEmergencyExitActive.selector);
+            VM.prank(admin);
+            integrationFacetInterface().deployToStrategy(assets_);
+            return;
+        }
+
+        VM.prank(admin);
+        integrationFacetInterface().deployToStrategy(assets_);
+    }
+
+    function actionWithdrawFromStrategy(uint96 assetsRaw) external {
+        if (integrationFacetInterface().strategy() != address(strategyContract)) {
+            return;
+        }
+
+        uint256 strategyDebt = integrationFacetInterface().strategyDebt();
+        uint256 assets_ = _boundAmount(assetsRaw, strategyDebt);
+        if (assets_ == 0) {
+            return;
+        }
+
+        VM.prank(admin);
+        integrationFacetInterface().withdrawFromStrategy(assets_);
     }
 
     function actionSyncStrategyAssets() external {
-        AccountingSnapshot memory snapshot = _snapshotAccounting();
-
-        if (integrationFacetInterface().strategy() == address(0)) {
+        if (integrationFacetInterface().strategy() != address(strategyContract)) {
             return;
         }
 
         VM.prank(admin);
         integrationFacetInterface().syncStrategyAssets();
-
-        _assertAccountingUnchanged(snapshot, "strategy sync should not mutate core accounting without deployed assets");
     }
 
-    function invariantManagedAssetsTrackUnderlyingBalance() public view {
+    function actionEmergencyExitStrategy(bool forceFailure) external {
+        if (integrationFacetInterface().strategy() != address(strategyContract)) {
+            return;
+        }
+
+        strategyContract.setWithdrawAllReverts(forceFailure && integrationFacetInterface().strategyDebt() != 0);
+
+        VM.prank(admin);
+        integrationFacetInterface().emergencyExitStrategy();
+    }
+
+    function actionInjectStrategyProfit(uint96 assetsRaw) external {
+        if (integrationFacetInterface().strategy() != address(strategyContract)) {
+            return;
+        }
+        if (integrationFacetInterface().strategyDebt() == 0 || integrationFacetInterface().strategyEmergencyExit()) {
+            return;
+        }
+
+        uint256 available = _min(asset.balanceOf(profitSource), INITIAL_ASSETS);
+        uint256 assets_ = _boundAmount(assetsRaw, available);
+        if (assets_ == 0) {
+            return;
+        }
+
+        strategyContract.injectProfit(assets_);
+    }
+
+    function actionApplyStrategyLoss(uint96 lossRaw, uint96 withdrawableRaw) external {
+        if (integrationFacetInterface().strategy() != address(strategyContract)) {
+            return;
+        }
+        if (integrationFacetInterface().strategyEmergencyExit()) {
+            return;
+        }
+
+        uint256 liveAssets = integrationFacetInterface().liveStrategyAssets();
+        if (liveAssets == 0) {
+            return;
+        }
+
+        uint256 lossAssets = _boundAmount(lossRaw, _min(liveAssets, INITIAL_ASSETS));
+        uint256 remainingLiveAssets = liveAssets - lossAssets;
+        uint256 withdrawableAssets = remainingLiveAssets == 0 ? 0 : uint256(withdrawableRaw) % (remainingLiveAssets + 1);
+
+        strategyContract.applyLoss(lossAssets, withdrawableAssets);
+    }
+
+    function actionWithdrawBeyondImmediateLiquidityAttempt(uint8 actorSeed, uint96 extraRaw) external {
+        if (controlsFacetInterface().paused()) {
+            return;
+        }
+
+        address actor = _actor(actorSeed);
+        uint256 ownerShares = coreFacetInterface().balanceOf(actor);
+        if (ownerShares == 0) {
+            return;
+        }
+
+        uint256 maxWithdraw = coreFacetInterface().maxWithdraw(actor);
+        uint256 grossEntitlement = coreFacetInterface().previewRedeem(ownerShares);
+        if (grossEntitlement <= maxWithdraw) {
+            return;
+        }
+
+        uint256 attemptAssets = maxWithdraw + _boundAmount(extraRaw, grossEntitlement - maxWithdraw);
+
+        VM.startPrank(actor);
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IERC4626VaultControls.ERC4626VaultWithdrawLimitExceeded.selector, attemptAssets, maxWithdraw
+            )
+        );
+        coreFacetInterface().withdraw(attemptAssets, actor, actor);
+        VM.stopPrank();
+    }
+
+    function invariantIdleAssetsMatchVaultBalance() public view {
         assertTrue(
-            coreFacetInterface().totalAssets() == asset.balanceOf(address(diamond)),
-            "managed assets should match vault-held underlying"
+            integrationFacetInterface().idleAssets() == asset.balanceOf(address(diamond)),
+            "idle assets should match vault-held underlying"
+        );
+    }
+
+    function invariantBookAccountingMatchesIdlePlusStrategyDebt() public view {
+        assertTrue(
+            coreFacetInterface().totalManagedAssets()
+                == integrationFacetInterface().idleAssets() + integrationFacetInterface().strategyDebt(),
+            "book accounting should equal idle assets plus strategy debt"
+        );
+    }
+
+    function invariantLiveAccountingMatchesIdlePlusStrategyAssets() public view {
+        assertTrue(
+            coreFacetInterface().totalAssets()
+                == integrationFacetInterface().idleAssets() + integrationFacetInterface().liveStrategyAssets(),
+            "live accounting should equal idle assets plus live strategy assets"
         );
     }
 
@@ -239,15 +378,7 @@ contract DiamondVaultHostInvariantTest is DiamondVaultHostHardeningFixture {
     function invariantTrackedUnderlyingRemainsConserved() public view {
         assertTrue(
             _sumTrackedUnderlying() == EXPECTED_INITIAL_ASSET_SUPPLY,
-            "tracked underlying should remain conserved across actors, vault, and fee sink"
-        );
-    }
-
-    function invariantStrategyLifecycleStateRemainsZeroWithoutDeploy() public view {
-        assertTrue(integrationFacetInterface().strategyDebt() == 0, "strategy debt should remain zero without deploy");
-        assertTrue(
-            integrationFacetInterface().liveStrategyAssets() == 0,
-            "live strategy assets should remain zero without deploy"
+            "tracked underlying should remain conserved across actors, vault, fee sink, strategy, and reserves"
         );
     }
 
@@ -264,4 +395,45 @@ contract DiamondVaultHostInvariantTest is DiamondVaultHostHardeningFixture {
             assertTrue(coreFacetInterface().maxRedeem(actor) == 0, "paused vault should expose zero maxRedeem");
         }
     }
+
+    function invariantMaxWithdrawBoundedByImmediateLiquidity() public view {
+        uint256 immediateLiquidity = _immediateLiquidity();
+
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            address actor = actors[i];
+            uint256 actorBalance = coreFacetInterface().balanceOf(actor);
+            uint256 grossEntitlement = actorBalance == 0 ? 0 : coreFacetInterface().previewRedeem(actorBalance);
+            uint256 maxWithdraw = coreFacetInterface().maxWithdraw(actor);
+
+            assertTrue(maxWithdraw <= immediateLiquidity, "maxWithdraw should stay within immediate liquidity");
+            assertTrue(maxWithdraw <= grossEntitlement, "maxWithdraw should stay within live-priced entitlement");
+        }
+    }
+
+    function invariantPreviewRedeemOfMaxRedeemBoundedByImmediateLiquidity() public view {
+        uint256 immediateLiquidity = _immediateLiquidity();
+
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            address actor = actors[i];
+            uint256 maxRedeem = coreFacetInterface().maxRedeem(actor);
+            assertTrue(
+                coreFacetInterface().previewRedeem(maxRedeem) <= immediateLiquidity,
+                "previewRedeem(maxRedeem) should stay within immediate liquidity"
+            );
+        }
+    }
+
+    function _immediateLiquidity() internal view returns (uint256) {
+        if (integrationFacetInterface().strategyDebt() == 0) {
+            return coreFacetInterface().totalAssets();
+        }
+
+        uint256 liquidity = integrationFacetInterface().idleAssets();
+        if (integrationFacetInterface().strategy() == address(strategyContract)) {
+            liquidity += strategyContract.maxWithdrawableAssets();
+        }
+        return liquidity;
+    }
+
+
 }

--- a/test/ERC4626VaultIntegrationFacetCore.t.sol
+++ b/test/ERC4626VaultIntegrationFacetCore.t.sol
@@ -54,9 +54,26 @@ contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFix
         VM.prank(admin);
         integrationFacet.deployToStrategy(40);
 
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorized.selector, bob, integrationFacet.VAULT_MANAGER_ROLE()
+            )
+        );
+        VM.prank(bob);
+        integrationFacet.withdrawFromStrategy(20);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorized.selector, bob, integrationFacet.VAULT_MANAGER_ROLE()
+            )
+        );
+        VM.prank(bob);
+        integrationFacet.emergencyExitStrategy();
+
         assertTrue(integrationFacet.strategyDebt() == 40, "strategy debt mismatch");
         assertTrue(integrationFacet.idleAssets() == 60, "idle assets mismatch");
         assertTrue(integrationFacet.liveStrategyAssets() == 40, "live strategy assets mismatch");
+        assertFalse(integrationFacet.strategyEmergencyExit(), "emergency exit should be inactive");
     }
 
     function testDirectIntegrationFacetRejectsInvalidBindingAndOutstandingDebtOnStrategySwap() public {
@@ -100,15 +117,42 @@ contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFix
         integrationFacet.setStrategy(address(0));
 
         VM.prank(admin);
-        integrationFacet.withdrawFromStrategy(40);
+        uint256 returnedAssets = integrationFacet.withdrawFromStrategy(40);
+        assertTrue(returnedAssets == 40, "returned assets mismatch");
+
         VM.prank(admin);
         integrationFacet.setStrategy(address(0));
 
         assertTrue(integrationFacet.strategy() == address(0), "strategy should clear after debt reaches zero");
         assertTrue(integrationFacet.strategyDebt() == 0, "strategy debt should clear after full withdraw");
+        assertFalse(integrationFacet.strategyEmergencyExit(), "emergency exit should clear on strategy reset");
     }
 
-    function testDirectIntegrationFacetSyncRealizesProfitAndPartialWithdrawPreservesBookValue() public {
+    function testDirectIntegrationFacetPartialWithdrawRealizesLossAndReturnsActualAssets() public {
+        _initializeDirectIntegrationFacet();
+        _approveAsset(bob, address(integrationFacet), 100);
+
+        VM.prank(bob);
+        integrationFacet.deposit(100, bob);
+
+        VM.prank(admin);
+        integrationFacet.setStrategy(address(directLossStrategy));
+        VM.prank(admin);
+        integrationFacet.deployToStrategy(60);
+        directLossStrategy.applyLoss(10, 30);
+
+        VM.prank(admin);
+        uint256 returnedAssets = integrationFacet.withdrawFromStrategy(40);
+
+        assertTrue(returnedAssets == 30, "partial withdraw should return actual assets");
+        assertTrue(integrationFacet.strategyDebt() == 20, "strategy debt should update to remaining live assets");
+        assertTrue(integrationFacet.liveStrategyAssets() == 20, "live strategy assets mismatch after partial withdraw");
+        assertTrue(integrationFacet.idleAssets() == 70, "idle assets should increase by returned assets");
+        assertTrue(integrationFacet.totalManagedAssets() == 90, "book value should realize loss on partial withdraw");
+        assertTrue(integrationFacet.totalAssets() == 90, "direct integration facet total assets should match book value");
+    }
+
+    function testDirectIntegrationFacetSyncRealizesProfit() public {
         _initializeDirectIntegrationFacet();
         _approveAsset(bob, address(integrationFacet), 100);
 
@@ -121,24 +165,13 @@ contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFix
         integrationFacet.deployToStrategy(60);
         directProfitStrategy.injectProfit(20);
 
-        assertTrue(integrationFacet.totalManagedAssets() == 100, "book value should remain unchanged before sync");
-        assertTrue(integrationFacet.liveStrategyAssets() == 80, "live strategy assets should reflect unsynced profit");
-
         VM.prank(admin);
         integrationFacet.syncStrategyAssets();
 
-        assertTrue(integrationFacet.strategyDebt() == 80, "strategy debt should sync to live assets");
+        assertTrue(integrationFacet.strategyDebt() == 80, "strategy debt should sync to profit-adjusted live assets");
         assertTrue(integrationFacet.liveStrategyAssets() == 80, "live strategy assets mismatch after profit sync");
         assertTrue(integrationFacet.totalManagedAssets() == 120, "book value should realize profit on sync");
-        assertTrue(integrationFacet.totalAssets() == 120, "total assets should remain mark-to-market after sync");
-
-        VM.prank(admin);
-        integrationFacet.withdrawFromStrategy(30);
-
-        assertTrue(integrationFacet.strategyDebt() == 50, "strategy debt should decrease after withdraw");
-        assertTrue(integrationFacet.liveStrategyAssets() == 50, "live strategy assets should decrease after withdraw");
-        assertTrue(integrationFacet.idleAssets() == 70, "idle assets should increase after withdraw");
-        assertTrue(integrationFacet.totalManagedAssets() == 120, "book value should stay unchanged after pull");
+        assertTrue(integrationFacet.totalAssets() == 120, "direct integration facet total assets should match book value");
     }
 
     function testDirectIntegrationFacetSyncRealizesLoss() public {
@@ -160,10 +193,10 @@ contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFix
         assertTrue(integrationFacet.strategyDebt() == 45, "strategy debt should sync to loss-adjusted live assets");
         assertTrue(integrationFacet.liveStrategyAssets() == 45, "live strategy assets mismatch after loss sync");
         assertTrue(integrationFacet.totalManagedAssets() == 85, "book value should realize loss on sync");
-        assertTrue(integrationFacet.totalAssets() == 85, "total assets should reflect realized loss");
+        assertTrue(integrationFacet.totalAssets() == 85, "direct integration facet total assets should reflect realized loss");
     }
 
-    function testDirectIntegrationFacetRejectsUnexpectedPartialWithdrawResult() public {
+    function testDirectIntegrationFacetEmergencyExitUnwindsAndBlocksRedeploy() public {
         _initializeDirectIntegrationFacet();
         _approveAsset(bob, address(integrationFacet), 100);
 
@@ -171,18 +204,56 @@ contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFix
         integrationFacet.deposit(100, bob);
 
         VM.prank(admin);
-        integrationFacet.setStrategy(address(directLossStrategy));
+        integrationFacet.setStrategy(address(directProfitStrategy));
         VM.prank(admin);
         integrationFacet.deployToStrategy(60);
-        directLossStrategy.applyLoss(0, 30);
+        directProfitStrategy.injectProfit(20);
 
-        VM.expectRevert(
-            abi.encodeWithSelector(
-                IERC4626VaultIntegrationFacet.ERC4626VaultStrategyUnexpectedWithdrawResult.selector, 40, 30
-            )
-        );
         VM.prank(admin);
-        integrationFacet.withdrawFromStrategy(40);
+        uint256 returnedAssets = integrationFacet.emergencyExitStrategy();
+
+        assertTrue(returnedAssets == 80, "emergency exit should return all live assets");
+        assertTrue(integrationFacet.strategyEmergencyExit(), "emergency exit flag should remain active");
+        assertTrue(integrationFacet.strategyDebt() == 0, "strategy debt should be zero after full unwind");
+        assertTrue(integrationFacet.liveStrategyAssets() == 0, "live strategy assets should be zero after unwind");
+        assertTrue(integrationFacet.idleAssets() == 120, "idle assets should include fully unwound strategy assets");
+        assertTrue(integrationFacet.totalManagedAssets() == 120, "book value should realize profit during emergency exit");
+
+        VM.expectRevert(IERC4626VaultIntegrationFacet.ERC4626VaultStrategyEmergencyExitActive.selector);
+        VM.prank(admin);
+        integrationFacet.deployToStrategy(10);
+
+        VM.prank(admin);
+        integrationFacet.setStrategy(address(0));
+        assertFalse(integrationFacet.strategyEmergencyExit(), "emergency exit should clear when strategy clears");
+    }
+
+    function testDirectIntegrationFacetEmergencyExitFailureDoesNotRevert() public {
+        _initializeDirectIntegrationFacet();
+        _approveAsset(bob, address(integrationFacet), 100);
+
+        VM.prank(bob);
+        integrationFacet.deposit(100, bob);
+
+        VM.prank(admin);
+        integrationFacet.setStrategy(address(directRevertingStrategy));
+        VM.prank(admin);
+        integrationFacet.deployToStrategy(60);
+        directRevertingStrategy.setRevertModes(false, false, false, true);
+
+        VM.prank(admin);
+        uint256 returnedAssets = integrationFacet.emergencyExitStrategy();
+
+        assertTrue(returnedAssets == 0, "failing emergency exit should return zero assets");
+        assertTrue(integrationFacet.strategyEmergencyExit(), "emergency exit flag should stay active after failure");
+        assertTrue(integrationFacet.strategyDebt() == 60, "strategy debt should remain unchanged after failed unwind");
+        assertTrue(integrationFacet.liveStrategyAssets() == 60, "live strategy assets should remain unchanged");
+        assertTrue(integrationFacet.idleAssets() == 40, "idle assets should remain unchanged after failed unwind");
+        assertTrue(integrationFacet.totalManagedAssets() == 100, "book value should remain unchanged after failed unwind");
+
+        VM.expectRevert(IERC4626VaultIntegrationFacet.ERC4626VaultStrategyEmergencyExitActive.selector);
+        VM.prank(admin);
+        integrationFacet.deployToStrategy(10);
     }
 
     function testDirectIntegrationFacetHelpersRevertBeforeVaultInit() public {
@@ -216,11 +287,15 @@ contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFix
         VM.prank(admin);
         IERC4626VaultIntegrationFacet(address(diamond)).syncStrategyAssets();
         VM.prank(admin);
-        IERC4626VaultIntegrationFacet(address(diamond)).withdrawFromStrategy(30);
+        uint256 returnedAssets = IERC4626VaultIntegrationFacet(address(diamond)).withdrawFromStrategy(30);
+        VM.prank(admin);
+        uint256 emergencyAssets = IERC4626VaultIntegrationFacet(address(diamond)).emergencyExitStrategy();
 
         IOracleAdapter.OracleQuote memory quotePayload = IERC4626VaultIntegrationFacet(address(diamond)).oracleQuote();
 
         assertTrue(mintedShares == 100, "deposit shares mismatch");
+        assertTrue(returnedAssets == 30, "partial withdraw return mismatch");
+        assertTrue(emergencyAssets == 50, "emergency exit return mismatch");
         assertTrue(
             IERC4626VaultIntegrationFacet(address(diamond)).oracleAdapter() == address(adapter), "adapter mismatch"
         );
@@ -228,11 +303,15 @@ contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFix
             IERC4626VaultIntegrationFacet(address(diamond)).strategy() == address(diamondProfitStrategy),
             "strategy mismatch"
         );
-        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).strategyDebt() == 50, "strategy debt mismatch");
         assertTrue(
-            IERC4626VaultIntegrationFacet(address(diamond)).liveStrategyAssets() == 50, "live strategy assets mismatch"
+            IERC4626VaultIntegrationFacet(address(diamond)).strategyEmergencyExit(),
+            "emergency exit should remain active"
         );
-        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).idleAssets() == 70, "idle assets mismatch");
+        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).strategyDebt() == 0, "strategy debt mismatch");
+        assertTrue(
+            IERC4626VaultIntegrationFacet(address(diamond)).liveStrategyAssets() == 0, "live strategy assets mismatch"
+        );
+        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).idleAssets() == 120, "idle assets mismatch");
         assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 120, "managed assets mismatch");
         assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 120, "total assets mismatch");
         assertTrue(quotePayload.value == 100_000_000, "quote value mismatch");

--- a/test/ERC4626VaultIntegrationFacetCore.t.sol
+++ b/test/ERC4626VaultIntegrationFacetCore.t.sol
@@ -149,7 +149,9 @@ contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFix
         assertTrue(integrationFacet.liveStrategyAssets() == 20, "live strategy assets mismatch after partial withdraw");
         assertTrue(integrationFacet.idleAssets() == 70, "idle assets should increase by returned assets");
         assertTrue(integrationFacet.totalManagedAssets() == 90, "book value should realize loss on partial withdraw");
-        assertTrue(integrationFacet.totalAssets() == 90, "direct integration facet total assets should match book value");
+        assertTrue(
+            integrationFacet.totalAssets() == 90, "direct integration facet total assets should match book value"
+        );
     }
 
     function testDirectIntegrationFacetSyncRealizesProfit() public {
@@ -171,7 +173,9 @@ contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFix
         assertTrue(integrationFacet.strategyDebt() == 80, "strategy debt should sync to profit-adjusted live assets");
         assertTrue(integrationFacet.liveStrategyAssets() == 80, "live strategy assets mismatch after profit sync");
         assertTrue(integrationFacet.totalManagedAssets() == 120, "book value should realize profit on sync");
-        assertTrue(integrationFacet.totalAssets() == 120, "direct integration facet total assets should match book value");
+        assertTrue(
+            integrationFacet.totalAssets() == 120, "direct integration facet total assets should match book value"
+        );
     }
 
     function testDirectIntegrationFacetSyncRealizesLoss() public {
@@ -193,7 +197,9 @@ contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFix
         assertTrue(integrationFacet.strategyDebt() == 45, "strategy debt should sync to loss-adjusted live assets");
         assertTrue(integrationFacet.liveStrategyAssets() == 45, "live strategy assets mismatch after loss sync");
         assertTrue(integrationFacet.totalManagedAssets() == 85, "book value should realize loss on sync");
-        assertTrue(integrationFacet.totalAssets() == 85, "direct integration facet total assets should reflect realized loss");
+        assertTrue(
+            integrationFacet.totalAssets() == 85, "direct integration facet total assets should reflect realized loss"
+        );
     }
 
     function testDirectIntegrationFacetEmergencyExitUnwindsAndBlocksRedeploy() public {
@@ -217,7 +223,9 @@ contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFix
         assertTrue(integrationFacet.strategyDebt() == 0, "strategy debt should be zero after full unwind");
         assertTrue(integrationFacet.liveStrategyAssets() == 0, "live strategy assets should be zero after unwind");
         assertTrue(integrationFacet.idleAssets() == 120, "idle assets should include fully unwound strategy assets");
-        assertTrue(integrationFacet.totalManagedAssets() == 120, "book value should realize profit during emergency exit");
+        assertTrue(
+            integrationFacet.totalManagedAssets() == 120, "book value should realize profit during emergency exit"
+        );
 
         VM.expectRevert(IERC4626VaultIntegrationFacet.ERC4626VaultStrategyEmergencyExitActive.selector);
         VM.prank(admin);
@@ -249,7 +257,9 @@ contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFix
         assertTrue(integrationFacet.strategyDebt() == 60, "strategy debt should remain unchanged after failed unwind");
         assertTrue(integrationFacet.liveStrategyAssets() == 60, "live strategy assets should remain unchanged");
         assertTrue(integrationFacet.idleAssets() == 40, "idle assets should remain unchanged after failed unwind");
-        assertTrue(integrationFacet.totalManagedAssets() == 100, "book value should remain unchanged after failed unwind");
+        assertTrue(
+            integrationFacet.totalManagedAssets() == 100, "book value should remain unchanged after failed unwind"
+        );
 
         VM.expectRevert(IERC4626VaultIntegrationFacet.ERC4626VaultStrategyEmergencyExitActive.selector);
         VM.prank(admin);

--- a/test/ERC4626VaultIntegrationFacetCore.t.sol
+++ b/test/ERC4626VaultIntegrationFacetCore.t.sol
@@ -12,8 +12,12 @@ import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelect
 import {ERC4626VaultIntegrationFacetFixture} from "./helpers/ERC4626VaultIntegrationFacetTestHarness.sol";
 
 contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFixture {
-    function testDirectIntegrationFacetRequiresManagerForConfigAndReporterAuth() public {
+    function testDirectIntegrationFacetRequiresManagerForConfigAndLifecycle() public {
         _initializeDirectIntegrationFacet();
+        _approveAsset(bob, address(integrationFacet), 100);
+
+        VM.prank(bob);
+        integrationFacet.deposit(100, bob);
 
         VM.expectRevert(
             abi.encodeWithSelector(
@@ -27,67 +31,158 @@ contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFix
         integrationFacet.setOracleAdapter(address(adapter));
         assertTrue(integrationFacet.oracleAdapter() == address(adapter), "adapter mismatch");
 
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorized.selector, bob, integrationFacet.VAULT_MANAGER_ROLE()
+            )
+        );
+        VM.prank(bob);
+        integrationFacet.setStrategy(address(directProfitStrategy));
+
         VM.prank(admin);
-        integrationFacet.setStrategy(bob);
-        assertTrue(integrationFacet.strategy() == bob, "strategy mismatch");
+        integrationFacet.setStrategy(address(directProfitStrategy));
+        assertTrue(integrationFacet.strategy() == address(directProfitStrategy), "strategy mismatch");
 
         VM.expectRevert(
             abi.encodeWithSelector(
-                IERC4626VaultIntegrationFacet.ERC4626VaultStrategyReporterUnauthorized.selector, eve, bob
+                IAccessControl.AccessControlUnauthorized.selector, bob, integrationFacet.VAULT_MANAGER_ROLE()
             )
         );
-        VM.prank(eve);
-        integrationFacet.reportStrategyAssets(25);
-
         VM.prank(bob);
-        integrationFacet.reportStrategyAssets(25);
-        assertTrue(integrationFacet.strategyReportedAssets() == 25, "reported assets mismatch");
+        integrationFacet.deployToStrategy(40);
+
+        VM.prank(admin);
+        integrationFacet.deployToStrategy(40);
+
+        assertTrue(integrationFacet.strategyDebt() == 40, "strategy debt mismatch");
+        assertTrue(integrationFacet.idleAssets() == 60, "idle assets mismatch");
+        assertTrue(integrationFacet.liveStrategyAssets() == 40, "live strategy assets mismatch");
     }
 
-    function testDirectIntegrationFacetChangingStrategyClearsReportedAssets() public {
+    function testDirectIntegrationFacetRejectsInvalidBindingAndOutstandingDebtOnStrategySwap() public {
         _initializeDirectIntegrationFacet();
+        _approveAsset(bob, address(integrationFacet), 100);
 
-        VM.prank(admin);
-        integrationFacet.setStrategy(bob);
         VM.prank(bob);
-        integrationFacet.reportStrategyAssets(75);
-
-        VM.prank(admin);
-        integrationFacet.setStrategy(eve);
-
-        assertTrue(integrationFacet.strategy() == eve, "strategy should update");
-        assertTrue(integrationFacet.strategyReportedAssets() == 0, "reported assets should reset");
-
-        VM.prank(admin);
-        integrationFacet.setStrategy(address(0));
-        assertTrue(integrationFacet.strategy() == address(0), "strategy should clear");
-        assertTrue(integrationFacet.strategyReportedAssets() == 0, "reported assets should stay cleared");
-    }
-
-    function testDirectIntegrationFacetOracleQuoteAndEstimatedAssets() public {
-        _initializeDirectIntegrationFacet();
+        integrationFacet.deposit(100, bob);
 
         VM.expectRevert(
-            abi.encodeWithSelector(IERC4626VaultIntegrationFacet.ERC4626VaultOracleAdapterNotConfigured.selector)
+            abi.encodeWithSelector(
+                IERC4626VaultIntegrationFacet.ERC4626VaultStrategyInvalidVault.selector,
+                address(wrongVaultStrategy),
+                address(integrationFacet),
+                address(0xBAD)
+            )
         );
-        integrationFacet.oracleQuote();
+        VM.prank(admin);
+        integrationFacet.setStrategy(address(wrongVaultStrategy));
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IERC4626VaultIntegrationFacet.ERC4626VaultStrategyInvalidAsset.selector,
+                address(directWrongAssetStrategy),
+                address(asset),
+                address(otherAsset)
+            )
+        );
+        VM.prank(admin);
+        integrationFacet.setStrategy(address(directWrongAssetStrategy));
 
         VM.prank(admin);
-        integrationFacet.setOracleAdapter(address(adapter));
+        integrationFacet.setStrategy(address(directProfitStrategy));
+        VM.prank(admin);
+        integrationFacet.deployToStrategy(40);
 
-        asset.mint(address(integrationFacet), 40);
+        VM.expectRevert(
+            abi.encodeWithSelector(IERC4626VaultIntegrationFacet.ERC4626VaultStrategyDebtOutstanding.selector, 40)
+        );
+        VM.prank(admin);
+        integrationFacet.setStrategy(address(0));
 
         VM.prank(admin);
-        integrationFacet.reportStrategyAssets(25);
+        integrationFacet.withdrawFromStrategy(40);
+        VM.prank(admin);
+        integrationFacet.setStrategy(address(0));
 
-        IOracleAdapter.OracleQuote memory quotePayload = integrationFacet.oracleQuote();
+        assertTrue(integrationFacet.strategy() == address(0), "strategy should clear after debt reaches zero");
+        assertTrue(integrationFacet.strategyDebt() == 0, "strategy debt should clear after full withdraw");
+    }
 
-        assertTrue(quotePayload.value == 100_000_000, "quote value mismatch");
-        assertTrue(quotePayload.updatedAt == quoteUpdatedAt, "quote timestamp mismatch");
-        assertTrue(quotePayload.decimals == 8, "quote decimals mismatch");
-        assertTrue(integrationFacet.idleAssets() == 40, "idle assets mismatch");
-        assertTrue(integrationFacet.estimatedTotalManagedAssets() == 65, "estimated assets mismatch");
-        assertTrue(integrationFacet.totalManagedAssets() == 0, "managed assets should remain unchanged");
+    function testDirectIntegrationFacetSyncRealizesProfitAndPartialWithdrawPreservesBookValue() public {
+        _initializeDirectIntegrationFacet();
+        _approveAsset(bob, address(integrationFacet), 100);
+
+        VM.prank(bob);
+        integrationFacet.deposit(100, bob);
+
+        VM.prank(admin);
+        integrationFacet.setStrategy(address(directProfitStrategy));
+        VM.prank(admin);
+        integrationFacet.deployToStrategy(60);
+        directProfitStrategy.injectProfit(20);
+
+        assertTrue(integrationFacet.totalManagedAssets() == 100, "book value should remain unchanged before sync");
+        assertTrue(integrationFacet.liveStrategyAssets() == 80, "live strategy assets should reflect unsynced profit");
+
+        VM.prank(admin);
+        integrationFacet.syncStrategyAssets();
+
+        assertTrue(integrationFacet.strategyDebt() == 80, "strategy debt should sync to live assets");
+        assertTrue(integrationFacet.liveStrategyAssets() == 80, "live strategy assets mismatch after profit sync");
+        assertTrue(integrationFacet.totalManagedAssets() == 120, "book value should realize profit on sync");
+        assertTrue(integrationFacet.totalAssets() == 120, "total assets should remain mark-to-market after sync");
+
+        VM.prank(admin);
+        integrationFacet.withdrawFromStrategy(30);
+
+        assertTrue(integrationFacet.strategyDebt() == 50, "strategy debt should decrease after withdraw");
+        assertTrue(integrationFacet.liveStrategyAssets() == 50, "live strategy assets should decrease after withdraw");
+        assertTrue(integrationFacet.idleAssets() == 70, "idle assets should increase after withdraw");
+        assertTrue(integrationFacet.totalManagedAssets() == 120, "book value should stay unchanged after pull");
+    }
+
+    function testDirectIntegrationFacetSyncRealizesLoss() public {
+        _initializeDirectIntegrationFacet();
+        _approveAsset(bob, address(integrationFacet), 100);
+
+        VM.prank(bob);
+        integrationFacet.deposit(100, bob);
+
+        VM.prank(admin);
+        integrationFacet.setStrategy(address(directLossStrategy));
+        VM.prank(admin);
+        integrationFacet.deployToStrategy(60);
+        directLossStrategy.applyLoss(15, 35);
+
+        VM.prank(admin);
+        integrationFacet.syncStrategyAssets();
+
+        assertTrue(integrationFacet.strategyDebt() == 45, "strategy debt should sync to loss-adjusted live assets");
+        assertTrue(integrationFacet.liveStrategyAssets() == 45, "live strategy assets mismatch after loss sync");
+        assertTrue(integrationFacet.totalManagedAssets() == 85, "book value should realize loss on sync");
+        assertTrue(integrationFacet.totalAssets() == 85, "total assets should reflect realized loss");
+    }
+
+    function testDirectIntegrationFacetRejectsUnexpectedPartialWithdrawResult() public {
+        _initializeDirectIntegrationFacet();
+        _approveAsset(bob, address(integrationFacet), 100);
+
+        VM.prank(bob);
+        integrationFacet.deposit(100, bob);
+
+        VM.prank(admin);
+        integrationFacet.setStrategy(address(directLossStrategy));
+        VM.prank(admin);
+        integrationFacet.deployToStrategy(60);
+        directLossStrategy.applyLoss(0, 30);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IERC4626VaultIntegrationFacet.ERC4626VaultStrategyUnexpectedWithdrawResult.selector, 40, 30
+            )
+        );
+        VM.prank(admin);
+        integrationFacet.withdrawFromStrategy(40);
     }
 
     function testDirectIntegrationFacetHelpersRevertBeforeVaultInit() public {
@@ -95,7 +190,7 @@ contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFix
         integrationFacet.idleAssets();
 
         VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultNotInitialized.selector));
-        integrationFacet.estimatedTotalManagedAssets();
+        integrationFacet.liveStrategyAssets();
 
         VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultNotInitialized.selector));
         VM.prank(admin);
@@ -109,33 +204,37 @@ contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFix
         _approveAsset(bob, address(diamond), 100);
 
         VM.prank(bob);
-        uint256 mintedShares = IERC4626VaultFacet(address(diamond)).deposit(40, bob);
+        uint256 mintedShares = IERC4626VaultFacet(address(diamond)).deposit(100, bob);
 
         VM.prank(admin);
         IERC4626VaultIntegrationFacet(address(diamond)).setOracleAdapter(address(adapter));
         VM.prank(admin);
-        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(eve);
-
-        VM.prank(eve);
-        IERC4626VaultIntegrationFacet(address(diamond)).reportStrategyAssets(25);
+        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(address(diamondProfitStrategy));
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).deployToStrategy(60);
+        diamondProfitStrategy.injectProfit(20);
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).syncStrategyAssets();
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).withdrawFromStrategy(30);
 
         IOracleAdapter.OracleQuote memory quotePayload = IERC4626VaultIntegrationFacet(address(diamond)).oracleQuote();
 
-        assertTrue(mintedShares == 40, "deposit shares mismatch");
+        assertTrue(mintedShares == 100, "deposit shares mismatch");
         assertTrue(
             IERC4626VaultIntegrationFacet(address(diamond)).oracleAdapter() == address(adapter), "adapter mismatch"
         );
-        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).strategy() == eve, "strategy mismatch");
         assertTrue(
-            IERC4626VaultIntegrationFacet(address(diamond)).strategyReportedAssets() == 25, "reported assets mismatch"
+            IERC4626VaultIntegrationFacet(address(diamond)).strategy() == address(diamondProfitStrategy),
+            "strategy mismatch"
         );
-        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).idleAssets() == 40, "idle assets mismatch");
+        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).strategyDebt() == 50, "strategy debt mismatch");
         assertTrue(
-            IERC4626VaultIntegrationFacet(address(diamond)).estimatedTotalManagedAssets() == 65,
-            "estimated assets mismatch"
+            IERC4626VaultIntegrationFacet(address(diamond)).liveStrategyAssets() == 50, "live strategy assets mismatch"
         );
-        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 40, "managed assets mismatch");
-        assertTrue(IERC4626VaultFacet(address(diamond)).previewDeposit(10) == 10, "preview should remain core-based");
+        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).idleAssets() == 70, "idle assets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 120, "managed assets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 120, "total assets mismatch");
         assertTrue(quotePayload.value == 100_000_000, "quote value mismatch");
         assertTrue(quotePayload.updatedAt == quoteUpdatedAt, "quote timestamp mismatch");
         assertTrue(quotePayload.decimals == 8, "quote decimals mismatch");

--- a/test/ERC4626VaultStrategyAccountingCore.t.sol
+++ b/test/ERC4626VaultStrategyAccountingCore.t.sol
@@ -168,8 +168,7 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
             "maxWithdraw should include strategy liquidity"
         );
         assertTrue(
-            IERC4626VaultFacet(address(diamond)).maxRedeem(bob) == 100,
-            "maxRedeem should include strategy liquidity"
+            IERC4626VaultFacet(address(diamond)).maxRedeem(bob) == 100, "maxRedeem should include strategy liquidity"
         );
 
         VM.prank(bob);

--- a/test/ERC4626VaultStrategyAccountingCore.t.sol
+++ b/test/ERC4626VaultStrategyAccountingCore.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
+import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol";
 import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControlsFacet.sol";
 import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
 import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
@@ -25,7 +26,7 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
         assertTrue(facet.maxRedeem(bob) == DEPOSIT_ASSETS, "maxRedeem baseline mismatch");
     }
 
-    function testDirectStrategyProfitMakesPricingMarkToMarketAndCapsLiquidity() public {
+    function testDirectStrategyProfitMakesPricingMarkToMarketAndExtendsLiquidity() public {
         _initializeDirectVault();
         _approveAsset(bob, address(facet), DEPOSIT_ASSETS);
 
@@ -45,11 +46,11 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
         assertTrue(facet.previewMint(10) == 12, "previewMint profit mismatch");
         assertTrue(facet.previewWithdraw(12) == 10, "previewWithdraw profit mismatch");
         assertTrue(facet.previewRedeem(10) == 12, "previewRedeem profit mismatch");
-        assertTrue(facet.maxWithdraw(bob) == 40, "maxWithdraw should cap to idle liquidity");
-        assertTrue(facet.maxRedeem(bob) == 33, "maxRedeem should cap to idle liquidity");
+        assertTrue(facet.maxWithdraw(bob) == 120, "maxWithdraw should include strategy liquidity");
+        assertTrue(facet.maxRedeem(bob) == 100, "maxRedeem should include strategy liquidity");
     }
 
-    function testDirectStrategyLossMovesPricingDownward() public {
+    function testDirectStrategyLossMovesPricingDownwardAndCapsLiquidityByWithdrawableAssets() public {
         _initializeDirectVault();
         _approveAsset(bob, address(facet), DEPOSIT_ASSETS);
 
@@ -58,7 +59,7 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
 
         facet.setStrategyStateForTest(address(directLossStrategy), STRATEGY_DEBT);
         _simulateStrategyDeployment(address(facet), directLossStrategy, STRATEGY_DEBT);
-        directLossStrategy.applyLoss(30, 30);
+        directLossStrategy.applyLoss(30, 10);
 
         assertTrue(facet.totalManagedAssets() == DEPOSIT_ASSETS, "book value should remain unchanged");
         assertTrue(facet.totalAssets() == 70, "loss should reduce mark-to-market assets");
@@ -68,27 +69,76 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
         assertTrue(facet.previewMint(10) == 7, "previewMint loss mismatch");
         assertTrue(facet.previewWithdraw(12) == 18, "previewWithdraw loss mismatch");
         assertTrue(facet.previewRedeem(10) == 7, "previewRedeem loss mismatch");
-        assertTrue(facet.maxWithdraw(bob) == 40, "maxWithdraw should remain idle-capped");
-        assertTrue(facet.maxRedeem(bob) == 57, "maxRedeem loss cap mismatch");
+        assertTrue(facet.maxWithdraw(bob) == 50, "maxWithdraw should cap to idle plus withdrawable strategy assets");
+        assertTrue(facet.maxRedeem(bob) == 71, "maxRedeem should cap to immediate liquidity");
     }
 
-    function testConfiguredStrategyWithZeroDebtKeepsHostedPricingBaseline() public {
+    function testDirectWithdrawAutoPullsFromStrategyLiquidity() public {
         _initializeDirectVault();
         _approveAsset(bob, address(facet), DEPOSIT_ASSETS);
 
         VM.prank(bob);
         facet.deposit(DEPOSIT_ASSETS, bob);
 
-        facet.setStrategyStateForTest(address(directProfitStrategy), 0);
-        directProfitStrategy.injectProfit(20);
+        facet.setStrategyStateForTest(address(directProfitStrategy), STRATEGY_DEBT);
+        _simulateStrategyDeployment(address(facet), directProfitStrategy, STRATEGY_DEBT);
 
-        assertTrue(facet.totalManagedAssets() == DEPOSIT_ASSETS, "book value mismatch");
-        assertTrue(facet.totalAssets() == DEPOSIT_ASSETS, "zero debt strategy should not affect pricing");
-        assertTrue(facet.previewDeposit(10) == 10, "previewDeposit should ignore zero-debt strategy");
-        assertTrue(facet.maxWithdraw(bob) == DEPOSIT_ASSETS, "maxWithdraw should ignore zero-debt strategy");
+        VM.prank(bob);
+        uint256 burnedShares = facet.withdraw(80, bob, bob);
+
+        assertTrue(burnedShares == 80, "withdraw should burn shares at current price");
+        assertTrue(facet.balanceOf(bob) == 20, "remaining shares mismatch");
+        assertTrue(facet.totalManagedAssets() == 20, "book value mismatch after withdraw");
+        assertTrue(facet.totalAssets() == 20, "total assets mismatch after withdraw");
+        assertTrue(facet.maxWithdraw(bob) == 20, "remaining withdraw capacity mismatch");
+        assertTrue(facet.maxRedeem(bob) == 20, "remaining redeem capacity mismatch");
+        assertTrue(asset.balanceOf(address(facet)) == 0, "vault idle balance should be exhausted");
+        assertTrue(directProfitStrategy.totalAssets() == 20, "strategy live assets mismatch");
+        assertTrue(asset.balanceOf(bob) == INITIAL_ASSETS - 20, "underlying balance mismatch after withdraw");
     }
 
-    function testDiamondHostedVaultStrategyAccountingUsesLiveStrategyAssets() public {
+    function testDirectRedeemAutoPullsAndReturnsCurrentShareValue() public {
+        _initializeDirectVault();
+        _approveAsset(bob, address(facet), DEPOSIT_ASSETS);
+
+        VM.prank(bob);
+        facet.deposit(DEPOSIT_ASSETS, bob);
+
+        facet.setStrategyStateForTest(address(directProfitStrategy), STRATEGY_DEBT);
+        _simulateStrategyDeployment(address(facet), directProfitStrategy, STRATEGY_DEBT);
+        directProfitStrategy.injectProfit(20);
+
+        VM.prank(bob);
+        uint256 returnedAssets = facet.redeem(50, bob, bob);
+
+        assertTrue(returnedAssets == 60, "redeem should return current share value");
+        assertTrue(facet.balanceOf(bob) == 50, "remaining shares mismatch after redeem");
+        assertTrue(facet.totalManagedAssets() == 60, "book value mismatch after redeem");
+        assertTrue(facet.totalAssets() == 60, "total assets mismatch after redeem");
+        assertTrue(asset.balanceOf(address(facet)) == 0, "vault idle balance should be exhausted after redeem");
+        assertTrue(directProfitStrategy.totalAssets() == 60, "remaining strategy assets mismatch");
+        assertTrue(asset.balanceOf(bob) == INITIAL_ASSETS - 40, "underlying balance mismatch after redeem");
+    }
+
+    function testDirectWithdrawRevertsWhenStrategyLiquidityCannotCoverExactAssets() public {
+        _initializeDirectVault();
+        _approveAsset(bob, address(facet), DEPOSIT_ASSETS);
+
+        VM.prank(bob);
+        facet.deposit(DEPOSIT_ASSETS, bob);
+
+        facet.setStrategyStateForTest(address(directLossStrategy), STRATEGY_DEBT);
+        _simulateStrategyDeployment(address(facet), directLossStrategy, STRATEGY_DEBT);
+        directLossStrategy.applyLoss(20, 10);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(IERC4626VaultControls.ERC4626VaultWithdrawLimitExceeded.selector, 70, 50)
+        );
+        VM.prank(bob);
+        facet.withdraw(70, bob, bob);
+    }
+
+    function testDiamondHostedVaultStrategyAccountingUsesRealLifecycleAndAutoPull() public {
         _installHostedVaultFacetsToDiamond();
         _initializeDiamondVault();
         _approveAsset(bob, address(diamond), DEPOSIT_ASSETS);
@@ -98,8 +148,8 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
 
         VM.prank(admin);
         IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(address(diamondProfitStrategy));
-        _seedDiamondStrategyState(address(diamondProfitStrategy), STRATEGY_DEBT);
-        _simulateStrategyDeployment(address(diamond), diamondProfitStrategy, STRATEGY_DEBT);
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).deployToStrategy(60);
         diamondProfitStrategy.injectProfit(20);
 
         VM.prank(admin);
@@ -114,13 +164,24 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
         assertTrue(IERC4626VaultFacet(address(diamond)).maxDeposit(bob) == 5, "maxDeposit should use live totalAssets");
         assertTrue(IERC4626VaultFacet(address(diamond)).maxMint(bob) == 4, "maxMint should use live totalAssets");
         assertTrue(
-            IERC4626VaultFacet(address(diamond)).maxWithdraw(bob) == 40, "maxWithdraw should cap to idle liquidity"
+            IERC4626VaultFacet(address(diamond)).maxWithdraw(bob) == 120,
+            "maxWithdraw should include strategy liquidity"
         );
-        assertTrue(IERC4626VaultFacet(address(diamond)).maxRedeem(bob) == 33, "maxRedeem should cap to idle liquidity");
-        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).idleAssets() == 40, "idle assets mismatch");
-        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).strategyDebt() == 60, "strategy debt mismatch");
         assertTrue(
-            IERC4626VaultIntegrationFacet(address(diamond)).liveStrategyAssets() == 80, "live strategy assets mismatch"
+            IERC4626VaultFacet(address(diamond)).maxRedeem(bob) == 100,
+            "maxRedeem should include strategy liquidity"
         );
+
+        VM.prank(bob);
+        uint256 burnedShares = IERC4626VaultFacet(address(diamond)).withdraw(80, bob, bob);
+
+        assertTrue(burnedShares == 67, "diamond withdraw should burn shares at updated price");
+        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).idleAssets() == 0, "idle assets should be zero");
+        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).strategyDebt() == 40, "strategy debt mismatch");
+        assertTrue(
+            IERC4626VaultIntegrationFacet(address(diamond)).liveStrategyAssets() == 40, "live strategy assets mismatch"
+        );
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 40, "managed assets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 40, "post-withdraw totalAssets mismatch");
     }
 }

--- a/test/ERC4626VaultStrategyAccountingCore.t.sol
+++ b/test/ERC4626VaultStrategyAccountingCore.t.sol
@@ -88,7 +88,7 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
         assertTrue(facet.maxWithdraw(bob) == DEPOSIT_ASSETS, "maxWithdraw should ignore zero-debt strategy");
     }
 
-    function testDiamondHostedVaultStrategyAccountingUsesLiveStrategyAssetsAndKeepsAdvisoryReportsSeparate() public {
+    function testDiamondHostedVaultStrategyAccountingUsesLiveStrategyAssets() public {
         _installHostedVaultFacetsToDiamond();
         _initializeDiamondVault();
         _approveAsset(bob, address(diamond), DEPOSIT_ASSETS);
@@ -102,8 +102,6 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
         _simulateStrategyDeployment(address(diamond), diamondProfitStrategy, STRATEGY_DEBT);
         diamondProfitStrategy.injectProfit(20);
 
-        VM.prank(admin);
-        IERC4626VaultIntegrationFacet(address(diamond)).reportStrategyAssets(25);
         VM.prank(admin);
         IERC4626VaultControlsFacet(address(diamond)).setLimitConfig(125, 0, 0, 0, 0);
 
@@ -120,12 +118,9 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
         );
         assertTrue(IERC4626VaultFacet(address(diamond)).maxRedeem(bob) == 33, "maxRedeem should cap to idle liquidity");
         assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).idleAssets() == 40, "idle assets mismatch");
+        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).strategyDebt() == 60, "strategy debt mismatch");
         assertTrue(
-            IERC4626VaultIntegrationFacet(address(diamond)).strategyReportedAssets() == 25, "reported assets mismatch"
-        );
-        assertTrue(
-            IERC4626VaultIntegrationFacet(address(diamond)).estimatedTotalManagedAssets() == 65,
-            "estimated assets should remain advisory"
+            IERC4626VaultIntegrationFacet(address(diamond)).liveStrategyAssets() == 80, "live strategy assets mismatch"
         );
     }
 }

--- a/test/ERC4626VaultStrategyAccountingCore.t.sol
+++ b/test/ERC4626VaultStrategyAccountingCore.t.sol
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControlsFacet.sol";
+import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
+import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
+import {ERC4626VaultStrategyAccountingFixture} from "./helpers/ERC4626VaultStrategyAccountingTestHarness.sol";
+
+contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountingFixture {
+    function testDirectHostedVaultWithoutStrategyMatchesBaselineAccounting() public {
+        _initializeDirectVault();
+        _approveAsset(bob, address(facet), DEPOSIT_ASSETS);
+
+        VM.prank(bob);
+        uint256 mintedShares = facet.deposit(DEPOSIT_ASSETS, bob);
+
+        assertTrue(mintedShares == DEPOSIT_ASSETS, "deposit shares mismatch");
+        assertTrue(facet.totalManagedAssets() == DEPOSIT_ASSETS, "book value mismatch");
+        assertTrue(facet.totalAssets() == DEPOSIT_ASSETS, "total assets mismatch");
+        assertTrue(facet.previewDeposit(10) == 10, "previewDeposit baseline mismatch");
+        assertTrue(facet.previewMint(10) == 10, "previewMint baseline mismatch");
+        assertTrue(facet.previewWithdraw(10) == 10, "previewWithdraw baseline mismatch");
+        assertTrue(facet.previewRedeem(10) == 10, "previewRedeem baseline mismatch");
+        assertTrue(facet.maxWithdraw(bob) == DEPOSIT_ASSETS, "maxWithdraw baseline mismatch");
+        assertTrue(facet.maxRedeem(bob) == DEPOSIT_ASSETS, "maxRedeem baseline mismatch");
+    }
+
+    function testDirectStrategyProfitMakesPricingMarkToMarketAndCapsLiquidity() public {
+        _initializeDirectVault();
+        _approveAsset(bob, address(facet), DEPOSIT_ASSETS);
+
+        VM.prank(bob);
+        facet.deposit(DEPOSIT_ASSETS, bob);
+
+        facet.setStrategyStateForTest(address(directProfitStrategy), STRATEGY_DEBT);
+        _simulateStrategyDeployment(address(facet), directProfitStrategy, STRATEGY_DEBT);
+        directProfitStrategy.injectProfit(20);
+
+        assertTrue(facet.strategyDebtForTest() == STRATEGY_DEBT, "strategy debt mismatch");
+        assertTrue(facet.totalManagedAssets() == DEPOSIT_ASSETS, "book value should remain unchanged");
+        assertTrue(facet.totalAssets() == 120, "mark-to-market assets mismatch");
+        assertTrue(facet.convertToShares(12) == 10, "convertToShares profit mismatch");
+        assertTrue(facet.convertToAssets(10) == 12, "convertToAssets profit mismatch");
+        assertTrue(facet.previewDeposit(12) == 10, "previewDeposit profit mismatch");
+        assertTrue(facet.previewMint(10) == 12, "previewMint profit mismatch");
+        assertTrue(facet.previewWithdraw(12) == 10, "previewWithdraw profit mismatch");
+        assertTrue(facet.previewRedeem(10) == 12, "previewRedeem profit mismatch");
+        assertTrue(facet.maxWithdraw(bob) == 40, "maxWithdraw should cap to idle liquidity");
+        assertTrue(facet.maxRedeem(bob) == 33, "maxRedeem should cap to idle liquidity");
+    }
+
+    function testDirectStrategyLossMovesPricingDownward() public {
+        _initializeDirectVault();
+        _approveAsset(bob, address(facet), DEPOSIT_ASSETS);
+
+        VM.prank(bob);
+        facet.deposit(DEPOSIT_ASSETS, bob);
+
+        facet.setStrategyStateForTest(address(directLossStrategy), STRATEGY_DEBT);
+        _simulateStrategyDeployment(address(facet), directLossStrategy, STRATEGY_DEBT);
+        directLossStrategy.applyLoss(30, 30);
+
+        assertTrue(facet.totalManagedAssets() == DEPOSIT_ASSETS, "book value should remain unchanged");
+        assertTrue(facet.totalAssets() == 70, "loss should reduce mark-to-market assets");
+        assertTrue(facet.convertToShares(12) == 17, "convertToShares loss mismatch");
+        assertTrue(facet.convertToAssets(10) == 7, "convertToAssets loss mismatch");
+        assertTrue(facet.previewDeposit(12) == 17, "previewDeposit loss mismatch");
+        assertTrue(facet.previewMint(10) == 7, "previewMint loss mismatch");
+        assertTrue(facet.previewWithdraw(12) == 18, "previewWithdraw loss mismatch");
+        assertTrue(facet.previewRedeem(10) == 7, "previewRedeem loss mismatch");
+        assertTrue(facet.maxWithdraw(bob) == 40, "maxWithdraw should remain idle-capped");
+        assertTrue(facet.maxRedeem(bob) == 57, "maxRedeem loss cap mismatch");
+    }
+
+    function testConfiguredStrategyWithZeroDebtKeepsHostedPricingBaseline() public {
+        _initializeDirectVault();
+        _approveAsset(bob, address(facet), DEPOSIT_ASSETS);
+
+        VM.prank(bob);
+        facet.deposit(DEPOSIT_ASSETS, bob);
+
+        facet.setStrategyStateForTest(address(directProfitStrategy), 0);
+        directProfitStrategy.injectProfit(20);
+
+        assertTrue(facet.totalManagedAssets() == DEPOSIT_ASSETS, "book value mismatch");
+        assertTrue(facet.totalAssets() == DEPOSIT_ASSETS, "zero debt strategy should not affect pricing");
+        assertTrue(facet.previewDeposit(10) == 10, "previewDeposit should ignore zero-debt strategy");
+        assertTrue(facet.maxWithdraw(bob) == DEPOSIT_ASSETS, "maxWithdraw should ignore zero-debt strategy");
+    }
+
+    function testDiamondHostedVaultStrategyAccountingUsesLiveStrategyAssetsAndKeepsAdvisoryReportsSeparate() public {
+        _installHostedVaultFacetsToDiamond();
+        _initializeDiamondVault();
+        _approveAsset(bob, address(diamond), DEPOSIT_ASSETS);
+
+        VM.prank(bob);
+        IERC4626VaultFacet(address(diamond)).deposit(DEPOSIT_ASSETS, bob);
+
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(address(diamondProfitStrategy));
+        _seedDiamondStrategyState(address(diamondProfitStrategy), STRATEGY_DEBT);
+        _simulateStrategyDeployment(address(diamond), diamondProfitStrategy, STRATEGY_DEBT);
+        diamondProfitStrategy.injectProfit(20);
+
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).reportStrategyAssets(25);
+        VM.prank(admin);
+        IERC4626VaultControlsFacet(address(diamond)).setLimitConfig(125, 0, 0, 0, 0);
+
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == DEPOSIT_ASSETS, "book value mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 120, "diamond totalAssets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewDeposit(12) == 10, "diamond previewDeposit mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewMint(10) == 12, "diamond previewMint mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewWithdraw(12) == 10, "diamond previewWithdraw mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewRedeem(10) == 12, "diamond previewRedeem mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxDeposit(bob) == 5, "maxDeposit should use live totalAssets");
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxMint(bob) == 4, "maxMint should use live totalAssets");
+        assertTrue(
+            IERC4626VaultFacet(address(diamond)).maxWithdraw(bob) == 40, "maxWithdraw should cap to idle liquidity"
+        );
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxRedeem(bob) == 33, "maxRedeem should cap to idle liquidity");
+        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).idleAssets() == 40, "idle assets mismatch");
+        assertTrue(
+            IERC4626VaultIntegrationFacet(address(diamond)).strategyReportedAssets() == 25, "reported assets mismatch"
+        );
+        assertTrue(
+            IERC4626VaultIntegrationFacet(address(diamond)).estimatedTotalManagedAssets() == 65,
+            "estimated assets should remain advisory"
+        );
+    }
+}

--- a/test/VaultStrategyFoundationCore.t.sol
+++ b/test/VaultStrategyFoundationCore.t.sol
@@ -10,7 +10,7 @@ import {
 contract VaultStrategyFoundationCoreTest is ERC4626VaultStrategyFixture {
     function testStorageDefaultsAfterHostedVaultInit() public view {
         assertTrue(storageHarness.strategy() == address(0), "strategy should default to zero");
-        assertTrue(storageHarness.strategyReportedAssets() == 0, "reported assets should default to zero");
+        assertTrue(storageHarness.liveStrategyAssets() == 0, "live strategy assets should default to zero");
         assertTrue(storageHarness.strategyDebtForTest() == 0, "strategy debt should default to zero");
         assertFalse(storageHarness.strategyEmergencyExitForTest(), "emergency exit should default to false");
     }
@@ -30,6 +30,7 @@ contract VaultStrategyFoundationCoreTest is ERC4626VaultStrategyFixture {
     }
 
     function testProfitMockReportsHigherAssetsAfterProfitInjection() public {
+        asset.mint(address(profitStrategy), 100);
         VM.prank(vault);
         profitStrategy.deployFunds(100);
 
@@ -37,9 +38,11 @@ contract VaultStrategyFoundationCoreTest is ERC4626VaultStrategyFixture {
 
         assertTrue(profitStrategy.totalAssets() == 125, "profit should increase tracked assets");
         assertTrue(profitStrategy.maxWithdrawableAssets() == 125, "profit should increase withdrawable assets");
+        assertTrue(asset.balanceOf(address(profitStrategy)) == 125, "strategy balance should reflect profit");
     }
 
     function testLossShortfallMockReturnsLessThanRequestedAndShrinksAssets() public {
+        asset.mint(address(lossStrategy), 100);
         VM.prank(vault);
         lossStrategy.deployFunds(100);
 
@@ -47,6 +50,7 @@ contract VaultStrategyFoundationCoreTest is ERC4626VaultStrategyFixture {
 
         assertTrue(lossStrategy.totalAssets() == 60, "loss should reduce tracked assets");
         assertTrue(lossStrategy.maxWithdrawableAssets() == 35, "shortfall should cap withdrawable assets");
+        assertTrue(asset.balanceOf(address(lossStrategy)) == 60, "strategy balance should reflect realized loss");
 
         VM.prank(vault);
         uint256 returnedAssets = lossStrategy.withdrawToVault(50);
@@ -54,6 +58,7 @@ contract VaultStrategyFoundationCoreTest is ERC4626VaultStrategyFixture {
         assertTrue(returnedAssets == 35, "withdraw should return available assets only");
         assertTrue(lossStrategy.totalAssets() == 25, "tracked assets should reduce by returned amount");
         assertTrue(lossStrategy.maxWithdrawableAssets() == 0, "withdrawable assets should be depleted");
+        assertTrue(asset.balanceOf(vault) == 35, "vault should receive returned assets");
     }
 
     function testRevertingMockRevertsOnConfiguredCalls() public {
@@ -63,6 +68,8 @@ contract VaultStrategyFoundationCoreTest is ERC4626VaultStrategyFixture {
             abi.encodeWithSelector(MockVaultStrategyForcedRevert.selector, revertingStrategy.totalAssets.selector)
         );
         revertingStrategy.totalAssets();
+
+        asset.mint(address(revertingStrategy), 100);
 
         VM.expectRevert(
             abi.encodeWithSelector(MockVaultStrategyForcedRevert.selector, revertingStrategy.deployFunds.selector)
@@ -86,6 +93,7 @@ contract VaultStrategyFoundationCoreTest is ERC4626VaultStrategyFixture {
     }
 
     function testEmergencyUnwindMockReturnsAllAssetsAndClearsState() public {
+        asset.mint(address(unwindStrategy), 100);
         VM.prank(vault);
         unwindStrategy.deployFunds(100);
 
@@ -97,6 +105,7 @@ contract VaultStrategyFoundationCoreTest is ERC4626VaultStrategyFixture {
         assertTrue(returnedAssets == 100, "emergency unwind should return all tracked assets");
         assertTrue(unwindStrategy.totalAssets() == 0, "tracked assets should clear on unwind");
         assertTrue(unwindStrategy.maxWithdrawableAssets() == 0, "withdrawable assets should clear on unwind");
+        assertTrue(asset.balanceOf(vault) == 100, "vault should receive unwound assets");
     }
 
     function _assertBinding(IERC4626VaultStrategy strategy_) internal view {

--- a/test/VaultStrategyFoundationCore.t.sol
+++ b/test/VaultStrategyFoundationCore.t.sol
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC4626VaultStrategy} from "../src/interfaces/IERC4626VaultStrategy.sol";
+import {
+    ERC4626VaultStrategyFixture,
+    MockVaultStrategyForcedRevert
+} from "./helpers/ERC4626VaultStrategyTestHarness.sol";
+
+contract VaultStrategyFoundationCoreTest is ERC4626VaultStrategyFixture {
+    function testStorageDefaultsAfterHostedVaultInit() public view {
+        assertTrue(storageHarness.strategy() == address(0), "strategy should default to zero");
+        assertTrue(storageHarness.strategyReportedAssets() == 0, "reported assets should default to zero");
+        assertTrue(storageHarness.strategyDebtForTest() == 0, "strategy debt should default to zero");
+        assertFalse(storageHarness.strategyEmergencyExitForTest(), "emergency exit should default to false");
+    }
+
+    function testMockStrategiesBindVaultAndAsset() public view {
+        _assertBinding(profitStrategy);
+        _assertBinding(lossStrategy);
+        _assertBinding(revertingStrategy);
+        _assertBinding(unwindStrategy);
+    }
+
+    function testOnlyVaultCanOperateStrategyLifecycle() public {
+        _assertOnlyVault(profitStrategy);
+        _assertOnlyVault(lossStrategy);
+        _assertOnlyVault(revertingStrategy);
+        _assertOnlyVault(unwindStrategy);
+    }
+
+    function testProfitMockReportsHigherAssetsAfterProfitInjection() public {
+        VM.prank(vault);
+        profitStrategy.deployFunds(100);
+
+        profitStrategy.injectProfit(25);
+
+        assertTrue(profitStrategy.totalAssets() == 125, "profit should increase tracked assets");
+        assertTrue(profitStrategy.maxWithdrawableAssets() == 125, "profit should increase withdrawable assets");
+    }
+
+    function testLossShortfallMockReturnsLessThanRequestedAndShrinksAssets() public {
+        VM.prank(vault);
+        lossStrategy.deployFunds(100);
+
+        lossStrategy.applyLoss(40, 35);
+
+        assertTrue(lossStrategy.totalAssets() == 60, "loss should reduce tracked assets");
+        assertTrue(lossStrategy.maxWithdrawableAssets() == 35, "shortfall should cap withdrawable assets");
+
+        VM.prank(vault);
+        uint256 returnedAssets = lossStrategy.withdrawToVault(50);
+
+        assertTrue(returnedAssets == 35, "withdraw should return available assets only");
+        assertTrue(lossStrategy.totalAssets() == 25, "tracked assets should reduce by returned amount");
+        assertTrue(lossStrategy.maxWithdrawableAssets() == 0, "withdrawable assets should be depleted");
+    }
+
+    function testRevertingMockRevertsOnConfiguredCalls() public {
+        revertingStrategy.setRevertModes(true, true, true, true);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(MockVaultStrategyForcedRevert.selector, revertingStrategy.totalAssets.selector)
+        );
+        revertingStrategy.totalAssets();
+
+        VM.expectRevert(
+            abi.encodeWithSelector(MockVaultStrategyForcedRevert.selector, revertingStrategy.deployFunds.selector)
+        );
+        VM.prank(vault);
+        revertingStrategy.deployFunds(100);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(MockVaultStrategyForcedRevert.selector, revertingStrategy.withdrawToVault.selector)
+        );
+        VM.prank(vault);
+        revertingStrategy.withdrawToVault(100);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                MockVaultStrategyForcedRevert.selector, revertingStrategy.withdrawAllToVault.selector
+            )
+        );
+        VM.prank(vault);
+        revertingStrategy.withdrawAllToVault();
+    }
+
+    function testEmergencyUnwindMockReturnsAllAssetsAndClearsState() public {
+        VM.prank(vault);
+        unwindStrategy.deployFunds(100);
+
+        unwindStrategy.setWithdrawableAssets(40);
+
+        VM.prank(vault);
+        uint256 returnedAssets = unwindStrategy.withdrawAllToVault();
+
+        assertTrue(returnedAssets == 100, "emergency unwind should return all tracked assets");
+        assertTrue(unwindStrategy.totalAssets() == 0, "tracked assets should clear on unwind");
+        assertTrue(unwindStrategy.maxWithdrawableAssets() == 0, "withdrawable assets should clear on unwind");
+    }
+
+    function _assertBinding(IERC4626VaultStrategy strategy_) internal view {
+        assertTrue(strategy_.vault() == vault, "vault binding mismatch");
+        assertTrue(strategy_.asset() == address(asset), "asset binding mismatch");
+    }
+
+    function _assertOnlyVault(IERC4626VaultStrategy strategy_) internal {
+        VM.expectRevert(
+            abi.encodeWithSelector(IERC4626VaultStrategy.ERC4626VaultStrategyOnlyVault.selector, outsider, vault)
+        );
+        VM.prank(outsider);
+        strategy_.deployFunds(1);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(IERC4626VaultStrategy.ERC4626VaultStrategyOnlyVault.selector, outsider, vault)
+        );
+        VM.prank(outsider);
+        strategy_.withdrawToVault(1);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(IERC4626VaultStrategy.ERC4626VaultStrategyOnlyVault.selector, outsider, vault)
+        );
+        VM.prank(outsider);
+        strategy_.withdrawAllToVault();
+    }
+}

--- a/test/helpers/DiamondVaultDeploymentTestHarness.sol
+++ b/test/helpers/DiamondVaultDeploymentTestHarness.sol
@@ -10,11 +10,13 @@ import {ERC4626VaultIntegrationFacetHarness} from "./ERC4626VaultIntegrationFace
 import {MockVaultAsset} from "./ERC4626CoreTestHarness.sol";
 import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
 import {MockOracleFeed, OracleAdapterHarness} from "./OracleAdapterTestHarness.sol";
+import {ProfitMockVaultStrategy} from "./ERC4626VaultStrategyTestHarness.sol";
 import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {TestBase} from "./AccessControlTestHarness.sol";
 
 abstract contract DiamondVaultDeploymentFixture is TestBase {
     address internal admin = address(0xA11CE);
+    address internal alice = address(0xA11CE0);
 
     uint64 internal maxStaleness = 1 hours;
     uint64 internal currentTime = 1_000_000;
@@ -29,6 +31,7 @@ abstract contract DiamondVaultDeploymentFixture is TestBase {
     MockVaultAsset internal asset;
     MockOracleFeed internal feed;
     OracleAdapterHarness internal adapter;
+    ProfitMockVaultStrategy internal strategy;
 
     function setUp() public virtual {
         VM.warp(currentTime);
@@ -43,6 +46,7 @@ abstract contract DiamondVaultDeploymentFixture is TestBase {
         feed = new MockOracleFeed(8);
         feed.setLatestRoundData(1, 100_000_000, quoteUpdatedAt, quoteUpdatedAt, 1);
         adapter = new OracleAdapterHarness(admin, address(feed), maxStaleness);
+        strategy = new ProfitMockVaultStrategy(address(diamond), address(asset));
 
         _installLoupeFacet();
     }
@@ -89,6 +93,11 @@ abstract contract DiamondVaultDeploymentFixture is TestBase {
     function _wireOracleAdapter() internal {
         VM.prank(admin);
         integrationFacetInterface().setOracleAdapter(address(adapter));
+    }
+
+    function _wireStrategy() internal {
+        VM.prank(admin);
+        integrationFacetInterface().setStrategy(address(strategy));
     }
 
     function coreFacetInterface() internal view returns (ERC4626VaultFacetHarness) {

--- a/test/helpers/DiamondVaultHostHardeningTestHarness.sol
+++ b/test/helpers/DiamondVaultHostHardeningTestHarness.sol
@@ -10,6 +10,7 @@ import {ERC4626VaultFacet} from "../../src/vault/facets/ERC4626VaultFacet.sol";
 import {ERC4626VaultIntegrationFacet} from "../../src/vault/facets/ERC4626VaultIntegrationFacet.sol";
 import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {DiamondVaultDeploymentFixture} from "./DiamondVaultDeploymentTestHarness.sol";
+import {ProfitMockVaultStrategy} from "./ERC4626VaultStrategyTestHarness.sol";
 
 interface IFacetVersionMarker {
     function facetVersion() external view returns (uint256);
@@ -48,16 +49,17 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
     uint256 internal constant BOB_DEPOSIT = 200_000;
     uint256 internal constant CAROL_DEPOSIT = 150_000;
     uint256 internal constant SHARE_ALLOWANCE = 25_000;
-    uint256 internal constant STRATEGY_REPORTED_ASSETS = 75_000;
+    uint256 internal constant STRATEGY_DEPLOYED_ASSETS = 75_000;
 
     address internal bob = address(0xB0B);
     address internal carol = address(0xCA11);
     address internal dave = address(0xD0D);
     address internal eve = address(0xE11E);
     address internal feeSink = address(0xFEE);
-    address internal strategyReporter = address(0x57A7);
 
     address[ACTOR_COUNT] internal actors;
+
+    ProfitMockVaultStrategy internal strategyContract;
 
     ERC4626VaultFacetReplacement internal coreReplacement;
     ERC4626VaultControlsFacetReplacement internal controlsReplacement;
@@ -74,6 +76,8 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
         actors[1] = carol;
         actors[2] = dave;
         actors[3] = eve;
+
+        strategyContract = new ProfitMockVaultStrategy(address(diamond), address(asset));
 
         for (uint256 i = 0; i < ACTOR_COUNT; i++) {
             address actor = actors[i];
@@ -122,10 +126,10 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
 
     function _seedIntegrationState() internal {
         VM.prank(admin);
-        integrationFacetInterface().setStrategy(strategyReporter);
+        integrationFacetInterface().setStrategy(address(strategyContract));
 
-        VM.prank(strategyReporter);
-        integrationFacetInterface().reportStrategyAssets(STRATEGY_REPORTED_ASSETS);
+        VM.prank(admin);
+        integrationFacetInterface().deployToStrategy(STRATEGY_DEPLOYED_ASSETS);
     }
 
     function _replaceCoreFacet(address facetAddress_) internal {

--- a/test/helpers/DiamondVaultHostHardeningTestHarness.sol
+++ b/test/helpers/DiamondVaultHostHardeningTestHarness.sol
@@ -2,15 +2,12 @@
 pragma solidity ^0.8.30;
 
 import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
-import {IERC4626VaultControls} from "../../src/interfaces/IERC4626VaultControls.sol";
-import {IERC4626VaultFacet} from "../../src/interfaces/IERC4626VaultFacet.sol";
-import {IERC4626VaultIntegrationFacet} from "../../src/interfaces/IERC4626VaultIntegrationFacet.sol";
 import {ERC4626VaultControlsFacet} from "../../src/vault/facets/ERC4626VaultControlsFacet.sol";
 import {ERC4626VaultFacet} from "../../src/vault/facets/ERC4626VaultFacet.sol";
 import {ERC4626VaultIntegrationFacet} from "../../src/vault/facets/ERC4626VaultIntegrationFacet.sol";
 import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {DiamondVaultDeploymentFixture} from "./DiamondVaultDeploymentTestHarness.sol";
-import {ProfitMockVaultStrategy} from "./ERC4626VaultStrategyTestHarness.sol";
+import {MutableMockVaultStrategy} from "./ERC4626VaultStrategyTestHarness.sol";
 
 interface IFacetVersionMarker {
     function facetVersion() external view returns (uint256);
@@ -42,24 +39,46 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
         uint256 feeSinkBalance;
         uint256 actorUnderlyingBalanceSum;
         uint256 actorShareBalanceSum;
+        uint256 strategyUnderlyingBalance;
+        uint256 profitSourceBalance;
+        uint256 lossSinkBalance;
+        uint256 strategyDebt;
+        uint256 liveStrategyAssets;
+    }
+
+    struct StrategyStateSnapshot {
+        address strategy;
+        uint256 strategyDebt;
+        uint256 liveStrategyAssets;
+        uint256 idleAssets;
+        bool emergencyExit;
+        uint256 totalManagedAssets;
+        uint256 totalAssets;
+        uint256 bobMaxWithdraw;
+        uint256 bobMaxRedeem;
     }
 
     uint256 internal constant INITIAL_ASSETS = 1_000_000;
+    uint256 internal constant STRATEGY_PROFIT_RESERVE = 1_000_000_000_000;
     uint256 internal constant ACTOR_COUNT = 4;
     uint256 internal constant BOB_DEPOSIT = 200_000;
     uint256 internal constant CAROL_DEPOSIT = 150_000;
     uint256 internal constant SHARE_ALLOWANCE = 25_000;
-    uint256 internal constant STRATEGY_DEPLOYED_ASSETS = 75_000;
+    uint256 internal constant STRATEGY_DEPLOYED_ASSETS = 225_000;
+    uint256 internal constant STRATEGY_PROFIT_ASSETS = 25_000;
+    uint256 internal constant BOB_AUTO_PULL_WITHDRAW_ASSETS = 150_000;
+    uint256 internal constant CAROL_AUTO_PULL_REDEEM_SHARES = 50_000;
 
     address internal bob = address(0xB0B);
     address internal carol = address(0xCA11);
     address internal dave = address(0xD0D);
     address internal eve = address(0xE11E);
     address internal feeSink = address(0xFEE);
+    address internal profitSource = address(0xBEEF1234);
 
     address[ACTOR_COUNT] internal actors;
 
-    ProfitMockVaultStrategy internal strategyContract;
+    MutableMockVaultStrategy internal strategyContract;
 
     ERC4626VaultFacetReplacement internal coreReplacement;
     ERC4626VaultControlsFacetReplacement internal controlsReplacement;
@@ -77,7 +96,7 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
         actors[2] = dave;
         actors[3] = eve;
 
-        strategyContract = new ProfitMockVaultStrategy(address(diamond), address(asset));
+        strategyContract = new MutableMockVaultStrategy(address(diamond), address(asset), profitSource);
 
         for (uint256 i = 0; i < ACTOR_COUNT; i++) {
             address actor = actors[i];
@@ -85,6 +104,10 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
             VM.prank(actor);
             asset.approve(address(diamond), type(uint256).max);
         }
+
+        asset.mint(profitSource, STRATEGY_PROFIT_RESERVE);
+        VM.prank(profitSource);
+        asset.approve(address(strategyContract), type(uint256).max);
     }
 
     function _installAndSeedVaultHost() internal {
@@ -130,6 +153,18 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
 
         VM.prank(admin);
         integrationFacetInterface().deployToStrategy(STRATEGY_DEPLOYED_ASSETS);
+    }
+
+    function _injectStrategyProfit(uint256 assets) internal {
+        strategyContract.injectProfit(assets);
+    }
+
+    function _applyStrategyLoss(uint256 lossAssets, uint256 withdrawableAssets) internal {
+        strategyContract.applyLoss(lossAssets, withdrawableAssets);
+    }
+
+    function _setStrategyWithdrawAllReverts(bool shouldRevert) internal {
+        strategyContract.setWithdrawAllReverts(shouldRevert);
     }
 
     function _replaceCoreFacet(address facetAddress_) internal {
@@ -225,6 +260,9 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
 
         sum += asset.balanceOf(address(diamond));
         sum += asset.balanceOf(feeSink);
+        sum += asset.balanceOf(address(strategyContract));
+        sum += asset.balanceOf(profitSource);
+        sum += asset.balanceOf(strategyContract.lossSink());
     }
 
     function _snapshotAccounting() internal view returns (AccountingSnapshot memory snapshot) {
@@ -232,6 +270,11 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
         snapshot.totalSupply = coreFacetInterface().totalSupply();
         snapshot.vaultUnderlyingBalance = asset.balanceOf(address(diamond));
         snapshot.feeSinkBalance = asset.balanceOf(feeSink);
+        snapshot.strategyUnderlyingBalance = asset.balanceOf(address(strategyContract));
+        snapshot.profitSourceBalance = asset.balanceOf(profitSource);
+        snapshot.lossSinkBalance = asset.balanceOf(strategyContract.lossSink());
+        snapshot.strategyDebt = integrationFacetInterface().strategyDebt();
+        snapshot.liveStrategyAssets = integrationFacetInterface().liveStrategyAssets();
 
         for (uint256 i = 0; i < ACTOR_COUNT; i++) {
             snapshot.actorUnderlyingBalanceSum += asset.balanceOf(actors[i]);
@@ -247,6 +290,42 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
         assertTrue(afterSnapshot.feeSinkBalance == snapshot.feeSinkBalance, reason);
         assertTrue(afterSnapshot.actorUnderlyingBalanceSum == snapshot.actorUnderlyingBalanceSum, reason);
         assertTrue(afterSnapshot.actorShareBalanceSum == snapshot.actorShareBalanceSum, reason);
+        assertTrue(afterSnapshot.strategyUnderlyingBalance == snapshot.strategyUnderlyingBalance, reason);
+        assertTrue(afterSnapshot.profitSourceBalance == snapshot.profitSourceBalance, reason);
+        assertTrue(afterSnapshot.lossSinkBalance == snapshot.lossSinkBalance, reason);
+        assertTrue(afterSnapshot.strategyDebt == snapshot.strategyDebt, reason);
+        assertTrue(afterSnapshot.liveStrategyAssets == snapshot.liveStrategyAssets, reason);
+    }
+
+    function _snapshotStrategyState() internal view returns (StrategyStateSnapshot memory snapshot) {
+        snapshot.strategy = integrationFacetInterface().strategy();
+        snapshot.strategyDebt = integrationFacetInterface().strategyDebt();
+        snapshot.liveStrategyAssets = integrationFacetInterface().liveStrategyAssets();
+        snapshot.idleAssets = integrationFacetInterface().idleAssets();
+        snapshot.emergencyExit = integrationFacetInterface().strategyEmergencyExit();
+        snapshot.totalManagedAssets = coreFacetInterface().totalManagedAssets();
+        snapshot.totalAssets = coreFacetInterface().totalAssets();
+        snapshot.bobMaxWithdraw = coreFacetInterface().maxWithdraw(bob);
+        snapshot.bobMaxRedeem = coreFacetInterface().maxRedeem(bob);
+    }
+
+    function _assertStrategyState(StrategyStateSnapshot memory snapshot) internal view {
+        assertTrue(integrationFacetInterface().strategy() == snapshot.strategy, "strategy mismatch");
+        assertTrue(integrationFacetInterface().strategyDebt() == snapshot.strategyDebt, "strategy debt mismatch");
+        assertTrue(
+            integrationFacetInterface().liveStrategyAssets() == snapshot.liveStrategyAssets,
+            "live strategy assets mismatch"
+        );
+        assertTrue(integrationFacetInterface().idleAssets() == snapshot.idleAssets, "idle assets mismatch");
+        assertTrue(
+            integrationFacetInterface().strategyEmergencyExit() == snapshot.emergencyExit, "emergency exit mismatch"
+        );
+        assertTrue(
+            coreFacetInterface().totalManagedAssets() == snapshot.totalManagedAssets, "totalManagedAssets mismatch"
+        );
+        assertTrue(coreFacetInterface().totalAssets() == snapshot.totalAssets, "totalAssets mismatch");
+        assertTrue(coreFacetInterface().maxWithdraw(bob) == snapshot.bobMaxWithdraw, "bob maxWithdraw mismatch");
+        assertTrue(coreFacetInterface().maxRedeem(bob) == snapshot.bobMaxRedeem, "bob maxRedeem mismatch");
     }
 
     function _addFacet(address facetAddress_, bytes4[] memory selectors) internal {

--- a/test/helpers/ERC4626VaultIntegrationFacetTestHarness.sol
+++ b/test/helpers/ERC4626VaultIntegrationFacetTestHarness.sol
@@ -14,15 +14,16 @@ import {ReentrantMockVaultAsset} from "./ERC4626VaultControlsTestHarness.sol";
 import {ERC4626VaultFacetHarness} from "./ERC4626VaultFacetTestHarness.sol";
 import {MockOracleFeed, OracleAdapterHarness} from "./OracleAdapterTestHarness.sol";
 import {MockVaultAsset} from "./ERC4626CoreTestHarness.sol";
-import {LossShortfallMockVaultStrategy, ProfitMockVaultStrategy, RevertingMockVaultStrategy} from "./ERC4626VaultStrategyTestHarness.sol";
+import {
+    LossShortfallMockVaultStrategy,
+    ProfitMockVaultStrategy,
+    RevertingMockVaultStrategy
+} from "./ERC4626VaultStrategyTestHarness.sol";
 
-contract ERC4626VaultIntegrationFacetHarness is ERC4626VaultIntegrationFacet {
-    function initializeHostedVaultForTest(
-        address vaultAsset,
-        string memory vaultName,
-        string memory vaultSymbol,
-        address admin
-    ) external {
+contract ERC4626VaultIntegrationFacetHarness is ERC4626VaultIntegrationFacet {}
+
+contract InitializedERC4626VaultIntegrationFacetHarness is ERC4626VaultIntegrationFacet {
+    constructor(address vaultAsset, string memory vaultName, string memory vaultSymbol, address admin) {
         _initializeVaultFacetControl(admin);
         _initializeErc4626Vault(vaultAsset, vaultName, vaultSymbol);
     }
@@ -43,7 +44,7 @@ abstract contract ERC4626VaultIntegrationFacetFixture is TestBase {
     MockVaultAsset internal otherAsset;
     ERC4626VaultFacetHarness internal coreFacet;
     ERC4626VaultControlsFacetHarness internal controlsFacet;
-    ERC4626VaultIntegrationFacetHarness internal integrationFacet;
+    ERC4626VaultIntegrationFacet internal integrationFacet;
     DiamondCutFacet internal cutFacet;
     DiamondLoupeFacet internal loupeFacet;
     DiamondProxyHarness internal diamond;
@@ -70,12 +71,8 @@ abstract contract ERC4626VaultIntegrationFacetFixture is TestBase {
         feed = new MockOracleFeed(8);
         feed.setLatestRoundData(1, 100_000_000, quoteUpdatedAt, quoteUpdatedAt, 1);
         adapter = new OracleAdapterHarness(admin, address(feed), maxStaleness);
-        directProfitStrategy = new ProfitMockVaultStrategy(address(integrationFacet), address(asset));
-        directLossStrategy = new LossShortfallMockVaultStrategy(address(integrationFacet), address(asset));
-        directRevertingStrategy = new RevertingMockVaultStrategy(address(integrationFacet), address(asset));
         diamondProfitStrategy = new ProfitMockVaultStrategy(address(diamond), address(asset));
         wrongVaultStrategy = new ProfitMockVaultStrategy(address(0xBAD), address(asset));
-        directWrongAssetStrategy = new ProfitMockVaultStrategy(address(integrationFacet), address(otherAsset));
 
         asset.mint(bob, INITIAL_ASSETS);
         asset.mint(eve, INITIAL_ASSETS);
@@ -84,7 +81,12 @@ abstract contract ERC4626VaultIntegrationFacetFixture is TestBase {
     }
 
     function _initializeDirectIntegrationFacet() internal {
-        integrationFacet.initializeHostedVaultForTest(address(asset), "Vault Share", "vSHARE", admin);
+        integrationFacet =
+            new InitializedERC4626VaultIntegrationFacetHarness(address(asset), "Vault Share", "vSHARE", admin);
+        directProfitStrategy = new ProfitMockVaultStrategy(address(integrationFacet), address(asset));
+        directLossStrategy = new LossShortfallMockVaultStrategy(address(integrationFacet), address(asset));
+        directRevertingStrategy = new RevertingMockVaultStrategy(address(integrationFacet), address(asset));
+        directWrongAssetStrategy = new ProfitMockVaultStrategy(address(integrationFacet), address(otherAsset));
     }
 
     function _initializeDiamondVault() internal {

--- a/test/helpers/ERC4626VaultIntegrationFacetTestHarness.sol
+++ b/test/helpers/ERC4626VaultIntegrationFacetTestHarness.sol
@@ -13,6 +13,8 @@ import {ERC4626VaultControlsFacetHarness} from "./ERC4626VaultControlsFacetTestH
 import {ReentrantMockVaultAsset} from "./ERC4626VaultControlsTestHarness.sol";
 import {ERC4626VaultFacetHarness} from "./ERC4626VaultFacetTestHarness.sol";
 import {MockOracleFeed, OracleAdapterHarness} from "./OracleAdapterTestHarness.sol";
+import {MockVaultAsset} from "./ERC4626CoreTestHarness.sol";
+import {LossShortfallMockVaultStrategy, ProfitMockVaultStrategy} from "./ERC4626VaultStrategyTestHarness.sol";
 
 contract ERC4626VaultIntegrationFacetHarness is ERC4626VaultIntegrationFacet {
     function initializeHostedVaultForTest(
@@ -38,6 +40,7 @@ abstract contract ERC4626VaultIntegrationFacetFixture is TestBase {
     uint64 internal quoteUpdatedAt = 999_900;
 
     ReentrantMockVaultAsset internal asset;
+    MockVaultAsset internal otherAsset;
     ERC4626VaultFacetHarness internal coreFacet;
     ERC4626VaultControlsFacetHarness internal controlsFacet;
     ERC4626VaultIntegrationFacetHarness internal integrationFacet;
@@ -46,11 +49,17 @@ abstract contract ERC4626VaultIntegrationFacetFixture is TestBase {
     DiamondProxyHarness internal diamond;
     MockOracleFeed internal feed;
     OracleAdapterHarness internal adapter;
+    ProfitMockVaultStrategy internal directProfitStrategy;
+    LossShortfallMockVaultStrategy internal directLossStrategy;
+    ProfitMockVaultStrategy internal diamondProfitStrategy;
+    ProfitMockVaultStrategy internal wrongVaultStrategy;
+    ProfitMockVaultStrategy internal directWrongAssetStrategy;
 
     function setUp() public virtual {
         VM.warp(currentTime);
 
         asset = new ReentrantMockVaultAsset();
+        otherAsset = new MockVaultAsset("Other USD", "oUSD", 6);
         coreFacet = new ERC4626VaultFacetHarness();
         controlsFacet = new ERC4626VaultControlsFacetHarness();
         integrationFacet = new ERC4626VaultIntegrationFacetHarness();
@@ -60,6 +69,11 @@ abstract contract ERC4626VaultIntegrationFacetFixture is TestBase {
         feed = new MockOracleFeed(8);
         feed.setLatestRoundData(1, 100_000_000, quoteUpdatedAt, quoteUpdatedAt, 1);
         adapter = new OracleAdapterHarness(admin, address(feed), maxStaleness);
+        directProfitStrategy = new ProfitMockVaultStrategy(address(integrationFacet), address(asset));
+        directLossStrategy = new LossShortfallMockVaultStrategy(address(integrationFacet), address(asset));
+        diamondProfitStrategy = new ProfitMockVaultStrategy(address(diamond), address(asset));
+        wrongVaultStrategy = new ProfitMockVaultStrategy(address(0xBAD), address(asset));
+        directWrongAssetStrategy = new ProfitMockVaultStrategy(address(integrationFacet), address(otherAsset));
 
         asset.mint(bob, INITIAL_ASSETS);
         asset.mint(eve, INITIAL_ASSETS);

--- a/test/helpers/ERC4626VaultIntegrationFacetTestHarness.sol
+++ b/test/helpers/ERC4626VaultIntegrationFacetTestHarness.sol
@@ -14,7 +14,7 @@ import {ReentrantMockVaultAsset} from "./ERC4626VaultControlsTestHarness.sol";
 import {ERC4626VaultFacetHarness} from "./ERC4626VaultFacetTestHarness.sol";
 import {MockOracleFeed, OracleAdapterHarness} from "./OracleAdapterTestHarness.sol";
 import {MockVaultAsset} from "./ERC4626CoreTestHarness.sol";
-import {LossShortfallMockVaultStrategy, ProfitMockVaultStrategy} from "./ERC4626VaultStrategyTestHarness.sol";
+import {LossShortfallMockVaultStrategy, ProfitMockVaultStrategy, RevertingMockVaultStrategy} from "./ERC4626VaultStrategyTestHarness.sol";
 
 contract ERC4626VaultIntegrationFacetHarness is ERC4626VaultIntegrationFacet {
     function initializeHostedVaultForTest(
@@ -51,6 +51,7 @@ abstract contract ERC4626VaultIntegrationFacetFixture is TestBase {
     OracleAdapterHarness internal adapter;
     ProfitMockVaultStrategy internal directProfitStrategy;
     LossShortfallMockVaultStrategy internal directLossStrategy;
+    RevertingMockVaultStrategy internal directRevertingStrategy;
     ProfitMockVaultStrategy internal diamondProfitStrategy;
     ProfitMockVaultStrategy internal wrongVaultStrategy;
     ProfitMockVaultStrategy internal directWrongAssetStrategy;
@@ -71,6 +72,7 @@ abstract contract ERC4626VaultIntegrationFacetFixture is TestBase {
         adapter = new OracleAdapterHarness(admin, address(feed), maxStaleness);
         directProfitStrategy = new ProfitMockVaultStrategy(address(integrationFacet), address(asset));
         directLossStrategy = new LossShortfallMockVaultStrategy(address(integrationFacet), address(asset));
+        directRevertingStrategy = new RevertingMockVaultStrategy(address(integrationFacet), address(asset));
         diamondProfitStrategy = new ProfitMockVaultStrategy(address(diamond), address(asset));
         wrongVaultStrategy = new ProfitMockVaultStrategy(address(0xBAD), address(asset));
         directWrongAssetStrategy = new ProfitMockVaultStrategy(address(integrationFacet), address(otherAsset));

--- a/test/helpers/ERC4626VaultStrategyAccountingTestHarness.sol
+++ b/test/helpers/ERC4626VaultStrategyAccountingTestHarness.sol
@@ -45,7 +45,6 @@ abstract contract ERC4626VaultStrategyAccountingFixture is TestBase {
     address internal admin = address(0xA11CE);
     address internal bob = address(0xB0B);
     address internal eve = address(0xE11E);
-    address internal sink = address(0x515E);
 
     ReentrantMockVaultAsset internal asset;
     ERC4626VaultStrategyAccountingFacetHarness internal facet;
@@ -108,7 +107,7 @@ abstract contract ERC4626VaultStrategyAccountingFixture is TestBase {
         internal
     {
         VM.prank(vaultAccount);
-        asset.transfer(sink, assets_);
+        asset.transfer(address(strategy_), assets_);
 
         VM.prank(vaultAccount);
         strategy_.deployFunds(assets_);

--- a/test/helpers/ERC4626VaultStrategyAccountingTestHarness.sol
+++ b/test/helpers/ERC4626VaultStrategyAccountingTestHarness.sol
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
+import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
+import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
+import {IERC4626VaultFacet} from "../../src/interfaces/IERC4626VaultFacet.sol";
+import {IERC4626VaultIntegrationFacet} from "../../src/interfaces/IERC4626VaultIntegrationFacet.sol";
+import {IERC4626VaultStrategy} from "../../src/interfaces/IERC4626VaultStrategy.sol";
+import {ERC4626VaultFacet} from "../../src/vault/facets/ERC4626VaultFacet.sol";
+import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
+import {LibERC4626VaultStorage} from "../../src/vault/storage/LibERC4626VaultStorage.sol";
+import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+import {ERC4626VaultControlsFacetHarness} from "./ERC4626VaultControlsFacetTestHarness.sol";
+import {ReentrantMockVaultAsset} from "./ERC4626VaultControlsTestHarness.sol";
+import {ERC4626VaultIntegrationFacetHarness} from "./ERC4626VaultIntegrationFacetTestHarness.sol";
+import {LossShortfallMockVaultStrategy, ProfitMockVaultStrategy} from "./ERC4626VaultStrategyTestHarness.sol";
+
+contract ERC4626VaultStrategyAccountingFacetHarness is ERC4626VaultFacet {
+    function setStrategyStateForTest(address strategy_, uint256 strategyDebt_) external {
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        layout.strategy = strategy_;
+        layout.strategyDebt = strategyDebt_;
+    }
+
+    function strategyDebtForTest() external view returns (uint256) {
+        return LibERC4626VaultStorage.layout().strategyDebt;
+    }
+}
+
+contract ERC4626VaultStrategyAccountingInitMock {
+    function seedStrategyState(address strategy_, uint256 strategyDebt_) external {
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        layout.strategy = strategy_;
+        layout.strategyDebt = strategyDebt_;
+    }
+}
+
+abstract contract ERC4626VaultStrategyAccountingFixture is TestBase {
+    uint256 internal constant INITIAL_ASSETS = 1_000_000;
+    uint256 internal constant DEPOSIT_ASSETS = 100;
+    uint256 internal constant STRATEGY_DEBT = 60;
+
+    address internal admin = address(0xA11CE);
+    address internal bob = address(0xB0B);
+    address internal eve = address(0xE11E);
+    address internal sink = address(0x515E);
+
+    ReentrantMockVaultAsset internal asset;
+    ERC4626VaultStrategyAccountingFacetHarness internal facet;
+    ERC4626VaultControlsFacetHarness internal controlsFacet;
+    ERC4626VaultIntegrationFacetHarness internal integrationFacet;
+    DiamondCutFacet internal cutFacet;
+    DiamondLoupeFacet internal loupeFacet;
+    DiamondProxyHarness internal diamond;
+    ERC4626VaultStrategyAccountingInitMock internal accountingInit;
+    ProfitMockVaultStrategy internal directProfitStrategy;
+    LossShortfallMockVaultStrategy internal directLossStrategy;
+    ProfitMockVaultStrategy internal diamondProfitStrategy;
+
+    function setUp() public virtual {
+        asset = new ReentrantMockVaultAsset();
+        facet = new ERC4626VaultStrategyAccountingFacetHarness();
+        controlsFacet = new ERC4626VaultControlsFacetHarness();
+        integrationFacet = new ERC4626VaultIntegrationFacetHarness();
+        cutFacet = new DiamondCutFacet();
+        loupeFacet = new DiamondLoupeFacet();
+        diamond = new DiamondProxyHarness(admin, address(cutFacet));
+        accountingInit = new ERC4626VaultStrategyAccountingInitMock();
+        directProfitStrategy = new ProfitMockVaultStrategy(address(facet), address(asset));
+        directLossStrategy = new LossShortfallMockVaultStrategy(address(facet), address(asset));
+        diamondProfitStrategy = new ProfitMockVaultStrategy(address(diamond), address(asset));
+
+        asset.mint(bob, INITIAL_ASSETS);
+        asset.mint(eve, INITIAL_ASSETS);
+
+        _installLoupeFacet();
+    }
+
+    function _initializeDirectVault() internal {
+        facet.initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function _initializeDiamondVault() internal {
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond)).initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function _approveAsset(address owner, address spender, uint256 amount) internal {
+        VM.prank(owner);
+        asset.approve(spender, amount);
+    }
+
+    function _seedDiamondStrategyState(address strategy_, uint256 strategyDebt_) internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](0);
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond))
+            .diamondCut(
+                cut,
+                address(accountingInit),
+                abi.encodeCall(ERC4626VaultStrategyAccountingInitMock.seedStrategyState, (strategy_, strategyDebt_))
+            );
+    }
+
+    function _simulateStrategyDeployment(address vaultAccount, IERC4626VaultStrategy strategy_, uint256 assets_)
+        internal
+    {
+        VM.prank(vaultAccount);
+        asset.transfer(sink, assets_);
+
+        VM.prank(vaultAccount);
+        strategy_.deployFunds(assets_);
+    }
+
+    function _installLoupeFacet() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(loupeFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: _loupeSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installVaultCoreFacetToDiamond() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(facet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultCoreSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installVaultControlsFacetToDiamond() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(controlsFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultControlsSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installVaultIntegrationFacetToDiamond() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(integrationFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultIntegrationSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installHostedVaultFacetsToDiamond() internal {
+        _installVaultCoreFacetToDiamond();
+        _installVaultControlsFacetToDiamond();
+        _installVaultIntegrationFacetToDiamond();
+    }
+
+    function _loupeSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](6);
+        selectors[0] = DiamondLoupeFacet.facets.selector;
+        selectors[1] = DiamondLoupeFacet.facetFunctionSelectors.selector;
+        selectors[2] = DiamondLoupeFacet.facetAddresses.selector;
+        selectors[3] = DiamondLoupeFacet.facetAddress.selector;
+        selectors[4] = DiamondLoupeFacet.owner.selector;
+        selectors[5] = DiamondLoupeFacet.transferOwnership.selector;
+    }
+}

--- a/test/helpers/ERC4626VaultStrategyTestHarness.sol
+++ b/test/helpers/ERC4626VaultStrategyTestHarness.sol
@@ -8,12 +8,7 @@ import {TestBase} from "./AccessControlTestHarness.sol";
 import {MockVaultAsset} from "./ERC4626CoreTestHarness.sol";
 
 contract ERC4626VaultStrategyStorageHarness is ERC4626VaultIntegrationFacet {
-    function initializeHostedVaultForStrategyTest(
-        address vaultAsset,
-        string memory vaultName,
-        string memory vaultSymbol,
-        address admin
-    ) external {
+    constructor(address vaultAsset, string memory vaultName, string memory vaultSymbol, address admin) {
         _initializeVaultFacetControl(admin);
         _initializeErc4626Vault(vaultAsset, vaultName, vaultSymbol);
     }
@@ -211,8 +206,7 @@ abstract contract ERC4626VaultStrategyFixture is TestBase {
 
     function setUp() public virtual {
         asset = new MockVaultAsset("Mock USD", "mUSD", 6);
-        storageHarness = new ERC4626VaultStrategyStorageHarness();
-        storageHarness.initializeHostedVaultForStrategyTest(address(asset), "Vault Share", "vSHARE", admin);
+        storageHarness = new ERC4626VaultStrategyStorageHarness(address(asset), "Vault Share", "vSHARE", admin);
 
         profitStrategy = new ProfitMockVaultStrategy(vault, address(asset));
         lossStrategy = new LossShortfallMockVaultStrategy(vault, address(asset));

--- a/test/helpers/ERC4626VaultStrategyTestHarness.sol
+++ b/test/helpers/ERC4626VaultStrategyTestHarness.sol
@@ -30,6 +30,8 @@ contract ERC4626VaultStrategyStorageHarness is ERC4626VaultIntegrationFacet {
 error MockVaultStrategyForcedRevert(bytes4 selector);
 
 abstract contract MockVaultStrategyBase is IERC4626VaultStrategy {
+    address internal constant LOSS_SINK = address(0x1055);
+
     address internal immutable _vault;
     address internal immutable _asset;
 
@@ -67,18 +69,25 @@ abstract contract MockVaultStrategyBase is IERC4626VaultStrategy {
     function deployFunds(uint256 assets) external virtual override onlyVault {
         _trackedAssets += assets;
         _withdrawableAssets += assets;
+        require(MockVaultAsset(_asset).balanceOf(address(this)) >= _trackedAssets, "STRATEGY_BALANCE_UNDERFUNDED");
     }
 
     function withdrawToVault(uint256 assets) external virtual override onlyVault returns (uint256 assetsReturned) {
         assetsReturned = _min(assets, maxWithdrawableAssets());
         _trackedAssets -= assetsReturned;
         _withdrawableAssets -= assetsReturned;
+        if (assetsReturned != 0) {
+            MockVaultAsset(_asset).transfer(_vault, assetsReturned);
+        }
     }
 
     function withdrawAllToVault() external virtual override onlyVault returns (uint256 assetsReturned) {
         assetsReturned = maxWithdrawableAssets();
         _trackedAssets -= assetsReturned;
         _withdrawableAssets -= assetsReturned;
+        if (assetsReturned != 0) {
+            MockVaultAsset(_asset).transfer(_vault, assetsReturned);
+        }
     }
 
     function setWithdrawableAssets(uint256 assets) external {
@@ -94,6 +103,11 @@ contract ProfitMockVaultStrategy is MockVaultStrategyBase {
     constructor(address vault_, address asset_) MockVaultStrategyBase(vault_, asset_) {}
 
     function injectProfit(uint256 assets) external {
+        if (assets == 0) {
+            return;
+        }
+
+        MockVaultAsset(_asset).mint(address(this), assets);
         _trackedAssets += assets;
         _withdrawableAssets += assets;
     }
@@ -103,7 +117,11 @@ contract LossShortfallMockVaultStrategy is MockVaultStrategyBase {
     constructor(address vault_, address asset_) MockVaultStrategyBase(vault_, asset_) {}
 
     function applyLoss(uint256 lossAssets, uint256 withdrawableAssets_) external {
-        _trackedAssets = lossAssets >= _trackedAssets ? 0 : _trackedAssets - lossAssets;
+        uint256 realizedLoss = _min(lossAssets, _trackedAssets);
+        if (realizedLoss != 0) {
+            MockVaultAsset(_asset).transfer(LOSS_SINK, realizedLoss);
+            _trackedAssets -= realizedLoss;
+        }
         _withdrawableAssets = _min(withdrawableAssets_, _trackedAssets);
     }
 }
@@ -138,6 +156,7 @@ contract RevertingMockVaultStrategy is MockVaultStrategyBase {
         }
         _trackedAssets += assets;
         _withdrawableAssets += assets;
+        require(MockVaultAsset(_asset).balanceOf(address(this)) >= _trackedAssets, "STRATEGY_BALANCE_UNDERFUNDED");
     }
 
     function withdrawToVault(uint256 assets) external override onlyVault returns (uint256 assetsReturned) {
@@ -147,6 +166,9 @@ contract RevertingMockVaultStrategy is MockVaultStrategyBase {
         assetsReturned = _min(assets, maxWithdrawableAssets());
         _trackedAssets -= assetsReturned;
         _withdrawableAssets -= assetsReturned;
+        if (assetsReturned != 0) {
+            MockVaultAsset(_asset).transfer(_vault, assetsReturned);
+        }
     }
 
     function withdrawAllToVault() external override onlyVault returns (uint256 assetsReturned) {
@@ -156,6 +178,9 @@ contract RevertingMockVaultStrategy is MockVaultStrategyBase {
         assetsReturned = maxWithdrawableAssets();
         _trackedAssets -= assetsReturned;
         _withdrawableAssets -= assetsReturned;
+        if (assetsReturned != 0) {
+            MockVaultAsset(_asset).transfer(_vault, assetsReturned);
+        }
     }
 }
 
@@ -166,6 +191,9 @@ contract EmergencyUnwindMockVaultStrategy is MockVaultStrategyBase {
         assetsReturned = _trackedAssets;
         _trackedAssets = 0;
         _withdrawableAssets = 0;
+        if (assetsReturned != 0) {
+            MockVaultAsset(_asset).transfer(_vault, assetsReturned);
+        }
     }
 }
 

--- a/test/helpers/ERC4626VaultStrategyTestHarness.sol
+++ b/test/helpers/ERC4626VaultStrategyTestHarness.sol
@@ -192,6 +192,59 @@ contract EmergencyUnwindMockVaultStrategy is MockVaultStrategyBase {
     }
 }
 
+contract MutableMockVaultStrategy is MockVaultStrategyBase {
+    address internal immutable _profitSource;
+    bool internal _revertWithdrawAllToVault;
+
+    constructor(address vault_, address asset_, address profitSource_) MockVaultStrategyBase(vault_, asset_) {
+        _profitSource = profitSource_;
+    }
+
+    function profitSource() external view returns (address) {
+        return _profitSource;
+    }
+
+    function lossSink() external pure returns (address) {
+        return LOSS_SINK;
+    }
+
+    function injectProfit(uint256 assets) external {
+        if (assets == 0) {
+            return;
+        }
+
+        MockVaultAsset(_asset).transferFrom(_profitSource, address(this), assets);
+        _trackedAssets += assets;
+        _withdrawableAssets += assets;
+    }
+
+    function applyLoss(uint256 lossAssets, uint256 withdrawableAssets_) external {
+        uint256 realizedLoss = _min(lossAssets, _trackedAssets);
+        if (realizedLoss != 0) {
+            MockVaultAsset(_asset).transfer(LOSS_SINK, realizedLoss);
+            _trackedAssets -= realizedLoss;
+        }
+        _withdrawableAssets = _min(withdrawableAssets_, _trackedAssets);
+    }
+
+    function setWithdrawAllReverts(bool shouldRevert) external {
+        _revertWithdrawAllToVault = shouldRevert;
+    }
+
+    function withdrawAllToVault() external override onlyVault returns (uint256 assetsReturned) {
+        if (_revertWithdrawAllToVault) {
+            revert MockVaultStrategyForcedRevert(this.withdrawAllToVault.selector);
+        }
+
+        assetsReturned = maxWithdrawableAssets();
+        _trackedAssets -= assetsReturned;
+        _withdrawableAssets -= assetsReturned;
+        if (assetsReturned != 0) {
+            MockVaultAsset(_asset).transfer(_vault, assetsReturned);
+        }
+    }
+}
+
 abstract contract ERC4626VaultStrategyFixture is TestBase {
     address internal admin = address(0xA11CE);
     address internal vault = address(0xA417);

--- a/test/helpers/ERC4626VaultStrategyTestHarness.sol
+++ b/test/helpers/ERC4626VaultStrategyTestHarness.sol
@@ -1,0 +1,194 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC4626VaultStrategy} from "../../src/interfaces/IERC4626VaultStrategy.sol";
+import {ERC4626VaultIntegrationFacet} from "../../src/vault/facets/ERC4626VaultIntegrationFacet.sol";
+import {LibERC4626VaultStorage} from "../../src/vault/storage/LibERC4626VaultStorage.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+import {MockVaultAsset} from "./ERC4626CoreTestHarness.sol";
+
+contract ERC4626VaultStrategyStorageHarness is ERC4626VaultIntegrationFacet {
+    function initializeHostedVaultForStrategyTest(
+        address vaultAsset,
+        string memory vaultName,
+        string memory vaultSymbol,
+        address admin
+    ) external {
+        _initializeVaultFacetControl(admin);
+        _initializeErc4626Vault(vaultAsset, vaultName, vaultSymbol);
+    }
+
+    function strategyDebtForTest() external view returns (uint256) {
+        return LibERC4626VaultStorage.layout().strategyDebt;
+    }
+
+    function strategyEmergencyExitForTest() external view returns (bool) {
+        return LibERC4626VaultStorage.layout().strategyEmergencyExit;
+    }
+}
+
+error MockVaultStrategyForcedRevert(bytes4 selector);
+
+abstract contract MockVaultStrategyBase is IERC4626VaultStrategy {
+    address internal immutable _vault;
+    address internal immutable _asset;
+
+    uint256 internal _trackedAssets;
+    uint256 internal _withdrawableAssets;
+
+    constructor(address vault_, address asset_) {
+        _vault = vault_;
+        _asset = asset_;
+    }
+
+    modifier onlyVault() {
+        if (msg.sender != _vault) {
+            revert ERC4626VaultStrategyOnlyVault(msg.sender, _vault);
+        }
+        _;
+    }
+
+    function vault() external view override returns (address) {
+        return _vault;
+    }
+
+    function asset() external view override returns (address) {
+        return _asset;
+    }
+
+    function totalAssets() public view virtual override returns (uint256) {
+        return _trackedAssets;
+    }
+
+    function maxWithdrawableAssets() public view virtual override returns (uint256) {
+        return _min(_trackedAssets, _withdrawableAssets);
+    }
+
+    function deployFunds(uint256 assets) external virtual override onlyVault {
+        _trackedAssets += assets;
+        _withdrawableAssets += assets;
+    }
+
+    function withdrawToVault(uint256 assets) external virtual override onlyVault returns (uint256 assetsReturned) {
+        assetsReturned = _min(assets, maxWithdrawableAssets());
+        _trackedAssets -= assetsReturned;
+        _withdrawableAssets -= assetsReturned;
+    }
+
+    function withdrawAllToVault() external virtual override onlyVault returns (uint256 assetsReturned) {
+        assetsReturned = maxWithdrawableAssets();
+        _trackedAssets -= assetsReturned;
+        _withdrawableAssets -= assetsReturned;
+    }
+
+    function setWithdrawableAssets(uint256 assets) external {
+        _withdrawableAssets = _min(assets, _trackedAssets);
+    }
+
+    function _min(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a < b ? a : b;
+    }
+}
+
+contract ProfitMockVaultStrategy is MockVaultStrategyBase {
+    constructor(address vault_, address asset_) MockVaultStrategyBase(vault_, asset_) {}
+
+    function injectProfit(uint256 assets) external {
+        _trackedAssets += assets;
+        _withdrawableAssets += assets;
+    }
+}
+
+contract LossShortfallMockVaultStrategy is MockVaultStrategyBase {
+    constructor(address vault_, address asset_) MockVaultStrategyBase(vault_, asset_) {}
+
+    function applyLoss(uint256 lossAssets, uint256 withdrawableAssets_) external {
+        _trackedAssets = lossAssets >= _trackedAssets ? 0 : _trackedAssets - lossAssets;
+        _withdrawableAssets = _min(withdrawableAssets_, _trackedAssets);
+    }
+}
+
+contract RevertingMockVaultStrategy is MockVaultStrategyBase {
+    bool internal _revertTotalAssets;
+    bool internal _revertDeployFunds;
+    bool internal _revertWithdrawToVault;
+    bool internal _revertWithdrawAllToVault;
+
+    constructor(address vault_, address asset_) MockVaultStrategyBase(vault_, asset_) {}
+
+    function setRevertModes(bool totalAssets_, bool deployFunds_, bool withdrawToVault_, bool withdrawAllToVault_)
+        external
+    {
+        _revertTotalAssets = totalAssets_;
+        _revertDeployFunds = deployFunds_;
+        _revertWithdrawToVault = withdrawToVault_;
+        _revertWithdrawAllToVault = withdrawAllToVault_;
+    }
+
+    function totalAssets() public view override returns (uint256) {
+        if (_revertTotalAssets) {
+            revert MockVaultStrategyForcedRevert(this.totalAssets.selector);
+        }
+        return super.totalAssets();
+    }
+
+    function deployFunds(uint256 assets) external override onlyVault {
+        if (_revertDeployFunds) {
+            revert MockVaultStrategyForcedRevert(this.deployFunds.selector);
+        }
+        _trackedAssets += assets;
+        _withdrawableAssets += assets;
+    }
+
+    function withdrawToVault(uint256 assets) external override onlyVault returns (uint256 assetsReturned) {
+        if (_revertWithdrawToVault) {
+            revert MockVaultStrategyForcedRevert(this.withdrawToVault.selector);
+        }
+        assetsReturned = _min(assets, maxWithdrawableAssets());
+        _trackedAssets -= assetsReturned;
+        _withdrawableAssets -= assetsReturned;
+    }
+
+    function withdrawAllToVault() external override onlyVault returns (uint256 assetsReturned) {
+        if (_revertWithdrawAllToVault) {
+            revert MockVaultStrategyForcedRevert(this.withdrawAllToVault.selector);
+        }
+        assetsReturned = maxWithdrawableAssets();
+        _trackedAssets -= assetsReturned;
+        _withdrawableAssets -= assetsReturned;
+    }
+}
+
+contract EmergencyUnwindMockVaultStrategy is MockVaultStrategyBase {
+    constructor(address vault_, address asset_) MockVaultStrategyBase(vault_, asset_) {}
+
+    function withdrawAllToVault() external override onlyVault returns (uint256 assetsReturned) {
+        assetsReturned = _trackedAssets;
+        _trackedAssets = 0;
+        _withdrawableAssets = 0;
+    }
+}
+
+abstract contract ERC4626VaultStrategyFixture is TestBase {
+    address internal admin = address(0xA11CE);
+    address internal vault = address(0xA417);
+    address internal outsider = address(0x0B5E1D3);
+
+    MockVaultAsset internal asset;
+    ERC4626VaultStrategyStorageHarness internal storageHarness;
+    ProfitMockVaultStrategy internal profitStrategy;
+    LossShortfallMockVaultStrategy internal lossStrategy;
+    RevertingMockVaultStrategy internal revertingStrategy;
+    EmergencyUnwindMockVaultStrategy internal unwindStrategy;
+
+    function setUp() public virtual {
+        asset = new MockVaultAsset("Mock USD", "mUSD", 6);
+        storageHarness = new ERC4626VaultStrategyStorageHarness();
+        storageHarness.initializeHostedVaultForStrategyTest(address(asset), "Vault Share", "vSHARE", admin);
+
+        profitStrategy = new ProfitMockVaultStrategy(vault, address(asset));
+        lossStrategy = new LossShortfallMockVaultStrategy(vault, address(asset));
+        revertingStrategy = new RevertingMockVaultStrategy(vault, address(asset));
+        unwindStrategy = new EmergencyUnwindMockVaultStrategy(vault, address(asset));
+    }
+}


### PR DESCRIPTION
## Summary
- complete the Strategy / Yield Abstraction milestone for the hosted vault platform
- add the strategy interface foundation, live strategy-aware accounting, active strategy lifecycle, loss and emergency-exit safety, deployment integration, hardening and invariants, and milestone docs
- keep the hosted vault model single-strategy, single-asset, and diamond-routed throughout

## Included Issues
- closes #21
- completed #112 Define strategy interface and mock strategy foundation
- completed #113 Refactor vault accounting for live strategy assets
- completed #114 Implement active strategy lifecycle on the integration facet
- completed #115 Add loss accounting and emergency-exit safety
- completed #116 Add strategy-enabled vault deployment and init integration
- completed #117 Add cross-facet hardening and invariants for the strategy-enabled vault
- completed #118 Document strategy lifecycle and safety assumptions

## Validation
- forge test --offline
- targeted strategy lifecycle, accounting, deployment, hardening, and invariant suites
- local Anvil deployment and Auralis smoke and activity flows for the strategy-enabled hosted vault

## Notes
- the hosted vault now supports a real active strategy lifecycle instead of advisory reporting only
- book accounting and live pricing are intentionally distinct: totalManagedAssets() remains book value while totalAssets() is strategy-aware mark-to-market pricing
- emergency exit is sticky for the configured strategy until debt is zero and the strategy is cleared or replaced