### PR TITLE
Add strategy-enabled vault deployment and init integration

### DIFF
--- a/docs/auralis-local.md
+++ b/docs/auralis-local.md
@@ -43,19 +43,21 @@ bash scripts/auralis-reset.sh
 
 `auralis-up.sh`
 - starts Anvil if one is not already available
-- deploys the ERC20 host, ERC721 host, and vault host
+- deploys the ERC20 host, ERC721 host, and strategy-enabled vault host
 - writes `deployments/auralis.local.json`
 
 `auralis-smoke.sh`
 - checks deployed code is present
-- runs token, NFT, and vault happy-path transactions
+- runs token and NFT happy-path transactions
+- runs vault deposit, strategy deploy, profit sync, manager pull, user auto-pull, and emergency-exit flows
+- restores the local vault to a ready state by re-binding the configured strategy after the emergency-exit smoke
 - verifies the vault oracle quote path is live
 
 `auralis-activity.sh`
 - generates deterministic demo traffic across the deployed hosts
 - mints and transfers ERC20 balances
 - mints and moves an ERC721 token
-- deposits into the vault, moves shares, redeems shares, updates the oracle, and reports strategy assets
+- deposits into the vault, deploys capital to strategy, syncs profit, pulls funds back, moves shares, redeems shares, updates the oracle, and toggles pause state
 
 `auralis-reset.sh`
 - stops the managed Anvil process if `auralis-up.sh` started it
@@ -72,6 +74,7 @@ and records:
 - ERC20 host addresses
 - ERC721 host addresses
 - vault host addresses
+- configured vault strategy address and zeroed initial strategy state
 
 ## Simulated Activity
 

--- a/script/DeployDiamondVaultHost.s.sol
+++ b/script/DeployDiamondVaultHost.s.sol
@@ -11,6 +11,7 @@ import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol
 import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControlsFacet.sol";
 import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
 import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
+import {IERC4626VaultStrategy} from "../src/interfaces/IERC4626VaultStrategy.sol";
 import {IOracleAdapter} from "../src/interfaces/IOracleAdapter.sol";
 import {ERC4626VaultControlsFacet} from "../src/vault/facets/ERC4626VaultControlsFacet.sol";
 import {ERC4626VaultFacet} from "../src/vault/facets/ERC4626VaultFacet.sol";
@@ -18,6 +19,7 @@ import {ERC4626VaultIntegrationFacet} from "../src/vault/facets/ERC4626VaultInte
 import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {DiamondVaultHostScriptBase} from "./common/DiamondVaultHostScriptBase.sol";
 import {
+    LocalHappyPathVaultStrategy,
     LocalMintableVaultAsset,
     LocalMockOracleFeed,
     LocalOracleAdapterHarness
@@ -36,6 +38,7 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
         address vaultAssetAddress;
         address oracleFeedAddress;
         address oracleAdapterAddress;
+        address strategyAddress;
     }
 
     string internal constant VAULT_OBJECT = "diamondVaultHost";
@@ -68,6 +71,7 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
         IERC4626VaultFacet(state.diamondAddress)
             .initializeVault(state.vaultAssetAddress, VAULT_NAME, VAULT_SYMBOL, owner);
         IERC4626VaultIntegrationFacet(state.diamondAddress).setOracleAdapter(state.oracleAdapterAddress);
+        IERC4626VaultIntegrationFacet(state.diamondAddress).setStrategy(state.strategyAddress);
 
         VM.stopBroadcast();
 
@@ -85,9 +89,12 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
                 vaultAsset: state.vaultAssetAddress,
                 oracleFeed: state.oracleFeedAddress,
                 oracleAdapter: state.oracleAdapterAddress,
-                strategy: address(0),
+                strategy: state.strategyAddress,
                 owner: owner,
                 chainId: block.chainid,
+                strategyDebt: 0,
+                liveStrategyAssets: 0,
+                strategyEmergencyExit: false,
                 vaultName: VAULT_NAME,
                 vaultSymbol: VAULT_SYMBOL
             })
@@ -110,6 +117,7 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
         state.oracleFeedAddress = address(new LocalMockOracleFeed(ORACLE_DECIMALS, ORACLE_ANSWER, block.timestamp - 1));
         state.oracleAdapterAddress =
             address(new LocalOracleAdapterHarness(owner, state.oracleFeedAddress, MAX_STALENESS));
+        state.strategyAddress = address(new LocalHappyPathVaultStrategy(state.diamondAddress, state.vaultAssetAddress));
         return state;
     }
 
@@ -140,6 +148,7 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
         IERC4626VaultFacet vaultCore = IERC4626VaultFacet(state.diamondAddress);
         IERC4626VaultControlsFacet vaultControls = IERC4626VaultControlsFacet(state.diamondAddress);
         IERC4626VaultIntegrationFacet vaultIntegration = IERC4626VaultIntegrationFacet(state.diamondAddress);
+        IERC4626VaultStrategy strategy = IERC4626VaultStrategy(state.strategyAddress);
         address[] memory facetAddresses = loupe.facetAddresses();
 
         require(facetAddresses.length == 5, "vault host facet count mismatch");
@@ -185,9 +194,12 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
         require(feeRecipient == owner, "vault fee recipient mismatch");
 
         require(vaultIntegration.oracleAdapter() == state.oracleAdapterAddress, "vault oracle adapter mismatch");
-        require(vaultIntegration.strategy() == address(0), "vault strategy should be unset");
+        require(vaultIntegration.strategy() == state.strategyAddress, "vault strategy mismatch");
         require(vaultIntegration.strategyDebt() == 0, "vault strategy debt should be zero");
+        require(!vaultIntegration.strategyEmergencyExit(), "vault emergency exit should be inactive");
         require(vaultIntegration.liveStrategyAssets() == 0, "vault live strategy assets should be zero");
+        require(strategy.vault() == state.diamondAddress, "strategy vault binding mismatch");
+        require(strategy.asset() == state.vaultAssetAddress, "strategy asset binding mismatch");
 
         IOracleAdapter.OracleQuote memory quotePayload = vaultIntegration.oracleQuote();
         require(quotePayload.value == ORACLE_ANSWER, "vault quote value mismatch");
@@ -223,6 +235,12 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
             IERC4626VaultIntegrationFacet.oracleAdapter.selector,
             state.vaultIntegrationFacetAddress,
             "vault oracle owner"
+        );
+        _requireSelectorOwner(
+            loupe,
+            IERC4626VaultIntegrationFacet.deployToStrategy.selector,
+            state.vaultIntegrationFacetAddress,
+            "vault deploy strategy owner"
         );
         _requireSelectorOwner(
             loupe, IERC165.supportsInterface.selector, state.vaultControlsFacetAddress, "vault erc165 owner"

--- a/script/common/DiamondVaultHostScriptBase.sol
+++ b/script/common/DiamondVaultHostScriptBase.sol
@@ -26,6 +26,9 @@ abstract contract DiamondVaultHostScriptBase is DiamondCoreScriptBase {
         address strategy;
         address owner;
         uint256 chainId;
+        uint256 strategyDebt;
+        uint256 liveStrategyAssets;
+        bool strategyEmergencyExit;
         string vaultName;
         string vaultSymbol;
     }
@@ -89,6 +92,9 @@ abstract contract DiamondVaultHostScriptBase is DiamondCoreScriptBase {
         json = VM.serializeAddress(objectKey, "oracleFeed", artifact.oracleFeed);
         json = VM.serializeAddress(objectKey, "oracleAdapter", artifact.oracleAdapter);
         json = VM.serializeAddress(objectKey, "strategy", artifact.strategy);
+        json = VM.serializeUint(objectKey, "strategyDebt", artifact.strategyDebt);
+        json = VM.serializeUint(objectKey, "liveStrategyAssets", artifact.liveStrategyAssets);
+        json = VM.serializeBool(objectKey, "strategyEmergencyExit", artifact.strategyEmergencyExit);
         json = VM.serializeString(objectKey, "vaultName", artifact.vaultName);
         json = VM.serializeString(objectKey, "vaultSymbol", artifact.vaultSymbol);
         VM.writeJson(json, string.concat(VM.projectRoot(), outputRelativePath));

--- a/script/common/Vm.sol
+++ b/script/common/Vm.sol
@@ -18,6 +18,9 @@ interface Vm {
     function serializeUint(string calldata objectKey, string calldata valueKey, uint256 value)
         external
         returns (string memory);
+    function serializeBool(string calldata objectKey, string calldata valueKey, bool value)
+        external
+        returns (string memory);
     function startBroadcast(uint256 privateKey) external;
     function stopBroadcast() external;
     function writeJson(string calldata json, string calldata path) external;

--- a/script/mocks/LocalVaultDeploymentMocks.sol
+++ b/script/mocks/LocalVaultDeploymentMocks.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.30;
 
 import {IERC20Metadata} from "../../src/interfaces/IERC20Metadata.sol";
 import {IOracleFeed} from "../../src/interfaces/IOracleFeed.sol";
+import {IERC4626VaultStrategy} from "../../src/interfaces/IERC4626VaultStrategy.sol";
 import {OracleAdapter} from "../../src/oracle/OracleAdapter.sol";
 
 /// @title LocalMintableVaultAsset
@@ -126,6 +127,72 @@ contract LocalMockOracleFeed is IOracleFeed {
         returns (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound)
     {
         return (_roundId, _answer, _updatedAt, _updatedAt, _answeredInRound);
+    }
+}
+
+/// @title LocalHappyPathVaultStrategy
+/// @notice Simple vault-bound, asset-bound strategy used for local hosted-vault deployment and smoke flows.
+contract LocalHappyPathVaultStrategy is IERC4626VaultStrategy {
+    address internal immutable VAULT;
+    address internal immutable ASSET;
+    uint256 internal _trackedAssets;
+
+    constructor(address vault_, address asset_) {
+        VAULT = vault_;
+        ASSET = asset_;
+    }
+
+    modifier onlyVault() {
+        if (msg.sender != VAULT) {
+            revert ERC4626VaultStrategyOnlyVault(msg.sender, VAULT);
+        }
+        _;
+    }
+
+    function vault() external view returns (address) {
+        return VAULT;
+    }
+
+    function asset() external view returns (address) {
+        return ASSET;
+    }
+
+    function totalAssets() external view returns (uint256) {
+        return _trackedAssets;
+    }
+
+    function maxWithdrawableAssets() external view returns (uint256) {
+        return _trackedAssets;
+    }
+
+    function deployFunds(uint256 assets) external onlyVault {
+        _trackedAssets += assets;
+        require(LocalMintableVaultAsset(ASSET).balanceOf(address(this)) >= _trackedAssets, "STRATEGY_UNDERFUNDED");
+    }
+
+    function withdrawToVault(uint256 assets) external onlyVault returns (uint256 assetsReturned) {
+        assetsReturned = assets > _trackedAssets ? _trackedAssets : assets;
+        _trackedAssets -= assetsReturned;
+        if (assetsReturned != 0) {
+            require(LocalMintableVaultAsset(ASSET).transfer(VAULT, assetsReturned), "STRATEGY_TRANSFER_FAILED");
+        }
+    }
+
+    function withdrawAllToVault() external onlyVault returns (uint256 assetsReturned) {
+        assetsReturned = _trackedAssets;
+        _trackedAssets = 0;
+        if (assetsReturned != 0) {
+            require(LocalMintableVaultAsset(ASSET).transfer(VAULT, assetsReturned), "STRATEGY_TRANSFER_FAILED");
+        }
+    }
+
+    function injectProfit(uint256 assets) external {
+        if (assets == 0) {
+            return;
+        }
+
+        LocalMintableVaultAsset(ASSET).mint(address(this), assets);
+        _trackedAssets += assets;
     }
 }
 

--- a/scripts/auralis-activity.sh
+++ b/scripts/auralis-activity.sh
@@ -11,6 +11,7 @@ erc721_diamond="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" erc721Host.diamond
 vault_diamond="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.diamond)"
 vault_asset="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.vaultAsset)"
 oracle_feed="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.oracleFeed)"
+strategy="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.strategy)"
 
 now_ts="$(date +%s)"
 
@@ -30,40 +31,48 @@ cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_
 cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_ALICE_PRIVATE_KEY}" \
   "${erc721_diamond}" "transferFrom(address,address,uint256)" "${AURALIS_OWNER_ADDRESS}" "${AURALIS_ALICE_ADDRESS}" 2 >/dev/null
 
-auralis_note "Generating vault flow activity"
+auralis_note "Generating vault and strategy activity"
 cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
   "${vault_asset}" "mint(address,uint256)" "${AURALIS_ALICE_ADDRESS}" 4000000000 >/dev/null
 cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_ALICE_PRIVATE_KEY}" \
   "${vault_asset}" "approve(address,uint256)" "${vault_diamond}" 4000000000 >/dev/null
 cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_ALICE_PRIVATE_KEY}" \
   "${vault_diamond}" "deposit(uint256,address)(uint256)" 1250000000 "${AURALIS_ALICE_ADDRESS}" >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${vault_diamond}" "deployToStrategy(uint256)" 750000000 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${strategy}" "injectProfit(uint256)" 125000000 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${vault_diamond}" "syncStrategyAssets()" >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${vault_diamond}" "withdrawFromStrategy(uint256)(uint256)" 200000000 >/dev/null
 cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_ALICE_PRIVATE_KEY}" \
   "${vault_diamond}" "transfer(address,uint256)" "${AURALIS_OWNER_ADDRESS}" 250000000 >/dev/null
 cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
   "${vault_diamond}" "redeem(uint256,address,address)(uint256)" 100000000 "${AURALIS_OWNER_ADDRESS}" "${AURALIS_OWNER_ADDRESS}" >/dev/null
 
-auralis_note "Updating oracle and strategy reporting"
+auralis_note "Updating oracle and pause state"
 cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
   "${oracle_feed}" "setRoundData(int256,uint256)" 102000000 "${now_ts}" >/dev/null
-cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
-  "${vault_diamond}" "setStrategy(address)" "${AURALIS_ALICE_ADDRESS}" >/dev/null
-cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_ALICE_PRIVATE_KEY}" \
-  "${vault_diamond}" "reportStrategyAssets(uint256)" 275000000 >/dev/null
-
-auralis_note "Toggling global pause state"
 cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
   "${vault_diamond}" "pause()" >/dev/null
 cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
   "${vault_diamond}" "unpause()" >/dev/null
 
-estimated_assets="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "estimatedTotalManagedAssets()(uint256)" | awk '{print $1}')"
+idle_assets="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "idleAssets()(uint256)" | awk '{print $1}')"
+strategy_debt="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "strategyDebt()(uint256)" | awk '{print $1}')"
+live_strategy_assets="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "liveStrategyAssets()(uint256)" | awk '{print $1}')"
+total_assets="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "totalAssets()(uint256)" | awk '{print $1}')"
 quote_tuple="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "oracleQuote()((int256,uint64,uint8))")"
 
 cat <<MSG
 Auralis simulated activity complete.
 
-Estimated managed assets: ${estimated_assets}
+Idle assets: ${idle_assets}
+Strategy debt: ${strategy_debt}
+Live strategy assets: ${live_strategy_assets}
+Total assets: ${total_assets}
 Oracle quote tuple: ${quote_tuple}
 
-The local chain now has representative token, NFT, vault, oracle, and strategy-report activity.
+The local chain now has representative token, NFT, vault, oracle, and live strategy lifecycle activity.
 MSG

--- a/scripts/auralis-smoke.sh
+++ b/scripts/auralis-smoke.sh
@@ -11,8 +11,9 @@ erc721_diamond="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" erc721Host.diamond
 vault_diamond="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.diamond)"
 vault_asset="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.vaultAsset)"
 oracle_adapter="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.oracleAdapter)"
+strategy="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.strategy)"
 
-for address in "${erc20_diamond}" "${erc721_diamond}" "${vault_diamond}" "${vault_asset}" "${oracle_adapter}"; do
+for address in "${erc20_diamond}" "${erc721_diamond}" "${vault_diamond}" "${vault_asset}" "${oracle_adapter}" "${strategy}"; do
   code="$(cast code --rpc-url "${AURALIS_RPC_URL}" "${address}")"
   if [[ "${code}" == "0x" ]]; then
     echo "Expected deployed code at ${address}, found empty code." >&2
@@ -42,20 +43,45 @@ if [[ "${nft_owner,,}" != "${AURALIS_OWNER_ADDRESS,,}" ]]; then
   exit 1
 fi
 
-auralis_note "Vault host smoke: deposit, quote, and withdraw"
+auralis_note "Vault host smoke: strategy-enabled lifecycle"
 cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
   "${vault_asset}" "mint(address,uint256)" "${AURALIS_ALICE_ADDRESS}" 1500000000 >/dev/null
 cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_ALICE_PRIVATE_KEY}" \
   "${vault_asset}" "approve(address,uint256)" "${vault_diamond}" 1500000000 >/dev/null
 cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_ALICE_PRIVATE_KEY}" \
   "${vault_diamond}" "deposit(uint256,address)(uint256)" 1000000000 "${AURALIS_ALICE_ADDRESS}" >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${vault_diamond}" "deployToStrategy(uint256)" 600000000 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${strategy}" "injectProfit(uint256)" 100000000 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${vault_diamond}" "syncStrategyAssets()" >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${vault_diamond}" "withdrawFromStrategy(uint256)(uint256)" 150000000 >/dev/null
 cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_ALICE_PRIVATE_KEY}" \
-  "${vault_diamond}" "withdraw(uint256,address,address)(uint256)" 250000000 "${AURALIS_ALICE_ADDRESS}" "${AURALIS_ALICE_ADDRESS}" >/dev/null
-shares_after="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "balanceOf(address)(uint256)" "${AURALIS_ALICE_ADDRESS}" | awk '{print $1}')"
-if [[ "${shares_after}" != "750000000" ]]; then
-  echo "Unexpected vault share balance after smoke flow: ${shares_after}" >&2
+  "${vault_diamond}" "withdraw(uint256,address,address)(uint256)" 700000000 "${AURALIS_ALICE_ADDRESS}" "${AURALIS_ALICE_ADDRESS}" >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${vault_diamond}" "emergencyExitStrategy()(uint256)" >/dev/null
+
+strategy_debt="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "strategyDebt()(uint256)" | awk '{print $1}')"
+strategy_exit="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "strategyEmergencyExit()(bool)")"
+if [[ "${strategy_debt}" != "0" || "${strategy_exit}" != "true" ]]; then
+  echo "Unexpected strategy state after emergency exit: debt=${strategy_debt}, emergency=${strategy_exit}" >&2
   exit 1
 fi
+
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${vault_diamond}" "setStrategy(address)" 0x0000000000000000000000000000000000000000 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${vault_diamond}" "setStrategy(address)" "${strategy}" >/dev/null
+
+strategy_rebound="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "strategy()(address)")"
+strategy_exit="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "strategyEmergencyExit()(bool)")"
+if [[ "${strategy_rebound,,}" != "${strategy,,}" || "${strategy_exit}" != "false" ]]; then
+  echo "Strategy was not rebound cleanly after smoke flow." >&2
+  exit 1
+fi
+
 quote_tuple="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "oracleQuote()((int256,uint64,uint8))")"
 if [[ -z "${quote_tuple}" ]]; then
   echo "oracleQuote() returned empty output." >&2

--- a/scripts/auralis-up.sh
+++ b/scripts/auralis-up.sh
@@ -22,7 +22,7 @@ auralis_note "Deploying ERC721 host"
   forge script script/DeployDiamondErc721Host.s.sol:DeployDiamondErc721HostScript --rpc-url "${AURALIS_RPC_URL}" --broadcast
 )
 
-auralis_note "Deploying vault host"
+auralis_note "Deploying strategy-enabled vault host"
 (
   cd "${AURALIS_ROOT}"
   forge script script/DeployDiamondVaultHost.s.sol:DeployDiamondVaultHostScript --rpc-url "${AURALIS_RPC_URL}" --broadcast
@@ -31,6 +31,8 @@ auralis_note "Deploying vault host"
 auralis_note "Writing unified Auralis artifact"
 auralis_write_unified_artifact
 
+vault_strategy="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.strategy)"
+
 cat <<MSG
 Auralis local environment is ready.
 
@@ -38,6 +40,7 @@ RPC: ${AURALIS_RPC_URL}
 Artifact: ${AURALIS_ARTIFACT_PATH}
 Owner: ${AURALIS_OWNER_ADDRESS}
 Alice: ${AURALIS_ALICE_ADDRESS}
+Vault strategy: ${vault_strategy}
 
 Next steps:
 - bash scripts/auralis-smoke.sh

--- a/test/DiamondVaultDeploymentIntegration.t.sol
+++ b/test/DiamondVaultDeploymentIntegration.t.sol
@@ -11,15 +11,17 @@ import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol
 import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControlsFacet.sol";
 import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
 import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
+import {IERC4626VaultStrategy} from "../src/interfaces/IERC4626VaultStrategy.sol";
 import {IOracleAdapter} from "../src/interfaces/IOracleAdapter.sol";
 import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {DiamondVaultDeploymentFixture} from "./helpers/DiamondVaultDeploymentTestHarness.sol";
 
 contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture {
-    function testVaultHostDeployInstallInitAndOracleWiring() public {
+    function testVaultHostDeployInstallInitOracleAndStrategyWiring() public {
         _installVaultHostFacets();
         _initializeVaultHost();
         _wireOracleAdapter();
+        _wireStrategy();
 
         IDiamondLoupe loupe = IDiamondLoupe(address(diamond));
         address[] memory facetAddresses = loupe.facetAddresses();
@@ -66,6 +68,10 @@ contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture 
             "oracle selector owner mismatch"
         );
         assertTrue(
+            loupe.facetAddress(IERC4626VaultIntegrationFacet.deployToStrategy.selector) == address(integrationFacet),
+            "deploy strategy selector owner mismatch"
+        );
+        assertTrue(
             loupe.facetAddress(IERC165.supportsInterface.selector) == address(controlsFacet),
             "supportsInterface owner mismatch"
         );
@@ -93,9 +99,12 @@ contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture 
         assertTrue(feeRecipient == admin, "fee recipient mismatch");
 
         assertTrue(integrationFacetInterface().oracleAdapter() == address(adapter), "adapter mismatch");
-        assertTrue(integrationFacetInterface().strategy() == address(0), "strategy should be unset");
+        assertTrue(integrationFacetInterface().strategy() == address(strategy), "strategy should be configured");
         assertTrue(integrationFacetInterface().strategyDebt() == 0, "strategy debt should be zero");
+        assertFalse(integrationFacetInterface().strategyEmergencyExit(), "emergency exit should be inactive");
         assertTrue(integrationFacetInterface().liveStrategyAssets() == 0, "live strategy assets should be zero");
+        assertTrue(IERC4626VaultStrategy(address(strategy)).vault() == address(diamond), "strategy vault mismatch");
+        assertTrue(IERC4626VaultStrategy(address(strategy)).asset() == address(asset), "strategy asset mismatch");
         assertTrue(quotePayload.value == 100_000_000, "quote value mismatch");
         assertTrue(quotePayload.updatedAt == quoteUpdatedAt, "quote timestamp mismatch");
         assertTrue(quotePayload.decimals == 8, "quote decimals mismatch");
@@ -115,6 +124,63 @@ contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture 
         VM.prank(admin);
         VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultAlreadyInitialized.selector));
         coreFacetInterface().initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function testVaultHostSmokeCoversStrategyLifecycle() public {
+        _installVaultHostFacets();
+        _initializeVaultHost();
+        _wireOracleAdapter();
+        _wireStrategy();
+
+        asset.mint(admin, 1_500_000_000);
+        VM.prank(admin);
+        asset.approve(address(diamond), 1_500_000_000);
+        VM.prank(admin);
+        coreFacetInterface().deposit(1_000_000_000, admin);
+
+        VM.prank(admin);
+        integrationFacetInterface().deployToStrategy(600_000_000);
+        strategy.injectProfit(100_000_000);
+        VM.prank(admin);
+        integrationFacetInterface().syncStrategyAssets();
+
+        assertTrue(integrationFacetInterface().strategyDebt() == 700_000_000, "strategy debt mismatch after sync");
+        assertTrue(coreFacetInterface().totalManagedAssets() == 1_100_000_000, "book value mismatch after sync");
+        assertTrue(coreFacetInterface().totalAssets() == 1_100_000_000, "total assets mismatch after sync");
+
+        VM.prank(admin);
+        uint256 managerReturned = integrationFacetInterface().withdrawFromStrategy(150_000_000);
+        assertTrue(managerReturned == 150_000_000, "manager withdraw should return requested assets");
+        assertTrue(
+            integrationFacetInterface().strategyDebt() == 550_000_000, "strategy debt mismatch after manager withdraw"
+        );
+
+        VM.prank(admin);
+        coreFacetInterface().withdraw(700_000_000, admin, admin);
+
+        assertTrue(
+            integrationFacetInterface().strategyDebt() == 400_000_000, "strategy debt mismatch after user withdraw"
+        );
+        assertTrue(integrationFacetInterface().liveStrategyAssets() == 400_000_000, "live strategy assets mismatch");
+        assertTrue(integrationFacetInterface().idleAssets() == 0, "idle assets should be exhausted after auto-pull");
+        assertTrue(coreFacetInterface().totalManagedAssets() == 400_000_000, "book value mismatch after user withdraw");
+
+        VM.prank(admin);
+        uint256 emergencyAssets = integrationFacetInterface().emergencyExitStrategy();
+
+        assertTrue(emergencyAssets == 400_000_000, "emergency exit should unwind remaining assets");
+        assertTrue(integrationFacetInterface().strategyEmergencyExit(), "emergency exit should be active");
+        assertTrue(integrationFacetInterface().strategyDebt() == 0, "strategy debt should be zero after unwind");
+        assertTrue(integrationFacetInterface().idleAssets() == 400_000_000, "idle assets should contain unwound funds");
+
+        VM.prank(admin);
+        integrationFacetInterface().setStrategy(address(0));
+        VM.prank(admin);
+        integrationFacetInterface().setStrategy(address(strategy));
+
+        assertFalse(integrationFacetInterface().strategyEmergencyExit(), "emergency exit should clear on rebind");
+        assertTrue(integrationFacetInterface().strategy() == address(strategy), "strategy should be rebound");
+        assertTrue(integrationFacetInterface().strategyDebt() == 0, "strategy debt should reset to zero");
     }
 
     function _assertSelectorsOwnedByFacet(bytes4[] memory selectors, address expectedFacet) internal view {

--- a/test/helpers/DiamondVaultDeploymentTestHarness.sol
+++ b/test/helpers/DiamondVaultDeploymentTestHarness.sol
@@ -10,11 +10,13 @@ import {ERC4626VaultIntegrationFacetHarness} from "./ERC4626VaultIntegrationFace
 import {MockVaultAsset} from "./ERC4626CoreTestHarness.sol";
 import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
 import {MockOracleFeed, OracleAdapterHarness} from "./OracleAdapterTestHarness.sol";
+import {ProfitMockVaultStrategy} from "./ERC4626VaultStrategyTestHarness.sol";
 import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {TestBase} from "./AccessControlTestHarness.sol";
 
 abstract contract DiamondVaultDeploymentFixture is TestBase {
     address internal admin = address(0xA11CE);
+    address internal alice = address(0xA11CE0);
 
     uint64 internal maxStaleness = 1 hours;
     uint64 internal currentTime = 1_000_000;
@@ -29,6 +31,7 @@ abstract contract DiamondVaultDeploymentFixture is TestBase {
     MockVaultAsset internal asset;
     MockOracleFeed internal feed;
     OracleAdapterHarness internal adapter;
+    ProfitMockVaultStrategy internal strategy;
 
     function setUp() public virtual {
         VM.warp(currentTime);
@@ -43,6 +46,7 @@ abstract contract DiamondVaultDeploymentFixture is TestBase {
         feed = new MockOracleFeed(8);
         feed.setLatestRoundData(1, 100_000_000, quoteUpdatedAt, quoteUpdatedAt, 1);
         adapter = new OracleAdapterHarness(admin, address(feed), maxStaleness);
+        strategy = new ProfitMockVaultStrategy(address(diamond), address(asset));
 
         _installLoupeFacet();
     }
@@ -89,6 +93,11 @@ abstract contract DiamondVaultDeploymentFixture is TestBase {
     function _wireOracleAdapter() internal {
         VM.prank(admin);
         integrationFacetInterface().setOracleAdapter(address(adapter));
+    }
+
+    function _wireStrategy() internal {
+        VM.prank(admin);
+        integrationFacetInterface().setStrategy(address(strategy));
     }
 
     function coreFacetInterface() internal view returns (ERC4626VaultFacetHarness) {


### PR DESCRIPTION
## Summary
- deploy and bind a script-local happy-path strategy in the hosted vault reference deployment
- extend the deployment artifact and local Auralis scripts for the strategy-enabled vault lifecycle
- add deployment integration coverage for strategy wiring and smoke lifecycle flows

## Validation
- bash -n scripts/auralis-up.sh scripts/auralis-smoke.sh scripts/auralis-activity.sh
- forge fmt --check
- forge build --sizes --skip script
- forge test --offline --match-path test/DiamondVaultDeploymentIntegration.t.sol
- forge test --offline --match-path test/ERC4626VaultIntegrationFacetCore.t.sol
- forge test --offline --match-path test/ERC4626VaultStrategyAccountingCore.t.sol
- bash scripts/auralis-reset.sh && bash scripts/auralis-up.sh && bash scripts/auralis-smoke.sh && bash scripts/auralis-activity.sh && bash scripts/auralis-reset.sh
- git diff --check
- forge test --offline

Closes #116