### PR TITLE
Add loss accounting and emergency-exit safety

### DIFF
--- a/src/interfaces/IERC4626VaultIntegrationFacet.sol
+++ b/src/interfaces/IERC4626VaultIntegrationFacet.sol
@@ -19,10 +19,18 @@ interface IERC4626VaultIntegrationFacet is IERC165 {
     event VaultStrategyDeployed(uint256 assets, uint256 newStrategyDebt, address indexed sender);
 
     /// @notice Emitted when assets are withdrawn from the configured strategy back to the vault.
-    event VaultStrategyWithdrawn(uint256 assets, uint256 newStrategyDebt, address indexed sender);
+    event VaultStrategyWithdrawn(
+        uint256 requestedAssets, uint256 returnedAssets, uint256 newStrategyDebt, address indexed sender
+    );
 
     /// @notice Emitted when live strategy assets are synced into vault book accounting.
     event VaultStrategySynced(uint256 previousDebt, uint256 liveAssets, address indexed sender);
+
+    /// @notice Emitted when emergency exit is triggered and the strategy is unwound as far as possible.
+    event VaultStrategyEmergencyExitTriggered(uint256 returnedAssets, uint256 newStrategyDebt, address indexed sender);
+
+    /// @notice Emitted when emergency exit is activated but the unwind attempt reverts.
+    event VaultStrategyEmergencyExitFailed(address indexed strategy, address indexed sender, bytes revertData);
 
     /// @notice Thrown when `oracleQuote()` is called without a configured adapter.
     error ERC4626VaultOracleAdapterNotConfigured();
@@ -51,10 +59,8 @@ interface IERC4626VaultIntegrationFacet is IERC165 {
     /// @param idleAssets The vault's immediately available idle asset amount.
     error ERC4626VaultStrategyInsufficientIdleAssets(uint256 requestedAssets, uint256 idleAssets);
 
-    /// @notice Thrown when a strategy withdrawal returns less than requested in the happy-path lifecycle surface.
-    /// @param requestedAssets The requested withdrawal amount.
-    /// @param returnedAssets The actual returned amount.
-    error ERC4626VaultStrategyUnexpectedWithdrawResult(uint256 requestedAssets, uint256 returnedAssets);
+    /// @notice Thrown when a strategy deploy is attempted after emergency exit has been activated.
+    error ERC4626VaultStrategyEmergencyExitActive();
 
     /// @notice Returns the configured external oracle adapter address.
     /// @return The adapter address, or zero when unset.
@@ -63,6 +69,10 @@ interface IERC4626VaultIntegrationFacet is IERC165 {
     /// @notice Returns the configured strategy address.
     /// @return The strategy address, or zero when unset.
     function strategy() external view returns (address);
+
+    /// @notice Returns true when the current strategy is in emergency-exit mode.
+    /// @return True when emergency exit is active.
+    function strategyEmergencyExit() external view returns (bool);
 
     /// @notice Returns the vault's current stored book debt allocated to the configured strategy.
     /// @return The strategy debt amount.
@@ -93,9 +103,14 @@ interface IERC4626VaultIntegrationFacet is IERC165 {
     function deployToStrategy(uint256 assets) external;
 
     /// @notice Withdraws assets from the configured strategy back to the vault.
-    /// @param assets The asset amount to withdraw.
-    function withdrawFromStrategy(uint256 assets) external;
+    /// @param assets The requested asset amount to withdraw.
+    /// @return assetsReturned The actual returned asset amount.
+    function withdrawFromStrategy(uint256 assets) external returns (uint256 assetsReturned);
 
     /// @notice Syncs live strategy assets into vault book accounting.
     function syncStrategyAssets() external;
+
+    /// @notice Activates emergency-exit mode and attempts to unwind the configured strategy.
+    /// @return assetsReturned The actual returned asset amount from the unwind attempt.
+    function emergencyExitStrategy() external returns (uint256 assetsReturned);
 }

--- a/src/vault/ERC4626Vault.sol
+++ b/src/vault/ERC4626Vault.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.30;
 
 import {IERC20} from "../interfaces/IERC20.sol";
 import {IERC4626} from "../interfaces/IERC4626.sol";
+import {IERC4626VaultStrategy} from "../interfaces/IERC4626VaultStrategy.sol";
+import {LibERC4626VaultStorage} from "./storage/LibERC4626VaultStorage.sol";
 import {ERC4626VaultBase} from "./ERC4626VaultBase.sol";
 
 /// @title ERC4626Vault
@@ -16,6 +18,10 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
     error ERC4626VaultAssetTransferFailed();
     /// @notice Thrown when asset transferFrom fails.
     error ERC4626VaultAssetTransferFromFailed();
+    /// @notice Thrown when the vault cannot source enough immediate liquidity for a withdrawal flow.
+    /// @param requiredAssets The gross asset amount required.
+    /// @param availableAssets The currently sourced idle asset amount.
+    error ERC4626VaultInsufficientLiquidity(uint256 requiredAssets, uint256 availableAssets);
 
     /// @notice Returns vault underlying asset token address.
     /// @return The underlying asset token.
@@ -257,5 +263,76 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
         if (!success || (data.length != 0 && !abi.decode(data, (bool)))) {
             revert ERC4626VaultAssetTransferFromFailed();
         }
+    }
+
+    /// @dev Returns the vault's immediately idle asset balance.
+    function _idleAssetBalance() internal view returns (uint256) {
+        return IERC20(asset()).balanceOf(address(this));
+    }
+
+    /// @dev Returns the configured strategy's immediately withdrawable assets.
+    function _strategyWithdrawableAssets() internal view returns (uint256) {
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        if (layout.strategy == address(0) || layout.strategyDebt == 0) {
+            return 0;
+        }
+
+        IERC4626VaultStrategy configuredStrategy = IERC4626VaultStrategy(layout.strategy);
+        uint256 liveAssets = configuredStrategy.totalAssets();
+        uint256 withdrawableAssets = configuredStrategy.maxWithdrawableAssets();
+        return liveAssets < withdrawableAssets ? liveAssets : withdrawableAssets;
+    }
+
+    /// @dev Pulls assets from the configured strategy back to the vault.
+    function _withdrawStrategyAssets(uint256 assets)
+        internal
+        returns (uint256 returnedAssets, uint256 postCallLiveAssets)
+    {
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        IERC4626VaultStrategy configuredStrategy = IERC4626VaultStrategy(layout.strategy);
+        returnedAssets = configuredStrategy.withdrawToVault(assets);
+        postCallLiveAssets = configuredStrategy.totalAssets();
+    }
+
+    /// @dev Fully unwinds assets from the configured strategy back to the vault.
+    function _withdrawAllStrategyAssets() internal returns (uint256 returnedAssets, uint256 postCallLiveAssets) {
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        IERC4626VaultStrategy configuredStrategy = IERC4626VaultStrategy(layout.strategy);
+        returnedAssets = configuredStrategy.withdrawAllToVault();
+        postCallLiveAssets = configuredStrategy.totalAssets();
+    }
+
+    /// @dev Realizes strategy mark-to-market changes into book accounting without moving idle vault assets.
+    function _syncStrategyDebtToLiveAssets(uint256 liveAssets) internal returns (uint256 previousDebt) {
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        previousDebt = layout.strategyDebt;
+
+        if (liveAssets > previousDebt) {
+            _increaseManagedAssets(liveAssets - previousDebt);
+        } else if (previousDebt > liveAssets) {
+            _decreaseManagedAssets(previousDebt - liveAssets);
+        }
+
+        layout.strategyDebt = liveAssets;
+        layout.strategyReportedAssets = 0;
+    }
+
+    /// @dev Reconciles book accounting after a strategy withdrawal-like call that returned assets to the vault.
+    function _reconcileStrategyWithdrawalAccounting(uint256 returnedAssets, uint256 postCallLiveAssets)
+        internal
+        returns (uint256 previousDebt)
+    {
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        previousDebt = layout.strategyDebt;
+        uint256 combinedAssets = returnedAssets + postCallLiveAssets;
+
+        if (combinedAssets > previousDebt) {
+            _increaseManagedAssets(combinedAssets - previousDebt);
+        } else if (previousDebt > combinedAssets) {
+            _decreaseManagedAssets(previousDebt - combinedAssets);
+        }
+
+        layout.strategyDebt = postCallLiveAssets;
+        layout.strategyReportedAssets = 0;
     }
 }

--- a/src/vault/facets/ERC4626VaultFacet.sol
+++ b/src/vault/facets/ERC4626VaultFacet.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
-import {IERC20} from "../../interfaces/IERC20.sol";
 import {IERC4626} from "../../interfaces/IERC4626.sol";
+import {IERC4626VaultControls} from "../../interfaces/IERC4626VaultControls.sol";
 import {IERC4626VaultFacet} from "../../interfaces/IERC4626VaultFacet.sol";
 import {IERC4626VaultStrategy} from "../../interfaces/IERC4626VaultStrategy.sol";
 import {ERC4626Vault} from "../ERC4626Vault.sol";
 import {ERC4626VaultBase} from "../ERC4626VaultBase.sol";
-import {ERC4626VaultControlledCore} from "../ERC4626VaultControlLogic.sol";
+import {ERC4626VaultControlledCore, LibERC4626VaultControlLogic} from "../ERC4626VaultControlLogic.sol";
 import {VaultFacetControl} from "../VaultFacetControl.sol";
 import {LibERC4626VaultStorage} from "../storage/LibERC4626VaultStorage.sol";
 
@@ -95,7 +95,41 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
         nonReentrant
         returns (uint256 shares)
     {
-        return _withdrawWithControls(assets, receiver, owner);
+        _requireInitialized();
+        _requireNonZeroAddress(receiver);
+        _requireNonZeroAddress(owner);
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        (uint256 grossAssets, uint256 feeAssets) = LibERC4626VaultControlLogic.withdrawGrossFromNet(assets);
+        _sourceStrategyLiquidity(grossAssets);
+
+        uint256 maxAssets = maxWithdraw(owner);
+        if (assets > maxAssets) {
+            revert IERC4626VaultControls.ERC4626VaultWithdrawLimitExceeded(assets, maxAssets);
+        }
+
+        uint256 availableIdleAssets = _idleAssetBalance();
+        if (grossAssets > availableIdleAssets) {
+            revert ERC4626VaultInsufficientLiquidity(grossAssets, availableIdleAssets);
+        }
+
+        shares = _convertToShares(grossAssets, Rounding.Up);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        if (msg.sender != owner) {
+            _spendAllowance(owner, msg.sender, shares);
+        }
+
+        _burnShares(owner, shares);
+        _decreaseManagedAssets(grossAssets);
+        _safeTransferAsset(receiver, assets);
+        _payoutFee(feeAssets);
+
+        emit Withdraw(msg.sender, receiver, owner, assets, shares);
     }
 
     /// @notice Redeems `shares` from `owner` to `receiver`.
@@ -111,7 +145,45 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
         nonReentrant
         returns (uint256 assets)
     {
-        return _redeemWithControls(shares, receiver, owner);
+        _requireInitialized();
+        _requireNonZeroAddress(receiver);
+        _requireNonZeroAddress(owner);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        uint256 maxShares = maxRedeem(owner);
+        if (shares > maxShares) {
+            revert IERC4626VaultControls.ERC4626VaultRedeemLimitExceeded(shares, maxShares);
+        }
+
+        uint256 grossAssets = _convertToAssets(shares, Rounding.Down);
+        _sourceStrategyLiquidity(grossAssets);
+
+        grossAssets = _convertToAssets(shares, Rounding.Down);
+        _sourceStrategyLiquidity(grossAssets);
+
+        uint256 availableIdleAssets = _idleAssetBalance();
+        if (grossAssets > availableIdleAssets) {
+            revert ERC4626VaultInsufficientLiquidity(grossAssets, availableIdleAssets);
+        }
+
+        uint256 feeAssets;
+        (assets, feeAssets) = LibERC4626VaultControlLogic.withdrawNetFromGross(grossAssets);
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        if (msg.sender != owner) {
+            _spendAllowance(owner, msg.sender, shares);
+        }
+
+        _burnShares(owner, shares);
+        _decreaseManagedAssets(grossAssets);
+        _safeTransferAsset(receiver, assets);
+        _payoutFee(feeAssets);
+
+        emit Withdraw(msg.sender, receiver, owner, assets, shares);
     }
 
     function _managedAssetsForPricing() internal view virtual override returns (uint256) {
@@ -131,12 +203,44 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
             return type(uint256).max;
         }
 
-        uint256 idleBookAssets = layout.totalManagedAssets - layout.strategyDebt;
-        uint256 idleVaultAssets = IERC20(asset()).balanceOf(address(this));
-        return idleVaultAssets < idleBookAssets ? idleVaultAssets : idleBookAssets;
+        return _idleAssetBalance() + _strategyWithdrawableAssets();
     }
 
     function _vaultOperationsPaused() internal view virtual override returns (bool) {
         return paused();
+    }
+
+    function _sourceStrategyLiquidity(uint256 requiredGrossAssets) internal {
+        if (requiredGrossAssets == 0) {
+            return;
+        }
+
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        if (layout.strategy == address(0) || layout.strategyDebt == 0) {
+            return;
+        }
+
+        uint256 idleAssets = _idleAssetBalance();
+        while (idleAssets < requiredGrossAssets) {
+            uint256 strategyLiquidity = _strategyWithdrawableAssets();
+            if (strategyLiquidity == 0) {
+                break;
+            }
+
+            uint256 requestedAssets = requiredGrossAssets - idleAssets;
+            if (requestedAssets > strategyLiquidity) {
+                requestedAssets = strategyLiquidity;
+            }
+
+            (uint256 returnedAssets, uint256 postCallLiveAssets) = _withdrawStrategyAssets(requestedAssets);
+            _reconcileStrategyWithdrawalAccounting(returnedAssets, postCallLiveAssets);
+
+            uint256 nextIdleAssets = _idleAssetBalance();
+            if (nextIdleAssets <= idleAssets) {
+                break;
+            }
+
+            idleAssets = nextIdleAssets;
+        }
     }
 }

--- a/src/vault/facets/ERC4626VaultIntegrationFacet.sol
+++ b/src/vault/facets/ERC4626VaultIntegrationFacet.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
-import {IERC20} from "../../interfaces/IERC20.sol";
 import {IERC4626VaultIntegrationFacet} from "../../interfaces/IERC4626VaultIntegrationFacet.sol";
 import {IERC4626VaultStrategy} from "../../interfaces/IERC4626VaultStrategy.sol";
 import {IOracleAdapter} from "../../interfaces/IOracleAdapter.sol";
@@ -24,6 +23,12 @@ contract ERC4626VaultIntegrationFacet is ERC4626Vault, VaultFacetControl, IERC46
         return LibERC4626VaultStorage.layout().strategy;
     }
 
+    /// @notice Returns true when the current strategy is in emergency-exit mode.
+    /// @return True when emergency exit is active.
+    function strategyEmergencyExit() public view returns (bool) {
+        return LibERC4626VaultStorage.layout().strategyEmergencyExit;
+    }
+
     /// @notice Returns the vault's current stored book debt allocated to the configured strategy.
     /// @return The strategy debt amount.
     function strategyDebt() public view returns (uint256) {
@@ -34,7 +39,7 @@ contract ERC4626VaultIntegrationFacet is ERC4626Vault, VaultFacetControl, IERC46
     /// @return The idle asset amount held directly by the vault.
     function idleAssets() public view returns (uint256) {
         _requireInitialized();
-        return IERC20(asset()).balanceOf(address(this));
+        return _idleAssetBalance();
     }
 
     /// @notice Returns the configured strategy's live reported assets.
@@ -75,7 +80,7 @@ contract ERC4626VaultIntegrationFacet is ERC4626Vault, VaultFacetControl, IERC46
 
     /// @notice Sets the configured strategy reference.
     /// @param newStrategy The new strategy address, or zero to clear.
-    function setStrategy(address newStrategy) public {
+    function setStrategy(address newStrategy) public nonReentrant {
         _requireInitialized();
         _checkRole(VAULT_MANAGER_ROLE(), msg.sender);
 
@@ -99,15 +104,20 @@ contract ERC4626VaultIntegrationFacet is ERC4626Vault, VaultFacetControl, IERC46
 
     /// @notice Deploys idle vault assets into the configured strategy.
     /// @param assets The asset amount to deploy.
-    function deployToStrategy(uint256 assets) public {
+    function deployToStrategy(uint256 assets) public nonReentrant {
         _requireInitialized();
         _checkRole(VAULT_MANAGER_ROLE(), msg.sender);
         if (assets == 0) {
             revert ERC4626VaultZeroAssets();
         }
 
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        if (layout.strategyEmergencyExit) {
+            revert ERC4626VaultStrategyEmergencyExitActive();
+        }
+
         IERC4626VaultStrategy configuredStrategy = _configuredStrategy();
-        uint256 availableIdleAssets = _availableIdleAssetsForStrategy();
+        uint256 availableIdleAssets = _availableIdleAssetsForStrategyDeploy();
         if (assets > availableIdleAssets) {
             revert ERC4626VaultStrategyInsufficientIdleAssets(assets, availableIdleAssets);
         }
@@ -115,7 +125,6 @@ contract ERC4626VaultIntegrationFacet is ERC4626Vault, VaultFacetControl, IERC46
         _safeTransferAsset(address(configuredStrategy), assets);
         configuredStrategy.deployFunds(assets);
 
-        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
         layout.strategyDebt += assets;
         layout.strategyReportedAssets = 0;
 
@@ -123,51 +132,52 @@ contract ERC4626VaultIntegrationFacet is ERC4626Vault, VaultFacetControl, IERC46
     }
 
     /// @notice Withdraws assets from the configured strategy back to the vault.
-    /// @param assets The asset amount to withdraw.
-    function withdrawFromStrategy(uint256 assets) public {
+    /// @param assets The requested asset amount to withdraw.
+    /// @return returnedAssets The actual returned asset amount.
+    function withdrawFromStrategy(uint256 assets) public nonReentrant returns (uint256 returnedAssets) {
         _requireInitialized();
         _checkRole(VAULT_MANAGER_ROLE(), msg.sender);
         if (assets == 0) {
             revert ERC4626VaultZeroAssets();
         }
 
-        IERC4626VaultStrategy configuredStrategy = _configuredStrategy();
-        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
-        uint256 currentStrategyDebt = layout.strategyDebt;
-        if (assets > currentStrategyDebt) {
-            revert ERC4626VaultStrategyDebtOutstanding(currentStrategyDebt);
-        }
+        _configuredStrategy();
+        uint256 postCallLiveAssets;
+        (returnedAssets, postCallLiveAssets) = _withdrawStrategyAssets(assets);
+        _reconcileStrategyWithdrawalAccounting(returnedAssets, postCallLiveAssets);
 
-        uint256 returnedAssets = configuredStrategy.withdrawToVault(assets);
-        if (returnedAssets != assets) {
-            revert ERC4626VaultStrategyUnexpectedWithdrawResult(assets, returnedAssets);
-        }
-
-        layout.strategyDebt = currentStrategyDebt - assets;
-        layout.strategyReportedAssets = 0;
-
-        emit VaultStrategyWithdrawn(assets, layout.strategyDebt, msg.sender);
+        emit VaultStrategyWithdrawn(assets, returnedAssets, LibERC4626VaultStorage.layout().strategyDebt, msg.sender);
     }
 
     /// @notice Syncs live strategy assets into vault book accounting.
-    function syncStrategyAssets() public {
+    function syncStrategyAssets() public nonReentrant {
+        _requireInitialized();
+        _checkRole(VAULT_MANAGER_ROLE(), msg.sender);
+
+        uint256 liveAssets = _configuredStrategy().totalAssets();
+        uint256 previousDebt = _syncStrategyDebtToLiveAssets(liveAssets);
+
+        emit VaultStrategySynced(previousDebt, liveAssets, msg.sender);
+    }
+
+    /// @notice Activates emergency-exit mode and attempts to unwind the configured strategy.
+    /// @return assetsReturned The actual returned asset amount from the unwind attempt.
+    function emergencyExitStrategy() public nonReentrant returns (uint256 assetsReturned) {
         _requireInitialized();
         _checkRole(VAULT_MANAGER_ROLE(), msg.sender);
 
         LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
-        uint256 previousDebt = layout.strategyDebt;
-        uint256 liveAssets = _configuredStrategy().totalAssets();
+        IERC4626VaultStrategy configuredStrategy = _configuredStrategy();
+        layout.strategyEmergencyExit = true;
 
-        if (liveAssets > previousDebt) {
-            _increaseManagedAssets(liveAssets - previousDebt);
-        } else if (previousDebt > liveAssets) {
-            _decreaseManagedAssets(previousDebt - liveAssets);
+        try configuredStrategy.withdrawAllToVault() returns (uint256 returnedAssets) {
+            uint256 postCallLiveAssets = configuredStrategy.totalAssets();
+            assetsReturned = returnedAssets;
+            _reconcileStrategyWithdrawalAccounting(assetsReturned, postCallLiveAssets);
+            emit VaultStrategyEmergencyExitTriggered(assetsReturned, layout.strategyDebt, msg.sender);
+        } catch (bytes memory revertData) {
+            emit VaultStrategyEmergencyExitFailed(address(configuredStrategy), msg.sender, revertData);
         }
-
-        layout.strategyDebt = liveAssets;
-        layout.strategyReportedAssets = 0;
-
-        emit VaultStrategySynced(previousDebt, liveAssets, msg.sender);
     }
 
     function _configuredStrategy() internal view returns (IERC4626VaultStrategy configuredStrategy) {
@@ -194,9 +204,9 @@ contract ERC4626VaultIntegrationFacet is ERC4626Vault, VaultFacetControl, IERC46
         }
     }
 
-    function _availableIdleAssetsForStrategy() internal view returns (uint256) {
+    function _availableIdleAssetsForStrategyDeploy() internal view returns (uint256) {
         LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
-        uint256 actualIdleAssets = IERC20(asset()).balanceOf(address(this));
+        uint256 actualIdleAssets = _idleAssetBalance();
         uint256 idleBookAssets = layout.totalManagedAssets - layout.strategyDebt;
         return actualIdleAssets < idleBookAssets ? actualIdleAssets : idleBookAssets;
     }

--- a/src/vault/libraries/LibVaultFacetSelectors.sol
+++ b/src/vault/libraries/LibVaultFacetSelectors.sol
@@ -85,17 +85,19 @@ library LibVaultFacetSelectors {
 
     /// @notice Returns the hosted vault integration selector group.
     function vaultIntegrationSelectors() internal pure returns (bytes4[] memory selectors) {
-        selectors = new bytes4[](11);
+        selectors = new bytes4[](13);
         selectors[0] = IERC4626VaultIntegrationFacet.oracleAdapter.selector;
         selectors[1] = IERC4626VaultIntegrationFacet.strategy.selector;
-        selectors[2] = IERC4626VaultIntegrationFacet.strategyDebt.selector;
-        selectors[3] = IERC4626VaultIntegrationFacet.idleAssets.selector;
-        selectors[4] = IERC4626VaultIntegrationFacet.liveStrategyAssets.selector;
-        selectors[5] = IERC4626VaultIntegrationFacet.oracleQuote.selector;
-        selectors[6] = IERC4626VaultIntegrationFacet.setOracleAdapter.selector;
-        selectors[7] = IERC4626VaultIntegrationFacet.setStrategy.selector;
-        selectors[8] = IERC4626VaultIntegrationFacet.deployToStrategy.selector;
-        selectors[9] = IERC4626VaultIntegrationFacet.withdrawFromStrategy.selector;
-        selectors[10] = IERC4626VaultIntegrationFacet.syncStrategyAssets.selector;
+        selectors[2] = IERC4626VaultIntegrationFacet.strategyEmergencyExit.selector;
+        selectors[3] = IERC4626VaultIntegrationFacet.strategyDebt.selector;
+        selectors[4] = IERC4626VaultIntegrationFacet.idleAssets.selector;
+        selectors[5] = IERC4626VaultIntegrationFacet.liveStrategyAssets.selector;
+        selectors[6] = IERC4626VaultIntegrationFacet.oracleQuote.selector;
+        selectors[7] = IERC4626VaultIntegrationFacet.setOracleAdapter.selector;
+        selectors[8] = IERC4626VaultIntegrationFacet.setStrategy.selector;
+        selectors[9] = IERC4626VaultIntegrationFacet.deployToStrategy.selector;
+        selectors[10] = IERC4626VaultIntegrationFacet.withdrawFromStrategy.selector;
+        selectors[11] = IERC4626VaultIntegrationFacet.syncStrategyAssets.selector;
+        selectors[12] = IERC4626VaultIntegrationFacet.emergencyExitStrategy.selector;
     }
 }

--- a/test/ERC4626VaultIntegrationFacetCore.t.sol
+++ b/test/ERC4626VaultIntegrationFacetCore.t.sol
@@ -54,9 +54,26 @@ contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFix
         VM.prank(admin);
         integrationFacet.deployToStrategy(40);
 
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorized.selector, bob, integrationFacet.VAULT_MANAGER_ROLE()
+            )
+        );
+        VM.prank(bob);
+        integrationFacet.withdrawFromStrategy(20);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorized.selector, bob, integrationFacet.VAULT_MANAGER_ROLE()
+            )
+        );
+        VM.prank(bob);
+        integrationFacet.emergencyExitStrategy();
+
         assertTrue(integrationFacet.strategyDebt() == 40, "strategy debt mismatch");
         assertTrue(integrationFacet.idleAssets() == 60, "idle assets mismatch");
         assertTrue(integrationFacet.liveStrategyAssets() == 40, "live strategy assets mismatch");
+        assertFalse(integrationFacet.strategyEmergencyExit(), "emergency exit should be inactive");
     }
 
     function testDirectIntegrationFacetRejectsInvalidBindingAndOutstandingDebtOnStrategySwap() public {
@@ -100,15 +117,42 @@ contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFix
         integrationFacet.setStrategy(address(0));
 
         VM.prank(admin);
-        integrationFacet.withdrawFromStrategy(40);
+        uint256 returnedAssets = integrationFacet.withdrawFromStrategy(40);
+        assertTrue(returnedAssets == 40, "returned assets mismatch");
+
         VM.prank(admin);
         integrationFacet.setStrategy(address(0));
 
         assertTrue(integrationFacet.strategy() == address(0), "strategy should clear after debt reaches zero");
         assertTrue(integrationFacet.strategyDebt() == 0, "strategy debt should clear after full withdraw");
+        assertFalse(integrationFacet.strategyEmergencyExit(), "emergency exit should clear on strategy reset");
     }
 
-    function testDirectIntegrationFacetSyncRealizesProfitAndPartialWithdrawPreservesBookValue() public {
+    function testDirectIntegrationFacetPartialWithdrawRealizesLossAndReturnsActualAssets() public {
+        _initializeDirectIntegrationFacet();
+        _approveAsset(bob, address(integrationFacet), 100);
+
+        VM.prank(bob);
+        integrationFacet.deposit(100, bob);
+
+        VM.prank(admin);
+        integrationFacet.setStrategy(address(directLossStrategy));
+        VM.prank(admin);
+        integrationFacet.deployToStrategy(60);
+        directLossStrategy.applyLoss(10, 30);
+
+        VM.prank(admin);
+        uint256 returnedAssets = integrationFacet.withdrawFromStrategy(40);
+
+        assertTrue(returnedAssets == 30, "partial withdraw should return actual assets");
+        assertTrue(integrationFacet.strategyDebt() == 20, "strategy debt should update to remaining live assets");
+        assertTrue(integrationFacet.liveStrategyAssets() == 20, "live strategy assets mismatch after partial withdraw");
+        assertTrue(integrationFacet.idleAssets() == 70, "idle assets should increase by returned assets");
+        assertTrue(integrationFacet.totalManagedAssets() == 90, "book value should realize loss on partial withdraw");
+        assertTrue(integrationFacet.totalAssets() == 90, "direct integration facet total assets should match book value");
+    }
+
+    function testDirectIntegrationFacetSyncRealizesProfit() public {
         _initializeDirectIntegrationFacet();
         _approveAsset(bob, address(integrationFacet), 100);
 
@@ -121,24 +165,13 @@ contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFix
         integrationFacet.deployToStrategy(60);
         directProfitStrategy.injectProfit(20);
 
-        assertTrue(integrationFacet.totalManagedAssets() == 100, "book value should remain unchanged before sync");
-        assertTrue(integrationFacet.liveStrategyAssets() == 80, "live strategy assets should reflect unsynced profit");
-
         VM.prank(admin);
         integrationFacet.syncStrategyAssets();
 
-        assertTrue(integrationFacet.strategyDebt() == 80, "strategy debt should sync to live assets");
+        assertTrue(integrationFacet.strategyDebt() == 80, "strategy debt should sync to profit-adjusted live assets");
         assertTrue(integrationFacet.liveStrategyAssets() == 80, "live strategy assets mismatch after profit sync");
         assertTrue(integrationFacet.totalManagedAssets() == 120, "book value should realize profit on sync");
-        assertTrue(integrationFacet.totalAssets() == 120, "total assets should remain mark-to-market after sync");
-
-        VM.prank(admin);
-        integrationFacet.withdrawFromStrategy(30);
-
-        assertTrue(integrationFacet.strategyDebt() == 50, "strategy debt should decrease after withdraw");
-        assertTrue(integrationFacet.liveStrategyAssets() == 50, "live strategy assets should decrease after withdraw");
-        assertTrue(integrationFacet.idleAssets() == 70, "idle assets should increase after withdraw");
-        assertTrue(integrationFacet.totalManagedAssets() == 120, "book value should stay unchanged after pull");
+        assertTrue(integrationFacet.totalAssets() == 120, "direct integration facet total assets should match book value");
     }
 
     function testDirectIntegrationFacetSyncRealizesLoss() public {
@@ -160,10 +193,10 @@ contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFix
         assertTrue(integrationFacet.strategyDebt() == 45, "strategy debt should sync to loss-adjusted live assets");
         assertTrue(integrationFacet.liveStrategyAssets() == 45, "live strategy assets mismatch after loss sync");
         assertTrue(integrationFacet.totalManagedAssets() == 85, "book value should realize loss on sync");
-        assertTrue(integrationFacet.totalAssets() == 85, "total assets should reflect realized loss");
+        assertTrue(integrationFacet.totalAssets() == 85, "direct integration facet total assets should reflect realized loss");
     }
 
-    function testDirectIntegrationFacetRejectsUnexpectedPartialWithdrawResult() public {
+    function testDirectIntegrationFacetEmergencyExitUnwindsAndBlocksRedeploy() public {
         _initializeDirectIntegrationFacet();
         _approveAsset(bob, address(integrationFacet), 100);
 
@@ -171,18 +204,56 @@ contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFix
         integrationFacet.deposit(100, bob);
 
         VM.prank(admin);
-        integrationFacet.setStrategy(address(directLossStrategy));
+        integrationFacet.setStrategy(address(directProfitStrategy));
         VM.prank(admin);
         integrationFacet.deployToStrategy(60);
-        directLossStrategy.applyLoss(0, 30);
+        directProfitStrategy.injectProfit(20);
 
-        VM.expectRevert(
-            abi.encodeWithSelector(
-                IERC4626VaultIntegrationFacet.ERC4626VaultStrategyUnexpectedWithdrawResult.selector, 40, 30
-            )
-        );
         VM.prank(admin);
-        integrationFacet.withdrawFromStrategy(40);
+        uint256 returnedAssets = integrationFacet.emergencyExitStrategy();
+
+        assertTrue(returnedAssets == 80, "emergency exit should return all live assets");
+        assertTrue(integrationFacet.strategyEmergencyExit(), "emergency exit flag should remain active");
+        assertTrue(integrationFacet.strategyDebt() == 0, "strategy debt should be zero after full unwind");
+        assertTrue(integrationFacet.liveStrategyAssets() == 0, "live strategy assets should be zero after unwind");
+        assertTrue(integrationFacet.idleAssets() == 120, "idle assets should include fully unwound strategy assets");
+        assertTrue(integrationFacet.totalManagedAssets() == 120, "book value should realize profit during emergency exit");
+
+        VM.expectRevert(IERC4626VaultIntegrationFacet.ERC4626VaultStrategyEmergencyExitActive.selector);
+        VM.prank(admin);
+        integrationFacet.deployToStrategy(10);
+
+        VM.prank(admin);
+        integrationFacet.setStrategy(address(0));
+        assertFalse(integrationFacet.strategyEmergencyExit(), "emergency exit should clear when strategy clears");
+    }
+
+    function testDirectIntegrationFacetEmergencyExitFailureDoesNotRevert() public {
+        _initializeDirectIntegrationFacet();
+        _approveAsset(bob, address(integrationFacet), 100);
+
+        VM.prank(bob);
+        integrationFacet.deposit(100, bob);
+
+        VM.prank(admin);
+        integrationFacet.setStrategy(address(directRevertingStrategy));
+        VM.prank(admin);
+        integrationFacet.deployToStrategy(60);
+        directRevertingStrategy.setRevertModes(false, false, false, true);
+
+        VM.prank(admin);
+        uint256 returnedAssets = integrationFacet.emergencyExitStrategy();
+
+        assertTrue(returnedAssets == 0, "failing emergency exit should return zero assets");
+        assertTrue(integrationFacet.strategyEmergencyExit(), "emergency exit flag should stay active after failure");
+        assertTrue(integrationFacet.strategyDebt() == 60, "strategy debt should remain unchanged after failed unwind");
+        assertTrue(integrationFacet.liveStrategyAssets() == 60, "live strategy assets should remain unchanged");
+        assertTrue(integrationFacet.idleAssets() == 40, "idle assets should remain unchanged after failed unwind");
+        assertTrue(integrationFacet.totalManagedAssets() == 100, "book value should remain unchanged after failed unwind");
+
+        VM.expectRevert(IERC4626VaultIntegrationFacet.ERC4626VaultStrategyEmergencyExitActive.selector);
+        VM.prank(admin);
+        integrationFacet.deployToStrategy(10);
     }
 
     function testDirectIntegrationFacetHelpersRevertBeforeVaultInit() public {
@@ -216,11 +287,15 @@ contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFix
         VM.prank(admin);
         IERC4626VaultIntegrationFacet(address(diamond)).syncStrategyAssets();
         VM.prank(admin);
-        IERC4626VaultIntegrationFacet(address(diamond)).withdrawFromStrategy(30);
+        uint256 returnedAssets = IERC4626VaultIntegrationFacet(address(diamond)).withdrawFromStrategy(30);
+        VM.prank(admin);
+        uint256 emergencyAssets = IERC4626VaultIntegrationFacet(address(diamond)).emergencyExitStrategy();
 
         IOracleAdapter.OracleQuote memory quotePayload = IERC4626VaultIntegrationFacet(address(diamond)).oracleQuote();
 
         assertTrue(mintedShares == 100, "deposit shares mismatch");
+        assertTrue(returnedAssets == 30, "partial withdraw return mismatch");
+        assertTrue(emergencyAssets == 50, "emergency exit return mismatch");
         assertTrue(
             IERC4626VaultIntegrationFacet(address(diamond)).oracleAdapter() == address(adapter), "adapter mismatch"
         );
@@ -228,11 +303,15 @@ contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFix
             IERC4626VaultIntegrationFacet(address(diamond)).strategy() == address(diamondProfitStrategy),
             "strategy mismatch"
         );
-        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).strategyDebt() == 50, "strategy debt mismatch");
         assertTrue(
-            IERC4626VaultIntegrationFacet(address(diamond)).liveStrategyAssets() == 50, "live strategy assets mismatch"
+            IERC4626VaultIntegrationFacet(address(diamond)).strategyEmergencyExit(),
+            "emergency exit should remain active"
         );
-        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).idleAssets() == 70, "idle assets mismatch");
+        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).strategyDebt() == 0, "strategy debt mismatch");
+        assertTrue(
+            IERC4626VaultIntegrationFacet(address(diamond)).liveStrategyAssets() == 0, "live strategy assets mismatch"
+        );
+        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).idleAssets() == 120, "idle assets mismatch");
         assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 120, "managed assets mismatch");
         assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 120, "total assets mismatch");
         assertTrue(quotePayload.value == 100_000_000, "quote value mismatch");

--- a/test/ERC4626VaultIntegrationFacetCore.t.sol
+++ b/test/ERC4626VaultIntegrationFacetCore.t.sol
@@ -149,7 +149,9 @@ contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFix
         assertTrue(integrationFacet.liveStrategyAssets() == 20, "live strategy assets mismatch after partial withdraw");
         assertTrue(integrationFacet.idleAssets() == 70, "idle assets should increase by returned assets");
         assertTrue(integrationFacet.totalManagedAssets() == 90, "book value should realize loss on partial withdraw");
-        assertTrue(integrationFacet.totalAssets() == 90, "direct integration facet total assets should match book value");
+        assertTrue(
+            integrationFacet.totalAssets() == 90, "direct integration facet total assets should match book value"
+        );
     }
 
     function testDirectIntegrationFacetSyncRealizesProfit() public {
@@ -171,7 +173,9 @@ contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFix
         assertTrue(integrationFacet.strategyDebt() == 80, "strategy debt should sync to profit-adjusted live assets");
         assertTrue(integrationFacet.liveStrategyAssets() == 80, "live strategy assets mismatch after profit sync");
         assertTrue(integrationFacet.totalManagedAssets() == 120, "book value should realize profit on sync");
-        assertTrue(integrationFacet.totalAssets() == 120, "direct integration facet total assets should match book value");
+        assertTrue(
+            integrationFacet.totalAssets() == 120, "direct integration facet total assets should match book value"
+        );
     }
 
     function testDirectIntegrationFacetSyncRealizesLoss() public {
@@ -193,7 +197,9 @@ contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFix
         assertTrue(integrationFacet.strategyDebt() == 45, "strategy debt should sync to loss-adjusted live assets");
         assertTrue(integrationFacet.liveStrategyAssets() == 45, "live strategy assets mismatch after loss sync");
         assertTrue(integrationFacet.totalManagedAssets() == 85, "book value should realize loss on sync");
-        assertTrue(integrationFacet.totalAssets() == 85, "direct integration facet total assets should reflect realized loss");
+        assertTrue(
+            integrationFacet.totalAssets() == 85, "direct integration facet total assets should reflect realized loss"
+        );
     }
 
     function testDirectIntegrationFacetEmergencyExitUnwindsAndBlocksRedeploy() public {
@@ -217,7 +223,9 @@ contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFix
         assertTrue(integrationFacet.strategyDebt() == 0, "strategy debt should be zero after full unwind");
         assertTrue(integrationFacet.liveStrategyAssets() == 0, "live strategy assets should be zero after unwind");
         assertTrue(integrationFacet.idleAssets() == 120, "idle assets should include fully unwound strategy assets");
-        assertTrue(integrationFacet.totalManagedAssets() == 120, "book value should realize profit during emergency exit");
+        assertTrue(
+            integrationFacet.totalManagedAssets() == 120, "book value should realize profit during emergency exit"
+        );
 
         VM.expectRevert(IERC4626VaultIntegrationFacet.ERC4626VaultStrategyEmergencyExitActive.selector);
         VM.prank(admin);
@@ -249,7 +257,9 @@ contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFix
         assertTrue(integrationFacet.strategyDebt() == 60, "strategy debt should remain unchanged after failed unwind");
         assertTrue(integrationFacet.liveStrategyAssets() == 60, "live strategy assets should remain unchanged");
         assertTrue(integrationFacet.idleAssets() == 40, "idle assets should remain unchanged after failed unwind");
-        assertTrue(integrationFacet.totalManagedAssets() == 100, "book value should remain unchanged after failed unwind");
+        assertTrue(
+            integrationFacet.totalManagedAssets() == 100, "book value should remain unchanged after failed unwind"
+        );
 
         VM.expectRevert(IERC4626VaultIntegrationFacet.ERC4626VaultStrategyEmergencyExitActive.selector);
         VM.prank(admin);

--- a/test/ERC4626VaultStrategyAccountingCore.t.sol
+++ b/test/ERC4626VaultStrategyAccountingCore.t.sol
@@ -168,8 +168,7 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
             "maxWithdraw should include strategy liquidity"
         );
         assertTrue(
-            IERC4626VaultFacet(address(diamond)).maxRedeem(bob) == 100,
-            "maxRedeem should include strategy liquidity"
+            IERC4626VaultFacet(address(diamond)).maxRedeem(bob) == 100, "maxRedeem should include strategy liquidity"
         );
 
         VM.prank(bob);

--- a/test/ERC4626VaultStrategyAccountingCore.t.sol
+++ b/test/ERC4626VaultStrategyAccountingCore.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
+import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol";
 import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControlsFacet.sol";
 import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
 import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
@@ -25,7 +26,7 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
         assertTrue(facet.maxRedeem(bob) == DEPOSIT_ASSETS, "maxRedeem baseline mismatch");
     }
 
-    function testDirectStrategyProfitMakesPricingMarkToMarketAndCapsLiquidity() public {
+    function testDirectStrategyProfitMakesPricingMarkToMarketAndExtendsLiquidity() public {
         _initializeDirectVault();
         _approveAsset(bob, address(facet), DEPOSIT_ASSETS);
 
@@ -45,11 +46,11 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
         assertTrue(facet.previewMint(10) == 12, "previewMint profit mismatch");
         assertTrue(facet.previewWithdraw(12) == 10, "previewWithdraw profit mismatch");
         assertTrue(facet.previewRedeem(10) == 12, "previewRedeem profit mismatch");
-        assertTrue(facet.maxWithdraw(bob) == 40, "maxWithdraw should cap to idle liquidity");
-        assertTrue(facet.maxRedeem(bob) == 33, "maxRedeem should cap to idle liquidity");
+        assertTrue(facet.maxWithdraw(bob) == 120, "maxWithdraw should include strategy liquidity");
+        assertTrue(facet.maxRedeem(bob) == 100, "maxRedeem should include strategy liquidity");
     }
 
-    function testDirectStrategyLossMovesPricingDownward() public {
+    function testDirectStrategyLossMovesPricingDownwardAndCapsLiquidityByWithdrawableAssets() public {
         _initializeDirectVault();
         _approveAsset(bob, address(facet), DEPOSIT_ASSETS);
 
@@ -58,7 +59,7 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
 
         facet.setStrategyStateForTest(address(directLossStrategy), STRATEGY_DEBT);
         _simulateStrategyDeployment(address(facet), directLossStrategy, STRATEGY_DEBT);
-        directLossStrategy.applyLoss(30, 30);
+        directLossStrategy.applyLoss(30, 10);
 
         assertTrue(facet.totalManagedAssets() == DEPOSIT_ASSETS, "book value should remain unchanged");
         assertTrue(facet.totalAssets() == 70, "loss should reduce mark-to-market assets");
@@ -68,27 +69,76 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
         assertTrue(facet.previewMint(10) == 7, "previewMint loss mismatch");
         assertTrue(facet.previewWithdraw(12) == 18, "previewWithdraw loss mismatch");
         assertTrue(facet.previewRedeem(10) == 7, "previewRedeem loss mismatch");
-        assertTrue(facet.maxWithdraw(bob) == 40, "maxWithdraw should remain idle-capped");
-        assertTrue(facet.maxRedeem(bob) == 57, "maxRedeem loss cap mismatch");
+        assertTrue(facet.maxWithdraw(bob) == 50, "maxWithdraw should cap to idle plus withdrawable strategy assets");
+        assertTrue(facet.maxRedeem(bob) == 71, "maxRedeem should cap to immediate liquidity");
     }
 
-    function testConfiguredStrategyWithZeroDebtKeepsHostedPricingBaseline() public {
+    function testDirectWithdrawAutoPullsFromStrategyLiquidity() public {
         _initializeDirectVault();
         _approveAsset(bob, address(facet), DEPOSIT_ASSETS);
 
         VM.prank(bob);
         facet.deposit(DEPOSIT_ASSETS, bob);
 
-        facet.setStrategyStateForTest(address(directProfitStrategy), 0);
-        directProfitStrategy.injectProfit(20);
+        facet.setStrategyStateForTest(address(directProfitStrategy), STRATEGY_DEBT);
+        _simulateStrategyDeployment(address(facet), directProfitStrategy, STRATEGY_DEBT);
 
-        assertTrue(facet.totalManagedAssets() == DEPOSIT_ASSETS, "book value mismatch");
-        assertTrue(facet.totalAssets() == DEPOSIT_ASSETS, "zero debt strategy should not affect pricing");
-        assertTrue(facet.previewDeposit(10) == 10, "previewDeposit should ignore zero-debt strategy");
-        assertTrue(facet.maxWithdraw(bob) == DEPOSIT_ASSETS, "maxWithdraw should ignore zero-debt strategy");
+        VM.prank(bob);
+        uint256 burnedShares = facet.withdraw(80, bob, bob);
+
+        assertTrue(burnedShares == 80, "withdraw should burn shares at current price");
+        assertTrue(facet.balanceOf(bob) == 20, "remaining shares mismatch");
+        assertTrue(facet.totalManagedAssets() == 20, "book value mismatch after withdraw");
+        assertTrue(facet.totalAssets() == 20, "total assets mismatch after withdraw");
+        assertTrue(facet.maxWithdraw(bob) == 20, "remaining withdraw capacity mismatch");
+        assertTrue(facet.maxRedeem(bob) == 20, "remaining redeem capacity mismatch");
+        assertTrue(asset.balanceOf(address(facet)) == 0, "vault idle balance should be exhausted");
+        assertTrue(directProfitStrategy.totalAssets() == 20, "strategy live assets mismatch");
+        assertTrue(asset.balanceOf(bob) == INITIAL_ASSETS - 20, "underlying balance mismatch after withdraw");
     }
 
-    function testDiamondHostedVaultStrategyAccountingUsesLiveStrategyAssets() public {
+    function testDirectRedeemAutoPullsAndReturnsCurrentShareValue() public {
+        _initializeDirectVault();
+        _approveAsset(bob, address(facet), DEPOSIT_ASSETS);
+
+        VM.prank(bob);
+        facet.deposit(DEPOSIT_ASSETS, bob);
+
+        facet.setStrategyStateForTest(address(directProfitStrategy), STRATEGY_DEBT);
+        _simulateStrategyDeployment(address(facet), directProfitStrategy, STRATEGY_DEBT);
+        directProfitStrategy.injectProfit(20);
+
+        VM.prank(bob);
+        uint256 returnedAssets = facet.redeem(50, bob, bob);
+
+        assertTrue(returnedAssets == 60, "redeem should return current share value");
+        assertTrue(facet.balanceOf(bob) == 50, "remaining shares mismatch after redeem");
+        assertTrue(facet.totalManagedAssets() == 60, "book value mismatch after redeem");
+        assertTrue(facet.totalAssets() == 60, "total assets mismatch after redeem");
+        assertTrue(asset.balanceOf(address(facet)) == 0, "vault idle balance should be exhausted after redeem");
+        assertTrue(directProfitStrategy.totalAssets() == 60, "remaining strategy assets mismatch");
+        assertTrue(asset.balanceOf(bob) == INITIAL_ASSETS - 40, "underlying balance mismatch after redeem");
+    }
+
+    function testDirectWithdrawRevertsWhenStrategyLiquidityCannotCoverExactAssets() public {
+        _initializeDirectVault();
+        _approveAsset(bob, address(facet), DEPOSIT_ASSETS);
+
+        VM.prank(bob);
+        facet.deposit(DEPOSIT_ASSETS, bob);
+
+        facet.setStrategyStateForTest(address(directLossStrategy), STRATEGY_DEBT);
+        _simulateStrategyDeployment(address(facet), directLossStrategy, STRATEGY_DEBT);
+        directLossStrategy.applyLoss(20, 10);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(IERC4626VaultControls.ERC4626VaultWithdrawLimitExceeded.selector, 70, 50)
+        );
+        VM.prank(bob);
+        facet.withdraw(70, bob, bob);
+    }
+
+    function testDiamondHostedVaultStrategyAccountingUsesRealLifecycleAndAutoPull() public {
         _installHostedVaultFacetsToDiamond();
         _initializeDiamondVault();
         _approveAsset(bob, address(diamond), DEPOSIT_ASSETS);
@@ -98,8 +148,8 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
 
         VM.prank(admin);
         IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(address(diamondProfitStrategy));
-        _seedDiamondStrategyState(address(diamondProfitStrategy), STRATEGY_DEBT);
-        _simulateStrategyDeployment(address(diamond), diamondProfitStrategy, STRATEGY_DEBT);
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).deployToStrategy(60);
         diamondProfitStrategy.injectProfit(20);
 
         VM.prank(admin);
@@ -114,13 +164,24 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
         assertTrue(IERC4626VaultFacet(address(diamond)).maxDeposit(bob) == 5, "maxDeposit should use live totalAssets");
         assertTrue(IERC4626VaultFacet(address(diamond)).maxMint(bob) == 4, "maxMint should use live totalAssets");
         assertTrue(
-            IERC4626VaultFacet(address(diamond)).maxWithdraw(bob) == 40, "maxWithdraw should cap to idle liquidity"
+            IERC4626VaultFacet(address(diamond)).maxWithdraw(bob) == 120,
+            "maxWithdraw should include strategy liquidity"
         );
-        assertTrue(IERC4626VaultFacet(address(diamond)).maxRedeem(bob) == 33, "maxRedeem should cap to idle liquidity");
-        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).idleAssets() == 40, "idle assets mismatch");
-        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).strategyDebt() == 60, "strategy debt mismatch");
         assertTrue(
-            IERC4626VaultIntegrationFacet(address(diamond)).liveStrategyAssets() == 80, "live strategy assets mismatch"
+            IERC4626VaultFacet(address(diamond)).maxRedeem(bob) == 100,
+            "maxRedeem should include strategy liquidity"
         );
+
+        VM.prank(bob);
+        uint256 burnedShares = IERC4626VaultFacet(address(diamond)).withdraw(80, bob, bob);
+
+        assertTrue(burnedShares == 67, "diamond withdraw should burn shares at updated price");
+        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).idleAssets() == 0, "idle assets should be zero");
+        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).strategyDebt() == 40, "strategy debt mismatch");
+        assertTrue(
+            IERC4626VaultIntegrationFacet(address(diamond)).liveStrategyAssets() == 40, "live strategy assets mismatch"
+        );
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 40, "managed assets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 40, "post-withdraw totalAssets mismatch");
     }
 }

--- a/test/helpers/ERC4626VaultIntegrationFacetTestHarness.sol
+++ b/test/helpers/ERC4626VaultIntegrationFacetTestHarness.sol
@@ -14,15 +14,16 @@ import {ReentrantMockVaultAsset} from "./ERC4626VaultControlsTestHarness.sol";
 import {ERC4626VaultFacetHarness} from "./ERC4626VaultFacetTestHarness.sol";
 import {MockOracleFeed, OracleAdapterHarness} from "./OracleAdapterTestHarness.sol";
 import {MockVaultAsset} from "./ERC4626CoreTestHarness.sol";
-import {LossShortfallMockVaultStrategy, ProfitMockVaultStrategy, RevertingMockVaultStrategy} from "./ERC4626VaultStrategyTestHarness.sol";
+import {
+    LossShortfallMockVaultStrategy,
+    ProfitMockVaultStrategy,
+    RevertingMockVaultStrategy
+} from "./ERC4626VaultStrategyTestHarness.sol";
 
-contract ERC4626VaultIntegrationFacetHarness is ERC4626VaultIntegrationFacet {
-    function initializeHostedVaultForTest(
-        address vaultAsset,
-        string memory vaultName,
-        string memory vaultSymbol,
-        address admin
-    ) external {
+contract ERC4626VaultIntegrationFacetHarness is ERC4626VaultIntegrationFacet {}
+
+contract InitializedERC4626VaultIntegrationFacetHarness is ERC4626VaultIntegrationFacet {
+    constructor(address vaultAsset, string memory vaultName, string memory vaultSymbol, address admin) {
         _initializeVaultFacetControl(admin);
         _initializeErc4626Vault(vaultAsset, vaultName, vaultSymbol);
     }
@@ -43,7 +44,7 @@ abstract contract ERC4626VaultIntegrationFacetFixture is TestBase {
     MockVaultAsset internal otherAsset;
     ERC4626VaultFacetHarness internal coreFacet;
     ERC4626VaultControlsFacetHarness internal controlsFacet;
-    ERC4626VaultIntegrationFacetHarness internal integrationFacet;
+    ERC4626VaultIntegrationFacet internal integrationFacet;
     DiamondCutFacet internal cutFacet;
     DiamondLoupeFacet internal loupeFacet;
     DiamondProxyHarness internal diamond;
@@ -70,12 +71,8 @@ abstract contract ERC4626VaultIntegrationFacetFixture is TestBase {
         feed = new MockOracleFeed(8);
         feed.setLatestRoundData(1, 100_000_000, quoteUpdatedAt, quoteUpdatedAt, 1);
         adapter = new OracleAdapterHarness(admin, address(feed), maxStaleness);
-        directProfitStrategy = new ProfitMockVaultStrategy(address(integrationFacet), address(asset));
-        directLossStrategy = new LossShortfallMockVaultStrategy(address(integrationFacet), address(asset));
-        directRevertingStrategy = new RevertingMockVaultStrategy(address(integrationFacet), address(asset));
         diamondProfitStrategy = new ProfitMockVaultStrategy(address(diamond), address(asset));
         wrongVaultStrategy = new ProfitMockVaultStrategy(address(0xBAD), address(asset));
-        directWrongAssetStrategy = new ProfitMockVaultStrategy(address(integrationFacet), address(otherAsset));
 
         asset.mint(bob, INITIAL_ASSETS);
         asset.mint(eve, INITIAL_ASSETS);
@@ -84,7 +81,12 @@ abstract contract ERC4626VaultIntegrationFacetFixture is TestBase {
     }
 
     function _initializeDirectIntegrationFacet() internal {
-        integrationFacet.initializeHostedVaultForTest(address(asset), "Vault Share", "vSHARE", admin);
+        integrationFacet =
+            new InitializedERC4626VaultIntegrationFacetHarness(address(asset), "Vault Share", "vSHARE", admin);
+        directProfitStrategy = new ProfitMockVaultStrategy(address(integrationFacet), address(asset));
+        directLossStrategy = new LossShortfallMockVaultStrategy(address(integrationFacet), address(asset));
+        directRevertingStrategy = new RevertingMockVaultStrategy(address(integrationFacet), address(asset));
+        directWrongAssetStrategy = new ProfitMockVaultStrategy(address(integrationFacet), address(otherAsset));
     }
 
     function _initializeDiamondVault() internal {

--- a/test/helpers/ERC4626VaultIntegrationFacetTestHarness.sol
+++ b/test/helpers/ERC4626VaultIntegrationFacetTestHarness.sol
@@ -14,7 +14,7 @@ import {ReentrantMockVaultAsset} from "./ERC4626VaultControlsTestHarness.sol";
 import {ERC4626VaultFacetHarness} from "./ERC4626VaultFacetTestHarness.sol";
 import {MockOracleFeed, OracleAdapterHarness} from "./OracleAdapterTestHarness.sol";
 import {MockVaultAsset} from "./ERC4626CoreTestHarness.sol";
-import {LossShortfallMockVaultStrategy, ProfitMockVaultStrategy} from "./ERC4626VaultStrategyTestHarness.sol";
+import {LossShortfallMockVaultStrategy, ProfitMockVaultStrategy, RevertingMockVaultStrategy} from "./ERC4626VaultStrategyTestHarness.sol";
 
 contract ERC4626VaultIntegrationFacetHarness is ERC4626VaultIntegrationFacet {
     function initializeHostedVaultForTest(
@@ -51,6 +51,7 @@ abstract contract ERC4626VaultIntegrationFacetFixture is TestBase {
     OracleAdapterHarness internal adapter;
     ProfitMockVaultStrategy internal directProfitStrategy;
     LossShortfallMockVaultStrategy internal directLossStrategy;
+    RevertingMockVaultStrategy internal directRevertingStrategy;
     ProfitMockVaultStrategy internal diamondProfitStrategy;
     ProfitMockVaultStrategy internal wrongVaultStrategy;
     ProfitMockVaultStrategy internal directWrongAssetStrategy;
@@ -71,6 +72,7 @@ abstract contract ERC4626VaultIntegrationFacetFixture is TestBase {
         adapter = new OracleAdapterHarness(admin, address(feed), maxStaleness);
         directProfitStrategy = new ProfitMockVaultStrategy(address(integrationFacet), address(asset));
         directLossStrategy = new LossShortfallMockVaultStrategy(address(integrationFacet), address(asset));
+        directRevertingStrategy = new RevertingMockVaultStrategy(address(integrationFacet), address(asset));
         diamondProfitStrategy = new ProfitMockVaultStrategy(address(diamond), address(asset));
         wrongVaultStrategy = new ProfitMockVaultStrategy(address(0xBAD), address(asset));
         directWrongAssetStrategy = new ProfitMockVaultStrategy(address(integrationFacet), address(otherAsset));

--- a/test/helpers/ERC4626VaultStrategyTestHarness.sol
+++ b/test/helpers/ERC4626VaultStrategyTestHarness.sol
@@ -8,12 +8,7 @@ import {TestBase} from "./AccessControlTestHarness.sol";
 import {MockVaultAsset} from "./ERC4626CoreTestHarness.sol";
 
 contract ERC4626VaultStrategyStorageHarness is ERC4626VaultIntegrationFacet {
-    function initializeHostedVaultForStrategyTest(
-        address vaultAsset,
-        string memory vaultName,
-        string memory vaultSymbol,
-        address admin
-    ) external {
+    constructor(address vaultAsset, string memory vaultName, string memory vaultSymbol, address admin) {
         _initializeVaultFacetControl(admin);
         _initializeErc4626Vault(vaultAsset, vaultName, vaultSymbol);
     }
@@ -211,8 +206,7 @@ abstract contract ERC4626VaultStrategyFixture is TestBase {
 
     function setUp() public virtual {
         asset = new MockVaultAsset("Mock USD", "mUSD", 6);
-        storageHarness = new ERC4626VaultStrategyStorageHarness();
-        storageHarness.initializeHostedVaultForStrategyTest(address(asset), "Vault Share", "vSHARE", admin);
+        storageHarness = new ERC4626VaultStrategyStorageHarness(address(asset), "Vault Share", "vSHARE", admin);
 
         profitStrategy = new ProfitMockVaultStrategy(vault, address(asset));
         lossStrategy = new LossShortfallMockVaultStrategy(vault, address(asset));


### PR DESCRIPTION
## Summary
- harden hosted vault strategy flows with loss-aware withdrawals and a sticky emergency-exit mode
- auto-source strategy liquidity during user `withdraw` and `redeem` when idle vault liquidity is insufficient
- update the integration lifecycle and selector set for emergency-exit state and partial strategy withdrawals
- extend integration and accounting tests to cover partial loss realization and emergency-exit behavior

## What Changed
- `withdrawFromStrategy(uint256)` now returns the actual assets pulled and reconciles realized profit/loss into book value
- added `strategyEmergencyExit()` and `emergencyExitStrategy()` to the integration interface and facet
- blocked `deployToStrategy(...)` while emergency exit is active
- taught the hosted core facet to auto-pull strategy liquidity for user withdrawals/redemptions while preserving exact-asset withdraw semantics
- updated integration/accounting tests for the new lifecycle surface and safety behavior

## Validation
- `forge test --offline --match-path test/ERC4626VaultIntegrationFacetCore.t.sol`
- `forge test --offline --match-path test/ERC4626VaultStrategyAccountingCore.t.sol`
- `forge test --offline --match-path test/DiamondVaultHostInvariant.t.sol`
- `forge test --offline --match-path test/VaultStrategyFoundationCore.t.sol`
- `git diff --check`
- `forge test --offline`

Closes #115
