### PR TITLE
Add native-asset mode to hosted vault core

### DIFF
--- a/src/interfaces/IERC7535VaultFacet.sol
+++ b/src/interfaces/IERC7535VaultFacet.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title IERC7535VaultFacet
+/// @notice Hosted native-asset extension surface for ERC-7535-style vault flows.
+interface IERC7535VaultFacet {
+    /// @notice Deposits native asset and mints shares to `receiver`.
+    /// @param receiver Receiver of minted shares.
+    /// @return shares Minted shares.
+    function depositNative(address receiver) external payable returns (uint256 shares);
+
+    /// @notice Mints `shares` to `receiver` using native asset funding.
+    /// @param shares Share amount.
+    /// @param receiver Receiver of minted shares.
+    /// @return assets Native assets consumed.
+    function mintNative(uint256 shares, address receiver) external payable returns (uint256 assets);
+}

--- a/src/vault/ERC4626Vault.sol
+++ b/src/vault/ERC4626Vault.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.30;
 import {IERC20} from "../interfaces/IERC20.sol";
 import {IERC4626} from "../interfaces/IERC4626.sol";
 import {IERC4626VaultStrategy} from "../interfaces/IERC4626VaultStrategy.sol";
+import {LibNativeAsset} from "./libraries/LibNativeAsset.sol";
 import {LibERC4626VaultStorage} from "./storage/LibERC4626VaultStorage.sol";
 import {ERC4626VaultBase} from "./ERC4626VaultBase.sol";
 
@@ -22,6 +23,12 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
     /// @param requiredAssets The gross asset amount required.
     /// @param availableAssets The currently sourced idle asset amount.
     error ERC4626VaultInsufficientLiquidity(uint256 requiredAssets, uint256 availableAssets);
+    /// @notice Thrown when a native vault requires the hosted native entrypoint.
+    error ERC4626VaultNativeAssetUseNativeEntrypoint();
+    /// @notice Thrown when a native-only entrypoint is used on an ERC-20 vault.
+    error ERC4626VaultNativeAssetDisabled();
+    /// @notice Thrown when `msg.value` does not match the required native asset amount.
+    error ERC4626VaultInvalidNativeAssetValue(uint256 supplied, uint256 required);
 
     /// @notice Returns vault underlying asset token address.
     /// @return The underlying asset token.
@@ -247,7 +254,7 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
     /// @dev Performs ERC-20 transfer and handles optional return values.
     /// @param to Asset receiver.
     /// @param value Asset amount.
-    function _safeTransferAsset(address to, uint256 value) internal {
+    function _safeTransferAsset(address to, uint256 value) internal virtual {
         (bool success, bytes memory data) = asset().call(abi.encodeCall(IERC20.transfer, (to, value)));
         if (!success || (data.length != 0 && !abi.decode(data, (bool)))) {
             revert ERC4626VaultAssetTransferFailed();
@@ -258,7 +265,7 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
     /// @param from Asset sender.
     /// @param to Asset receiver.
     /// @param value Asset amount.
-    function _safeTransferFromAsset(address from, address to, uint256 value) internal {
+    function _safeTransferFromAsset(address from, address to, uint256 value) internal virtual {
         (bool success, bytes memory data) = asset().call(abi.encodeCall(IERC20.transferFrom, (from, to, value)));
         if (!success || (data.length != 0 && !abi.decode(data, (bool)))) {
             revert ERC4626VaultAssetTransferFromFailed();
@@ -267,6 +274,10 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
 
     /// @dev Returns the vault's immediately idle asset balance.
     function _idleAssetBalance() internal view returns (uint256) {
+        if (LibNativeAsset.isNativeAsset(asset())) {
+            return address(this).balance;
+        }
+
         return IERC20(asset()).balanceOf(address(this));
     }
 

--- a/src/vault/ERC4626Vault.sol
+++ b/src/vault/ERC4626Vault.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.30;
 import {IERC20} from "../interfaces/IERC20.sol";
 import {IERC4626} from "../interfaces/IERC4626.sol";
 import {IERC4626VaultStrategy} from "../interfaces/IERC4626VaultStrategy.sol";
-import {LibNativeAsset} from "./libraries/LibNativeAsset.sol";
+import {LibVaultAsset} from "./libraries/LibVaultAsset.sol";
 import {LibERC4626VaultStorage} from "./storage/LibERC4626VaultStorage.sol";
 import {ERC4626VaultBase} from "./ERC4626VaultBase.sol";
 
@@ -255,8 +255,7 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
     /// @param to Asset receiver.
     /// @param value Asset amount.
     function _safeTransferAsset(address to, uint256 value) internal virtual {
-        (bool success, bytes memory data) = asset().call(abi.encodeCall(IERC20.transfer, (to, value)));
-        if (!success || (data.length != 0 && !abi.decode(data, (bool)))) {
+        if (!LibVaultAsset.transferOut(asset(), to, value)) {
             revert ERC4626VaultAssetTransferFailed();
         }
     }
@@ -266,19 +265,18 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
     /// @param to Asset receiver.
     /// @param value Asset amount.
     function _safeTransferFromAsset(address from, address to, uint256 value) internal virtual {
-        (bool success, bytes memory data) = asset().call(abi.encodeCall(IERC20.transferFrom, (from, to, value)));
-        if (!success || (data.length != 0 && !abi.decode(data, (bool)))) {
+        if (LibVaultAsset.isNativeAsset(asset())) {
+            revert ERC4626VaultNativeAssetUseNativeEntrypoint();
+        }
+
+        if (!LibVaultAsset.transferIn(asset(), from, to, value)) {
             revert ERC4626VaultAssetTransferFromFailed();
         }
     }
 
     /// @dev Returns the vault's immediately idle asset balance.
     function _idleAssetBalance() internal view returns (uint256) {
-        if (LibNativeAsset.isNativeAsset(asset())) {
-            return address(this).balance;
-        }
-
-        return IERC20(asset()).balanceOf(address(this));
+        return LibVaultAsset.balanceOfSelf(asset());
     }
 
     /// @dev Returns the configured strategy's immediately withdrawable assets.

--- a/src/vault/ERC4626VaultControlLogic.sol
+++ b/src/vault/ERC4626VaultControlLogic.sol
@@ -275,6 +275,67 @@ abstract contract ERC4626VaultControlledCore is ERC4626Vault {
         emit Deposit(msg.sender, receiver, assets, shares);
     }
 
+    function _depositNativeWithControls(address receiver) internal returns (uint256 shares) {
+        _requireInitialized();
+        _requireNonZeroAddress(receiver);
+
+        uint256 assets = msg.value;
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        uint256 maxAssets = maxDeposit(receiver);
+        if (assets > maxAssets) {
+            revert IERC4626VaultControls.ERC4626VaultDepositLimitExceeded(assets, maxAssets);
+        }
+
+        (uint256 netAssets, uint256 feeAssets) = LibERC4626VaultControlLogic.netAfterDepositFee(assets);
+        _enforceTotalAssetsCap(netAssets);
+
+        shares = _convertToShares(netAssets, Rounding.Down);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        _increaseManagedAssets(netAssets);
+        _mintShares(receiver, shares);
+        _payoutFee(feeAssets);
+
+        emit Deposit(msg.sender, receiver, assets, shares);
+    }
+
+    function _mintNativeWithControls(uint256 shares, address receiver) internal returns (uint256 assets) {
+        _requireInitialized();
+        _requireNonZeroAddress(receiver);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        uint256 maxShares = maxMint(receiver);
+        if (shares > maxShares) {
+            revert IERC4626VaultControls.ERC4626VaultMintLimitExceeded(shares, maxShares);
+        }
+
+        uint256 netAssets = _convertToAssets(shares, Rounding.Up);
+        if (netAssets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        assets = LibERC4626VaultControlLogic.grossUpForDepositFee(netAssets);
+        if (msg.value != assets) {
+            revert ERC4626VaultInvalidNativeAssetValue(msg.value, assets);
+        }
+
+        uint256 feeAssets = assets - netAssets;
+
+        _enforceTotalAssetsCap(netAssets);
+        _increaseManagedAssets(netAssets);
+        _mintShares(receiver, shares);
+        _payoutFee(feeAssets);
+
+        emit Deposit(msg.sender, receiver, assets, shares);
+    }
+
     function _withdrawWithControls(uint256 assets, address receiver, address owner) internal returns (uint256 shares) {
         _requireInitialized();
         _requireNonZeroAddress(receiver);

--- a/src/vault/facets/ERC4626VaultControlsFacet.sol
+++ b/src/vault/facets/ERC4626VaultControlsFacet.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.30;
 import {IAccessControl} from "../../interfaces/IAccessControl.sol";
 import {IAccessControlTime} from "../../interfaces/IAccessControlTime.sol";
 import {IERC165} from "../../interfaces/IERC165.sol";
+import {IERC7535VaultFacet} from "../../interfaces/IERC7535VaultFacet.sol";
 import {IERC4626VaultControls} from "../../interfaces/IERC4626VaultControls.sol";
 import {IERC4626VaultControlsFacet} from "../../interfaces/IERC4626VaultControlsFacet.sol";
 import {IERC4626VaultFacet} from "../../interfaces/IERC4626VaultFacet.sol";
@@ -31,6 +32,8 @@ contract ERC4626VaultControlsFacet is ERC4626VaultControlSurface {
             || interfaceId == type(IERC4626VaultControlsFacet).interfaceId
             || (interfaceId == type(IERC4626VaultFacet).interfaceId
                 && LibDiamond.selectorExists(IERC4626VaultFacet.initializeVault.selector))
+            || (interfaceId == type(IERC7535VaultFacet).interfaceId
+                && LibDiamond.selectorExists(IERC7535VaultFacet.depositNative.selector))
             || (interfaceId == type(IERC4626VaultIntegrationFacet).interfaceId
                 && LibDiamond.selectorExists(IERC4626VaultIntegrationFacet.oracleAdapter.selector))
             || interfaceId == type(IAccessControl).interfaceId || interfaceId == type(IAccessControlTime).interfaceId

--- a/src/vault/facets/ERC4626VaultFacet.sol
+++ b/src/vault/facets/ERC4626VaultFacet.sol
@@ -3,19 +3,18 @@ pragma solidity ^0.8.30;
 
 import {IERC4626} from "../../interfaces/IERC4626.sol";
 import {IERC4626VaultControls} from "../../interfaces/IERC4626VaultControls.sol";
-import {IERC7535VaultFacet} from "../../interfaces/IERC7535VaultFacet.sol";
 import {IERC4626VaultFacet} from "../../interfaces/IERC4626VaultFacet.sol";
 import {IERC4626VaultStrategy} from "../../interfaces/IERC4626VaultStrategy.sol";
 import {ERC4626Vault} from "../ERC4626Vault.sol";
 import {ERC4626VaultBase} from "../ERC4626VaultBase.sol";
 import {ERC4626VaultControlledCore, LibERC4626VaultControlLogic} from "../ERC4626VaultControlLogic.sol";
 import {VaultFacetControl} from "../VaultFacetControl.sol";
-import {LibNativeAsset} from "../libraries/LibNativeAsset.sol";
+import {LibVaultAsset} from "../libraries/LibVaultAsset.sol";
 import {LibERC4626VaultStorage} from "../storage/LibERC4626VaultStorage.sol";
 
 /// @title ERC4626VaultFacet
 /// @notice Hosted ERC-4626 core facet with constructor-free initialization.
-contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IERC4626VaultFacet, IERC7535VaultFacet {
+contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IERC4626VaultFacet {
     /// @notice Returns true when vault storage is initialized.
     /// @return True if initialized.
     function isVaultInitialized() public view virtual override(IERC4626VaultFacet, ERC4626VaultBase) returns (bool) {
@@ -66,7 +65,7 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
         nonReentrant
         returns (uint256 shares)
     {
-        if (_isNativeVaultAsset()) {
+        if (LibVaultAsset.isNativeAsset(ERC4626Vault.asset())) {
             revert ERC4626VaultNativeAssetUseNativeEntrypoint();
         }
 
@@ -85,42 +84,11 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
         nonReentrant
         returns (uint256 assets)
     {
-        if (_isNativeVaultAsset()) {
+        if (LibVaultAsset.isNativeAsset(ERC4626Vault.asset())) {
             revert ERC4626VaultNativeAssetUseNativeEntrypoint();
         }
 
         return _mintWithControls(shares, receiver);
-    }
-
-    /// @notice Deposits native asset and mints shares to `receiver`.
-    /// @param receiver Receiver of minted shares.
-    /// @return shares Minted shares.
-    function depositNative(address receiver)
-        external
-        payable
-        virtual
-        whenNotPaused
-        nonReentrant
-        returns (uint256 shares)
-    {
-        _requireNativeVaultAsset();
-        return _depositNativeWithControls(receiver);
-    }
-
-    /// @notice Mints `shares` to `receiver` using native asset funding.
-    /// @param shares Share amount.
-    /// @param receiver Receiver of minted shares.
-    /// @return assets Native assets consumed.
-    function mintNative(uint256 shares, address receiver)
-        external
-        payable
-        virtual
-        whenNotPaused
-        nonReentrant
-        returns (uint256 assets)
-    {
-        _requireNativeVaultAsset();
-        return _mintNativeWithControls(shares, receiver);
     }
 
     /// @notice Withdraws `assets` to `receiver` from `owner`.
@@ -282,39 +250,6 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
             }
 
             idleAssets = nextIdleAssets;
-        }
-    }
-
-    function _safeTransferAsset(address to, uint256 value) internal virtual override {
-        if (_isNativeVaultAsset()) {
-            (bool success,) = payable(to).call{value: value}("");
-            if (!success) {
-                revert ERC4626VaultAssetTransferFailed();
-            }
-            return;
-        }
-
-        super._safeTransferAsset(to, value);
-    }
-
-    function _safeTransferFromAsset(address from, address to, uint256 value) internal virtual override {
-        from;
-        to;
-        value;
-        if (_isNativeVaultAsset()) {
-            revert ERC4626VaultNativeAssetUseNativeEntrypoint();
-        }
-
-        super._safeTransferFromAsset(from, to, value);
-    }
-
-    function _isNativeVaultAsset() internal view returns (bool) {
-        return LibNativeAsset.isNativeAsset(ERC4626Vault.asset());
-    }
-
-    function _requireNativeVaultAsset() internal view {
-        if (!_isNativeVaultAsset()) {
-            revert ERC4626VaultNativeAssetDisabled();
         }
     }
 }

--- a/src/vault/facets/ERC4626VaultFacet.sol
+++ b/src/vault/facets/ERC4626VaultFacet.sol
@@ -3,17 +3,19 @@ pragma solidity ^0.8.30;
 
 import {IERC4626} from "../../interfaces/IERC4626.sol";
 import {IERC4626VaultControls} from "../../interfaces/IERC4626VaultControls.sol";
+import {IERC7535VaultFacet} from "../../interfaces/IERC7535VaultFacet.sol";
 import {IERC4626VaultFacet} from "../../interfaces/IERC4626VaultFacet.sol";
 import {IERC4626VaultStrategy} from "../../interfaces/IERC4626VaultStrategy.sol";
 import {ERC4626Vault} from "../ERC4626Vault.sol";
 import {ERC4626VaultBase} from "../ERC4626VaultBase.sol";
 import {ERC4626VaultControlledCore, LibERC4626VaultControlLogic} from "../ERC4626VaultControlLogic.sol";
 import {VaultFacetControl} from "../VaultFacetControl.sol";
+import {LibNativeAsset} from "../libraries/LibNativeAsset.sol";
 import {LibERC4626VaultStorage} from "../storage/LibERC4626VaultStorage.sol";
 
 /// @title ERC4626VaultFacet
 /// @notice Hosted ERC-4626 core facet with constructor-free initialization.
-contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IERC4626VaultFacet {
+contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IERC4626VaultFacet, IERC7535VaultFacet {
     /// @notice Returns true when vault storage is initialized.
     /// @return True if initialized.
     function isVaultInitialized() public view virtual override(IERC4626VaultFacet, ERC4626VaultBase) returns (bool) {
@@ -64,6 +66,10 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
         nonReentrant
         returns (uint256 shares)
     {
+        if (_isNativeVaultAsset()) {
+            revert ERC4626VaultNativeAssetUseNativeEntrypoint();
+        }
+
         return _depositWithControls(assets, receiver);
     }
 
@@ -79,7 +85,42 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
         nonReentrant
         returns (uint256 assets)
     {
+        if (_isNativeVaultAsset()) {
+            revert ERC4626VaultNativeAssetUseNativeEntrypoint();
+        }
+
         return _mintWithControls(shares, receiver);
+    }
+
+    /// @notice Deposits native asset and mints shares to `receiver`.
+    /// @param receiver Receiver of minted shares.
+    /// @return shares Minted shares.
+    function depositNative(address receiver)
+        external
+        payable
+        virtual
+        whenNotPaused
+        nonReentrant
+        returns (uint256 shares)
+    {
+        _requireNativeVaultAsset();
+        return _depositNativeWithControls(receiver);
+    }
+
+    /// @notice Mints `shares` to `receiver` using native asset funding.
+    /// @param shares Share amount.
+    /// @param receiver Receiver of minted shares.
+    /// @return assets Native assets consumed.
+    function mintNative(uint256 shares, address receiver)
+        external
+        payable
+        virtual
+        whenNotPaused
+        nonReentrant
+        returns (uint256 assets)
+    {
+        _requireNativeVaultAsset();
+        return _mintNativeWithControls(shares, receiver);
     }
 
     /// @notice Withdraws `assets` to `receiver` from `owner`.
@@ -241,6 +282,39 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
             }
 
             idleAssets = nextIdleAssets;
+        }
+    }
+
+    function _safeTransferAsset(address to, uint256 value) internal virtual override {
+        if (_isNativeVaultAsset()) {
+            (bool success,) = payable(to).call{value: value}("");
+            if (!success) {
+                revert ERC4626VaultAssetTransferFailed();
+            }
+            return;
+        }
+
+        super._safeTransferAsset(to, value);
+    }
+
+    function _safeTransferFromAsset(address from, address to, uint256 value) internal virtual override {
+        from;
+        to;
+        value;
+        if (_isNativeVaultAsset()) {
+            revert ERC4626VaultNativeAssetUseNativeEntrypoint();
+        }
+
+        super._safeTransferFromAsset(from, to, value);
+    }
+
+    function _isNativeVaultAsset() internal view returns (bool) {
+        return LibNativeAsset.isNativeAsset(ERC4626Vault.asset());
+    }
+
+    function _requireNativeVaultAsset() internal view {
+        if (!_isNativeVaultAsset()) {
+            revert ERC4626VaultNativeAssetDisabled();
         }
     }
 }

--- a/src/vault/facets/ERC7535VaultFacet.sol
+++ b/src/vault/facets/ERC7535VaultFacet.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC7535VaultFacet} from "../../interfaces/IERC7535VaultFacet.sol";
+import {ERC4626Vault} from "../ERC4626Vault.sol";
+import {ERC4626VaultControlledCore} from "../ERC4626VaultControlLogic.sol";
+import {VaultFacetControl} from "../VaultFacetControl.sol";
+import {LibVaultAsset} from "../libraries/LibVaultAsset.sol";
+
+/// @title ERC7535VaultFacet
+/// @notice Hosted native-asset extension facet for ERC-7535-style vault entrypoints.
+contract ERC7535VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IERC7535VaultFacet {
+    /// @notice Deposits native asset and mints shares to `receiver`.
+    /// @param receiver Receiver of minted shares.
+    /// @return shares Minted shares.
+    function depositNative(address receiver)
+        external
+        payable
+        virtual
+        whenNotPaused
+        nonReentrant
+        returns (uint256 shares)
+    {
+        _requireNativeVaultAsset();
+        return _depositNativeWithControls(receiver);
+    }
+
+    /// @notice Mints `shares` to `receiver` using native asset funding.
+    /// @param shares Share amount.
+    /// @param receiver Receiver of minted shares.
+    /// @return assets Native assets consumed.
+    function mintNative(uint256 shares, address receiver)
+        external
+        payable
+        virtual
+        whenNotPaused
+        nonReentrant
+        returns (uint256 assets)
+    {
+        _requireNativeVaultAsset();
+        return _mintNativeWithControls(shares, receiver);
+    }
+
+    function _vaultOperationsPaused() internal view virtual override returns (bool) {
+        return paused();
+    }
+
+    function _requireNativeVaultAsset() internal view {
+        if (!LibVaultAsset.isNativeAsset(ERC4626Vault.asset())) {
+            revert ERC4626VaultNativeAssetDisabled();
+        }
+    }
+}

--- a/src/vault/libraries/LibNativeAsset.sol
+++ b/src/vault/libraries/LibNativeAsset.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title LibNativeAsset
+/// @notice Shared native-asset sentinel helpers for hosted vault flows.
+library LibNativeAsset {
+    address internal constant NATIVE_ASSET_SENTINEL = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+
+    function isNativeAsset(address asset_) internal pure returns (bool) {
+        return asset_ == NATIVE_ASSET_SENTINEL;
+    }
+}

--- a/src/vault/libraries/LibVaultAsset.sol
+++ b/src/vault/libraries/LibVaultAsset.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC20} from "../../interfaces/IERC20.sol";
+
+/// @title LibVaultAsset
+/// @notice Shared asset-mode helpers for hosted vault token and native flows.
+library LibVaultAsset {
+    address internal constant NATIVE_ASSET_SENTINEL = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+
+    function isNativeAsset(address asset_) internal pure returns (bool) {
+        return asset_ == NATIVE_ASSET_SENTINEL;
+    }
+
+    function balanceOfSelf(address asset_) internal view returns (uint256) {
+        if (isNativeAsset(asset_)) {
+            return address(this).balance;
+        }
+
+        return IERC20(asset_).balanceOf(address(this));
+    }
+
+    function transferOut(address asset_, address to, uint256 value) internal returns (bool) {
+        if (isNativeAsset(asset_)) {
+            (bool nativeSuccess,) = payable(to).call{value: value}("");
+            return nativeSuccess;
+        }
+
+        (bool success, bytes memory data) = asset_.call(abi.encodeCall(IERC20.transfer, (to, value)));
+        return success && (data.length == 0 || abi.decode(data, (bool)));
+    }
+
+    function transferIn(address asset_, address from, address to, uint256 value) internal returns (bool) {
+        if (isNativeAsset(asset_)) {
+            return false;
+        }
+
+        (bool success, bytes memory data) = asset_.call(abi.encodeCall(IERC20.transferFrom, (from, to, value)));
+        return success && (data.length == 0 || abi.decode(data, (bool)));
+    }
+}

--- a/src/vault/libraries/LibVaultFacetSelectors.sol
+++ b/src/vault/libraries/LibVaultFacetSelectors.sol
@@ -7,6 +7,7 @@ import {IERC20} from "../../interfaces/IERC20.sol";
 import {IERC20Metadata} from "../../interfaces/IERC20Metadata.sol";
 import {IERC165} from "../../interfaces/IERC165.sol";
 import {IERC4626} from "../../interfaces/IERC4626.sol";
+import {IERC7535VaultFacet} from "../../interfaces/IERC7535VaultFacet.sol";
 import {IERC4626VaultBase} from "../../interfaces/IERC4626VaultBase.sol";
 import {IERC4626VaultControls} from "../../interfaces/IERC4626VaultControls.sol";
 import {IERC4626VaultFacet} from "../../interfaces/IERC4626VaultFacet.sol";
@@ -19,7 +20,7 @@ import {IReentrancyGuard} from "../../interfaces/IReentrancyGuard.sol";
 library LibVaultFacetSelectors {
     /// @notice Returns the hosted vault core selector group.
     function vaultCoreSelectors() internal pure returns (bytes4[] memory selectors) {
-        selectors = new bytes4[](28);
+        selectors = new bytes4[](30);
         selectors[0] = IERC4626VaultFacet.initializeVault.selector;
         selectors[1] = IERC4626VaultBase.isVaultInitialized.selector;
         selectors[2] = IERC4626.asset.selector;
@@ -48,6 +49,8 @@ library LibVaultFacetSelectors {
         selectors[25] = IERC4626.maxRedeem.selector;
         selectors[26] = IERC4626.previewRedeem.selector;
         selectors[27] = IERC4626.redeem.selector;
+        selectors[28] = IERC7535VaultFacet.depositNative.selector;
+        selectors[29] = IERC7535VaultFacet.mintNative.selector;
     }
 
     /// @notice Returns the hosted vault controls selector group.

--- a/src/vault/libraries/LibVaultFacetSelectors.sol
+++ b/src/vault/libraries/LibVaultFacetSelectors.sol
@@ -16,11 +16,11 @@ import {IPausable} from "../../interfaces/IPausable.sol";
 import {IReentrancyGuard} from "../../interfaces/IReentrancyGuard.sol";
 
 /// @title LibVaultFacetSelectors
-/// @notice Canonical selector groups for future hosted vault facet splits.
+/// @notice Canonical selector groups for hosted vault facet splits.
 library LibVaultFacetSelectors {
     /// @notice Returns the hosted vault core selector group.
     function vaultCoreSelectors() internal pure returns (bytes4[] memory selectors) {
-        selectors = new bytes4[](30);
+        selectors = new bytes4[](28);
         selectors[0] = IERC4626VaultFacet.initializeVault.selector;
         selectors[1] = IERC4626VaultBase.isVaultInitialized.selector;
         selectors[2] = IERC4626.asset.selector;
@@ -49,8 +49,13 @@ library LibVaultFacetSelectors {
         selectors[25] = IERC4626.maxRedeem.selector;
         selectors[26] = IERC4626.previewRedeem.selector;
         selectors[27] = IERC4626.redeem.selector;
-        selectors[28] = IERC7535VaultFacet.depositNative.selector;
-        selectors[29] = IERC7535VaultFacet.mintNative.selector;
+    }
+
+    /// @notice Returns the hosted vault native selector group.
+    function vaultNativeSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](2);
+        selectors[0] = IERC7535VaultFacet.depositNative.selector;
+        selectors[1] = IERC7535VaultFacet.mintNative.selector;
     }
 
     /// @notice Returns the hosted vault controls selector group.

--- a/test/ERC4626VaultFacetCore.t.sol
+++ b/test/ERC4626VaultFacetCore.t.sol
@@ -3,12 +3,20 @@ pragma solidity ^0.8.30;
 
 import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
 import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
+import {IERC165} from "../src/interfaces/IERC165.sol";
+import {IERC4626} from "../src/interfaces/IERC4626.sol";
 import {IERC4626VaultBase} from "../src/interfaces/IERC4626VaultBase.sol";
 import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
+import {IERC7535VaultFacet} from "../src/interfaces/IERC7535VaultFacet.sol";
 import {IPausable} from "../src/interfaces/IPausable.sol";
 import {ERC4626Vault} from "../src/vault/ERC4626Vault.sol";
+import {LibNativeAsset} from "../src/vault/libraries/LibNativeAsset.sol";
 import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
-import {ERC4626VaultFacetFixture, ERC4626VaultFacetHarness} from "./helpers/ERC4626VaultFacetTestHarness.sol";
+import {
+    ERC4626VaultFacetFixture,
+    ERC4626VaultFacetHarness,
+    RejectingNativeReceiver
+} from "./helpers/ERC4626VaultFacetTestHarness.sol";
 
 contract ERC4626VaultFacetCoreTest is ERC4626VaultFacetFixture {
     function testInitializeVaultSeedsMetadataAndControlPlane() public {
@@ -223,6 +231,160 @@ contract ERC4626VaultFacetCoreTest is ERC4626VaultFacetFixture {
         _installVaultCoreFacetToDiamond();
 
         _assertSelectorsUnset(LibVaultFacetSelectors.vaultControlsSelectors());
+    }
+
+    function testInitializeNativeVaultUsesSentinelAssetAndDefaultDecimals() public {
+        _initializeHostedVaultWithAsset(address(facet), LibNativeAsset.NATIVE_ASSET_SENTINEL);
+
+        assertTrue(facet.asset() == LibNativeAsset.NATIVE_ASSET_SENTINEL, "native asset sentinel mismatch");
+        assertTrue(facet.decimals() == 18, "native decimals should default to 18");
+    }
+
+    function testNativeDepositAndMintEntrypointsWorkOnFacet() public {
+        _initializeHostedVaultWithAsset(address(facet), LibNativeAsset.NATIVE_ASSET_SENTINEL);
+        VM.deal(bob, 100);
+
+        VM.prank(bob);
+        uint256 depositShares = IERC7535VaultFacet(address(facet)).depositNative{value: 40}(bob);
+
+        VM.prank(bob);
+        uint256 mintAssets = IERC7535VaultFacet(address(facet)).mintNative{value: 10}(10, bob);
+
+        assertTrue(depositShares == 40, "native deposit shares mismatch");
+        assertTrue(mintAssets == 10, "native mint assets mismatch");
+        assertTrue(facet.totalAssets() == 50, "native total assets mismatch");
+        assertTrue(facet.totalManagedAssets() == 50, "native managed assets mismatch");
+        assertTrue(facet.totalSupply() == 50, "native supply mismatch");
+        assertTrue(facet.balanceOf(bob) == 50, "native share balance mismatch");
+        assertTrue(address(facet).balance == 50, "native vault balance mismatch");
+    }
+
+    function testNativeMintRequiresExactMsgValue() public {
+        _initializeHostedVaultWithAsset(address(facet), LibNativeAsset.NATIVE_ASSET_SENTINEL);
+        VM.deal(bob, 100);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(ERC4626Vault.ERC4626VaultInvalidNativeAssetValue.selector, 9, 10));
+        IERC7535VaultFacet(address(facet)).mintNative{value: 9}(10, bob);
+    }
+
+    function testNativeEntrypointsRejectErc20Vaults() public {
+        _initializeHostedVault(address(facet));
+        VM.deal(bob, 100);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(ERC4626Vault.ERC4626VaultNativeAssetDisabled.selector));
+        IERC7535VaultFacet(address(facet)).depositNative{value: 10}(bob);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(ERC4626Vault.ERC4626VaultNativeAssetDisabled.selector));
+        IERC7535VaultFacet(address(facet)).mintNative{value: 10}(10, bob);
+    }
+
+    function testStandardDepositAndMintRejectNativeVaultMode() public {
+        _initializeHostedVaultWithAsset(address(facet), LibNativeAsset.NATIVE_ASSET_SENTINEL);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(ERC4626Vault.ERC4626VaultNativeAssetUseNativeEntrypoint.selector));
+        facet.deposit(10, bob);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(ERC4626Vault.ERC4626VaultNativeAssetUseNativeEntrypoint.selector));
+        facet.mint(10, bob);
+    }
+
+    function testErc20VaultDepositAndMintRejectMsgValue() public {
+        _initializeHostedVault(address(facet));
+        VM.deal(bob, 100);
+
+        VM.prank(bob);
+        (bool depositSuccess,) = address(facet).call{value: 1}(abi.encodeCall(IERC4626.deposit, (1, bob)));
+        assertFalse(depositSuccess, "erc20 deposit should reject native value");
+
+        VM.prank(bob);
+        (bool mintSuccess,) = address(facet).call{value: 1}(abi.encodeCall(IERC4626.mint, (1, bob)));
+        assertFalse(mintSuccess, "erc20 mint should reject native value");
+    }
+
+    function testNativeWithdrawAndRedeemTransferRawNativeAsset() public {
+        _initializeHostedVaultWithAsset(address(facet), LibNativeAsset.NATIVE_ASSET_SENTINEL);
+        VM.deal(bob, 100);
+
+        VM.prank(bob);
+        IERC7535VaultFacet(address(facet)).depositNative{value: 40}(bob);
+
+        uint256 bobBalanceBeforeWithdraw = bob.balance;
+        VM.prank(bob);
+        uint256 withdrawnShares = facet.withdraw(10, bob, bob);
+        assertTrue(withdrawnShares == 10, "native withdraw share burn mismatch");
+        assertTrue(bob.balance == bobBalanceBeforeWithdraw + 10, "native withdraw payout mismatch");
+
+        uint256 bobBalanceBeforeRedeem = bob.balance;
+        VM.prank(bob);
+        uint256 redeemedAssets = facet.redeem(5, bob, bob);
+        assertTrue(redeemedAssets == 5, "native redeem asset mismatch");
+        assertTrue(bob.balance == bobBalanceBeforeRedeem + 5, "native redeem payout mismatch");
+        assertTrue(address(facet).balance == 25, "native vault balance after payout mismatch");
+    }
+
+    function testNativePayoutFailureRevertsCleanly() public {
+        _initializeHostedVaultWithAsset(address(facet), LibNativeAsset.NATIVE_ASSET_SENTINEL);
+        VM.deal(bob, 100);
+
+        VM.prank(bob);
+        IERC7535VaultFacet(address(facet)).depositNative{value: 10}(bob);
+
+        RejectingNativeReceiver receiver = new RejectingNativeReceiver();
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(ERC4626Vault.ERC4626VaultAssetTransferFailed.selector));
+        facet.withdraw(5, address(receiver), bob);
+    }
+
+    function testForceSentNativeAssetsDoNotChangeBookAccountingOrPricing() public {
+        _initializeHostedVaultWithAsset(address(facet), LibNativeAsset.NATIVE_ASSET_SENTINEL);
+        VM.deal(bob, 100);
+
+        VM.prank(bob);
+        IERC7535VaultFacet(address(facet)).depositNative{value: 10}(bob);
+
+        VM.deal(address(facet), address(facet).balance + 7);
+
+        assertTrue(address(facet).balance == 17, "native force-send balance mismatch");
+        assertTrue(facet.totalManagedAssets() == 10, "managed assets should ignore force-send");
+        assertTrue(facet.totalAssets() == 10, "pricing should ignore force-send");
+        assertTrue(facet.convertToShares(5) == 5, "force-send should not change share pricing");
+        assertTrue(facet.convertToAssets(10) == 10, "force-send should not change asset pricing");
+    }
+
+    function testDiamondNativeRoutingReportsHostedNativeInterfaceAndTransfersRawNativeAsset() public {
+        _installHostedVaultFacetsToDiamond();
+
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond))
+            .initializeVault(LibNativeAsset.NATIVE_ASSET_SENTINEL, "Vault Share", "vSHARE", admin);
+
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC7535VaultFacet).interfaceId),
+            "native hosted interface unsupported"
+        );
+
+        VM.deal(bob, 100);
+        VM.prank(bob);
+        uint256 mintedShares = IERC7535VaultFacet(address(diamond)).depositNative{value: 25}(bob);
+        assertTrue(mintedShares == 25, "diamond native deposit shares mismatch");
+
+        uint256 bobBalanceBeforeWithdraw = bob.balance;
+        VM.prank(bob);
+        uint256 burnedShares = IERC4626VaultFacet(address(diamond)).withdraw(10, bob, bob);
+        assertTrue(burnedShares == 10, "diamond native withdraw share burn mismatch");
+        assertTrue(bob.balance == bobBalanceBeforeWithdraw + 10, "diamond native withdraw payout mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 15, "diamond native total assets mismatch");
+        assertTrue(
+            IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 15, "diamond native managed assets mismatch"
+        );
+
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultCoreSelectors(), address(facet));
     }
 
     function _assertSelectorsOwnedByFacet(bytes4[] memory selectors, address expectedFacet) internal view {

--- a/test/ERC4626VaultFacetCore.t.sol
+++ b/test/ERC4626VaultFacetCore.t.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
-import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
 import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
 import {IERC165} from "../src/interfaces/IERC165.sol";
 import {IERC4626} from "../src/interfaces/IERC4626.sol";
@@ -10,7 +9,7 @@ import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
 import {IERC7535VaultFacet} from "../src/interfaces/IERC7535VaultFacet.sol";
 import {IPausable} from "../src/interfaces/IPausable.sol";
 import {ERC4626Vault} from "../src/vault/ERC4626Vault.sol";
-import {LibNativeAsset} from "../src/vault/libraries/LibNativeAsset.sol";
+import {LibVaultAsset} from "../src/vault/libraries/LibVaultAsset.sol";
 import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {
     ERC4626VaultFacetFixture,
@@ -23,7 +22,6 @@ contract ERC4626VaultFacetCoreTest is ERC4626VaultFacetFixture {
         _initializeHostedVault(address(facet));
 
         assertTrue(facet.isVaultInitialized(), "vault should initialize");
-        assertTrue(facet.controlPlaneInitialized(), "control plane should initialize");
         assertTrue(facet.asset() == address(asset), "asset mismatch");
         assertTrue(keccak256(bytes(facet.name())) == keccak256(bytes("Vault Share")), "name mismatch");
         assertTrue(keccak256(bytes(facet.symbol())) == keccak256(bytes("vSHARE")), "symbol mismatch");
@@ -45,23 +43,6 @@ contract ERC4626VaultFacetCoreTest is ERC4626VaultFacetFixture {
 
         VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultAlreadyInitialized.selector));
         _initializeHostedVault(address(facet));
-    }
-
-    function testInitializeVaultAfterControlOnlyInitRequiresDefaultAdmin() public {
-        facet.initializeControlOnly(admin);
-
-        VM.expectRevert(
-            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, facet.DEFAULT_ADMIN_ROLE())
-        );
-        VM.prank(bob);
-        facet.initializeVault(address(asset), "Vault Share", "vSHARE", admin);
-
-        VM.prank(admin);
-        facet.initializeVault(address(asset), "Vault Share", "vSHARE", admin);
-
-        assertTrue(facet.isVaultInitialized(), "vault should initialize");
-        assertTrue(facet.controlPlaneInitialized(), "control plane should stay initialized");
-        assertTrue(facet.feeRecipient() == admin, "fee recipient mismatch");
     }
 
     function testCoreFlowsAndShareTokenRoutingWorkOnFacet() public {
@@ -234,55 +215,66 @@ contract ERC4626VaultFacetCoreTest is ERC4626VaultFacetFixture {
     }
 
     function testInitializeNativeVaultUsesSentinelAssetAndDefaultDecimals() public {
-        _initializeHostedVaultWithAsset(address(facet), LibNativeAsset.NATIVE_ASSET_SENTINEL);
+        _initializeHostedVaultWithAsset(address(facet), LibVaultAsset.NATIVE_ASSET_SENTINEL);
 
-        assertTrue(facet.asset() == LibNativeAsset.NATIVE_ASSET_SENTINEL, "native asset sentinel mismatch");
+        assertTrue(facet.asset() == LibVaultAsset.NATIVE_ASSET_SENTINEL, "native asset sentinel mismatch");
         assertTrue(facet.decimals() == 18, "native decimals should default to 18");
     }
 
-    function testNativeDepositAndMintEntrypointsWorkOnFacet() public {
-        _initializeHostedVaultWithAsset(address(facet), LibNativeAsset.NATIVE_ASSET_SENTINEL);
+    function testNativeDepositAndMintEntrypointsWorkOnDiamond() public {
+        _installHostedVaultNativeFacetsToDiamond();
+
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond))
+            .initializeVault(LibVaultAsset.NATIVE_ASSET_SENTINEL, "Vault Share", "vSHARE", admin);
+
         VM.deal(bob, 100);
+        VM.prank(bob);
+        uint256 depositShares = IERC7535VaultFacet(address(diamond)).depositNative{value: 40}(bob);
 
         VM.prank(bob);
-        uint256 depositShares = IERC7535VaultFacet(address(facet)).depositNative{value: 40}(bob);
-
-        VM.prank(bob);
-        uint256 mintAssets = IERC7535VaultFacet(address(facet)).mintNative{value: 10}(10, bob);
+        uint256 mintAssets = IERC7535VaultFacet(address(diamond)).mintNative{value: 10}(10, bob);
 
         assertTrue(depositShares == 40, "native deposit shares mismatch");
         assertTrue(mintAssets == 10, "native mint assets mismatch");
-        assertTrue(facet.totalAssets() == 50, "native total assets mismatch");
-        assertTrue(facet.totalManagedAssets() == 50, "native managed assets mismatch");
-        assertTrue(facet.totalSupply() == 50, "native supply mismatch");
-        assertTrue(facet.balanceOf(bob) == 50, "native share balance mismatch");
-        assertTrue(address(facet).balance == 50, "native vault balance mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 50, "native total assets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 50, "native managed assets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalSupply() == 50, "native supply mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).balanceOf(bob) == 50, "native share balance mismatch");
+        assertTrue(address(diamond).balance == 50, "native vault balance mismatch");
     }
 
     function testNativeMintRequiresExactMsgValue() public {
-        _initializeHostedVaultWithAsset(address(facet), LibNativeAsset.NATIVE_ASSET_SENTINEL);
-        VM.deal(bob, 100);
+        _installHostedVaultNativeFacetsToDiamond();
 
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond))
+            .initializeVault(LibVaultAsset.NATIVE_ASSET_SENTINEL, "Vault Share", "vSHARE", admin);
+
+        VM.deal(bob, 100);
         VM.prank(bob);
         VM.expectRevert(abi.encodeWithSelector(ERC4626Vault.ERC4626VaultInvalidNativeAssetValue.selector, 9, 10));
-        IERC7535VaultFacet(address(facet)).mintNative{value: 9}(10, bob);
+        IERC7535VaultFacet(address(diamond)).mintNative{value: 9}(10, bob);
     }
 
-    function testNativeEntrypointsRejectErc20Vaults() public {
-        _initializeHostedVault(address(facet));
+    function testNativeEntrypointsRejectErc20VaultsOnDiamond() public {
+        _installHostedVaultNativeFacetsToDiamond();
+
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond)).initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+
         VM.deal(bob, 100);
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(ERC4626Vault.ERC4626VaultNativeAssetDisabled.selector));
+        IERC7535VaultFacet(address(diamond)).depositNative{value: 10}(bob);
 
         VM.prank(bob);
         VM.expectRevert(abi.encodeWithSelector(ERC4626Vault.ERC4626VaultNativeAssetDisabled.selector));
-        IERC7535VaultFacet(address(facet)).depositNative{value: 10}(bob);
-
-        VM.prank(bob);
-        VM.expectRevert(abi.encodeWithSelector(ERC4626Vault.ERC4626VaultNativeAssetDisabled.selector));
-        IERC7535VaultFacet(address(facet)).mintNative{value: 10}(10, bob);
+        IERC7535VaultFacet(address(diamond)).mintNative{value: 10}(10, bob);
     }
 
     function testStandardDepositAndMintRejectNativeVaultMode() public {
-        _initializeHostedVaultWithAsset(address(facet), LibNativeAsset.NATIVE_ASSET_SENTINEL);
+        _initializeHostedVaultWithAsset(address(facet), LibVaultAsset.NATIVE_ASSET_SENTINEL);
 
         VM.prank(bob);
         VM.expectRevert(abi.encodeWithSelector(ERC4626Vault.ERC4626VaultNativeAssetUseNativeEntrypoint.selector));
@@ -307,62 +299,80 @@ contract ERC4626VaultFacetCoreTest is ERC4626VaultFacetFixture {
     }
 
     function testNativeWithdrawAndRedeemTransferRawNativeAsset() public {
-        _initializeHostedVaultWithAsset(address(facet), LibNativeAsset.NATIVE_ASSET_SENTINEL);
-        VM.deal(bob, 100);
+        _installHostedVaultNativeFacetsToDiamond();
 
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond))
+            .initializeVault(LibVaultAsset.NATIVE_ASSET_SENTINEL, "Vault Share", "vSHARE", admin);
+
+        VM.deal(bob, 100);
         VM.prank(bob);
-        IERC7535VaultFacet(address(facet)).depositNative{value: 40}(bob);
+        IERC7535VaultFacet(address(diamond)).depositNative{value: 40}(bob);
 
         uint256 bobBalanceBeforeWithdraw = bob.balance;
         VM.prank(bob);
-        uint256 withdrawnShares = facet.withdraw(10, bob, bob);
+        uint256 withdrawnShares = IERC4626VaultFacet(address(diamond)).withdraw(10, bob, bob);
         assertTrue(withdrawnShares == 10, "native withdraw share burn mismatch");
         assertTrue(bob.balance == bobBalanceBeforeWithdraw + 10, "native withdraw payout mismatch");
 
         uint256 bobBalanceBeforeRedeem = bob.balance;
         VM.prank(bob);
-        uint256 redeemedAssets = facet.redeem(5, bob, bob);
+        uint256 redeemedAssets = IERC4626VaultFacet(address(diamond)).redeem(5, bob, bob);
         assertTrue(redeemedAssets == 5, "native redeem asset mismatch");
         assertTrue(bob.balance == bobBalanceBeforeRedeem + 5, "native redeem payout mismatch");
-        assertTrue(address(facet).balance == 25, "native vault balance after payout mismatch");
+        assertTrue(address(diamond).balance == 25, "native vault balance after payout mismatch");
     }
 
     function testNativePayoutFailureRevertsCleanly() public {
-        _initializeHostedVaultWithAsset(address(facet), LibNativeAsset.NATIVE_ASSET_SENTINEL);
-        VM.deal(bob, 100);
+        _installHostedVaultNativeFacetsToDiamond();
 
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond))
+            .initializeVault(LibVaultAsset.NATIVE_ASSET_SENTINEL, "Vault Share", "vSHARE", admin);
+
+        VM.deal(bob, 100);
         VM.prank(bob);
-        IERC7535VaultFacet(address(facet)).depositNative{value: 10}(bob);
+        IERC7535VaultFacet(address(diamond)).depositNative{value: 10}(bob);
 
         RejectingNativeReceiver receiver = new RejectingNativeReceiver();
 
         VM.prank(bob);
         VM.expectRevert(abi.encodeWithSelector(ERC4626Vault.ERC4626VaultAssetTransferFailed.selector));
-        facet.withdraw(5, address(receiver), bob);
+        IERC4626VaultFacet(address(diamond)).withdraw(5, address(receiver), bob);
     }
 
     function testForceSentNativeAssetsDoNotChangeBookAccountingOrPricing() public {
-        _initializeHostedVaultWithAsset(address(facet), LibNativeAsset.NATIVE_ASSET_SENTINEL);
-        VM.deal(bob, 100);
-
-        VM.prank(bob);
-        IERC7535VaultFacet(address(facet)).depositNative{value: 10}(bob);
-
-        VM.deal(address(facet), address(facet).balance + 7);
-
-        assertTrue(address(facet).balance == 17, "native force-send balance mismatch");
-        assertTrue(facet.totalManagedAssets() == 10, "managed assets should ignore force-send");
-        assertTrue(facet.totalAssets() == 10, "pricing should ignore force-send");
-        assertTrue(facet.convertToShares(5) == 5, "force-send should not change share pricing");
-        assertTrue(facet.convertToAssets(10) == 10, "force-send should not change asset pricing");
-    }
-
-    function testDiamondNativeRoutingReportsHostedNativeInterfaceAndTransfersRawNativeAsset() public {
-        _installHostedVaultFacetsToDiamond();
+        _installHostedVaultNativeFacetsToDiamond();
 
         VM.prank(admin);
         IERC4626VaultFacet(address(diamond))
-            .initializeVault(LibNativeAsset.NATIVE_ASSET_SENTINEL, "Vault Share", "vSHARE", admin);
+            .initializeVault(LibVaultAsset.NATIVE_ASSET_SENTINEL, "Vault Share", "vSHARE", admin);
+
+        VM.deal(bob, 100);
+        VM.prank(bob);
+        IERC7535VaultFacet(address(diamond)).depositNative{value: 10}(bob);
+
+        VM.deal(address(diamond), address(diamond).balance + 7);
+
+        assertTrue(address(diamond).balance == 17, "native force-send balance mismatch");
+        assertTrue(
+            IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 10, "managed assets should ignore force-send"
+        );
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 10, "pricing should ignore force-send");
+        assertTrue(
+            IERC4626VaultFacet(address(diamond)).convertToShares(5) == 5, "force-send should not change share pricing"
+        );
+        assertTrue(
+            IERC4626VaultFacet(address(diamond)).convertToAssets(10) == 10, "force-send should not change asset pricing"
+        );
+    }
+
+    function testDiamondNativeRoutingReportsHostedNativeInterfaceAndTransfersRawNativeAsset() public {
+        _installHostedVaultNativeFacetsToDiamond();
+
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond))
+            .initializeVault(LibVaultAsset.NATIVE_ASSET_SENTINEL, "Vault Share", "vSHARE", admin);
 
         assertTrue(
             IERC165(address(diamond)).supportsInterface(type(IERC7535VaultFacet).interfaceId),
@@ -385,6 +395,7 @@ contract ERC4626VaultFacetCoreTest is ERC4626VaultFacetFixture {
         );
 
         _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultCoreSelectors(), address(facet));
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultNativeSelectors(), address(nativeFacet));
     }
 
     function _assertSelectorsOwnedByFacet(bytes4[] memory selectors, address expectedFacet) internal view {

--- a/test/ERC4626VaultStrategyAccountingCore.t.sol
+++ b/test/ERC4626VaultStrategyAccountingCore.t.sol
@@ -37,7 +37,6 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
         _simulateStrategyDeployment(address(facet), directProfitStrategy, STRATEGY_DEBT);
         directProfitStrategy.injectProfit(20);
 
-        assertTrue(facet.strategyDebtForTest() == STRATEGY_DEBT, "strategy debt mismatch");
         assertTrue(facet.totalManagedAssets() == DEPOSIT_ASSETS, "book value should remain unchanged");
         assertTrue(facet.totalAssets() == 120, "mark-to-market assets mismatch");
         assertTrue(facet.convertToShares(12) == 10, "convertToShares profit mismatch");

--- a/test/VaultFacetFoundationCore.t.sol
+++ b/test/VaultFacetFoundationCore.t.sol
@@ -5,6 +5,7 @@ import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
 import {IAccessControlTime} from "../src/interfaces/IAccessControlTime.sol";
 import {IERC165} from "../src/interfaces/IERC165.sol";
 import {IERC4626} from "../src/interfaces/IERC4626.sol";
+import {IERC7535VaultFacet} from "../src/interfaces/IERC7535VaultFacet.sol";
 import {IERC4626VaultBase} from "../src/interfaces/IERC4626VaultBase.sol";
 import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol";
 import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControlsFacet.sol";
@@ -84,12 +85,14 @@ contract VaultFacetFoundationCoreTest is VaultFacetFoundationFixture {
         bytes4[] memory coreSelectors = LibVaultFacetSelectors.vaultCoreSelectors();
         bytes4[] memory controlSelectors = LibVaultFacetSelectors.vaultControlsSelectors();
 
-        assertTrue(coreSelectors.length == 28, "unexpected core selector count");
+        assertTrue(coreSelectors.length == 30, "unexpected core selector count");
         assertTrue(controlSelectors.length == 28, "unexpected controls selector count");
 
         _assertContains(coreSelectors, IERC4626VaultFacet.initializeVault.selector);
         _assertContains(coreSelectors, IERC4626.deposit.selector);
         _assertContains(coreSelectors, IERC4626.redeem.selector);
+        _assertContains(coreSelectors, IERC7535VaultFacet.depositNative.selector);
+        _assertContains(coreSelectors, IERC7535VaultFacet.mintNative.selector);
         _assertContains(coreSelectors, IERC4626VaultBase.totalManagedAssets.selector);
 
         _assertContains(controlSelectors, IERC4626VaultControls.setFeeConfig.selector);

--- a/test/VaultFacetFoundationCore.t.sol
+++ b/test/VaultFacetFoundationCore.t.sol
@@ -83,17 +83,20 @@ contract VaultFacetFoundationCoreTest is VaultFacetFoundationFixture {
 
     function testVaultSelectorGroupsCoverExpectedHostedSplit() public pure {
         bytes4[] memory coreSelectors = LibVaultFacetSelectors.vaultCoreSelectors();
+        bytes4[] memory nativeSelectors = LibVaultFacetSelectors.vaultNativeSelectors();
         bytes4[] memory controlSelectors = LibVaultFacetSelectors.vaultControlsSelectors();
 
-        assertTrue(coreSelectors.length == 30, "unexpected core selector count");
+        assertTrue(coreSelectors.length == 28, "unexpected core selector count");
+        assertTrue(nativeSelectors.length == 2, "unexpected native selector count");
         assertTrue(controlSelectors.length == 28, "unexpected controls selector count");
 
         _assertContains(coreSelectors, IERC4626VaultFacet.initializeVault.selector);
         _assertContains(coreSelectors, IERC4626.deposit.selector);
         _assertContains(coreSelectors, IERC4626.redeem.selector);
-        _assertContains(coreSelectors, IERC7535VaultFacet.depositNative.selector);
-        _assertContains(coreSelectors, IERC7535VaultFacet.mintNative.selector);
         _assertContains(coreSelectors, IERC4626VaultBase.totalManagedAssets.selector);
+
+        _assertContains(nativeSelectors, IERC7535VaultFacet.depositNative.selector);
+        _assertContains(nativeSelectors, IERC7535VaultFacet.mintNative.selector);
 
         _assertContains(controlSelectors, IERC4626VaultControls.setFeeConfig.selector);
         _assertContains(controlSelectors, IERC4626VaultControls.setLimitConfig.selector);
@@ -102,8 +105,11 @@ contract VaultFacetFoundationCoreTest is VaultFacetFoundationFixture {
         _assertContains(controlSelectors, IERC165.supportsInterface.selector);
 
         _assertUnique(coreSelectors);
+        _assertUnique(nativeSelectors);
         _assertUnique(controlSelectors);
+        _assertDisjoint(coreSelectors, nativeSelectors);
         _assertDisjoint(coreSelectors, controlSelectors);
+        _assertDisjoint(nativeSelectors, controlSelectors);
     }
 
     function _assertContains(bytes4[] memory selectors, bytes4 target) internal pure {

--- a/test/helpers/AccessControlTestHarness.sol
+++ b/test/helpers/AccessControlTestHarness.sol
@@ -9,6 +9,7 @@ interface Vm {
     function stopPrank() external;
     function assume(bool) external;
     function addr(uint256) external returns (address);
+    function deal(address who, uint256 newBalance) external;
     function sign(uint256, bytes32) external returns (uint8, bytes32, bytes32);
     function expectRevert(bytes4) external;
     function expectRevert(bytes calldata) external;

--- a/test/helpers/ERC4626VaultFacetTestHarness.sol
+++ b/test/helpers/ERC4626VaultFacetTestHarness.sol
@@ -5,6 +5,7 @@ import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
 import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
 import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
 import {IERC4626VaultFacet} from "../../src/interfaces/IERC4626VaultFacet.sol";
+import {ERC4626VaultControlsFacet} from "../../src/vault/facets/ERC4626VaultControlsFacet.sol";
 import {ERC4626VaultFacet} from "../../src/vault/facets/ERC4626VaultFacet.sol";
 import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {LibERC4626VaultStorage} from "../../src/vault/storage/LibERC4626VaultStorage.sol";
@@ -30,6 +31,12 @@ contract ERC4626VaultFacetHarness is ERC4626VaultFacet {
     }
 }
 
+contract RejectingNativeReceiver {
+    receive() external payable {
+        revert("rejecting native asset");
+    }
+}
+
 abstract contract ERC4626VaultFacetFixture is TestBase {
     uint256 internal constant INITIAL_ASSETS = 1_000_000;
 
@@ -39,6 +46,7 @@ abstract contract ERC4626VaultFacetFixture is TestBase {
 
     ReentrantMockVaultAsset internal asset;
     ERC4626VaultFacetHarness internal facet;
+    ERC4626VaultControlsFacet internal controlsFacet;
     DiamondCutFacet internal cutFacet;
     DiamondLoupeFacet internal loupeFacet;
     DiamondProxyHarness internal diamond;
@@ -46,6 +54,7 @@ abstract contract ERC4626VaultFacetFixture is TestBase {
     function setUp() public virtual {
         asset = new ReentrantMockVaultAsset();
         facet = new ERC4626VaultFacetHarness();
+        controlsFacet = new ERC4626VaultControlsFacet();
         cutFacet = new DiamondCutFacet();
         loupeFacet = new DiamondLoupeFacet();
         diamond = new DiamondProxyHarness(admin, address(cutFacet));
@@ -57,7 +66,11 @@ abstract contract ERC4626VaultFacetFixture is TestBase {
     }
 
     function _initializeHostedVault(address target) internal {
-        IERC4626VaultFacet(target).initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+        _initializeHostedVaultWithAsset(target, address(asset));
+    }
+
+    function _initializeHostedVaultWithAsset(address target, address vaultAsset) internal {
+        IERC4626VaultFacet(target).initializeVault(vaultAsset, "Vault Share", "vSHARE", admin);
     }
 
     function _approveAsset(address owner, address spender, uint256 amount) internal {
@@ -87,6 +100,23 @@ abstract contract ERC4626VaultFacetFixture is TestBase {
 
         VM.prank(admin);
         IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installVaultControlsFacetToDiamond() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(controlsFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultControlsSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installHostedVaultFacetsToDiamond() internal {
+        _installVaultCoreFacetToDiamond();
+        _installVaultControlsFacetToDiamond();
     }
 
     function _loupeSelectors() internal pure returns (bytes4[] memory selectors) {

--- a/test/helpers/ERC4626VaultFacetTestHarness.sol
+++ b/test/helpers/ERC4626VaultFacetTestHarness.sol
@@ -7,6 +7,7 @@ import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
 import {IERC4626VaultFacet} from "../../src/interfaces/IERC4626VaultFacet.sol";
 import {ERC4626VaultControlsFacet} from "../../src/vault/facets/ERC4626VaultControlsFacet.sol";
 import {ERC4626VaultFacet} from "../../src/vault/facets/ERC4626VaultFacet.sol";
+import {ERC7535VaultFacet} from "../../src/vault/facets/ERC7535VaultFacet.sol";
 import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {LibERC4626VaultStorage} from "../../src/vault/storage/LibERC4626VaultStorage.sol";
 import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
@@ -14,21 +15,11 @@ import {TestBase} from "./AccessControlTestHarness.sol";
 import {ReentrantMockVaultAsset} from "./ERC4626VaultControlsTestHarness.sol";
 
 contract ERC4626VaultFacetHarness is ERC4626VaultFacet {
-    function initializeControlOnly(address admin) external {
-        _initializeVaultFacetControl(admin);
-    }
-
     function feeRecipient() external view returns (address) {
         return LibERC4626VaultStorage.layout().fees.feeRecipient;
     }
 
-    function controlPlaneInitialized() external view returns (bool) {
-        return LibERC4626VaultStorage.layout().controlPlaneInitialized;
-    }
-
-    function probeNonReentrant() external nonReentrant returns (bool) {
-        return true;
-    }
+    function probeNonReentrant() external nonReentrant {}
 }
 
 contract RejectingNativeReceiver {
@@ -46,6 +37,7 @@ abstract contract ERC4626VaultFacetFixture is TestBase {
 
     ReentrantMockVaultAsset internal asset;
     ERC4626VaultFacetHarness internal facet;
+    ERC7535VaultFacet internal nativeFacet;
     ERC4626VaultControlsFacet internal controlsFacet;
     DiamondCutFacet internal cutFacet;
     DiamondLoupeFacet internal loupeFacet;
@@ -54,6 +46,7 @@ abstract contract ERC4626VaultFacetFixture is TestBase {
     function setUp() public virtual {
         asset = new ReentrantMockVaultAsset();
         facet = new ERC4626VaultFacetHarness();
+        nativeFacet = new ERC7535VaultFacet();
         controlsFacet = new ERC4626VaultControlsFacet();
         cutFacet = new DiamondCutFacet();
         loupeFacet = new DiamondLoupeFacet();
@@ -102,6 +95,18 @@ abstract contract ERC4626VaultFacetFixture is TestBase {
         IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
     }
 
+    function _installVaultNativeFacetToDiamond() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(nativeFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultNativeSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
     function _installVaultControlsFacetToDiamond() internal {
         IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
         cut[0] = IDiamondCut.FacetCut({
@@ -117,6 +122,11 @@ abstract contract ERC4626VaultFacetFixture is TestBase {
     function _installHostedVaultFacetsToDiamond() internal {
         _installVaultCoreFacetToDiamond();
         _installVaultControlsFacetToDiamond();
+    }
+
+    function _installHostedVaultNativeFacetsToDiamond() internal {
+        _installHostedVaultFacetsToDiamond();
+        _installVaultNativeFacetToDiamond();
     }
 
     function _loupeSelectors() internal pure returns (bytes4[] memory selectors) {

--- a/test/helpers/ERC4626VaultStrategyAccountingTestHarness.sol
+++ b/test/helpers/ERC4626VaultStrategyAccountingTestHarness.sol
@@ -23,10 +23,6 @@ contract ERC4626VaultStrategyAccountingFacetHarness is ERC4626VaultFacet {
         layout.strategy = strategy_;
         layout.strategyDebt = strategyDebt_;
     }
-
-    function strategyDebtForTest() external view returns (uint256) {
-        return LibERC4626VaultStorage.layout().strategyDebt;
-    }
 }
 
 contract ERC4626VaultStrategyAccountingInitMock {


### PR DESCRIPTION
## Summary
- add ERC-7535-style native-asset mode to the hosted vault core
- introduce hosted native entrypoints for payable deposits and mints
- make hosted withdraw and redeem native-aware when the vault asset is the ERC-7528 sentinel
- add direct and diamond-routed native-mode coverage without changing strategy or deployment layers

## What Changed
- added `IERC7535VaultFacet` with `depositNative` and `mintNative`
- added `LibNativeAsset` for the native sentinel helper
- added native-mode guards and payout logic in `ERC4626VaultFacet`
- kept standard `IERC4626` methods unchanged while rejecting native-mode `deposit` and `mint`
- extended core selector wiring and `supportsInterface(...)` for the hosted native extension
- added direct and diamond-routed tests for native init, entrypoints, payouts, and force-sent ETH behavior

## Validation
- `git diff --check`
- `forge fmt --check`
- `forge test --offline --match-path test/ERC4626VaultFacetCore.t.sol`
- `forge test --offline --match-path test/VaultFacetFoundationCore.t.sol`
- `forge test --offline --match-path test/ERC4626VaultControlsFacetCore.t.sol`

## Notes
- this issue keeps strategy support, deployment scripts, and local operator flows unchanged
- force-sent native asset is intentionally excluded from book accounting and share pricing in this phase

Closes #130