### PR TITLE
Add cross-facet hardening and invariants for the strategy-enabled vault

### DIFF
--- a/src/vault/ERC4626Vault.sol
+++ b/src/vault/ERC4626Vault.sol
@@ -127,7 +127,7 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
     /// @param owner Share owner.
     /// @return Max withdrawable assets.
     function maxWithdraw(address owner) public view virtual returns (uint256) {
-        if (owner == address(0)) {
+        if (owner == address(0) || totalAssets() == 0) {
             return 0;
         }
         return _convertToAssets(balanceOf(owner), Rounding.Down);
@@ -173,7 +173,7 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
     /// @param owner Share owner.
     /// @return Max redeemable shares.
     function maxRedeem(address owner) public view virtual returns (uint256) {
-        if (owner == address(0)) {
+        if (owner == address(0) || totalAssets() == 0) {
             return 0;
         }
         return balanceOf(owner);

--- a/src/vault/ERC4626VaultControlLogic.sol
+++ b/src/vault/ERC4626VaultControlLogic.sol
@@ -155,7 +155,7 @@ abstract contract ERC4626VaultControlledCore is ERC4626Vault {
     }
 
     function maxWithdraw(address owner) public view virtual override returns (uint256) {
-        if (owner == address(0) || _vaultOperationsPaused()) {
+        if (owner == address(0) || _vaultOperationsPaused() || totalAssets() == 0) {
             return 0;
         }
 
@@ -176,7 +176,7 @@ abstract contract ERC4626VaultControlledCore is ERC4626Vault {
     }
 
     function maxRedeem(address owner) public view virtual override returns (uint256) {
-        if (owner == address(0) || _vaultOperationsPaused()) {
+        if (owner == address(0) || _vaultOperationsPaused() || totalAssets() == 0) {
             return 0;
         }
 

--- a/test/DiamondVaultHostHardening.t.sol
+++ b/test/DiamondVaultHostHardening.t.sol
@@ -19,6 +19,9 @@ import {
 contract DiamondVaultHostHardeningTest is DiamondVaultHostHardeningFixture {
     function testCoreFacetReplaceRemoveReAddPreservesState() public {
         _installAndSeedVaultHost();
+        _injectStrategyProfit(STRATEGY_PROFIT_ASSETS);
+
+        StrategyStateSnapshot memory initialState = _snapshotStrategyState();
 
         _replaceCoreFacet(address(coreReplacement));
         _addCoreReplacementMarker(address(coreReplacement));
@@ -39,12 +42,10 @@ contract DiamondVaultHostHardeningTest is DiamondVaultHostHardeningFixture {
             keccak256(bytes(IERC20Metadata(address(diamond)).symbol())) == keccak256(bytes("vSHARE")),
             "core symbol mismatch after replace"
         );
-        assertTrue(coreFacetInterface().totalManagedAssets() == BOB_DEPOSIT + CAROL_DEPOSIT, "managed assets mismatch");
-        assertTrue(coreFacetInterface().totalAssets() == BOB_DEPOSIT + CAROL_DEPOSIT, "total assets mismatch");
-        assertTrue(coreFacetInterface().totalSupply() == BOB_DEPOSIT + CAROL_DEPOSIT, "total supply mismatch");
         assertTrue(coreFacetInterface().balanceOf(bob) == BOB_DEPOSIT, "bob balance mismatch");
         assertTrue(coreFacetInterface().balanceOf(carol) == CAROL_DEPOSIT, "carol balance mismatch");
         assertTrue(coreFacetInterface().allowance(bob, eve) == SHARE_ALLOWANCE, "share allowance mismatch");
+        _assertStrategyState(initialState);
         assertTrue(
             IERC165(address(diamond)).supportsInterface(type(IERC4626VaultFacet).interfaceId),
             "core interface missing after replace"
@@ -76,17 +77,17 @@ contract DiamondVaultHostHardeningTest is DiamondVaultHostHardeningFixture {
             "core interface missing after re-add"
         );
         assertTrue(coreFacetInterface().asset() == address(asset), "core asset mismatch after re-add");
-        assertTrue(
-            coreFacetInterface().totalSupply() == BOB_DEPOSIT + CAROL_DEPOSIT, "core supply mismatch after re-add"
-        );
         assertTrue(coreFacetInterface().balanceOf(bob) == BOB_DEPOSIT, "bob balance mismatch after re-add");
         assertTrue(coreFacetInterface().balanceOf(carol) == CAROL_DEPOSIT, "carol balance mismatch after re-add");
         assertTrue(coreFacetInterface().allowance(bob, eve) == SHARE_ALLOWANCE, "allowance mismatch after re-add");
+        _assertStrategyState(initialState);
     }
 
     function testControlsFacetReplaceRemoveReAddPreservesControlState() public {
         _installAndSeedVaultHost();
         _pauseVault();
+
+        StrategyStateSnapshot memory initialState = _snapshotStrategyState();
 
         _replaceControlsFacet(address(controlsReplacement));
         _addControlsReplacementMarker(address(controlsReplacement));
@@ -99,6 +100,7 @@ contract DiamondVaultHostHardeningTest is DiamondVaultHostHardeningFixture {
         );
         assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "controls replacement marker mismatch");
         _assertControlsState();
+        _assertStrategyState(initialState);
         assertTrue(controlsFacetInterface().paused(), "paused state should persist after replace");
         assertFalse(controlsFacetInterface().reentrancyGuardEntered(), "reentrancy should not be entered");
 
@@ -114,7 +116,7 @@ contract DiamondVaultHostHardeningTest is DiamondVaultHostHardeningFixture {
         );
         assertTrue(coreFacetInterface().asset() == address(asset), "core should still route after controls removal");
         assertTrue(
-            integrationFacetInterface().strategyDebt() == STRATEGY_DEPLOYED_ASSETS,
+            integrationFacetInterface().strategyDebt() == initialState.strategyDebt,
             "integration should still route after controls removal"
         );
 
@@ -127,6 +129,7 @@ contract DiamondVaultHostHardeningTest is DiamondVaultHostHardeningFixture {
         _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultControlsSelectors(), address(controlsReplacement));
         assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "controls marker mismatch after re-add");
         _assertControlsState();
+        _assertStrategyState(initialState);
         assertTrue(controlsFacetInterface().paused(), "paused state should persist after re-add");
         assertTrue(
             IERC165(address(diamond)).supportsInterface(type(IERC4626VaultFacet).interfaceId),
@@ -142,6 +145,8 @@ contract DiamondVaultHostHardeningTest is DiamondVaultHostHardeningFixture {
     function testIntegrationFacetReplaceRemoveReAddPreservesIntegrationState() public {
         _installAndSeedVaultHost();
 
+        StrategyStateSnapshot memory initialState = _snapshotStrategyState();
+
         _replaceIntegrationFacet(address(integrationReplacement));
         _addIntegrationReplacementMarker(address(integrationReplacement));
 
@@ -154,7 +159,7 @@ contract DiamondVaultHostHardeningTest is DiamondVaultHostHardeningFixture {
             "integration marker owner mismatch"
         );
         assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "integration replacement marker mismatch");
-        _assertIntegrationState();
+        _assertStrategyState(initialState);
         assertTrue(
             IERC165(address(diamond)).supportsInterface(type(IERC4626VaultIntegrationFacet).interfaceId),
             "integration interface missing after replace"
@@ -176,6 +181,27 @@ contract DiamondVaultHostHardeningTest is DiamondVaultHostHardeningFixture {
             "integration interface should be absent when selectors removed"
         );
 
+        uint256 expectedBobSharesBurned = coreFacetInterface().previewWithdraw(BOB_AUTO_PULL_WITHDRAW_ASSETS);
+        VM.prank(bob);
+        uint256 burnedShares = coreFacetInterface().withdraw(BOB_AUTO_PULL_WITHDRAW_ASSETS, bob, bob);
+        assertTrue(
+            burnedShares == expectedBobSharesBurned, "withdraw should use previewWithdraw semantics while removed"
+        );
+
+        uint256 expectedCarolAssetsReturned = coreFacetInterface().previewRedeem(CAROL_AUTO_PULL_REDEEM_SHARES);
+        VM.prank(carol);
+        uint256 returnedAssets = coreFacetInterface().redeem(CAROL_AUTO_PULL_REDEEM_SHARES, carol, carol);
+        assertTrue(
+            returnedAssets == expectedCarolAssetsReturned, "redeem should use previewRedeem semantics while removed"
+        );
+
+        uint256 expectedIdleAssets = asset.balanceOf(address(diamond));
+        uint256 expectedLiveStrategyAssets = strategyContract.totalAssets();
+        uint256 expectedTotalManagedAssets = coreFacetInterface().totalManagedAssets();
+        uint256 expectedTotalAssets = coreFacetInterface().totalAssets();
+        uint256 expectedBobBalance = coreFacetInterface().balanceOf(bob);
+        uint256 expectedCarolBalance = coreFacetInterface().balanceOf(carol);
+
         _reAddIntegrationFacetWithMarker(address(integrationReplacement));
 
         _assertSelectorsOwnedByFacet(
@@ -184,11 +210,67 @@ contract DiamondVaultHostHardeningTest is DiamondVaultHostHardeningFixture {
         assertTrue(
             IFacetVersionMarker(address(diamond)).facetVersion() == 2, "integration marker mismatch after re-add"
         );
-        _assertIntegrationState();
         assertTrue(
             IERC165(address(diamond)).supportsInterface(type(IERC4626VaultIntegrationFacet).interfaceId),
             "integration interface missing after re-add"
         );
+        assertTrue(
+            integrationFacetInterface().strategy() == address(strategyContract), "strategy mismatch after re-add"
+        );
+        assertTrue(
+            integrationFacetInterface().strategyDebt() == expectedTotalManagedAssets - expectedIdleAssets,
+            "strategy debt mismatch after re-add"
+        );
+        assertTrue(
+            integrationFacetInterface().liveStrategyAssets() == expectedLiveStrategyAssets,
+            "live strategy assets mismatch after re-add"
+        );
+        assertTrue(integrationFacetInterface().idleAssets() == expectedIdleAssets, "idle assets mismatch after re-add");
+        assertFalse(integrationFacetInterface().strategyEmergencyExit(), "emergency exit should stay inactive");
+        assertTrue(
+            coreFacetInterface().totalManagedAssets() == expectedTotalManagedAssets, "book value mismatch after re-add"
+        );
+        assertTrue(coreFacetInterface().totalAssets() == expectedTotalAssets, "total assets mismatch after re-add");
+        assertTrue(coreFacetInterface().balanceOf(bob) == expectedBobBalance, "bob balance mismatch after re-add");
+        assertTrue(coreFacetInterface().balanceOf(carol) == expectedCarolBalance, "carol balance mismatch after re-add");
+    }
+
+    function testIntegrationEmergencyExitStatePersistsAcrossFacetChurn() public {
+        _installAndSeedVaultHost();
+
+        VM.prank(admin);
+        uint256 emergencyAssets = integrationFacetInterface().emergencyExitStrategy();
+        assertTrue(emergencyAssets == STRATEGY_DEPLOYED_ASSETS, "emergency exit should unwind deployed assets");
+
+        _replaceIntegrationFacet(address(integrationReplacement));
+        _addIntegrationReplacementMarker(address(integrationReplacement));
+        _removeIntegrationFacetWithMarker();
+        _reAddIntegrationFacetWithMarker(address(integrationReplacement));
+
+        assertTrue(
+            IFacetVersionMarker(address(diamond)).facetVersion() == 2,
+            "integration marker mismatch after emergency re-add"
+        );
+        assertTrue(integrationFacetInterface().strategy() == address(strategyContract), "strategy mismatch after churn");
+        assertTrue(integrationFacetInterface().strategyEmergencyExit(), "emergency exit should persist after churn");
+        assertTrue(integrationFacetInterface().strategyDebt() == 0, "strategy debt should remain zero after churn");
+        assertTrue(integrationFacetInterface().liveStrategyAssets() == 0, "live strategy assets should remain zero");
+        assertTrue(integrationFacetInterface().idleAssets() == BOB_DEPOSIT + CAROL_DEPOSIT, "idle assets mismatch");
+
+        VM.expectRevert(IERC4626VaultIntegrationFacet.ERC4626VaultStrategyEmergencyExitActive.selector);
+        VM.prank(admin);
+        integrationFacetInterface().deployToStrategy(1);
+
+        VM.prank(admin);
+        integrationFacetInterface().setStrategy(address(0));
+        VM.prank(admin);
+        integrationFacetInterface().setStrategy(address(strategyContract));
+
+        assertFalse(integrationFacetInterface().strategyEmergencyExit(), "emergency exit should clear on rebind");
+
+        VM.prank(admin);
+        integrationFacetInterface().deployToStrategy(1);
+        assertTrue(integrationFacetInterface().strategyDebt() == 1, "deploy should work after strategy rebind");
     }
 
     function _assertSelectorsOwnedByFacet(bytes4[] memory selectors, address expectedFacet) internal view {
@@ -219,19 +301,5 @@ contract DiamondVaultHostHardeningTest is DiamondVaultHostHardeningFixture {
         assertTrue(end == uint64(currentTime + 1_000), "role window end mismatch");
         assertTrue(exists, "role window should exist");
         assertTrue(controlsFacetInterface().hasActiveRole(managerRole, dave), "dave active manager role mismatch");
-    }
-
-    function _assertIntegrationState() internal view {
-        assertTrue(integrationFacetInterface().oracleAdapter() == address(adapter), "oracle adapter mismatch");
-        assertTrue(integrationFacetInterface().strategy() == address(strategyContract), "strategy mismatch");
-        assertTrue(integrationFacetInterface().strategyDebt() == STRATEGY_DEPLOYED_ASSETS, "strategy debt mismatch");
-        assertTrue(
-            integrationFacetInterface().liveStrategyAssets() == STRATEGY_DEPLOYED_ASSETS,
-            "live strategy assets mismatch"
-        );
-        assertTrue(
-            integrationFacetInterface().idleAssets() == BOB_DEPOSIT + CAROL_DEPOSIT - STRATEGY_DEPLOYED_ASSETS,
-            "idle assets mismatch"
-        );
     }
 }

--- a/test/DiamondVaultHostInvariant.t.sol
+++ b/test/DiamondVaultHostInvariant.t.sol
@@ -434,6 +434,4 @@ contract DiamondVaultHostInvariantTest is DiamondVaultHostHardeningFixture {
         }
         return liquidity;
     }
-
-
 }

--- a/test/DiamondVaultHostInvariant.t.sol
+++ b/test/DiamondVaultHostInvariant.t.sol
@@ -7,13 +7,14 @@ import {IPausable} from "../src/interfaces/IPausable.sol";
 import {DiamondVaultHostHardeningFixture} from "./helpers/DiamondVaultHostHardeningTestHarness.sol";
 
 contract DiamondVaultHostInvariantTest is DiamondVaultHostHardeningFixture {
-    uint256 internal constant EXPECTED_INITIAL_ASSET_SUPPLY = INITIAL_ASSETS * ACTOR_COUNT;
+    uint256 internal constant EXPECTED_INITIAL_ASSET_SUPPLY = INITIAL_ASSETS * ACTOR_COUNT + STRATEGY_PROFIT_RESERVE;
 
     function setUp() public override {
         super.setUp();
         _installVaultHostFacets();
         _initializeVaultHost();
         _wireOracleAdapter();
+        _wireStrategy();
 
         VM.prank(admin);
         controlsFacetInterface().setFeeConfig(0, 0, feeSink);
@@ -164,7 +165,7 @@ contract DiamondVaultHostInvariantTest is DiamondVaultHostHardeningFixture {
         VM.prank(admin);
         controlsFacetInterface().setFeeConfig(depositFeeBps, withdrawFeeBps, feeSink);
 
-        _assertAccountingUnchanged(snapshot, "fee config updates should not mutate core accounting");
+        _assertAccountingUnchanged(snapshot, "fee config updates should not mutate accounting");
     }
 
     function actionSetLimitConfig(
@@ -188,7 +189,7 @@ contract DiamondVaultHostInvariantTest is DiamondVaultHostHardeningFixture {
         VM.prank(admin);
         controlsFacetInterface().setLimitConfig(maxTotalAssets, maxDeposit, maxMint, maxWithdraw, maxRedeem);
 
-        _assertAccountingUnchanged(snapshot, "limit config updates should not mutate core accounting");
+        _assertAccountingUnchanged(snapshot, "limit config updates should not mutate accounting");
     }
 
     function actionSetOracleAdapter(bool configured) external {
@@ -197,35 +198,173 @@ contract DiamondVaultHostInvariantTest is DiamondVaultHostHardeningFixture {
         VM.prank(admin);
         integrationFacetInterface().setOracleAdapter(configured ? address(adapter) : address(0));
 
-        _assertAccountingUnchanged(snapshot, "oracle adapter updates should not mutate core accounting");
+        _assertAccountingUnchanged(snapshot, "oracle adapter updates should not mutate accounting");
     }
 
     function actionSetStrategy(bool configured) external {
+        if (integrationFacetInterface().strategyDebt() != 0) {
+            return;
+        }
+
         AccountingSnapshot memory snapshot = _snapshotAccounting();
 
-        VM.prank(admin);
-        integrationFacetInterface().setStrategy(configured ? address(strategyContract) : address(0));
+        if (!configured && integrationFacetInterface().strategy() != address(0)) {
+            VM.prank(admin);
+            integrationFacetInterface().setStrategy(address(0));
+            _assertAccountingUnchanged(snapshot, "strategy clear should not mutate accounting");
+            return;
+        }
 
-        _assertAccountingUnchanged(snapshot, "strategy updates should not mutate core accounting");
+        if (configured && integrationFacetInterface().strategy() == address(0)) {
+            strategyContract.setWithdrawAllReverts(false);
+            VM.prank(admin);
+            integrationFacetInterface().setStrategy(address(strategyContract));
+            _assertAccountingUnchanged(snapshot, "strategy rebind should not mutate accounting");
+        }
+    }
+
+    function actionDeployToStrategy(uint96 assetsRaw) external {
+        if (integrationFacetInterface().strategy() != address(strategyContract)) {
+            return;
+        }
+
+        uint256 assets_ = _boundAmount(assetsRaw, integrationFacetInterface().idleAssets());
+        if (assets_ == 0) {
+            return;
+        }
+
+        if (integrationFacetInterface().strategyEmergencyExit()) {
+            VM.expectRevert(IERC4626VaultIntegrationFacet.ERC4626VaultStrategyEmergencyExitActive.selector);
+            VM.prank(admin);
+            integrationFacetInterface().deployToStrategy(assets_);
+            return;
+        }
+
+        VM.prank(admin);
+        integrationFacetInterface().deployToStrategy(assets_);
+    }
+
+    function actionWithdrawFromStrategy(uint96 assetsRaw) external {
+        if (integrationFacetInterface().strategy() != address(strategyContract)) {
+            return;
+        }
+
+        uint256 strategyDebt = integrationFacetInterface().strategyDebt();
+        uint256 assets_ = _boundAmount(assetsRaw, strategyDebt);
+        if (assets_ == 0) {
+            return;
+        }
+
+        VM.prank(admin);
+        integrationFacetInterface().withdrawFromStrategy(assets_);
     }
 
     function actionSyncStrategyAssets() external {
-        AccountingSnapshot memory snapshot = _snapshotAccounting();
-
-        if (integrationFacetInterface().strategy() == address(0)) {
+        if (integrationFacetInterface().strategy() != address(strategyContract)) {
             return;
         }
 
         VM.prank(admin);
         integrationFacetInterface().syncStrategyAssets();
-
-        _assertAccountingUnchanged(snapshot, "strategy sync should not mutate core accounting without deployed assets");
     }
 
-    function invariantManagedAssetsTrackUnderlyingBalance() public view {
+    function actionEmergencyExitStrategy(bool forceFailure) external {
+        if (integrationFacetInterface().strategy() != address(strategyContract)) {
+            return;
+        }
+
+        strategyContract.setWithdrawAllReverts(forceFailure && integrationFacetInterface().strategyDebt() != 0);
+
+        VM.prank(admin);
+        integrationFacetInterface().emergencyExitStrategy();
+    }
+
+    function actionInjectStrategyProfit(uint96 assetsRaw) external {
+        if (integrationFacetInterface().strategy() != address(strategyContract)) {
+            return;
+        }
+        if (integrationFacetInterface().strategyDebt() == 0 || integrationFacetInterface().strategyEmergencyExit()) {
+            return;
+        }
+
+        uint256 available = _min(asset.balanceOf(profitSource), INITIAL_ASSETS);
+        uint256 assets_ = _boundAmount(assetsRaw, available);
+        if (assets_ == 0) {
+            return;
+        }
+
+        strategyContract.injectProfit(assets_);
+    }
+
+    function actionApplyStrategyLoss(uint96 lossRaw, uint96 withdrawableRaw) external {
+        if (integrationFacetInterface().strategy() != address(strategyContract)) {
+            return;
+        }
+        if (integrationFacetInterface().strategyEmergencyExit()) {
+            return;
+        }
+
+        uint256 liveAssets = integrationFacetInterface().liveStrategyAssets();
+        if (liveAssets == 0) {
+            return;
+        }
+
+        uint256 lossAssets = _boundAmount(lossRaw, _min(liveAssets, INITIAL_ASSETS));
+        uint256 remainingLiveAssets = liveAssets - lossAssets;
+        uint256 withdrawableAssets = remainingLiveAssets == 0 ? 0 : uint256(withdrawableRaw) % (remainingLiveAssets + 1);
+
+        strategyContract.applyLoss(lossAssets, withdrawableAssets);
+    }
+
+    function actionWithdrawBeyondImmediateLiquidityAttempt(uint8 actorSeed, uint96 extraRaw) external {
+        if (controlsFacetInterface().paused()) {
+            return;
+        }
+
+        address actor = _actor(actorSeed);
+        uint256 ownerShares = coreFacetInterface().balanceOf(actor);
+        if (ownerShares == 0) {
+            return;
+        }
+
+        uint256 maxWithdraw = coreFacetInterface().maxWithdraw(actor);
+        uint256 grossEntitlement = coreFacetInterface().previewRedeem(ownerShares);
+        if (grossEntitlement <= maxWithdraw) {
+            return;
+        }
+
+        uint256 attemptAssets = maxWithdraw + _boundAmount(extraRaw, grossEntitlement - maxWithdraw);
+
+        VM.startPrank(actor);
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IERC4626VaultControls.ERC4626VaultWithdrawLimitExceeded.selector, attemptAssets, maxWithdraw
+            )
+        );
+        coreFacetInterface().withdraw(attemptAssets, actor, actor);
+        VM.stopPrank();
+    }
+
+    function invariantIdleAssetsMatchVaultBalance() public view {
         assertTrue(
-            coreFacetInterface().totalAssets() == asset.balanceOf(address(diamond)),
-            "managed assets should match vault-held underlying"
+            integrationFacetInterface().idleAssets() == asset.balanceOf(address(diamond)),
+            "idle assets should match vault-held underlying"
+        );
+    }
+
+    function invariantBookAccountingMatchesIdlePlusStrategyDebt() public view {
+        assertTrue(
+            coreFacetInterface().totalManagedAssets()
+                == integrationFacetInterface().idleAssets() + integrationFacetInterface().strategyDebt(),
+            "book accounting should equal idle assets plus strategy debt"
+        );
+    }
+
+    function invariantLiveAccountingMatchesIdlePlusStrategyAssets() public view {
+        assertTrue(
+            coreFacetInterface().totalAssets()
+                == integrationFacetInterface().idleAssets() + integrationFacetInterface().liveStrategyAssets(),
+            "live accounting should equal idle assets plus live strategy assets"
         );
     }
 
@@ -239,15 +378,7 @@ contract DiamondVaultHostInvariantTest is DiamondVaultHostHardeningFixture {
     function invariantTrackedUnderlyingRemainsConserved() public view {
         assertTrue(
             _sumTrackedUnderlying() == EXPECTED_INITIAL_ASSET_SUPPLY,
-            "tracked underlying should remain conserved across actors, vault, and fee sink"
-        );
-    }
-
-    function invariantStrategyLifecycleStateRemainsZeroWithoutDeploy() public view {
-        assertTrue(integrationFacetInterface().strategyDebt() == 0, "strategy debt should remain zero without deploy");
-        assertTrue(
-            integrationFacetInterface().liveStrategyAssets() == 0,
-            "live strategy assets should remain zero without deploy"
+            "tracked underlying should remain conserved across actors, vault, fee sink, strategy, and reserves"
         );
     }
 
@@ -264,4 +395,45 @@ contract DiamondVaultHostInvariantTest is DiamondVaultHostHardeningFixture {
             assertTrue(coreFacetInterface().maxRedeem(actor) == 0, "paused vault should expose zero maxRedeem");
         }
     }
+
+    function invariantMaxWithdrawBoundedByImmediateLiquidity() public view {
+        uint256 immediateLiquidity = _immediateLiquidity();
+
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            address actor = actors[i];
+            uint256 actorBalance = coreFacetInterface().balanceOf(actor);
+            uint256 grossEntitlement = actorBalance == 0 ? 0 : coreFacetInterface().previewRedeem(actorBalance);
+            uint256 maxWithdraw = coreFacetInterface().maxWithdraw(actor);
+
+            assertTrue(maxWithdraw <= immediateLiquidity, "maxWithdraw should stay within immediate liquidity");
+            assertTrue(maxWithdraw <= grossEntitlement, "maxWithdraw should stay within live-priced entitlement");
+        }
+    }
+
+    function invariantPreviewRedeemOfMaxRedeemBoundedByImmediateLiquidity() public view {
+        uint256 immediateLiquidity = _immediateLiquidity();
+
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            address actor = actors[i];
+            uint256 maxRedeem = coreFacetInterface().maxRedeem(actor);
+            assertTrue(
+                coreFacetInterface().previewRedeem(maxRedeem) <= immediateLiquidity,
+                "previewRedeem(maxRedeem) should stay within immediate liquidity"
+            );
+        }
+    }
+
+    function _immediateLiquidity() internal view returns (uint256) {
+        if (integrationFacetInterface().strategyDebt() == 0) {
+            return coreFacetInterface().totalAssets();
+        }
+
+        uint256 liquidity = integrationFacetInterface().idleAssets();
+        if (integrationFacetInterface().strategy() == address(strategyContract)) {
+            liquidity += strategyContract.maxWithdrawableAssets();
+        }
+        return liquidity;
+    }
+
+
 }

--- a/test/helpers/DiamondVaultHostHardeningTestHarness.sol
+++ b/test/helpers/DiamondVaultHostHardeningTestHarness.sol
@@ -2,15 +2,12 @@
 pragma solidity ^0.8.30;
 
 import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
-import {IERC4626VaultControls} from "../../src/interfaces/IERC4626VaultControls.sol";
-import {IERC4626VaultFacet} from "../../src/interfaces/IERC4626VaultFacet.sol";
-import {IERC4626VaultIntegrationFacet} from "../../src/interfaces/IERC4626VaultIntegrationFacet.sol";
 import {ERC4626VaultControlsFacet} from "../../src/vault/facets/ERC4626VaultControlsFacet.sol";
 import {ERC4626VaultFacet} from "../../src/vault/facets/ERC4626VaultFacet.sol";
 import {ERC4626VaultIntegrationFacet} from "../../src/vault/facets/ERC4626VaultIntegrationFacet.sol";
 import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {DiamondVaultDeploymentFixture} from "./DiamondVaultDeploymentTestHarness.sol";
-import {ProfitMockVaultStrategy} from "./ERC4626VaultStrategyTestHarness.sol";
+import {MutableMockVaultStrategy} from "./ERC4626VaultStrategyTestHarness.sol";
 
 interface IFacetVersionMarker {
     function facetVersion() external view returns (uint256);
@@ -42,24 +39,46 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
         uint256 feeSinkBalance;
         uint256 actorUnderlyingBalanceSum;
         uint256 actorShareBalanceSum;
+        uint256 strategyUnderlyingBalance;
+        uint256 profitSourceBalance;
+        uint256 lossSinkBalance;
+        uint256 strategyDebt;
+        uint256 liveStrategyAssets;
+    }
+
+    struct StrategyStateSnapshot {
+        address strategy;
+        uint256 strategyDebt;
+        uint256 liveStrategyAssets;
+        uint256 idleAssets;
+        bool emergencyExit;
+        uint256 totalManagedAssets;
+        uint256 totalAssets;
+        uint256 bobMaxWithdraw;
+        uint256 bobMaxRedeem;
     }
 
     uint256 internal constant INITIAL_ASSETS = 1_000_000;
+    uint256 internal constant STRATEGY_PROFIT_RESERVE = 1_000_000_000_000;
     uint256 internal constant ACTOR_COUNT = 4;
     uint256 internal constant BOB_DEPOSIT = 200_000;
     uint256 internal constant CAROL_DEPOSIT = 150_000;
     uint256 internal constant SHARE_ALLOWANCE = 25_000;
-    uint256 internal constant STRATEGY_DEPLOYED_ASSETS = 75_000;
+    uint256 internal constant STRATEGY_DEPLOYED_ASSETS = 225_000;
+    uint256 internal constant STRATEGY_PROFIT_ASSETS = 25_000;
+    uint256 internal constant BOB_AUTO_PULL_WITHDRAW_ASSETS = 150_000;
+    uint256 internal constant CAROL_AUTO_PULL_REDEEM_SHARES = 50_000;
 
     address internal bob = address(0xB0B);
     address internal carol = address(0xCA11);
     address internal dave = address(0xD0D);
     address internal eve = address(0xE11E);
     address internal feeSink = address(0xFEE);
+    address internal profitSource = address(0xBEEF1234);
 
     address[ACTOR_COUNT] internal actors;
 
-    ProfitMockVaultStrategy internal strategyContract;
+    MutableMockVaultStrategy internal strategyContract;
 
     ERC4626VaultFacetReplacement internal coreReplacement;
     ERC4626VaultControlsFacetReplacement internal controlsReplacement;
@@ -77,7 +96,7 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
         actors[2] = dave;
         actors[3] = eve;
 
-        strategyContract = new ProfitMockVaultStrategy(address(diamond), address(asset));
+        strategyContract = new MutableMockVaultStrategy(address(diamond), address(asset), profitSource);
 
         for (uint256 i = 0; i < ACTOR_COUNT; i++) {
             address actor = actors[i];
@@ -85,6 +104,10 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
             VM.prank(actor);
             asset.approve(address(diamond), type(uint256).max);
         }
+
+        asset.mint(profitSource, STRATEGY_PROFIT_RESERVE);
+        VM.prank(profitSource);
+        asset.approve(address(strategyContract), type(uint256).max);
     }
 
     function _installAndSeedVaultHost() internal {
@@ -130,6 +153,18 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
 
         VM.prank(admin);
         integrationFacetInterface().deployToStrategy(STRATEGY_DEPLOYED_ASSETS);
+    }
+
+    function _injectStrategyProfit(uint256 assets) internal {
+        strategyContract.injectProfit(assets);
+    }
+
+    function _applyStrategyLoss(uint256 lossAssets, uint256 withdrawableAssets) internal {
+        strategyContract.applyLoss(lossAssets, withdrawableAssets);
+    }
+
+    function _setStrategyWithdrawAllReverts(bool shouldRevert) internal {
+        strategyContract.setWithdrawAllReverts(shouldRevert);
     }
 
     function _replaceCoreFacet(address facetAddress_) internal {
@@ -225,6 +260,9 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
 
         sum += asset.balanceOf(address(diamond));
         sum += asset.balanceOf(feeSink);
+        sum += asset.balanceOf(address(strategyContract));
+        sum += asset.balanceOf(profitSource);
+        sum += asset.balanceOf(strategyContract.lossSink());
     }
 
     function _snapshotAccounting() internal view returns (AccountingSnapshot memory snapshot) {
@@ -232,6 +270,11 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
         snapshot.totalSupply = coreFacetInterface().totalSupply();
         snapshot.vaultUnderlyingBalance = asset.balanceOf(address(diamond));
         snapshot.feeSinkBalance = asset.balanceOf(feeSink);
+        snapshot.strategyUnderlyingBalance = asset.balanceOf(address(strategyContract));
+        snapshot.profitSourceBalance = asset.balanceOf(profitSource);
+        snapshot.lossSinkBalance = asset.balanceOf(strategyContract.lossSink());
+        snapshot.strategyDebt = integrationFacetInterface().strategyDebt();
+        snapshot.liveStrategyAssets = integrationFacetInterface().liveStrategyAssets();
 
         for (uint256 i = 0; i < ACTOR_COUNT; i++) {
             snapshot.actorUnderlyingBalanceSum += asset.balanceOf(actors[i]);
@@ -247,6 +290,42 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
         assertTrue(afterSnapshot.feeSinkBalance == snapshot.feeSinkBalance, reason);
         assertTrue(afterSnapshot.actorUnderlyingBalanceSum == snapshot.actorUnderlyingBalanceSum, reason);
         assertTrue(afterSnapshot.actorShareBalanceSum == snapshot.actorShareBalanceSum, reason);
+        assertTrue(afterSnapshot.strategyUnderlyingBalance == snapshot.strategyUnderlyingBalance, reason);
+        assertTrue(afterSnapshot.profitSourceBalance == snapshot.profitSourceBalance, reason);
+        assertTrue(afterSnapshot.lossSinkBalance == snapshot.lossSinkBalance, reason);
+        assertTrue(afterSnapshot.strategyDebt == snapshot.strategyDebt, reason);
+        assertTrue(afterSnapshot.liveStrategyAssets == snapshot.liveStrategyAssets, reason);
+    }
+
+    function _snapshotStrategyState() internal view returns (StrategyStateSnapshot memory snapshot) {
+        snapshot.strategy = integrationFacetInterface().strategy();
+        snapshot.strategyDebt = integrationFacetInterface().strategyDebt();
+        snapshot.liveStrategyAssets = integrationFacetInterface().liveStrategyAssets();
+        snapshot.idleAssets = integrationFacetInterface().idleAssets();
+        snapshot.emergencyExit = integrationFacetInterface().strategyEmergencyExit();
+        snapshot.totalManagedAssets = coreFacetInterface().totalManagedAssets();
+        snapshot.totalAssets = coreFacetInterface().totalAssets();
+        snapshot.bobMaxWithdraw = coreFacetInterface().maxWithdraw(bob);
+        snapshot.bobMaxRedeem = coreFacetInterface().maxRedeem(bob);
+    }
+
+    function _assertStrategyState(StrategyStateSnapshot memory snapshot) internal view {
+        assertTrue(integrationFacetInterface().strategy() == snapshot.strategy, "strategy mismatch");
+        assertTrue(integrationFacetInterface().strategyDebt() == snapshot.strategyDebt, "strategy debt mismatch");
+        assertTrue(
+            integrationFacetInterface().liveStrategyAssets() == snapshot.liveStrategyAssets,
+            "live strategy assets mismatch"
+        );
+        assertTrue(integrationFacetInterface().idleAssets() == snapshot.idleAssets, "idle assets mismatch");
+        assertTrue(
+            integrationFacetInterface().strategyEmergencyExit() == snapshot.emergencyExit, "emergency exit mismatch"
+        );
+        assertTrue(
+            coreFacetInterface().totalManagedAssets() == snapshot.totalManagedAssets, "totalManagedAssets mismatch"
+        );
+        assertTrue(coreFacetInterface().totalAssets() == snapshot.totalAssets, "totalAssets mismatch");
+        assertTrue(coreFacetInterface().maxWithdraw(bob) == snapshot.bobMaxWithdraw, "bob maxWithdraw mismatch");
+        assertTrue(coreFacetInterface().maxRedeem(bob) == snapshot.bobMaxRedeem, "bob maxRedeem mismatch");
     }
 
     function _addFacet(address facetAddress_, bytes4[] memory selectors) internal {

--- a/test/helpers/ERC4626VaultStrategyTestHarness.sol
+++ b/test/helpers/ERC4626VaultStrategyTestHarness.sol
@@ -192,6 +192,59 @@ contract EmergencyUnwindMockVaultStrategy is MockVaultStrategyBase {
     }
 }
 
+contract MutableMockVaultStrategy is MockVaultStrategyBase {
+    address internal immutable _profitSource;
+    bool internal _revertWithdrawAllToVault;
+
+    constructor(address vault_, address asset_, address profitSource_) MockVaultStrategyBase(vault_, asset_) {
+        _profitSource = profitSource_;
+    }
+
+    function profitSource() external view returns (address) {
+        return _profitSource;
+    }
+
+    function lossSink() external pure returns (address) {
+        return LOSS_SINK;
+    }
+
+    function injectProfit(uint256 assets) external {
+        if (assets == 0) {
+            return;
+        }
+
+        MockVaultAsset(_asset).transferFrom(_profitSource, address(this), assets);
+        _trackedAssets += assets;
+        _withdrawableAssets += assets;
+    }
+
+    function applyLoss(uint256 lossAssets, uint256 withdrawableAssets_) external {
+        uint256 realizedLoss = _min(lossAssets, _trackedAssets);
+        if (realizedLoss != 0) {
+            MockVaultAsset(_asset).transfer(LOSS_SINK, realizedLoss);
+            _trackedAssets -= realizedLoss;
+        }
+        _withdrawableAssets = _min(withdrawableAssets_, _trackedAssets);
+    }
+
+    function setWithdrawAllReverts(bool shouldRevert) external {
+        _revertWithdrawAllToVault = shouldRevert;
+    }
+
+    function withdrawAllToVault() external override onlyVault returns (uint256 assetsReturned) {
+        if (_revertWithdrawAllToVault) {
+            revert MockVaultStrategyForcedRevert(this.withdrawAllToVault.selector);
+        }
+
+        assetsReturned = maxWithdrawableAssets();
+        _trackedAssets -= assetsReturned;
+        _withdrawableAssets -= assetsReturned;
+        if (assetsReturned != 0) {
+            MockVaultAsset(_asset).transfer(_vault, assetsReturned);
+        }
+    }
+}
+
 abstract contract ERC4626VaultStrategyFixture is TestBase {
     address internal admin = address(0xA11CE);
     address internal vault = address(0xA417);


### PR DESCRIPTION
## Summary
- extend the hosted-vault hardening fixture and tests to run against a live configured strategy
- extend the hosted-vault invariant suite to cover strategy deploy, withdraw, sync, profit, loss, and emergency-exit flows
- fix a zero-assets edge case where `maxWithdraw()` and `maxRedeem()` could advertise nonzero capacity after a full loss while shares still existed

## What Changed
- upgraded `DiamondVaultHostHardening` to seed an active strategy with nonzero debt and live assets
- added hardening coverage for emergency-exit persistence across integration facet replace/remove/re-add flows
- proved core withdraw/redeem behavior still works while integration selectors are removed
- refactored `DiamondVaultHostInvariant` to the live strategy lifecycle model with manager actions and mutable strategy-state actions
- added a mutable strategy mock that can inject profit, realize loss, constrain withdrawable liquidity, and force emergency-unwind failure
- corrected zero-liquidity `maxWithdraw()` / `maxRedeem()` behavior so full-loss states do not overstate redeemable capacity

## Why
`#117` is the first hardening pass after real strategy execution exists. The prior hosted-vault suites still assumed an unset strategy or purely advisory strategy state, which left the new lifecycle behavior under-tested across facet churn and invariants.

While extending the invariant suite, a real edge-case bug surfaced: after a strategy-driven full loss, `totalAssets()` could reach zero while shares still existed, and the vault would still report nonzero `maxWithdraw()` / `maxRedeem()`. This PR fixes that runtime behavior and then locks it in with hardening and invariant coverage.

## Impact
- reviewers get strategy-aware hardening coverage instead of idle-only hosted-vault coverage
- invariants now exercise the real live-strategy model behind the diamond address
- zero-liquidity loss states now report withdraw/redeem capacity correctly

## Validation
- `git diff --check`
- `forge test --offline --match-path test/DiamondVaultHostHardening.t.sol`
- `forge test --offline --match-path test/DiamondVaultHostInvariant.t.sol`
- `forge test --offline --match-path test/ERC4626VaultIntegrationFacetCore.t.sol`
- `forge test --offline --match-path test/ERC4626VaultStrategyAccountingCore.t.sol`
- `forge test --offline --match-path test/ERC4626VaultFacetCore.t.sol`
- `forge test --offline`

Closes #117
