### PR TITLE
Milestone: ERC-7535 Native Asset Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ reviewable engineering system.
   with init, selector ownership, Permit/metadata support, and host-level
   hardening coverage.
 - A hosted ERC-4626 vault platform deployed behind a diamond host, split across
-  core, controls, and integration facets with active strategy lifecycle
-  management, live strategy-aware accounting, loss-aware withdrawals,
-  emergency-exit safety, deployment-backed init, and diamond-routed hardening
-  plus invariant coverage.
+  core, native, controls, and integration facets with ERC20 and native-asset
+  modes, active strategy lifecycle management, live strategy-aware accounting,
+  loss-aware withdrawals, emergency-exit safety, deployment-backed init, and
+  diamond-routed hardening plus invariant coverage.
 - Operational maturity through local bootstrap, smoke validation, upgrade
   rehearsal, system-hardening flows, and matching CI gates.
 - A local Auralis workflow for full-stack bootstrap, smoke checks, simulated
@@ -94,8 +94,9 @@ constraint, and token-host upgrade assumptions.
 
 Hosted-vault architecture and safety assumptions live in
 `docs/vault-facets.md`, including the init model, selector ownership split,
-live strategy lifecycle, accounting model, emergency-exit behavior, deployment
-references, and hosted-vault upgrade assumptions.
+live strategy lifecycle, native-asset behavior, accounting model,
+emergency-exit behavior, deployment references, and hosted-vault upgrade
+assumptions.
 
 Local Auralis bootstrap, smoke, simulated activity, reset flow, and artifact
 layout are documented in `docs/auralis-local.md`.

--- a/docs/auralis-local.md
+++ b/docs/auralis-local.md
@@ -1,7 +1,8 @@
 # Auralis Local Workflow
 
 `Auralis` ships with a local-first workflow for bootstrapping the token hosts,
-vault host, and a small amount of simulated protocol activity on Anvil.
+ERC20 vault host, native vault host, and a small amount of simulated protocol
+activity on Anvil.
 
 ## Prerequisites
 
@@ -43,25 +44,26 @@ bash scripts/auralis-reset.sh
 
 `auralis-up.sh`
 - starts Anvil if one is not already available
-- deploys the ERC20 host, ERC721 host, and strategy-enabled vault host
+- deploys the ERC20 host, ERC721 host, ERC20 vault host, and native vault host
 - writes `deployments/auralis.local.json`
 
 `auralis-smoke.sh`
 - checks deployed code is present
 - runs token and NFT happy-path transactions
-- runs vault deposit, strategy deploy, profit sync, manager pull, user auto-pull, and emergency-exit flows
-- restores the local vault to a ready state by re-binding the configured strategy after the emergency-exit smoke
-- verifies the vault oracle quote path is live
+- runs ERC20 vault deposit, strategy deploy, profit sync, manager pull, user auto-pull, and emergency-exit flows
+- runs native vault deposit, strategy deploy, profit sync, manager pull, user auto-pull, and emergency-exit flows
+- restores both local vaults to a ready state by re-binding the configured strategy after the emergency-exit smoke
+- verifies both vault oracle quote paths are live
 
 `auralis-activity.sh`
 - generates deterministic demo traffic across the deployed hosts
 - mints and transfers ERC20 balances
 - mints and moves an ERC721 token
-- deposits into the vault, deploys capital to strategy, syncs profit, pulls funds back, moves shares, redeems shares, updates the oracle, and toggles pause state
+- deposits into the ERC20 vault and native vault, deploys capital to strategy, syncs profit, pulls funds back, moves shares, redeems shares, updates the oracle, and toggles pause state
 
 `auralis-reset.sh`
 - stops the managed Anvil process if `auralis-up.sh` started it
-- removes the Auralis deployment artifacts
+- removes the Auralis deployment artifacts, including the native vault artifact
 
 ## Artifact Layout
 
@@ -73,8 +75,9 @@ and records:
 - owner/alice actor addresses
 - ERC20 host addresses
 - ERC721 host addresses
-- vault host addresses
-- configured vault strategy address and zeroed initial strategy state
+- ERC20 vault host addresses
+- native vault host addresses
+- configured vault strategy addresses and zeroed initial strategy state
 
 ## Simulated Activity
 

--- a/docs/auralis-local.md
+++ b/docs/auralis-local.md
@@ -45,13 +45,15 @@ bash scripts/auralis-reset.sh
 `auralis-up.sh`
 - starts Anvil if one is not already available
 - deploys the ERC20 host, ERC721 host, ERC20 vault host, and native vault host
-- writes `deployments/auralis.local.json`
+- writes the host-specific vault artifacts and `deployments/auralis.local.json`
 
 `auralis-smoke.sh`
 - checks deployed code is present
 - runs token and NFT happy-path transactions
 - runs ERC20 vault deposit, strategy deploy, profit sync, manager pull, user auto-pull, and emergency-exit flows
-- runs native vault deposit, strategy deploy, profit sync, manager pull, user auto-pull, and emergency-exit flows
+- runs native vault exact-value deposit and mint, strategy deploy, payable
+  profit sync, manager pull, user auto-pull, emergency-exit, and strategy
+  rebind flows
 - restores both local vaults to a ready state by re-binding the configured strategy after the emergency-exit smoke
 - verifies both vault oracle quote paths are live
 
@@ -79,8 +81,33 @@ and records:
 - native vault host addresses
 - configured vault strategy addresses and zeroed initial strategy state
 
+The host-specific vault artifacts are:
+
+- `deployments/diamond-vault.local.json`
+- `deployments/diamond-native-vault.local.json`
+
+Each vault artifact records:
+
+- `assetMode` as `erc20` or `native`
+- the installed facet addresses, including `vaultNativeFacet`
+- the configured strategy and zeroed initial strategy state
+
+For backward compatibility:
+
+- `vaultHost` in `deployments/auralis.local.json` remains the ERC20 hosted
+  vault
+- `nativeVaultHost` is the parallel native hosted vault entry
+
 ## Simulated Activity
 
 The activity script is explicitly demo traffic for local development and review.
 It is meant to create realistic event history and state transitions, not to
 model production usage or strategy execution.
+
+For the native hosted vault specifically, the local workflow assumes:
+
+- asset-in flows use `depositNative` and `mintNative`
+- `mintNative` must be funded with exact `msg.value`
+- exits use standard `withdraw` and `redeem` and pay raw native asset
+- strategy profit injection is payable and uses raw ETH
+- force-sent ETH is not treated as managed assets by the vault accounting model

--- a/docs/erc4626-vault.md
+++ b/docs/erc4626-vault.md
@@ -9,6 +9,9 @@ repository:
 It covers the standalone vault modules and their math/control behavior. For the
 diamond-hosted vault platform, see `docs/vault-facets.md`.
 
+Native-asset mode is only supported through the diamond-hosted vault platform.
+The standalone `ERC4626Vault` module remains an ERC-20 asset vault surface.
+
 ## Contract Roles
 
 - `ERC4626VaultBase`: initializer + share/asset accounting primitives.
@@ -132,6 +135,19 @@ vault entrypoints. This is the primary emergency stop for vault write paths.
 - No native slippage parameters are present on ERC-4626 functions; integrators
   should pre-check previews and enforce client-side constraints.
 - The controls layer applies global limits, not per-user risk limits.
+
+## Hosted Native-Mode Boundary
+
+The hosted platform extends this ERC-20 vault model with an ERC-7535-style
+native entry surface, but the native behavior is not part of the standalone
+module contract described here.
+
+Implications:
+- `deposit` and `mint` remain ERC-20 entrypoints only.
+- native funding, exact `msg.value` validation, and raw native payouts are
+  documented in `docs/vault-facets.md`.
+- forced native transfers are a hosted-vault accounting concern, not a
+  standalone ERC-20 vault concern.
 
 ## Test References
 

--- a/docs/vault-facets.md
+++ b/docs/vault-facets.md
@@ -7,6 +7,7 @@ It covers the supported diamond-hosted vault deployment:
 
 - one diamond
 - one `ERC4626VaultFacet`
+- one `ERC7535VaultFacet` for native mode
 - one `ERC4626VaultControlsFacet`
 - one `ERC4626VaultIntegrationFacet`
 - one active strategy per vault
@@ -33,6 +34,24 @@ The core facet also owns runtime liquidity sourcing for user withdrawals and
 redemptions. When idle vault liquidity is insufficient, it will pull
 immediately withdrawable assets from the configured strategy before finishing
 `withdraw` or `redeem`.
+
+### Native Facet
+
+`ERC7535VaultFacet` owns the native-only selector group:
+
+- `depositNative(address receiver)`
+- `mintNative(uint256 shares, address receiver)`
+
+It exists only for hosted vaults initialized with the native asset sentinel:
+
+- `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE`
+
+Native mode keeps the standard ERC-4626 surface unchanged:
+
+- `deposit` and `mint` remain installed on the core facet but revert for native
+  vaults
+- `withdraw` and `redeem` stay on the core facet and pay raw native asset in
+  native mode
 
 ### Controls Facet
 
@@ -67,11 +86,12 @@ Initialization sequence:
 
 1. Install loupe selectors.
 2. Install the core, controls, and integration selector groups.
-3. Call
+3. For native mode, also install the native selector group.
+4. Call
    `initializeVault(address vaultAsset, string vaultName, string vaultSymbol, address admin)`
    through the diamond.
-4. Call `setOracleAdapter(address newAdapter)` through the integration facet.
-5. Call `setStrategy(address newStrategy)` through the integration facet.
+5. Call `setOracleAdapter(address newAdapter)` through the integration facet.
+6. Call `setStrategy(address newStrategy)` through the integration facet.
 
 Initialization behavior:
 
@@ -93,6 +113,10 @@ state with:
 - `strategyEmergencyExit() == false`
 
 No funds are deployed to strategy during deployment.
+
+The native local reference deployment in `script/DeployDiamondNativeVaultHost.s.sol`
+uses the same init model, but passes the native asset sentinel as
+`vaultAsset` and installs the native selector group.
 
 ## Role Model And Pause Behavior
 
@@ -123,6 +147,8 @@ Global pause blocks:
 
 - `deposit`
 - `mint`
+- `depositNative`
+- `mintNative`
 - `withdraw`
 - `redeem`
 
@@ -153,6 +179,9 @@ A strategy must satisfy `IERC4626VaultStrategy` and report:
 
 `setStrategy(...)` validates those bindings and requires `strategyDebt() == 0`
 before a strategy can be cleared or replaced.
+
+For native hosted vaults, `asset()` on both the vault and the strategy must be
+the native sentinel. No separate native-only strategy interface exists.
 
 ### Lifecycle Surface
 
@@ -214,6 +243,52 @@ while still keeping explicit book accounting for deployed debt.
 
 ## User-Facing Withdraw And Redeem Semantics
 
+### Native-Asset User Flows
+
+Native hosted vaults use the ERC-7535-style entry surface for asset-in flows.
+
+#### `depositNative(receiver)`
+
+- caller sends raw native asset as `msg.value`
+- shares are minted from the same fee/limit/pause logic used by hosted
+  `deposit`
+- the vault asset remains the sentinel address, not wrapped native token state
+
+#### `mintNative(shares, receiver)`
+
+- caller requests exact `shares`
+- the vault computes the gross native assets required under current fee logic
+- `msg.value` must equal that required gross amount exactly
+- underpayment reverts
+- overpayment also reverts
+- no refund path, excess credit, or donation semantics are supported
+
+#### `withdraw(assets)` and `redeem(shares)` in native mode
+
+- user exits remain on the standard ERC-4626 core facet
+- payouts are sent as raw native asset
+- if idle liquidity is short, the vault may auto-pull immediately withdrawable
+  native liquidity from strategy before paying the receiver
+
+## Native-Asset Accounting And Safety Assumptions
+
+Hosted native vaults still use tracked managed assets rather than raw
+`address(this).balance`.
+
+Implications:
+- force-sent ETH does not increase `totalManagedAssets()`
+- force-sent ETH does not increase share price through `totalAssets()` pricing
+- force-sent ETH does not increase hosted `maxWithdraw()` or `maxRedeem()`
+- if a native exit is satisfied partly or fully from untracked force-sent ETH,
+  book accounting only burns the tracked portion of assets
+
+This is an explicit safety choice:
+- untracked native surplus is treated as non-canonical balance
+- native integrators should not rely on arbitrary ETH transfers into the vault
+  to represent managed assets
+- the vault does not attempt to reconcile unsolicited ETH into strategy debt or
+  book value automatically
+
 `withdraw(assets)` and `redeem(shares)` remain core-facet entrypoints, but they
 are strategy-aware.
 
@@ -239,6 +314,8 @@ are strategy-aware.
   pricing and limit shaping
 - `maxWithdraw()` and `maxRedeem()` are bounded by immediate liquidity, not by
   total mark-to-market assets alone
+- in native mode, immediate liquidity excludes untracked force-sent ETH above
+  tracked idle assets
 - `maxWithdraw()` and `maxRedeem()` are zero when `totalAssets() == 0`, even if
   residual dust shares still exist after a full loss event
 
@@ -249,6 +326,8 @@ For the supported hosted vault deployment:
 - `diamondCut` is owned by `DiamondCutFacet`
 - loupe and ownership-introspection selectors are owned by `DiamondLoupeFacet`
 - core selectors are owned by `ERC4626VaultFacet`
+- native selectors are owned by `ERC7535VaultFacet` when native mode is
+  installed
 - controls selectors and `supportsInterface(bytes4)` are owned by
   `ERC4626VaultControlsFacet`
 - integration selectors are owned by `ERC4626VaultIntegrationFacet`
@@ -257,6 +336,8 @@ One important implication:
 
 - support for `IERC4626VaultFacet` and `IERC4626VaultIntegrationFacet` is
   reported through the controls facet
+- support for `IERC7535VaultFacet` is only reported when native selectors are
+  installed
 - those interface IDs are only reported when the corresponding core or
   integration selectors are installed
 
@@ -282,6 +363,7 @@ Current hardening coverage explicitly validates persistence for:
 Reference local deployment flow:
 
 - `script/DeployDiamondVaultHost.s.sol`
+- `script/DeployDiamondNativeVaultHost.s.sol`
 
 Reference deployment-backed validation:
 
@@ -291,6 +373,8 @@ Reference deployment-backed validation:
 - `test/VaultStrategyFoundationCore.t.sol`
 - `test/DiamondVaultHostHardening.t.sol`
 - `test/DiamondVaultHostInvariant.t.sol`
+- `test/DiamondNativeVaultHostHardening.t.sol`
+- `test/DiamondNativeVaultHostInvariant.t.sol`
 
 ## Out Of Scope
 
@@ -299,4 +383,6 @@ The current hosted strategy model does not include:
 - multi-strategy allocation
 - async or queued withdrawals
 - automatic harvest or keeper-driven execution
+- wrapping native balances into WETH or another canonical ERC-20 asset inside
+  the hosted vault
 - extension-standard work deferred to `#24 Advanced Extensions`

--- a/script/DeployDiamondNativeVaultHost.s.sol
+++ b/script/DeployDiamondNativeVaultHost.s.sol
@@ -12,27 +12,30 @@ import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControl
 import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
 import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
 import {IERC4626VaultStrategy} from "../src/interfaces/IERC4626VaultStrategy.sol";
+import {IERC7535VaultFacet} from "../src/interfaces/IERC7535VaultFacet.sol";
 import {IOracleAdapter} from "../src/interfaces/IOracleAdapter.sol";
 import {ERC4626VaultControlsFacet} from "../src/vault/facets/ERC4626VaultControlsFacet.sol";
 import {ERC4626VaultFacet} from "../src/vault/facets/ERC4626VaultFacet.sol";
 import {ERC4626VaultIntegrationFacet} from "../src/vault/facets/ERC4626VaultIntegrationFacet.sol";
+import {ERC7535VaultFacet} from "../src/vault/facets/ERC7535VaultFacet.sol";
+import {LibVaultAsset} from "../src/vault/libraries/LibVaultAsset.sol";
 import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {DiamondVaultHostScriptBase} from "./common/DiamondVaultHostScriptBase.sol";
 import {
-    LocalHappyPathVaultStrategy,
-    LocalMintableVaultAsset,
     LocalMockOracleFeed,
+    LocalNativeHappyPathVaultStrategy,
     LocalOracleAdapterHarness
 } from "./mocks/LocalVaultDeploymentMocks.sol";
 
-/// @title DeployDiamondVaultHostScript
-/// @notice Reference local deployment flow for the hosted vault diamond.
-contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
-    struct VaultHostDeploymentState {
+/// @title DeployDiamondNativeVaultHostScript
+/// @notice Reference local deployment flow for the native hosted vault diamond.
+contract DeployDiamondNativeVaultHostScript is DiamondVaultHostScriptBase {
+    struct NativeVaultHostDeploymentState {
         address diamondAddress;
         address cutFacetAddress;
         address loupeFacetAddress;
         address vaultCoreFacetAddress;
+        address vaultNativeFacetAddress;
         address vaultControlsFacetAddress;
         address vaultIntegrationFacetAddress;
         address vaultAssetAddress;
@@ -41,10 +44,10 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
         address strategyAddress;
     }
 
-    string internal constant VAULT_OBJECT = "diamondVaultHost";
-    string internal constant VAULT_OUTPUT_RELATIVE_PATH = "/deployments/diamond-vault.local.json";
-    string internal constant VAULT_NAME = "Vault Share";
-    string internal constant VAULT_SYMBOL = "vSHARE";
+    string internal constant VAULT_OBJECT = "diamondNativeVaultHost";
+    string internal constant VAULT_OUTPUT_RELATIVE_PATH = "/deployments/diamond-native-vault.local.json";
+    string internal constant VAULT_NAME = "Native Vault Share";
+    string internal constant VAULT_SYMBOL = "nvSHARE";
     uint64 internal constant MAX_STALENESS = 1 hours;
     uint8 internal constant ORACLE_DECIMALS = 8;
     int256 internal constant ORACLE_ANSWER = 100_000_000;
@@ -54,13 +57,14 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
         returns (
             address diamondAddress,
             address vaultCoreFacetAddress,
+            address vaultNativeFacetAddress,
             address vaultControlsFacetAddress,
             address vaultIntegrationFacetAddress
         )
     {
         uint256 deployerPrivateKey = VM.envUint("PRIVATE_KEY");
         address owner = VM.addr(deployerPrivateKey);
-        VaultHostDeploymentState memory state;
+        NativeVaultHostDeploymentState memory state;
 
         VM.startBroadcast(deployerPrivateKey);
 
@@ -84,7 +88,7 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
                 diamondCutFacet: state.cutFacetAddress,
                 diamondLoupeFacet: state.loupeFacetAddress,
                 vaultCoreFacet: state.vaultCoreFacetAddress,
-                vaultNativeFacet: address(0),
+                vaultNativeFacet: state.vaultNativeFacetAddress,
                 vaultControlsFacet: state.vaultControlsFacetAddress,
                 vaultIntegrationFacet: state.vaultIntegrationFacetAddress,
                 vaultAsset: state.vaultAssetAddress,
@@ -96,7 +100,7 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
                 strategyDebt: 0,
                 liveStrategyAssets: 0,
                 strategyEmergencyExit: false,
-                assetMode: "erc20",
+                assetMode: "native",
                 vaultName: VAULT_NAME,
                 vaultSymbol: VAULT_SYMBOL
             })
@@ -104,38 +108,45 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
 
         diamondAddress = state.diamondAddress;
         vaultCoreFacetAddress = state.vaultCoreFacetAddress;
+        vaultNativeFacetAddress = state.vaultNativeFacetAddress;
         vaultControlsFacetAddress = state.vaultControlsFacetAddress;
         vaultIntegrationFacetAddress = state.vaultIntegrationFacetAddress;
     }
 
-    function _deployVaultSupportContracts(VaultHostDeploymentState memory state, address owner)
+    function _deployVaultSupportContracts(NativeVaultHostDeploymentState memory state, address owner)
         internal
-        returns (VaultHostDeploymentState memory)
+        returns (NativeVaultHostDeploymentState memory)
     {
         state.vaultCoreFacetAddress = address(new ERC4626VaultFacet());
+        state.vaultNativeFacetAddress = address(new ERC7535VaultFacet());
         state.vaultControlsFacetAddress = address(new ERC4626VaultControlsFacet());
         state.vaultIntegrationFacetAddress = address(new ERC4626VaultIntegrationFacet());
-        state.vaultAssetAddress = address(new LocalMintableVaultAsset("Mock USD", "mUSD", 6));
+        state.vaultAssetAddress = LibVaultAsset.NATIVE_ASSET_SENTINEL;
         state.oracleFeedAddress = address(new LocalMockOracleFeed(ORACLE_DECIMALS, ORACLE_ANSWER, block.timestamp - 1));
         state.oracleAdapterAddress =
             address(new LocalOracleAdapterHarness(owner, state.oracleFeedAddress, MAX_STALENESS));
-        state.strategyAddress = address(new LocalHappyPathVaultStrategy(state.diamondAddress, state.vaultAssetAddress));
+        state.strategyAddress = address(new LocalNativeHappyPathVaultStrategy(state.diamondAddress));
         return state;
     }
 
-    function _installVaultHostFacets(VaultHostDeploymentState memory state) internal {
-        IDiamondCut.FacetCut[] memory vaultCut = new IDiamondCut.FacetCut[](3);
+    function _installVaultHostFacets(NativeVaultHostDeploymentState memory state) internal {
+        IDiamondCut.FacetCut[] memory vaultCut = new IDiamondCut.FacetCut[](4);
         vaultCut[0] = IDiamondCut.FacetCut({
             facetAddress: state.vaultCoreFacetAddress,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: LibVaultFacetSelectors.vaultCoreSelectors()
         });
         vaultCut[1] = IDiamondCut.FacetCut({
+            facetAddress: state.vaultNativeFacetAddress,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultNativeSelectors()
+        });
+        vaultCut[2] = IDiamondCut.FacetCut({
             facetAddress: state.vaultControlsFacetAddress,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: LibVaultFacetSelectors.vaultControlsSelectors()
         });
-        vaultCut[2] = IDiamondCut.FacetCut({
+        vaultCut[3] = IDiamondCut.FacetCut({
             facetAddress: state.vaultIntegrationFacetAddress,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: LibVaultFacetSelectors.vaultIntegrationSelectors()
@@ -143,7 +154,7 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
         IDiamondCut(state.diamondAddress).diamondCut(vaultCut, address(0), "");
     }
 
-    function _validateVaultHost(VaultHostDeploymentState memory state, address owner) internal view {
+    function _validateVaultHost(NativeVaultHostDeploymentState memory state, address owner) internal view {
         _validateDiamondCore(state.diamondAddress, owner, state.cutFacetAddress, state.loupeFacetAddress);
 
         IDiamondLoupe loupe = IDiamondLoupe(state.diamondAddress);
@@ -153,99 +164,125 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
         IERC4626VaultStrategy strategy = IERC4626VaultStrategy(state.strategyAddress);
         address[] memory facetAddresses = loupe.facetAddresses();
 
-        require(facetAddresses.length == 5, "vault host facet count mismatch");
-        require(_containsAddress(facetAddresses, state.cutFacetAddress), "vault host missing cut facet");
-        require(_containsAddress(facetAddresses, state.loupeFacetAddress), "vault host missing loupe facet");
-        require(_containsAddress(facetAddresses, state.vaultCoreFacetAddress), "vault host missing core facet");
-        require(_containsAddress(facetAddresses, state.vaultControlsFacetAddress), "vault host missing controls facet");
+        require(facetAddresses.length == 6, "native vault host facet count mismatch");
+        require(_containsAddress(facetAddresses, state.cutFacetAddress), "native vault host missing cut facet");
+        require(_containsAddress(facetAddresses, state.loupeFacetAddress), "native vault host missing loupe facet");
+        require(_containsAddress(facetAddresses, state.vaultCoreFacetAddress), "native vault host missing core facet");
         require(
-            _containsAddress(facetAddresses, state.vaultIntegrationFacetAddress), "vault host missing integration facet"
+            _containsAddress(facetAddresses, state.vaultNativeFacetAddress), "native vault host missing native facet"
+        );
+        require(
+            _containsAddress(facetAddresses, state.vaultControlsFacetAddress),
+            "native vault host missing controls facet"
+        );
+        require(
+            _containsAddress(facetAddresses, state.vaultIntegrationFacetAddress),
+            "native vault host missing integration facet"
         );
 
         require(
             loupe.facetFunctionSelectors(state.vaultCoreFacetAddress).length
                 == LibVaultFacetSelectors.vaultCoreSelectors().length,
-            "vault host core selector count mismatch"
+            "native vault host core selector count mismatch"
+        );
+        require(
+            loupe.facetFunctionSelectors(state.vaultNativeFacetAddress).length
+                == LibVaultFacetSelectors.vaultNativeSelectors().length,
+            "native vault host native selector count mismatch"
         );
         require(
             loupe.facetFunctionSelectors(state.vaultControlsFacetAddress).length
                 == LibVaultFacetSelectors.vaultControlsSelectors().length,
-            "vault host controls selector count mismatch"
+            "native vault host controls selector count mismatch"
         );
         require(
             loupe.facetFunctionSelectors(state.vaultIntegrationFacetAddress).length
                 == LibVaultFacetSelectors.vaultIntegrationSelectors().length,
-            "vault host integration selector count mismatch"
+            "native vault host integration selector count mismatch"
         );
 
-        require(vaultCore.isVaultInitialized(), "vault host not initialized");
-        require(vaultCore.asset() == state.vaultAssetAddress, "vault host asset mismatch");
+        require(vaultCore.isVaultInitialized(), "native vault host not initialized");
+        require(vaultCore.asset() == state.vaultAssetAddress, "native vault host asset mismatch");
         require(
             keccak256(bytes(IERC20Metadata(state.diamondAddress).name())) == keccak256(bytes(VAULT_NAME)),
-            "vault name mismatch"
+            "native vault name mismatch"
         );
         require(
             keccak256(bytes(IERC20Metadata(state.diamondAddress).symbol())) == keccak256(bytes(VAULT_SYMBOL)),
-            "vault symbol mismatch"
+            "native vault symbol mismatch"
         );
-        require(vaultControls.hasRole(vaultControls.DEFAULT_ADMIN_ROLE(), owner), "vault default admin missing");
-        require(vaultControls.hasRole(vaultControls.PAUSER_ROLE(), owner), "vault pauser missing");
-        require(vaultControls.hasRole(vaultControls.VAULT_MANAGER_ROLE(), owner), "vault manager missing");
+        require(vaultControls.hasRole(vaultControls.DEFAULT_ADMIN_ROLE(), owner), "native vault default admin missing");
+        require(vaultControls.hasRole(vaultControls.PAUSER_ROLE(), owner), "native vault pauser missing");
+        require(vaultControls.hasRole(vaultControls.VAULT_MANAGER_ROLE(), owner), "native vault manager missing");
 
         (,, address feeRecipient) = vaultControls.feeConfig();
-        require(feeRecipient == owner, "vault fee recipient mismatch");
+        require(feeRecipient == owner, "native vault fee recipient mismatch");
 
-        require(vaultIntegration.oracleAdapter() == state.oracleAdapterAddress, "vault oracle adapter mismatch");
-        require(vaultIntegration.strategy() == state.strategyAddress, "vault strategy mismatch");
-        require(vaultIntegration.strategyDebt() == 0, "vault strategy debt should be zero");
-        require(!vaultIntegration.strategyEmergencyExit(), "vault emergency exit should be inactive");
-        require(vaultIntegration.liveStrategyAssets() == 0, "vault live strategy assets should be zero");
-        require(strategy.vault() == state.diamondAddress, "strategy vault binding mismatch");
-        require(strategy.asset() == state.vaultAssetAddress, "strategy asset binding mismatch");
+        require(vaultIntegration.oracleAdapter() == state.oracleAdapterAddress, "native vault oracle adapter mismatch");
+        require(vaultIntegration.strategy() == state.strategyAddress, "native vault strategy mismatch");
+        require(vaultIntegration.strategyDebt() == 0, "native vault strategy debt should be zero");
+        require(!vaultIntegration.strategyEmergencyExit(), "native vault emergency exit should be inactive");
+        require(vaultIntegration.liveStrategyAssets() == 0, "native vault live strategy assets should be zero");
+        require(strategy.vault() == state.diamondAddress, "native strategy vault binding mismatch");
+        require(strategy.asset() == state.vaultAssetAddress, "native strategy asset binding mismatch");
 
         IOracleAdapter.OracleQuote memory quotePayload = vaultIntegration.oracleQuote();
-        require(quotePayload.value == ORACLE_ANSWER, "vault quote value mismatch");
-        require(quotePayload.decimals == ORACLE_DECIMALS, "vault quote decimals mismatch");
-        require(quotePayload.updatedAt != 0, "vault quote timestamp missing");
+        require(quotePayload.value == ORACLE_ANSWER, "native vault quote value mismatch");
+        require(quotePayload.decimals == ORACLE_DECIMALS, "native vault quote decimals mismatch");
+        require(quotePayload.updatedAt != 0, "native vault quote timestamp missing");
 
         require(
             IERC165(state.diamondAddress).supportsInterface(type(IERC4626VaultFacet).interfaceId),
-            "vault host missing core interface"
+            "native vault host missing core interface"
+        );
+        require(
+            IERC165(state.diamondAddress).supportsInterface(type(IERC7535VaultFacet).interfaceId),
+            "native vault host missing native interface"
         );
         require(
             IERC165(state.diamondAddress).supportsInterface(type(IERC4626VaultControlsFacet).interfaceId),
-            "vault host missing controls interface"
+            "native vault host missing controls interface"
         );
         require(
             IERC165(state.diamondAddress).supportsInterface(type(IERC4626VaultIntegrationFacet).interfaceId),
-            "vault host missing integration interface"
+            "native vault host missing integration interface"
         );
 
-        _requireSelectorOwner(loupe, DiamondCutFacet.diamondCut.selector, state.cutFacetAddress, "vault cut owner");
-        _requireSelectorOwner(loupe, DiamondLoupeFacet.facets.selector, state.loupeFacetAddress, "vault loupe owner");
         _requireSelectorOwner(
-            loupe, IERC4626VaultFacet.initializeVault.selector, state.vaultCoreFacetAddress, "vault init owner"
+            loupe, DiamondCutFacet.diamondCut.selector, state.cutFacetAddress, "native vault cut owner"
+        );
+        _requireSelectorOwner(
+            loupe, DiamondLoupeFacet.facets.selector, state.loupeFacetAddress, "native vault loupe owner"
+        );
+        _requireSelectorOwner(
+            loupe, IERC4626VaultFacet.initializeVault.selector, state.vaultCoreFacetAddress, "native vault init owner"
+        );
+        _requireSelectorOwner(
+            loupe,
+            IERC7535VaultFacet.depositNative.selector,
+            state.vaultNativeFacetAddress,
+            "native vault deposit owner"
         );
         _requireSelectorOwner(
             loupe,
             IERC4626VaultControls.VAULT_MANAGER_ROLE.selector,
             state.vaultControlsFacetAddress,
-            "vault manager owner"
+            "native vault manager owner"
         );
         _requireSelectorOwner(
             loupe,
             IERC4626VaultIntegrationFacet.oracleAdapter.selector,
             state.vaultIntegrationFacetAddress,
-            "vault oracle owner"
+            "native vault oracle owner"
         );
         _requireSelectorOwner(
             loupe,
             IERC4626VaultIntegrationFacet.deployToStrategy.selector,
             state.vaultIntegrationFacetAddress,
-            "vault deploy strategy owner"
+            "native vault deploy strategy owner"
         );
         _requireSelectorOwner(
-            loupe, IERC165.supportsInterface.selector, state.vaultControlsFacetAddress, "vault erc165 owner"
+            loupe, IERC165.supportsInterface.selector, state.vaultControlsFacetAddress, "native vault erc165 owner"
         );
     }
 

--- a/script/common/DiamondVaultHostScriptBase.sol
+++ b/script/common/DiamondVaultHostScriptBase.sol
@@ -18,6 +18,7 @@ abstract contract DiamondVaultHostScriptBase is DiamondCoreScriptBase {
         address diamondCutFacet;
         address diamondLoupeFacet;
         address vaultCoreFacet;
+        address vaultNativeFacet;
         address vaultControlsFacet;
         address vaultIntegrationFacet;
         address vaultAsset;
@@ -29,6 +30,7 @@ abstract contract DiamondVaultHostScriptBase is DiamondCoreScriptBase {
         uint256 strategyDebt;
         uint256 liveStrategyAssets;
         bool strategyEmergencyExit;
+        string assetMode;
         string vaultName;
         string vaultSymbol;
     }
@@ -86,6 +88,7 @@ abstract contract DiamondVaultHostScriptBase is DiamondCoreScriptBase {
         json = VM.serializeAddress(objectKey, "diamondCutFacet", artifact.diamondCutFacet);
         json = VM.serializeAddress(objectKey, "diamondLoupeFacet", artifact.diamondLoupeFacet);
         json = VM.serializeAddress(objectKey, "vaultCoreFacet", artifact.vaultCoreFacet);
+        json = VM.serializeAddress(objectKey, "vaultNativeFacet", artifact.vaultNativeFacet);
         json = VM.serializeAddress(objectKey, "vaultControlsFacet", artifact.vaultControlsFacet);
         json = VM.serializeAddress(objectKey, "vaultIntegrationFacet", artifact.vaultIntegrationFacet);
         json = VM.serializeAddress(objectKey, "vaultAsset", artifact.vaultAsset);
@@ -95,6 +98,7 @@ abstract contract DiamondVaultHostScriptBase is DiamondCoreScriptBase {
         json = VM.serializeUint(objectKey, "strategyDebt", artifact.strategyDebt);
         json = VM.serializeUint(objectKey, "liveStrategyAssets", artifact.liveStrategyAssets);
         json = VM.serializeBool(objectKey, "strategyEmergencyExit", artifact.strategyEmergencyExit);
+        json = VM.serializeString(objectKey, "assetMode", artifact.assetMode);
         json = VM.serializeString(objectKey, "vaultName", artifact.vaultName);
         json = VM.serializeString(objectKey, "vaultSymbol", artifact.vaultSymbol);
         VM.writeJson(json, string.concat(VM.projectRoot(), outputRelativePath));

--- a/script/mocks/LocalVaultDeploymentMocks.sol
+++ b/script/mocks/LocalVaultDeploymentMocks.sol
@@ -5,6 +5,7 @@ import {IERC20Metadata} from "../../src/interfaces/IERC20Metadata.sol";
 import {IOracleFeed} from "../../src/interfaces/IOracleFeed.sol";
 import {IERC4626VaultStrategy} from "../../src/interfaces/IERC4626VaultStrategy.sol";
 import {OracleAdapter} from "../../src/oracle/OracleAdapter.sol";
+import {LibVaultAsset} from "../../src/vault/libraries/LibVaultAsset.sol";
 
 /// @title LocalMintableVaultAsset
 /// @notice Minimal mintable ERC20 used for local hosted-vault deployment rehearsal.
@@ -192,6 +193,75 @@ contract LocalHappyPathVaultStrategy is IERC4626VaultStrategy {
         }
 
         LocalMintableVaultAsset(ASSET).mint(address(this), assets);
+        _trackedAssets += assets;
+    }
+}
+
+/// @title LocalNativeHappyPathVaultStrategy
+/// @notice Simple native vault-bound strategy used for local hosted-vault deployment and smoke flows.
+contract LocalNativeHappyPathVaultStrategy is IERC4626VaultStrategy {
+    address internal immutable VAULT;
+    uint256 internal _trackedAssets;
+
+    constructor(address vault_) {
+        VAULT = vault_;
+    }
+
+    receive() external payable {}
+
+    modifier onlyVault() {
+        if (msg.sender != VAULT) {
+            revert ERC4626VaultStrategyOnlyVault(msg.sender, VAULT);
+        }
+        _;
+    }
+
+    function vault() external view returns (address) {
+        return VAULT;
+    }
+
+    function asset() external pure returns (address) {
+        return LibVaultAsset.NATIVE_ASSET_SENTINEL;
+    }
+
+    function totalAssets() external view returns (uint256) {
+        return _trackedAssets;
+    }
+
+    function maxWithdrawableAssets() external view returns (uint256) {
+        return _trackedAssets;
+    }
+
+    function deployFunds(uint256 assets) external onlyVault {
+        _trackedAssets += assets;
+        require(address(this).balance >= _trackedAssets, "STRATEGY_UNDERFUNDED");
+    }
+
+    function withdrawToVault(uint256 assets) external onlyVault returns (uint256 assetsReturned) {
+        assetsReturned = assets > _trackedAssets ? _trackedAssets : assets;
+        _trackedAssets -= assetsReturned;
+        if (assetsReturned != 0) {
+            (bool success,) = payable(VAULT).call{value: assetsReturned}("");
+            require(success, "STRATEGY_TRANSFER_FAILED");
+        }
+    }
+
+    function withdrawAllToVault() external onlyVault returns (uint256 assetsReturned) {
+        assetsReturned = _trackedAssets;
+        _trackedAssets = 0;
+        if (assetsReturned != 0) {
+            (bool success,) = payable(VAULT).call{value: assetsReturned}("");
+            require(success, "STRATEGY_TRANSFER_FAILED");
+        }
+    }
+
+    function injectProfit(uint256 assets) external payable {
+        if (assets == 0) {
+            require(msg.value == 0, "STRATEGY_PROFIT_VALUE_MISMATCH");
+            return;
+        }
+
+        require(msg.value == assets, "STRATEGY_PROFIT_VALUE_MISMATCH");
         _trackedAssets += assets;
     }
 }

--- a/scripts/auralis-activity.sh
+++ b/scripts/auralis-activity.sh
@@ -12,6 +12,9 @@ vault_diamond="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.diamond)"
 vault_asset="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.vaultAsset)"
 oracle_feed="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.oracleFeed)"
 strategy="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.strategy)"
+native_vault_diamond="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" nativeVaultHost.diamond)"
+native_oracle_feed="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" nativeVaultHost.oracleFeed)"
+native_strategy="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" nativeVaultHost.strategy)"
 
 now_ts="$(date +%s)"
 
@@ -59,11 +62,38 @@ cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_
 cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
   "${vault_diamond}" "unpause()" >/dev/null
 
+auralis_note "Generating native vault and strategy activity"
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_ALICE_PRIVATE_KEY}" --value 1250000000000000000 \
+  "${native_vault_diamond}" "depositNative(address)(uint256)" "${AURALIS_ALICE_ADDRESS}" >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${native_vault_diamond}" "deployToStrategy(uint256)" 750000000000000000 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" --value 125000000000000000 \
+  "${native_strategy}" "injectProfit(uint256)" 125000000000000000 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${native_vault_diamond}" "syncStrategyAssets()" >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${native_vault_diamond}" "withdrawFromStrategy(uint256)(uint256)" 200000000000000000 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_ALICE_PRIVATE_KEY}" \
+  "${native_vault_diamond}" "transfer(address,uint256)" "${AURALIS_OWNER_ADDRESS}" 250000000000000000 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${native_vault_diamond}" "redeem(uint256,address,address)(uint256)" 100000000000000000 "${AURALIS_OWNER_ADDRESS}" "${AURALIS_OWNER_ADDRESS}" >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${native_oracle_feed}" "setRoundData(int256,uint256)" 102000000 "${now_ts}" >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${native_vault_diamond}" "pause()" >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${native_vault_diamond}" "unpause()" >/dev/null
+
 idle_assets="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "idleAssets()(uint256)" | awk '{print $1}')"
 strategy_debt="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "strategyDebt()(uint256)" | awk '{print $1}')"
 live_strategy_assets="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "liveStrategyAssets()(uint256)" | awk '{print $1}')"
 total_assets="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "totalAssets()(uint256)" | awk '{print $1}')"
 quote_tuple="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "oracleQuote()((int256,uint64,uint8))")"
+native_idle_assets="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${native_vault_diamond}" "idleAssets()(uint256)" | awk '{print $1}')"
+native_strategy_debt="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${native_vault_diamond}" "strategyDebt()(uint256)" | awk '{print $1}')"
+native_live_strategy_assets="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${native_vault_diamond}" "liveStrategyAssets()(uint256)" | awk '{print $1}')"
+native_total_assets="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${native_vault_diamond}" "totalAssets()(uint256)" | awk '{print $1}')"
+native_quote_tuple="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${native_vault_diamond}" "oracleQuote()((int256,uint64,uint8))")"
 
 cat <<MSG
 Auralis simulated activity complete.
@@ -74,5 +104,11 @@ Live strategy assets: ${live_strategy_assets}
 Total assets: ${total_assets}
 Oracle quote tuple: ${quote_tuple}
 
-The local chain now has representative token, NFT, vault, oracle, and live strategy lifecycle activity.
+Native idle assets: ${native_idle_assets}
+Native strategy debt: ${native_strategy_debt}
+Native live strategy assets: ${native_live_strategy_assets}
+Native total assets: ${native_total_assets}
+Native oracle quote tuple: ${native_quote_tuple}
+
+The local chain now has representative token, NFT, ERC20 vault, native vault, oracle, and live strategy lifecycle activity.
 MSG

--- a/scripts/auralis-smoke.sh
+++ b/scripts/auralis-smoke.sh
@@ -9,11 +9,35 @@ auralis_require_artifact
 erc20_diamond="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" erc20Host.diamond)"
 erc721_diamond="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" erc721Host.diamond)"
 vault_diamond="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.diamond)"
+vault_asset_mode="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.assetMode)"
 vault_asset="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.vaultAsset)"
 oracle_adapter="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.oracleAdapter)"
 strategy="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.strategy)"
+native_vault_diamond="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" nativeVaultHost.diamond)"
+native_vault_asset_mode="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" nativeVaultHost.assetMode)"
+native_vault_native_facet="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" nativeVaultHost.vaultNativeFacet)"
+native_oracle_adapter="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" nativeVaultHost.oracleAdapter)"
+native_strategy="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" nativeVaultHost.strategy)"
+
+if [[ "${vault_asset_mode}" != "erc20" ]]; then
+  echo "Expected vaultHost.assetMode to be erc20, got ${vault_asset_mode}." >&2
+  exit 1
+fi
+
+if [[ "${native_vault_asset_mode}" != "native" ]]; then
+  echo "Expected nativeVaultHost.assetMode to be native, got ${native_vault_asset_mode}." >&2
+  exit 1
+fi
 
 for address in "${erc20_diamond}" "${erc721_diamond}" "${vault_diamond}" "${vault_asset}" "${oracle_adapter}" "${strategy}"; do
+  code="$(cast code --rpc-url "${AURALIS_RPC_URL}" "${address}")"
+  if [[ "${code}" == "0x" ]]; then
+    echo "Expected deployed code at ${address}, found empty code." >&2
+    exit 1
+  fi
+done
+
+for address in "${native_vault_diamond}" "${native_vault_native_facet}" "${native_oracle_adapter}" "${native_strategy}"; do
   code="$(cast code --rpc-url "${AURALIS_RPC_URL}" "${address}")"
   if [[ "${code}" == "0x" ]]; then
     echo "Expected deployed code at ${address}, found empty code." >&2
@@ -85,6 +109,47 @@ fi
 quote_tuple="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "oracleQuote()((int256,uint64,uint8))")"
 if [[ -z "${quote_tuple}" ]]; then
   echo "oracleQuote() returned empty output." >&2
+  exit 1
+fi
+
+auralis_note "Native vault host smoke: strategy-enabled lifecycle"
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_ALICE_PRIVATE_KEY}" --value 1000000000000000000 \
+  "${native_vault_diamond}" "depositNative(address)(uint256)" "${AURALIS_ALICE_ADDRESS}" >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${native_vault_diamond}" "deployToStrategy(uint256)" 600000000000000000 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" --value 100000000000000000 \
+  "${native_strategy}" "injectProfit(uint256)" 100000000000000000 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${native_vault_diamond}" "syncStrategyAssets()" >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${native_vault_diamond}" "withdrawFromStrategy(uint256)(uint256)" 150000000000000000 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_ALICE_PRIVATE_KEY}" \
+  "${native_vault_diamond}" "withdraw(uint256,address,address)(uint256)" 700000000000000000 "${AURALIS_ALICE_ADDRESS}" "${AURALIS_ALICE_ADDRESS}" >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${native_vault_diamond}" "emergencyExitStrategy()(uint256)" >/dev/null
+
+native_strategy_debt="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${native_vault_diamond}" "strategyDebt()(uint256)" | awk '{print $1}')"
+native_strategy_exit="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${native_vault_diamond}" "strategyEmergencyExit()(bool)")"
+if [[ "${native_strategy_debt}" != "0" || "${native_strategy_exit}" != "true" ]]; then
+  echo "Unexpected native strategy state after emergency exit: debt=${native_strategy_debt}, emergency=${native_strategy_exit}" >&2
+  exit 1
+fi
+
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${native_vault_diamond}" "setStrategy(address)" 0x0000000000000000000000000000000000000000 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${native_vault_diamond}" "setStrategy(address)" "${native_strategy}" >/dev/null
+
+native_strategy_rebound="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${native_vault_diamond}" "strategy()(address)")"
+native_strategy_exit="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${native_vault_diamond}" "strategyEmergencyExit()(bool)")"
+if [[ "${native_strategy_rebound,,}" != "${native_strategy,,}" || "${native_strategy_exit}" != "false" ]]; then
+  echo "Native strategy was not rebound cleanly after smoke flow." >&2
+  exit 1
+fi
+
+native_quote_tuple="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${native_vault_diamond}" "oracleQuote()((int256,uint64,uint8))")"
+if [[ -z "${native_quote_tuple}" ]]; then
+  echo "native oracleQuote() returned empty output." >&2
   exit 1
 fi
 

--- a/scripts/auralis-up.sh
+++ b/scripts/auralis-up.sh
@@ -8,7 +8,7 @@ auralis_start_anvil_if_needed
 auralis_remove_artifacts
 
 auralis_note "Funding local actor accounts"
-auralis_fund_actor "${AURALIS_ALICE_ADDRESS}"
+auralis_fund_actor "${AURALIS_ALICE_ADDRESS}" 10000000000000000000
 
 auralis_note "Deploying ERC20 host"
 (
@@ -28,10 +28,17 @@ auralis_note "Deploying strategy-enabled vault host"
   forge script script/DeployDiamondVaultHost.s.sol:DeployDiamondVaultHostScript --rpc-url "${AURALIS_RPC_URL}" --broadcast
 )
 
+auralis_note "Deploying native strategy-enabled vault host"
+(
+  cd "${AURALIS_ROOT}"
+  forge script script/DeployDiamondNativeVaultHost.s.sol:DeployDiamondNativeVaultHostScript --rpc-url "${AURALIS_RPC_URL}" --broadcast
+)
+
 auralis_note "Writing unified Auralis artifact"
 auralis_write_unified_artifact
 
 vault_strategy="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.strategy)"
+native_vault_strategy="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" nativeVaultHost.strategy)"
 
 cat <<MSG
 Auralis local environment is ready.
@@ -41,6 +48,7 @@ Artifact: ${AURALIS_ARTIFACT_PATH}
 Owner: ${AURALIS_OWNER_ADDRESS}
 Alice: ${AURALIS_ALICE_ADDRESS}
 Vault strategy: ${vault_strategy}
+Native vault strategy: ${native_vault_strategy}
 
 Next steps:
 - bash scripts/auralis-smoke.sh

--- a/scripts/lib/auralis.sh
+++ b/scripts/lib/auralis.sh
@@ -7,6 +7,7 @@ AURALIS_ARTIFACT_PATH="${AURALIS_DEPLOYMENTS_DIR}/auralis.local.json"
 AURALIS_ERC20_ARTIFACT_PATH="${AURALIS_DEPLOYMENTS_DIR}/diamond-erc20.local.json"
 AURALIS_ERC721_ARTIFACT_PATH="${AURALIS_DEPLOYMENTS_DIR}/diamond-erc721.local.json"
 AURALIS_VAULT_ARTIFACT_PATH="${AURALIS_DEPLOYMENTS_DIR}/diamond-vault.local.json"
+AURALIS_NATIVE_VAULT_ARTIFACT_PATH="${AURALIS_DEPLOYMENTS_DIR}/diamond-native-vault.local.json"
 AURALIS_ANVIL_PID_PATH="${AURALIS_STATE_DIR}/anvil.pid"
 AURALIS_ANVIL_LOG_PATH="${ANVIL_LOG_PATH:-${AURALIS_STATE_DIR}/anvil.log}"
 AURALIS_OWNER_PRIVATE_KEY="${PRIVATE_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}"
@@ -122,11 +123,12 @@ auralis_remove_artifacts() {
     "${AURALIS_ARTIFACT_PATH}" \
     "${AURALIS_ERC20_ARTIFACT_PATH}" \
     "${AURALIS_ERC721_ARTIFACT_PATH}" \
-    "${AURALIS_VAULT_ARTIFACT_PATH}"
+    "${AURALIS_VAULT_ARTIFACT_PATH}" \
+    "${AURALIS_NATIVE_VAULT_ARTIFACT_PATH}"
 }
 
 auralis_write_unified_artifact() {
-  python3 - "${AURALIS_ERC20_ARTIFACT_PATH}" "${AURALIS_ERC721_ARTIFACT_PATH}" "${AURALIS_VAULT_ARTIFACT_PATH}" "${AURALIS_ARTIFACT_PATH}" "${AURALIS_RPC_URL}" "${AURALIS_OWNER_ADDRESS}" "${AURALIS_ALICE_ADDRESS}" <<'PY'
+  python3 - "${AURALIS_ERC20_ARTIFACT_PATH}" "${AURALIS_ERC721_ARTIFACT_PATH}" "${AURALIS_VAULT_ARTIFACT_PATH}" "${AURALIS_NATIVE_VAULT_ARTIFACT_PATH}" "${AURALIS_ARTIFACT_PATH}" "${AURALIS_RPC_URL}" "${AURALIS_OWNER_ADDRESS}" "${AURALIS_ALICE_ADDRESS}" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -134,10 +136,11 @@ from pathlib import Path
 erc20 = json.load(open(sys.argv[1], 'r', encoding='utf-8'))
 erc721 = json.load(open(sys.argv[2], 'r', encoding='utf-8'))
 vault = json.load(open(sys.argv[3], 'r', encoding='utf-8'))
-out_path = Path(sys.argv[4])
-rpc_url = sys.argv[5]
-owner = sys.argv[6]
-alice = sys.argv[7]
+native_vault = json.load(open(sys.argv[4], 'r', encoding='utf-8'))
+out_path = Path(sys.argv[5])
+rpc_url = sys.argv[6]
+owner = sys.argv[7]
+alice = sys.argv[8]
 
 artifact = {
     'project': 'Auralis',
@@ -158,7 +161,11 @@ artifact = {
     },
     'vaultHost': {
         **vault,
-        'label': 'Vault host',
+        'label': 'ERC20 vault host',
+    },
+    'nativeVaultHost': {
+        **native_vault,
+        'label': 'Native vault host',
     },
 }
 
@@ -171,4 +178,3 @@ auralis_fund_actor() {
   local value_wei="${2:-1000000000000000000}"
   cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" --value "${value_wei}" "${recipient}" >/dev/null
 }
-

--- a/src/interfaces/IERC7535VaultFacet.sol
+++ b/src/interfaces/IERC7535VaultFacet.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title IERC7535VaultFacet
+/// @notice Hosted native-asset extension surface for ERC-7535-style vault flows.
+interface IERC7535VaultFacet {
+    /// @notice Deposits native asset and mints shares to `receiver`.
+    /// @param receiver Receiver of minted shares.
+    /// @return shares Minted shares.
+    function depositNative(address receiver) external payable returns (uint256 shares);
+
+    /// @notice Mints `shares` to `receiver` using native asset funding.
+    /// @param shares Share amount.
+    /// @param receiver Receiver of minted shares.
+    /// @return assets Native assets consumed.
+    function mintNative(uint256 shares, address receiver) external payable returns (uint256 assets);
+}

--- a/src/vault/ERC4626Vault.sol
+++ b/src/vault/ERC4626Vault.sol
@@ -170,7 +170,7 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
         }
 
         _burnShares(owner, shares);
-        _decreaseManagedAssets(assets);
+        _decreaseManagedAssetsForAssetExit(assets);
         _safeTransferAsset(receiver, assets);
 
         emit Withdraw(msg.sender, receiver, owner, assets, shares);
@@ -216,7 +216,7 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
         }
 
         _burnShares(owner, shares);
-        _decreaseManagedAssets(assets);
+        _decreaseManagedAssetsForAssetExit(assets);
         _safeTransferAsset(receiver, assets);
 
         emit Withdraw(msg.sender, receiver, owner, assets, shares);
@@ -274,6 +274,26 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
         }
     }
 
+    /// @dev Decreases managed assets for a user exit while ignoring untracked native surplus.
+    /// @dev Forced ETH can increase `address(this).balance` without increasing managed assets. When a native
+    ///      withdrawal is satisfied from that surplus, book accounting must only burn the tracked portion.
+    function _decreaseManagedAssetsForAssetExit(uint256 assets) internal {
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        if (LibVaultAsset.isNativeAsset(layout.asset) && layout.strategyDebt != 0) {
+            uint256 nativeSurplus =
+                LibVaultAsset.balanceOfSelf(layout.asset) - (layout.totalManagedAssets - layout.strategyDebt);
+            if (nativeSurplus >= assets) {
+                return;
+            }
+
+            unchecked {
+                assets -= nativeSurplus;
+            }
+        }
+
+        _decreaseManagedAssets(assets);
+    }
+
     /// @dev Returns the vault's immediately idle asset balance.
     function _idleAssetBalance() internal view returns (uint256) {
         return LibVaultAsset.balanceOfSelf(asset());
@@ -282,7 +302,7 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
     /// @dev Returns the configured strategy's immediately withdrawable assets.
     function _strategyWithdrawableAssets() internal view returns (uint256) {
         LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
-        if (layout.strategy == address(0) || layout.strategyDebt == 0) {
+        if (layout.strategyDebt == 0) {
             return 0;
         }
 

--- a/src/vault/ERC4626Vault.sol
+++ b/src/vault/ERC4626Vault.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.30;
 import {IERC20} from "../interfaces/IERC20.sol";
 import {IERC4626} from "../interfaces/IERC4626.sol";
 import {IERC4626VaultStrategy} from "../interfaces/IERC4626VaultStrategy.sol";
+import {LibNativeAsset} from "./libraries/LibNativeAsset.sol";
 import {LibERC4626VaultStorage} from "./storage/LibERC4626VaultStorage.sol";
 import {ERC4626VaultBase} from "./ERC4626VaultBase.sol";
 
@@ -22,6 +23,12 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
     /// @param requiredAssets The gross asset amount required.
     /// @param availableAssets The currently sourced idle asset amount.
     error ERC4626VaultInsufficientLiquidity(uint256 requiredAssets, uint256 availableAssets);
+    /// @notice Thrown when a native vault requires the hosted native entrypoint.
+    error ERC4626VaultNativeAssetUseNativeEntrypoint();
+    /// @notice Thrown when a native-only entrypoint is used on an ERC-20 vault.
+    error ERC4626VaultNativeAssetDisabled();
+    /// @notice Thrown when `msg.value` does not match the required native asset amount.
+    error ERC4626VaultInvalidNativeAssetValue(uint256 supplied, uint256 required);
 
     /// @notice Returns vault underlying asset token address.
     /// @return The underlying asset token.
@@ -247,7 +254,7 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
     /// @dev Performs ERC-20 transfer and handles optional return values.
     /// @param to Asset receiver.
     /// @param value Asset amount.
-    function _safeTransferAsset(address to, uint256 value) internal {
+    function _safeTransferAsset(address to, uint256 value) internal virtual {
         (bool success, bytes memory data) = asset().call(abi.encodeCall(IERC20.transfer, (to, value)));
         if (!success || (data.length != 0 && !abi.decode(data, (bool)))) {
             revert ERC4626VaultAssetTransferFailed();
@@ -258,7 +265,7 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
     /// @param from Asset sender.
     /// @param to Asset receiver.
     /// @param value Asset amount.
-    function _safeTransferFromAsset(address from, address to, uint256 value) internal {
+    function _safeTransferFromAsset(address from, address to, uint256 value) internal virtual {
         (bool success, bytes memory data) = asset().call(abi.encodeCall(IERC20.transferFrom, (from, to, value)));
         if (!success || (data.length != 0 && !abi.decode(data, (bool)))) {
             revert ERC4626VaultAssetTransferFromFailed();
@@ -267,6 +274,10 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
 
     /// @dev Returns the vault's immediately idle asset balance.
     function _idleAssetBalance() internal view returns (uint256) {
+        if (LibNativeAsset.isNativeAsset(asset())) {
+            return address(this).balance;
+        }
+
         return IERC20(asset()).balanceOf(address(this));
     }
 

--- a/src/vault/ERC4626Vault.sol
+++ b/src/vault/ERC4626Vault.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.30;
 import {IERC20} from "../interfaces/IERC20.sol";
 import {IERC4626} from "../interfaces/IERC4626.sol";
 import {IERC4626VaultStrategy} from "../interfaces/IERC4626VaultStrategy.sol";
-import {LibNativeAsset} from "./libraries/LibNativeAsset.sol";
+import {LibVaultAsset} from "./libraries/LibVaultAsset.sol";
 import {LibERC4626VaultStorage} from "./storage/LibERC4626VaultStorage.sol";
 import {ERC4626VaultBase} from "./ERC4626VaultBase.sol";
 
@@ -255,8 +255,7 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
     /// @param to Asset receiver.
     /// @param value Asset amount.
     function _safeTransferAsset(address to, uint256 value) internal virtual {
-        (bool success, bytes memory data) = asset().call(abi.encodeCall(IERC20.transfer, (to, value)));
-        if (!success || (data.length != 0 && !abi.decode(data, (bool)))) {
+        if (!LibVaultAsset.transferOut(asset(), to, value)) {
             revert ERC4626VaultAssetTransferFailed();
         }
     }
@@ -266,19 +265,18 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
     /// @param to Asset receiver.
     /// @param value Asset amount.
     function _safeTransferFromAsset(address from, address to, uint256 value) internal virtual {
-        (bool success, bytes memory data) = asset().call(abi.encodeCall(IERC20.transferFrom, (from, to, value)));
-        if (!success || (data.length != 0 && !abi.decode(data, (bool)))) {
+        if (LibVaultAsset.isNativeAsset(asset())) {
+            revert ERC4626VaultNativeAssetUseNativeEntrypoint();
+        }
+
+        if (!LibVaultAsset.transferIn(asset(), from, to, value)) {
             revert ERC4626VaultAssetTransferFromFailed();
         }
     }
 
     /// @dev Returns the vault's immediately idle asset balance.
     function _idleAssetBalance() internal view returns (uint256) {
-        if (LibNativeAsset.isNativeAsset(asset())) {
-            return address(this).balance;
-        }
-
-        return IERC20(asset()).balanceOf(address(this));
+        return LibVaultAsset.balanceOfSelf(asset());
     }
 
     /// @dev Returns the configured strategy's immediately withdrawable assets.

--- a/src/vault/ERC4626VaultControlLogic.sol
+++ b/src/vault/ERC4626VaultControlLogic.sol
@@ -118,6 +118,10 @@ abstract contract ERC4626VaultControlledCore is ERC4626Vault {
 
             uint256 remainingAssets = maxTotalAssets_ - currentAssets;
             uint256 capBasedMaxAssets = LibERC4626VaultControlLogic.grossUpForDepositFee(remainingAssets);
+            (uint256 creditedAssets,) = LibERC4626VaultControlLogic.netAfterDepositFee(capBasedMaxAssets);
+            if (creditedAssets > remainingAssets) {
+                capBasedMaxAssets -= 1;
+            }
             if (capBasedMaxAssets < maxAssets) {
                 maxAssets = capBasedMaxAssets;
             }

--- a/src/vault/ERC4626VaultControlLogic.sol
+++ b/src/vault/ERC4626VaultControlLogic.sol
@@ -275,6 +275,67 @@ abstract contract ERC4626VaultControlledCore is ERC4626Vault {
         emit Deposit(msg.sender, receiver, assets, shares);
     }
 
+    function _depositNativeWithControls(address receiver) internal returns (uint256 shares) {
+        _requireInitialized();
+        _requireNonZeroAddress(receiver);
+
+        uint256 assets = msg.value;
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        uint256 maxAssets = maxDeposit(receiver);
+        if (assets > maxAssets) {
+            revert IERC4626VaultControls.ERC4626VaultDepositLimitExceeded(assets, maxAssets);
+        }
+
+        (uint256 netAssets, uint256 feeAssets) = LibERC4626VaultControlLogic.netAfterDepositFee(assets);
+        _enforceTotalAssetsCap(netAssets);
+
+        shares = _convertToShares(netAssets, Rounding.Down);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        _increaseManagedAssets(netAssets);
+        _mintShares(receiver, shares);
+        _payoutFee(feeAssets);
+
+        emit Deposit(msg.sender, receiver, assets, shares);
+    }
+
+    function _mintNativeWithControls(uint256 shares, address receiver) internal returns (uint256 assets) {
+        _requireInitialized();
+        _requireNonZeroAddress(receiver);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        uint256 maxShares = maxMint(receiver);
+        if (shares > maxShares) {
+            revert IERC4626VaultControls.ERC4626VaultMintLimitExceeded(shares, maxShares);
+        }
+
+        uint256 netAssets = _convertToAssets(shares, Rounding.Up);
+        if (netAssets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        assets = LibERC4626VaultControlLogic.grossUpForDepositFee(netAssets);
+        if (msg.value != assets) {
+            revert ERC4626VaultInvalidNativeAssetValue(msg.value, assets);
+        }
+
+        uint256 feeAssets = assets - netAssets;
+
+        _enforceTotalAssetsCap(netAssets);
+        _increaseManagedAssets(netAssets);
+        _mintShares(receiver, shares);
+        _payoutFee(feeAssets);
+
+        emit Deposit(msg.sender, receiver, assets, shares);
+    }
+
     function _withdrawWithControls(uint256 assets, address receiver, address owner) internal returns (uint256 shares) {
         _requireInitialized();
         _requireNonZeroAddress(receiver);

--- a/src/vault/ERC4626VaultControlLogic.sol
+++ b/src/vault/ERC4626VaultControlLogic.sol
@@ -364,7 +364,7 @@ abstract contract ERC4626VaultControlledCore is ERC4626Vault {
         }
 
         _burnShares(owner, shares);
-        _decreaseManagedAssets(grossAssets);
+        _decreaseManagedAssetsForAssetExit(grossAssets);
         _safeTransferAsset(receiver, assets);
         _payoutFee(feeAssets);
 
@@ -396,7 +396,7 @@ abstract contract ERC4626VaultControlledCore is ERC4626Vault {
         }
 
         _burnShares(owner, shares);
-        _decreaseManagedAssets(grossAssets);
+        _decreaseManagedAssetsForAssetExit(grossAssets);
         _safeTransferAsset(receiver, assets);
         _payoutFee(feeAssets);
 

--- a/src/vault/facets/ERC4626VaultControlsFacet.sol
+++ b/src/vault/facets/ERC4626VaultControlsFacet.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.30;
 import {IAccessControl} from "../../interfaces/IAccessControl.sol";
 import {IAccessControlTime} from "../../interfaces/IAccessControlTime.sol";
 import {IERC165} from "../../interfaces/IERC165.sol";
+import {IERC7535VaultFacet} from "../../interfaces/IERC7535VaultFacet.sol";
 import {IERC4626VaultControls} from "../../interfaces/IERC4626VaultControls.sol";
 import {IERC4626VaultControlsFacet} from "../../interfaces/IERC4626VaultControlsFacet.sol";
 import {IERC4626VaultFacet} from "../../interfaces/IERC4626VaultFacet.sol";
@@ -31,6 +32,8 @@ contract ERC4626VaultControlsFacet is ERC4626VaultControlSurface {
             || interfaceId == type(IERC4626VaultControlsFacet).interfaceId
             || (interfaceId == type(IERC4626VaultFacet).interfaceId
                 && LibDiamond.selectorExists(IERC4626VaultFacet.initializeVault.selector))
+            || (interfaceId == type(IERC7535VaultFacet).interfaceId
+                && LibDiamond.selectorExists(IERC7535VaultFacet.depositNative.selector))
             || (interfaceId == type(IERC4626VaultIntegrationFacet).interfaceId
                 && LibDiamond.selectorExists(IERC4626VaultIntegrationFacet.oracleAdapter.selector))
             || interfaceId == type(IAccessControl).interfaceId || interfaceId == type(IAccessControlTime).interfaceId

--- a/src/vault/facets/ERC4626VaultFacet.sol
+++ b/src/vault/facets/ERC4626VaultFacet.sol
@@ -3,19 +3,18 @@ pragma solidity ^0.8.30;
 
 import {IERC4626} from "../../interfaces/IERC4626.sol";
 import {IERC4626VaultControls} from "../../interfaces/IERC4626VaultControls.sol";
-import {IERC7535VaultFacet} from "../../interfaces/IERC7535VaultFacet.sol";
 import {IERC4626VaultFacet} from "../../interfaces/IERC4626VaultFacet.sol";
 import {IERC4626VaultStrategy} from "../../interfaces/IERC4626VaultStrategy.sol";
 import {ERC4626Vault} from "../ERC4626Vault.sol";
 import {ERC4626VaultBase} from "../ERC4626VaultBase.sol";
 import {ERC4626VaultControlledCore, LibERC4626VaultControlLogic} from "../ERC4626VaultControlLogic.sol";
 import {VaultFacetControl} from "../VaultFacetControl.sol";
-import {LibNativeAsset} from "../libraries/LibNativeAsset.sol";
+import {LibVaultAsset} from "../libraries/LibVaultAsset.sol";
 import {LibERC4626VaultStorage} from "../storage/LibERC4626VaultStorage.sol";
 
 /// @title ERC4626VaultFacet
 /// @notice Hosted ERC-4626 core facet with constructor-free initialization.
-contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IERC4626VaultFacet, IERC7535VaultFacet {
+contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IERC4626VaultFacet {
     /// @notice Returns true when vault storage is initialized.
     /// @return True if initialized.
     function isVaultInitialized() public view virtual override(IERC4626VaultFacet, ERC4626VaultBase) returns (bool) {
@@ -66,7 +65,7 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
         nonReentrant
         returns (uint256 shares)
     {
-        if (_isNativeVaultAsset()) {
+        if (LibVaultAsset.isNativeAsset(ERC4626Vault.asset())) {
             revert ERC4626VaultNativeAssetUseNativeEntrypoint();
         }
 
@@ -85,42 +84,11 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
         nonReentrant
         returns (uint256 assets)
     {
-        if (_isNativeVaultAsset()) {
+        if (LibVaultAsset.isNativeAsset(ERC4626Vault.asset())) {
             revert ERC4626VaultNativeAssetUseNativeEntrypoint();
         }
 
         return _mintWithControls(shares, receiver);
-    }
-
-    /// @notice Deposits native asset and mints shares to `receiver`.
-    /// @param receiver Receiver of minted shares.
-    /// @return shares Minted shares.
-    function depositNative(address receiver)
-        external
-        payable
-        virtual
-        whenNotPaused
-        nonReentrant
-        returns (uint256 shares)
-    {
-        _requireNativeVaultAsset();
-        return _depositNativeWithControls(receiver);
-    }
-
-    /// @notice Mints `shares` to `receiver` using native asset funding.
-    /// @param shares Share amount.
-    /// @param receiver Receiver of minted shares.
-    /// @return assets Native assets consumed.
-    function mintNative(uint256 shares, address receiver)
-        external
-        payable
-        virtual
-        whenNotPaused
-        nonReentrant
-        returns (uint256 assets)
-    {
-        _requireNativeVaultAsset();
-        return _mintNativeWithControls(shares, receiver);
     }
 
     /// @notice Withdraws `assets` to `receiver` from `owner`.
@@ -282,39 +250,6 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
             }
 
             idleAssets = nextIdleAssets;
-        }
-    }
-
-    function _safeTransferAsset(address to, uint256 value) internal virtual override {
-        if (_isNativeVaultAsset()) {
-            (bool success,) = payable(to).call{value: value}("");
-            if (!success) {
-                revert ERC4626VaultAssetTransferFailed();
-            }
-            return;
-        }
-
-        super._safeTransferAsset(to, value);
-    }
-
-    function _safeTransferFromAsset(address from, address to, uint256 value) internal virtual override {
-        from;
-        to;
-        value;
-        if (_isNativeVaultAsset()) {
-            revert ERC4626VaultNativeAssetUseNativeEntrypoint();
-        }
-
-        super._safeTransferFromAsset(from, to, value);
-    }
-
-    function _isNativeVaultAsset() internal view returns (bool) {
-        return LibNativeAsset.isNativeAsset(ERC4626Vault.asset());
-    }
-
-    function _requireNativeVaultAsset() internal view {
-        if (!_isNativeVaultAsset()) {
-            revert ERC4626VaultNativeAssetDisabled();
         }
     }
 }

--- a/src/vault/facets/ERC4626VaultFacet.sol
+++ b/src/vault/facets/ERC4626VaultFacet.sol
@@ -3,17 +3,19 @@ pragma solidity ^0.8.30;
 
 import {IERC4626} from "../../interfaces/IERC4626.sol";
 import {IERC4626VaultControls} from "../../interfaces/IERC4626VaultControls.sol";
+import {IERC7535VaultFacet} from "../../interfaces/IERC7535VaultFacet.sol";
 import {IERC4626VaultFacet} from "../../interfaces/IERC4626VaultFacet.sol";
 import {IERC4626VaultStrategy} from "../../interfaces/IERC4626VaultStrategy.sol";
 import {ERC4626Vault} from "../ERC4626Vault.sol";
 import {ERC4626VaultBase} from "../ERC4626VaultBase.sol";
 import {ERC4626VaultControlledCore, LibERC4626VaultControlLogic} from "../ERC4626VaultControlLogic.sol";
 import {VaultFacetControl} from "../VaultFacetControl.sol";
+import {LibNativeAsset} from "../libraries/LibNativeAsset.sol";
 import {LibERC4626VaultStorage} from "../storage/LibERC4626VaultStorage.sol";
 
 /// @title ERC4626VaultFacet
 /// @notice Hosted ERC-4626 core facet with constructor-free initialization.
-contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IERC4626VaultFacet {
+contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IERC4626VaultFacet, IERC7535VaultFacet {
     /// @notice Returns true when vault storage is initialized.
     /// @return True if initialized.
     function isVaultInitialized() public view virtual override(IERC4626VaultFacet, ERC4626VaultBase) returns (bool) {
@@ -64,6 +66,10 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
         nonReentrant
         returns (uint256 shares)
     {
+        if (_isNativeVaultAsset()) {
+            revert ERC4626VaultNativeAssetUseNativeEntrypoint();
+        }
+
         return _depositWithControls(assets, receiver);
     }
 
@@ -79,7 +85,42 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
         nonReentrant
         returns (uint256 assets)
     {
+        if (_isNativeVaultAsset()) {
+            revert ERC4626VaultNativeAssetUseNativeEntrypoint();
+        }
+
         return _mintWithControls(shares, receiver);
+    }
+
+    /// @notice Deposits native asset and mints shares to `receiver`.
+    /// @param receiver Receiver of minted shares.
+    /// @return shares Minted shares.
+    function depositNative(address receiver)
+        external
+        payable
+        virtual
+        whenNotPaused
+        nonReentrant
+        returns (uint256 shares)
+    {
+        _requireNativeVaultAsset();
+        return _depositNativeWithControls(receiver);
+    }
+
+    /// @notice Mints `shares` to `receiver` using native asset funding.
+    /// @param shares Share amount.
+    /// @param receiver Receiver of minted shares.
+    /// @return assets Native assets consumed.
+    function mintNative(uint256 shares, address receiver)
+        external
+        payable
+        virtual
+        whenNotPaused
+        nonReentrant
+        returns (uint256 assets)
+    {
+        _requireNativeVaultAsset();
+        return _mintNativeWithControls(shares, receiver);
     }
 
     /// @notice Withdraws `assets` to `receiver` from `owner`.
@@ -241,6 +282,39 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
             }
 
             idleAssets = nextIdleAssets;
+        }
+    }
+
+    function _safeTransferAsset(address to, uint256 value) internal virtual override {
+        if (_isNativeVaultAsset()) {
+            (bool success,) = payable(to).call{value: value}("");
+            if (!success) {
+                revert ERC4626VaultAssetTransferFailed();
+            }
+            return;
+        }
+
+        super._safeTransferAsset(to, value);
+    }
+
+    function _safeTransferFromAsset(address from, address to, uint256 value) internal virtual override {
+        from;
+        to;
+        value;
+        if (_isNativeVaultAsset()) {
+            revert ERC4626VaultNativeAssetUseNativeEntrypoint();
+        }
+
+        super._safeTransferFromAsset(from, to, value);
+    }
+
+    function _isNativeVaultAsset() internal view returns (bool) {
+        return LibNativeAsset.isNativeAsset(ERC4626Vault.asset());
+    }
+
+    function _requireNativeVaultAsset() internal view {
+        if (!_isNativeVaultAsset()) {
+            revert ERC4626VaultNativeAssetDisabled();
         }
     }
 }

--- a/src/vault/facets/ERC4626VaultFacet.sol
+++ b/src/vault/facets/ERC4626VaultFacet.sol
@@ -134,7 +134,7 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
         }
 
         _burnShares(owner, shares);
-        _decreaseManagedAssets(grossAssets);
+        _decreaseManagedAssetsForAssetExit(grossAssets);
         _safeTransferAsset(receiver, assets);
         _payoutFee(feeAssets);
 
@@ -185,7 +185,7 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
         }
 
         _burnShares(owner, shares);
-        _decreaseManagedAssets(grossAssets);
+        _decreaseManagedAssetsForAssetExit(grossAssets);
         _safeTransferAsset(receiver, assets);
         _payoutFee(feeAssets);
 
@@ -194,7 +194,7 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
 
     function _managedAssetsForPricing() internal view virtual override returns (uint256) {
         LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
-        if (layout.strategy == address(0) || layout.strategyDebt == 0) {
+        if (layout.strategyDebt == 0) {
             return layout.totalManagedAssets;
         }
 
@@ -205,11 +205,14 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
 
     function _withdrawLiquidityCapAssets() internal view virtual override returns (uint256) {
         LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
-        if (layout.strategy == address(0) || layout.strategyDebt == 0) {
+        if (layout.strategyDebt == 0) {
             return type(uint256).max;
         }
 
-        return _idleAssetBalance() + _strategyWithdrawableAssets();
+        uint256 actualIdleAssets = _idleAssetBalance();
+        uint256 idleBookAssets = layout.totalManagedAssets - layout.strategyDebt;
+        uint256 trackedIdleAssets = actualIdleAssets < idleBookAssets ? actualIdleAssets : idleBookAssets;
+        return trackedIdleAssets + _strategyWithdrawableAssets();
     }
 
     function _vaultOperationsPaused() internal view virtual override returns (bool) {
@@ -222,7 +225,7 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
         }
 
         LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
-        if (layout.strategy == address(0) || layout.strategyDebt == 0) {
+        if (layout.strategyDebt == 0) {
             return;
         }
 

--- a/src/vault/facets/ERC4626VaultFacet.sol
+++ b/src/vault/facets/ERC4626VaultFacet.sol
@@ -169,9 +169,6 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
         uint256 grossAssets = _convertToAssets(shares, Rounding.Down);
         _sourceStrategyLiquidity(grossAssets);
 
-        grossAssets = _convertToAssets(shares, Rounding.Down);
-        _sourceStrategyLiquidity(grossAssets);
-
         uint256 availableIdleAssets = _idleAssetBalance();
         if (grossAssets > availableIdleAssets) {
             revert ERC4626VaultInsufficientLiquidity(grossAssets, availableIdleAssets);

--- a/src/vault/facets/ERC7535VaultFacet.sol
+++ b/src/vault/facets/ERC7535VaultFacet.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC7535VaultFacet} from "../../interfaces/IERC7535VaultFacet.sol";
+import {ERC4626Vault} from "../ERC4626Vault.sol";
+import {ERC4626VaultControlledCore} from "../ERC4626VaultControlLogic.sol";
+import {VaultFacetControl} from "../VaultFacetControl.sol";
+import {LibVaultAsset} from "../libraries/LibVaultAsset.sol";
+
+/// @title ERC7535VaultFacet
+/// @notice Hosted native-asset extension facet for ERC-7535-style vault entrypoints.
+contract ERC7535VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IERC7535VaultFacet {
+    /// @notice Deposits native asset and mints shares to `receiver`.
+    /// @param receiver Receiver of minted shares.
+    /// @return shares Minted shares.
+    function depositNative(address receiver)
+        external
+        payable
+        virtual
+        whenNotPaused
+        nonReentrant
+        returns (uint256 shares)
+    {
+        _requireNativeVaultAsset();
+        return _depositNativeWithControls(receiver);
+    }
+
+    /// @notice Mints `shares` to `receiver` using native asset funding.
+    /// @param shares Share amount.
+    /// @param receiver Receiver of minted shares.
+    /// @return assets Native assets consumed.
+    function mintNative(uint256 shares, address receiver)
+        external
+        payable
+        virtual
+        whenNotPaused
+        nonReentrant
+        returns (uint256 assets)
+    {
+        _requireNativeVaultAsset();
+        return _mintNativeWithControls(shares, receiver);
+    }
+
+    function _vaultOperationsPaused() internal view virtual override returns (bool) {
+        return paused();
+    }
+
+    function _requireNativeVaultAsset() internal view {
+        if (!LibVaultAsset.isNativeAsset(ERC4626Vault.asset())) {
+            revert ERC4626VaultNativeAssetDisabled();
+        }
+    }
+}

--- a/src/vault/libraries/LibNativeAsset.sol
+++ b/src/vault/libraries/LibNativeAsset.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title LibNativeAsset
+/// @notice Shared native-asset sentinel helpers for hosted vault flows.
+library LibNativeAsset {
+    address internal constant NATIVE_ASSET_SENTINEL = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+
+    function isNativeAsset(address asset_) internal pure returns (bool) {
+        return asset_ == NATIVE_ASSET_SENTINEL;
+    }
+}

--- a/src/vault/libraries/LibVaultAsset.sol
+++ b/src/vault/libraries/LibVaultAsset.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC20} from "../../interfaces/IERC20.sol";
+
+/// @title LibVaultAsset
+/// @notice Shared asset-mode helpers for hosted vault token and native flows.
+library LibVaultAsset {
+    address internal constant NATIVE_ASSET_SENTINEL = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+
+    function isNativeAsset(address asset_) internal pure returns (bool) {
+        return asset_ == NATIVE_ASSET_SENTINEL;
+    }
+
+    function balanceOfSelf(address asset_) internal view returns (uint256) {
+        if (isNativeAsset(asset_)) {
+            return address(this).balance;
+        }
+
+        return IERC20(asset_).balanceOf(address(this));
+    }
+
+    function transferOut(address asset_, address to, uint256 value) internal returns (bool) {
+        if (isNativeAsset(asset_)) {
+            (bool nativeSuccess,) = payable(to).call{value: value}("");
+            return nativeSuccess;
+        }
+
+        (bool success, bytes memory data) = asset_.call(abi.encodeCall(IERC20.transfer, (to, value)));
+        return success && (data.length == 0 || abi.decode(data, (bool)));
+    }
+
+    function transferIn(address asset_, address from, address to, uint256 value) internal returns (bool) {
+        if (isNativeAsset(asset_)) {
+            return false;
+        }
+
+        (bool success, bytes memory data) = asset_.call(abi.encodeCall(IERC20.transferFrom, (from, to, value)));
+        return success && (data.length == 0 || abi.decode(data, (bool)));
+    }
+}

--- a/src/vault/libraries/LibVaultFacetSelectors.sol
+++ b/src/vault/libraries/LibVaultFacetSelectors.sol
@@ -7,6 +7,7 @@ import {IERC20} from "../../interfaces/IERC20.sol";
 import {IERC20Metadata} from "../../interfaces/IERC20Metadata.sol";
 import {IERC165} from "../../interfaces/IERC165.sol";
 import {IERC4626} from "../../interfaces/IERC4626.sol";
+import {IERC7535VaultFacet} from "../../interfaces/IERC7535VaultFacet.sol";
 import {IERC4626VaultBase} from "../../interfaces/IERC4626VaultBase.sol";
 import {IERC4626VaultControls} from "../../interfaces/IERC4626VaultControls.sol";
 import {IERC4626VaultFacet} from "../../interfaces/IERC4626VaultFacet.sol";
@@ -19,7 +20,7 @@ import {IReentrancyGuard} from "../../interfaces/IReentrancyGuard.sol";
 library LibVaultFacetSelectors {
     /// @notice Returns the hosted vault core selector group.
     function vaultCoreSelectors() internal pure returns (bytes4[] memory selectors) {
-        selectors = new bytes4[](28);
+        selectors = new bytes4[](30);
         selectors[0] = IERC4626VaultFacet.initializeVault.selector;
         selectors[1] = IERC4626VaultBase.isVaultInitialized.selector;
         selectors[2] = IERC4626.asset.selector;
@@ -48,6 +49,8 @@ library LibVaultFacetSelectors {
         selectors[25] = IERC4626.maxRedeem.selector;
         selectors[26] = IERC4626.previewRedeem.selector;
         selectors[27] = IERC4626.redeem.selector;
+        selectors[28] = IERC7535VaultFacet.depositNative.selector;
+        selectors[29] = IERC7535VaultFacet.mintNative.selector;
     }
 
     /// @notice Returns the hosted vault controls selector group.

--- a/src/vault/libraries/LibVaultFacetSelectors.sol
+++ b/src/vault/libraries/LibVaultFacetSelectors.sol
@@ -16,11 +16,11 @@ import {IPausable} from "../../interfaces/IPausable.sol";
 import {IReentrancyGuard} from "../../interfaces/IReentrancyGuard.sol";
 
 /// @title LibVaultFacetSelectors
-/// @notice Canonical selector groups for future hosted vault facet splits.
+/// @notice Canonical selector groups for hosted vault facet splits.
 library LibVaultFacetSelectors {
     /// @notice Returns the hosted vault core selector group.
     function vaultCoreSelectors() internal pure returns (bytes4[] memory selectors) {
-        selectors = new bytes4[](30);
+        selectors = new bytes4[](28);
         selectors[0] = IERC4626VaultFacet.initializeVault.selector;
         selectors[1] = IERC4626VaultBase.isVaultInitialized.selector;
         selectors[2] = IERC4626.asset.selector;
@@ -49,8 +49,13 @@ library LibVaultFacetSelectors {
         selectors[25] = IERC4626.maxRedeem.selector;
         selectors[26] = IERC4626.previewRedeem.selector;
         selectors[27] = IERC4626.redeem.selector;
-        selectors[28] = IERC7535VaultFacet.depositNative.selector;
-        selectors[29] = IERC7535VaultFacet.mintNative.selector;
+    }
+
+    /// @notice Returns the hosted vault native selector group.
+    function vaultNativeSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](2);
+        selectors[0] = IERC7535VaultFacet.depositNative.selector;
+        selectors[1] = IERC7535VaultFacet.mintNative.selector;
     }
 
     /// @notice Returns the hosted vault controls selector group.

--- a/test/DiamondNativeVaultHostHardening.t.sol
+++ b/test/DiamondNativeVaultHostHardening.t.sol
@@ -1,0 +1,388 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
+import {IERC165} from "../src/interfaces/IERC165.sol";
+import {IERC20Metadata} from "../src/interfaces/IERC20Metadata.sol";
+import {IERC4626} from "../src/interfaces/IERC4626.sol";
+import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol";
+import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
+import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
+import {IERC7535VaultFacet} from "../src/interfaces/IERC7535VaultFacet.sol";
+import {IPausable} from "../src/interfaces/IPausable.sol";
+import {LibVaultAsset} from "../src/vault/libraries/LibVaultAsset.sol";
+import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
+import {DiamondNativeVaultHostHardeningFixture} from "./helpers/DiamondNativeVaultHostHardeningTestHarness.sol";
+import {IFacetVersionMarker} from "./helpers/DiamondVaultHostHardeningTestHarness.sol";
+
+contract DiamondNativeVaultHostHardeningTest is DiamondNativeVaultHostHardeningFixture {
+    function testNativeCoreFacetReplaceRemoveReAddPreservesState() public {
+        _installAndSeedNativeVaultHost();
+        _injectStrategyProfit(STRATEGY_PROFIT_ASSETS);
+
+        StrategyStateSnapshot memory initialState = _snapshotStrategyState();
+
+        _replaceCoreFacet(address(coreReplacement));
+        _addCoreReplacementMarker(address(coreReplacement));
+
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultCoreSelectors(), address(coreReplacement));
+        assertTrue(
+            IDiamondLoupe(address(diamond)).facetAddress(IFacetVersionMarker.facetVersion.selector)
+                == address(coreReplacement),
+            "core marker owner mismatch"
+        );
+        assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "core replacement marker mismatch");
+        assertTrue(coreFacetInterface().asset() == LibVaultAsset.NATIVE_ASSET_SENTINEL, "core asset mismatch");
+        assertTrue(
+            keccak256(bytes(IERC20Metadata(address(diamond)).name())) == keccak256(bytes("Native Vault Share")),
+            "core name mismatch after replace"
+        );
+        assertTrue(
+            keccak256(bytes(IERC20Metadata(address(diamond)).symbol())) == keccak256(bytes("nvSHARE")),
+            "core symbol mismatch after replace"
+        );
+        assertTrue(coreFacetInterface().balanceOf(bob) == BOB_DEPOSIT, "bob balance mismatch");
+        assertTrue(coreFacetInterface().balanceOf(carol) == CAROL_DEPOSIT, "carol balance mismatch");
+        assertTrue(coreFacetInterface().allowance(bob, eve) == SHARE_ALLOWANCE, "share allowance mismatch");
+        _assertStrategyState(initialState);
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC4626VaultFacet).interfaceId),
+            "core interface missing after replace"
+        );
+
+        _removeCoreFacetWithMarker();
+
+        _assertMissingSelector(abi.encodeWithSelector(IERC4626.asset.selector), "core asset selector should be missing");
+        _assertMissingSelector(
+            abi.encodeWithSelector(IERC20Metadata.name.selector), "core metadata selector should be missing"
+        );
+        assertTrue(
+            !IERC165(address(diamond)).supportsInterface(type(IERC4626VaultFacet).interfaceId),
+            "core interface should be absent when selectors removed"
+        );
+        (,, address feeRecipient) = controlsFacetInterface().feeConfig();
+        assertTrue(feeRecipient == feeSink, "controls should still route after core removal");
+        assertTrue(
+            integrationFacetInterface().oracleAdapter() == address(adapter),
+            "integration should still route after core removal"
+        );
+
+        _reAddCoreFacetWithMarker(address(coreReplacement));
+
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultCoreSelectors(), address(coreReplacement));
+        assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "core marker mismatch after re-add");
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC4626VaultFacet).interfaceId),
+            "core interface missing after re-add"
+        );
+        assertTrue(coreFacetInterface().asset() == LibVaultAsset.NATIVE_ASSET_SENTINEL, "core asset mismatch");
+        assertTrue(coreFacetInterface().balanceOf(bob) == BOB_DEPOSIT, "bob balance mismatch after re-add");
+        assertTrue(coreFacetInterface().balanceOf(carol) == CAROL_DEPOSIT, "carol balance mismatch after re-add");
+        assertTrue(coreFacetInterface().allowance(bob, eve) == SHARE_ALLOWANCE, "allowance mismatch after re-add");
+        _assertStrategyState(initialState);
+    }
+
+    function testNativeFacetReplaceRemoveReAddPreservesState() public {
+        _installAndSeedNativeVaultHost();
+
+        StrategyStateSnapshot memory initialState = _snapshotStrategyState();
+
+        _replaceNativeFacet(address(nativeReplacement));
+        _addNativeReplacementMarker(address(nativeReplacement));
+
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultNativeSelectors(), address(nativeReplacement));
+        assertTrue(
+            IDiamondLoupe(address(diamond)).facetAddress(IFacetVersionMarker.facetVersion.selector)
+                == address(nativeReplacement),
+            "native marker owner mismatch"
+        );
+        assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "native replacement marker mismatch");
+        _assertStrategyState(initialState);
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC7535VaultFacet).interfaceId),
+            "native interface missing after replace"
+        );
+
+        _removeNativeFacetWithMarker();
+
+        _assertMissingSelector(
+            abi.encodeWithSelector(IERC7535VaultFacet.depositNative.selector, bob),
+            "native deposit selector should be missing"
+        );
+        assertTrue(coreFacetInterface().asset() == LibVaultAsset.NATIVE_ASSET_SENTINEL, "core should still route");
+        assertTrue(
+            !IERC165(address(diamond)).supportsInterface(type(IERC7535VaultFacet).interfaceId),
+            "native interface should be absent when selectors removed"
+        );
+
+        _reAddNativeFacetWithMarker(address(nativeReplacement));
+
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultNativeSelectors(), address(nativeReplacement));
+        assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "native marker mismatch after re-add");
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC7535VaultFacet).interfaceId),
+            "native interface missing after re-add"
+        );
+        _assertStrategyState(initialState);
+    }
+
+    function testNativeControlsFacetReplaceRemoveReAddPreservesControlState() public {
+        _installAndSeedNativeVaultHost();
+        _pauseVault();
+
+        StrategyStateSnapshot memory initialState = _snapshotStrategyState();
+
+        _replaceControlsFacet(address(controlsReplacement));
+        _addControlsReplacementMarker(address(controlsReplacement));
+
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultControlsSelectors(), address(controlsReplacement));
+        assertTrue(
+            IDiamondLoupe(address(diamond)).facetAddress(IERC165.supportsInterface.selector)
+                == address(controlsReplacement),
+            "supportsInterface owner mismatch after controls replace"
+        );
+        assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "controls replacement marker mismatch");
+        _assertControlsState();
+        _assertStrategyState(initialState);
+        assertTrue(controlsFacetInterface().paused(), "paused state should persist after replace");
+        assertFalse(controlsFacetInterface().reentrancyGuardEntered(), "reentrancy should not be entered");
+
+        _removeControlsFacetWithMarker();
+
+        _assertMissingSelector(
+            abi.encodeWithSelector(IERC4626VaultControls.feeConfig.selector),
+            "controls fee config selector should be missing"
+        );
+        _assertMissingSelector(
+            abi.encodeWithSelector(IERC165.supportsInterface.selector, type(IERC4626VaultFacet).interfaceId),
+            "supportsInterface selector should be missing"
+        );
+        assertTrue(
+            coreFacetInterface().asset() == LibVaultAsset.NATIVE_ASSET_SENTINEL,
+            "core should still route after controls removal"
+        );
+        assertTrue(
+            integrationFacetInterface().strategyDebt() == initialState.strategyDebt,
+            "integration should still route after controls removal"
+        );
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+        IERC7535VaultFacet(address(diamond)).depositNative{value: 1 ether}(bob);
+
+        _reAddControlsFacetWithMarker(address(controlsReplacement));
+
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultControlsSelectors(), address(controlsReplacement));
+        assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "controls marker mismatch after re-add");
+        _assertControlsState();
+        _assertStrategyState(initialState);
+        assertTrue(controlsFacetInterface().paused(), "paused state should persist after re-add");
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC7535VaultFacet).interfaceId),
+            "native interface should be reported after controls re-add"
+        );
+        _unpauseVault();
+
+        uint256 expectedShares = coreFacetInterface().previewDeposit(1 ether);
+        VM.prank(dave);
+        uint256 mintedShares = IERC7535VaultFacet(address(diamond)).depositNative{value: 1 ether}(dave);
+        assertTrue(mintedShares == expectedShares, "dave should receive previewed shares after unpause");
+    }
+
+    function testNativeIntegrationFacetReplaceRemoveReAddPreservesIntegrationState() public {
+        _installAndSeedNativeVaultHost();
+
+        StrategyStateSnapshot memory initialState = _snapshotStrategyState();
+
+        _replaceIntegrationFacet(address(integrationReplacement));
+        _addIntegrationReplacementMarker(address(integrationReplacement));
+
+        _assertSelectorsOwnedByFacet(
+            LibVaultFacetSelectors.vaultIntegrationSelectors(), address(integrationReplacement)
+        );
+        assertTrue(
+            IDiamondLoupe(address(diamond)).facetAddress(IFacetVersionMarker.facetVersion.selector)
+                == address(integrationReplacement),
+            "integration marker owner mismatch"
+        );
+        assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "integration replacement marker mismatch");
+        _assertStrategyState(initialState);
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC4626VaultIntegrationFacet).interfaceId),
+            "integration interface missing after replace"
+        );
+
+        _removeIntegrationFacetWithMarker();
+
+        _assertMissingSelector(
+            abi.encodeWithSelector(IERC4626VaultIntegrationFacet.oracleAdapter.selector),
+            "integration oracle selector should be missing"
+        );
+        assertTrue(
+            coreFacetInterface().asset() == LibVaultAsset.NATIVE_ASSET_SENTINEL,
+            "core should still route after integration removal"
+        );
+        assertTrue(
+            controlsFacetInterface().hasRole(controlsFacetInterface().VAULT_MANAGER_ROLE(), eve),
+            "controls should still route after integration removal"
+        );
+        assertTrue(
+            !IERC165(address(diamond)).supportsInterface(type(IERC4626VaultIntegrationFacet).interfaceId),
+            "integration interface should be absent when selectors removed"
+        );
+
+        uint256 expectedBobSharesBurned = coreFacetInterface().previewWithdraw(BOB_AUTO_PULL_WITHDRAW_ASSETS);
+        uint256 bobBalanceBefore = bob.balance;
+        VM.prank(bob);
+        uint256 burnedShares = coreFacetInterface().withdraw(BOB_AUTO_PULL_WITHDRAW_ASSETS, bob, bob);
+        assertTrue(
+            burnedShares == expectedBobSharesBurned, "withdraw should use previewWithdraw semantics while removed"
+        );
+        assertTrue(bob.balance == bobBalanceBefore + BOB_AUTO_PULL_WITHDRAW_ASSETS, "bob native payout mismatch");
+
+        uint256 expectedCarolAssetsReturned = coreFacetInterface().previewRedeem(CAROL_AUTO_PULL_REDEEM_SHARES);
+        uint256 carolBalanceBefore = carol.balance;
+        VM.prank(carol);
+        uint256 returnedAssets = coreFacetInterface().redeem(CAROL_AUTO_PULL_REDEEM_SHARES, carol, carol);
+        assertTrue(
+            returnedAssets == expectedCarolAssetsReturned, "redeem should use previewRedeem semantics while removed"
+        );
+        assertTrue(carol.balance == carolBalanceBefore + expectedCarolAssetsReturned, "carol native payout mismatch");
+
+        uint256 expectedIdleAssets = address(diamond).balance;
+        uint256 expectedLiveStrategyAssets = strategyContract.totalAssets();
+        uint256 expectedTotalManagedAssets = coreFacetInterface().totalManagedAssets();
+        uint256 expectedTotalAssets = coreFacetInterface().totalAssets();
+        uint256 expectedBobBalance = coreFacetInterface().balanceOf(bob);
+        uint256 expectedCarolBalance = coreFacetInterface().balanceOf(carol);
+
+        _reAddIntegrationFacetWithMarker(address(integrationReplacement));
+
+        _assertSelectorsOwnedByFacet(
+            LibVaultFacetSelectors.vaultIntegrationSelectors(), address(integrationReplacement)
+        );
+        assertTrue(
+            IFacetVersionMarker(address(diamond)).facetVersion() == 2, "integration marker mismatch after re-add"
+        );
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC4626VaultIntegrationFacet).interfaceId),
+            "integration interface missing after re-add"
+        );
+        assertTrue(
+            integrationFacetInterface().strategy() == address(strategyContract), "strategy mismatch after re-add"
+        );
+        assertTrue(
+            integrationFacetInterface().strategyDebt() == expectedTotalManagedAssets - expectedIdleAssets,
+            "strategy debt mismatch after re-add"
+        );
+        assertTrue(
+            integrationFacetInterface().liveStrategyAssets() == expectedLiveStrategyAssets,
+            "live strategy assets mismatch after re-add"
+        );
+        assertTrue(integrationFacetInterface().idleAssets() == expectedIdleAssets, "idle assets mismatch after re-add");
+        assertFalse(integrationFacetInterface().strategyEmergencyExit(), "emergency exit should stay inactive");
+        assertTrue(
+            coreFacetInterface().totalManagedAssets() == expectedTotalManagedAssets, "book value mismatch after re-add"
+        );
+        assertTrue(coreFacetInterface().totalAssets() == expectedTotalAssets, "total assets mismatch after re-add");
+        assertTrue(coreFacetInterface().balanceOf(bob) == expectedBobBalance, "bob balance mismatch after re-add");
+        assertTrue(coreFacetInterface().balanceOf(carol) == expectedCarolBalance, "carol balance mismatch after re-add");
+    }
+
+    function testNativeIntegrationEmergencyExitStatePersistsAcrossFacetChurnAndRebind() public {
+        _installAndSeedNativeVaultHost();
+
+        VM.prank(admin);
+        uint256 emergencyAssets = integrationFacetInterface().emergencyExitStrategy();
+        assertTrue(emergencyAssets == STRATEGY_DEPLOYED_ASSETS, "emergency exit should unwind deployed assets");
+
+        _replaceIntegrationFacet(address(integrationReplacement));
+        _addIntegrationReplacementMarker(address(integrationReplacement));
+        _replaceNativeFacet(address(nativeReplacement));
+        _removeIntegrationFacetWithMarker();
+        _removeSelectors(LibVaultFacetSelectors.vaultNativeSelectors());
+        _reAddIntegrationFacetWithMarker(address(integrationReplacement));
+        _addFacet(address(nativeReplacement), LibVaultFacetSelectors.vaultNativeSelectors());
+
+        assertTrue(
+            IFacetVersionMarker(address(diamond)).facetVersion() == 2,
+            "replacement marker mismatch after emergency re-add"
+        );
+        assertTrue(integrationFacetInterface().strategy() == address(strategyContract), "strategy mismatch after churn");
+        assertTrue(integrationFacetInterface().strategyEmergencyExit(), "emergency exit should persist after churn");
+        assertTrue(integrationFacetInterface().strategyDebt() == 0, "strategy debt should remain zero after churn");
+        assertTrue(integrationFacetInterface().liveStrategyAssets() == 0, "live strategy assets should remain zero");
+        assertTrue(integrationFacetInterface().idleAssets() == BOB_DEPOSIT + CAROL_DEPOSIT, "idle assets mismatch");
+
+        VM.expectRevert(IERC4626VaultIntegrationFacet.ERC4626VaultStrategyEmergencyExitActive.selector);
+        VM.prank(admin);
+        integrationFacetInterface().deployToStrategy(1);
+
+        VM.prank(admin);
+        integrationFacetInterface().setStrategy(address(0));
+        VM.prank(admin);
+        integrationFacetInterface().setStrategy(address(replacementStrategyContract));
+
+        assertFalse(integrationFacetInterface().strategyEmergencyExit(), "emergency exit should clear on rebind");
+
+        VM.prank(admin);
+        integrationFacetInterface().deployToStrategy(1 ether);
+        assertTrue(integrationFacetInterface().strategyDebt() == 1 ether, "deploy should work after strategy rebind");
+        assertTrue(
+            integrationFacetInterface().strategy() == address(replacementStrategyContract),
+            "replacement strategy should bind"
+        );
+    }
+
+    function testForceSentNativeAssetsDoNotChangeAccountingOrMaxFunctions() public {
+        _installAndSeedNativeVaultHost();
+        _injectStrategyProfit(STRATEGY_PROFIT_ASSETS);
+
+        StrategyStateSnapshot memory beforeState = _snapshotStrategyState();
+        uint256 expectedVaultBalance = address(diamond).balance + 3 ether;
+        uint256 expectedStrategyBalance = address(strategyContract).balance + 2 ether;
+
+        _forceSendToVault(3 ether);
+        _forceSendToStrategy(2 ether);
+
+        assertTrue(address(diamond).balance == expectedVaultBalance, "vault force-send balance mismatch");
+        assertTrue(address(strategyContract).balance == expectedStrategyBalance, "strategy force-send balance mismatch");
+        assertTrue(coreFacetInterface().totalManagedAssets() == beforeState.totalManagedAssets, "book assets changed");
+        assertTrue(coreFacetInterface().totalAssets() == beforeState.totalAssets, "pricing assets changed");
+        assertTrue(coreFacetInterface().maxWithdraw(bob) == beforeState.bobMaxWithdraw, "maxWithdraw changed");
+        assertTrue(coreFacetInterface().maxRedeem(bob) == beforeState.bobMaxRedeem, "maxRedeem changed");
+        assertTrue(
+            integrationFacetInterface().liveStrategyAssets() == beforeState.liveStrategyAssets, "live assets changed"
+        );
+    }
+
+    function _assertSelectorsOwnedByFacet(bytes4[] memory selectors, address expectedFacet) internal view {
+        for (uint256 i = 0; i < selectors.length; i++) {
+            assertTrue(
+                IDiamondLoupe(address(diamond)).facetAddress(selectors[i]) == expectedFacet, "selector owner mismatch"
+            );
+        }
+    }
+
+    function _assertControlsState() internal view {
+        bytes32 managerRole = controlsFacetInterface().VAULT_MANAGER_ROLE();
+        (uint16 depositFeeBps, uint16 withdrawFeeBps, address feeRecipient) = controlsFacetInterface().feeConfig();
+        (uint128 maxTotalAssets, uint128 maxDeposit, uint128 maxMint, uint128 maxWithdraw, uint128 maxRedeem) =
+            controlsFacetInterface().limitConfig();
+        (uint64 start, uint64 end, bool exists) = controlsFacetInterface().getRoleWindow(managerRole, dave);
+
+        assertTrue(depositFeeBps == 100, "deposit fee mismatch");
+        assertTrue(withdrawFeeBps == 50, "withdraw fee mismatch");
+        assertTrue(feeRecipient == feeSink, "fee recipient mismatch");
+        assertTrue(maxTotalAssets == 90 ether, "max total assets mismatch");
+        assertTrue(maxDeposit == 30 ether, "max deposit mismatch");
+        assertTrue(maxMint == 30 ether, "max mint mismatch");
+        assertTrue(maxWithdraw == 25 ether, "max withdraw mismatch");
+        assertTrue(maxRedeem == 25 ether, "max redeem mismatch");
+        assertTrue(controlsFacetInterface().hasRole(managerRole, eve), "eve manager role mismatch");
+        assertTrue(start == uint64(currentTime - 100), "role window start mismatch");
+        assertTrue(end == uint64(currentTime + 1_000), "role window end mismatch");
+        assertTrue(exists, "role window should exist");
+        assertTrue(controlsFacetInterface().hasActiveRole(managerRole, dave), "dave active manager role mismatch");
+    }
+}

--- a/test/DiamondNativeVaultHostInvariant.t.sol
+++ b/test/DiamondNativeVaultHostInvariant.t.sol
@@ -1,0 +1,481 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol";
+import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
+import {IERC7535VaultFacet} from "../src/interfaces/IERC7535VaultFacet.sol";
+import {IPausable} from "../src/interfaces/IPausable.sol";
+import {DiamondNativeVaultHostHardeningFixture} from "./helpers/DiamondNativeVaultHostHardeningTestHarness.sol";
+
+contract DiamondNativeVaultHostInvariantTest is DiamondNativeVaultHostHardeningFixture {
+    function setUp() public override {
+        super.setUp();
+        _installNativeVaultHostFacets();
+        _initializeNativeVaultHost();
+        _wireOracleAdapter();
+        _wireNativeStrategy();
+
+        VM.prank(admin);
+        controlsFacetInterface().setFeeConfig(0, 0, feeSink);
+    }
+
+    function targetContracts() external view returns (address[] memory contracts) {
+        contracts = new address[](1);
+        contracts[0] = address(this);
+    }
+
+    function actionDepositNative(uint8 actorSeed, uint96 assetsRaw) external {
+        address actor = _actor(actorSeed);
+        uint256 maxAssets = _min(coreFacetInterface().maxDeposit(actor), actor.balance);
+        uint256 assets_ = _boundAmount(assetsRaw, maxAssets);
+        if (assets_ == 0 || coreFacetInterface().previewDeposit(assets_) == 0) {
+            return;
+        }
+
+        if (controlsFacetInterface().paused()) {
+            VM.startPrank(actor);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+            IERC7535VaultFacet(address(diamond)).depositNative{value: assets_}(actor);
+            VM.stopPrank();
+            return;
+        }
+
+        VM.prank(actor);
+        IERC7535VaultFacet(address(diamond)).depositNative{value: assets_}(actor);
+    }
+
+    function actionMintNative(uint8 actorSeed, uint96 sharesRaw) external {
+        address actor = _actor(actorSeed);
+        uint256 feasibleShares = coreFacetInterface().previewDeposit(actor.balance);
+        uint256 maxShares = _min(coreFacetInterface().maxMint(actor), feasibleShares);
+        uint256 shares = _boundAmount(sharesRaw, maxShares);
+        if (shares == 0) {
+            return;
+        }
+
+        uint256 requiredAssets = coreFacetInterface().previewMint(shares);
+        if (requiredAssets == 0 || requiredAssets > actor.balance) {
+            return;
+        }
+
+        if (controlsFacetInterface().paused()) {
+            VM.startPrank(actor);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+            IERC7535VaultFacet(address(diamond)).mintNative{value: requiredAssets}(shares, actor);
+            VM.stopPrank();
+            return;
+        }
+
+        VM.prank(actor);
+        IERC7535VaultFacet(address(diamond)).mintNative{value: requiredAssets}(shares, actor);
+    }
+
+    function actionWithdraw(uint8 actorSeed, uint96 assetsRaw) external {
+        address actor = _actor(actorSeed);
+        uint256 assets_ = _boundAmount(assetsRaw, coreFacetInterface().maxWithdraw(actor));
+        if (assets_ == 0) {
+            return;
+        }
+
+        if (controlsFacetInterface().paused()) {
+            VM.startPrank(actor);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+            coreFacetInterface().withdraw(assets_, actor, actor);
+            VM.stopPrank();
+            return;
+        }
+
+        VM.prank(actor);
+        coreFacetInterface().withdraw(assets_, actor, actor);
+    }
+
+    function actionRedeem(uint8 actorSeed, uint96 sharesRaw) external {
+        address actor = _actor(actorSeed);
+        uint256 shares = _boundAmount(sharesRaw, coreFacetInterface().maxRedeem(actor));
+        if (shares == 0 || coreFacetInterface().previewRedeem(shares) == 0) {
+            return;
+        }
+
+        if (controlsFacetInterface().paused()) {
+            VM.startPrank(actor);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+            coreFacetInterface().redeem(shares, actor, actor);
+            VM.stopPrank();
+            return;
+        }
+
+        VM.prank(actor);
+        coreFacetInterface().redeem(shares, actor, actor);
+    }
+
+    function actionApprove(uint8 ownerSeed, uint8 spenderSeed, uint96 sharesRaw) external {
+        address owner = _actor(ownerSeed);
+        address spender = _actorExcluding(owner, spenderSeed);
+
+        VM.prank(owner);
+        coreFacetInterface().approve(spender, uint256(sharesRaw));
+    }
+
+    function actionTransfer(uint8 fromSeed, uint8 toSeed, uint96 sharesRaw) external {
+        address from = _actor(fromSeed);
+        address to = _actorExcluding(from, toSeed);
+        uint256 shares = _boundAmount(sharesRaw, coreFacetInterface().balanceOf(from));
+        if (shares == 0) {
+            return;
+        }
+
+        VM.prank(from);
+        coreFacetInterface().transfer(to, shares);
+    }
+
+    function actionTransferFrom(uint8 spenderSeed, uint8 ownerSeed, uint8 toSeed, uint96 sharesRaw) external {
+        address spender = _actor(spenderSeed);
+        address owner = _actor(ownerSeed);
+        if (spender == owner) {
+            return;
+        }
+
+        address to = _actorExcluding(owner, toSeed);
+        uint256 allowance = coreFacetInterface().allowance(owner, spender);
+        uint256 balance = coreFacetInterface().balanceOf(owner);
+        uint256 shares = _boundAmount(sharesRaw, allowance < balance ? allowance : balance);
+        if (shares == 0) {
+            return;
+        }
+
+        VM.prank(spender);
+        coreFacetInterface().transferFrom(owner, to, shares);
+    }
+
+    function actionPauseToggle(bool shouldPause) external {
+        bool isPaused = controlsFacetInterface().paused();
+        if (shouldPause && !isPaused) {
+            _pauseVault();
+        } else if (!shouldPause && isPaused) {
+            _unpauseVault();
+        }
+    }
+
+    function actionSetFeeConfig(uint16 depositFeeRaw, uint16 withdrawFeeRaw) external {
+        AccountingSnapshot memory snapshot = _snapshotAccounting();
+        uint16 depositFeeBps = uint16(uint256(depositFeeRaw) % 2_001);
+        uint16 withdrawFeeBps = uint16(uint256(withdrawFeeRaw) % 2_001);
+
+        VM.prank(admin);
+        controlsFacetInterface().setFeeConfig(depositFeeBps, withdrawFeeBps, feeSink);
+
+        _assertAccountingUnchanged(snapshot, "fee config updates should not mutate accounting");
+    }
+
+    function actionSetLimitConfig(
+        uint96 totalCapRaw,
+        uint96 depositRaw,
+        uint96 mintRaw,
+        uint96 withdrawRaw,
+        uint96 redeemRaw
+    ) external {
+        AccountingSnapshot memory snapshot = _snapshotAccounting();
+
+        uint256 currentAssets = coreFacetInterface().totalAssets();
+        uint128 maxTotalAssets = totalCapRaw % 4 == 0
+            ? 0
+            : uint128(currentAssets + (uint256(totalCapRaw) % _expectedTrackedUnderlying()) + 1);
+        uint128 maxDeposit = depositRaw % 4 == 0 ? 0 : uint128((uint256(depositRaw) % INITIAL_ASSETS) + 1);
+        uint128 maxMint = mintRaw % 4 == 0 ? 0 : uint128((uint256(mintRaw) % INITIAL_ASSETS) + 1);
+        uint128 maxWithdraw = withdrawRaw % 4 == 0 ? 0 : uint128((uint256(withdrawRaw) % INITIAL_ASSETS) + 1);
+        uint128 maxRedeem = redeemRaw % 4 == 0 ? 0 : uint128((uint256(redeemRaw) % INITIAL_ASSETS) + 1);
+
+        VM.prank(admin);
+        controlsFacetInterface().setLimitConfig(maxTotalAssets, maxDeposit, maxMint, maxWithdraw, maxRedeem);
+
+        _assertAccountingUnchanged(snapshot, "limit config updates should not mutate accounting");
+    }
+
+    function actionSetOracleAdapter(bool configured) external {
+        AccountingSnapshot memory snapshot = _snapshotAccounting();
+
+        VM.prank(admin);
+        integrationFacetInterface().setOracleAdapter(configured ? address(adapter) : address(0));
+
+        _assertAccountingUnchanged(snapshot, "oracle adapter updates should not mutate accounting");
+    }
+
+    function actionSetStrategy(bool configured) external {
+        if (integrationFacetInterface().strategyDebt() != 0) {
+            return;
+        }
+
+        AccountingSnapshot memory snapshot = _snapshotAccounting();
+
+        if (!configured && integrationFacetInterface().strategy() != address(0)) {
+            VM.prank(admin);
+            integrationFacetInterface().setStrategy(address(0));
+            _assertAccountingUnchanged(snapshot, "strategy clear should not mutate accounting");
+            return;
+        }
+
+        if (configured && integrationFacetInterface().strategy() == address(0)) {
+            strategyContract.setWithdrawAllReverts(false);
+            VM.prank(admin);
+            integrationFacetInterface().setStrategy(address(strategyContract));
+            _assertAccountingUnchanged(snapshot, "strategy rebind should not mutate accounting");
+        }
+    }
+
+    function actionDeployToStrategy(uint96 assetsRaw) external {
+        if (integrationFacetInterface().strategy() != address(strategyContract)) {
+            return;
+        }
+
+        uint256 assets_ = _boundAmount(assetsRaw, integrationFacetInterface().idleAssets());
+        if (assets_ == 0) {
+            return;
+        }
+
+        if (integrationFacetInterface().strategyEmergencyExit()) {
+            VM.expectRevert(IERC4626VaultIntegrationFacet.ERC4626VaultStrategyEmergencyExitActive.selector);
+            VM.prank(admin);
+            integrationFacetInterface().deployToStrategy(assets_);
+            return;
+        }
+
+        VM.prank(admin);
+        integrationFacetInterface().deployToStrategy(assets_);
+    }
+
+    function actionWithdrawFromStrategy(uint96 assetsRaw) external {
+        if (integrationFacetInterface().strategy() != address(strategyContract)) {
+            return;
+        }
+
+        uint256 strategyDebt = integrationFacetInterface().strategyDebt();
+        uint256 assets_ = _boundAmount(assetsRaw, strategyDebt);
+        if (assets_ == 0) {
+            return;
+        }
+
+        VM.prank(admin);
+        integrationFacetInterface().withdrawFromStrategy(assets_);
+    }
+
+    function actionSyncStrategyAssets() external {
+        if (integrationFacetInterface().strategy() != address(strategyContract)) {
+            return;
+        }
+
+        VM.prank(admin);
+        integrationFacetInterface().syncStrategyAssets();
+    }
+
+    function actionEmergencyExitStrategy(bool forceFailure) external {
+        if (integrationFacetInterface().strategy() != address(strategyContract)) {
+            return;
+        }
+
+        strategyContract.setWithdrawAllReverts(forceFailure && integrationFacetInterface().strategyDebt() != 0);
+
+        VM.prank(admin);
+        integrationFacetInterface().emergencyExitStrategy();
+    }
+
+    function actionInjectStrategyProfit(uint96 assetsRaw) external {
+        if (integrationFacetInterface().strategy() != address(strategyContract)) {
+            return;
+        }
+        if (integrationFacetInterface().strategyDebt() == 0 || integrationFacetInterface().strategyEmergencyExit()) {
+            return;
+        }
+
+        uint256 available = _min(profitSource.balance, INITIAL_ASSETS);
+        uint256 assets_ = _boundAmount(assetsRaw, available);
+        if (assets_ == 0) {
+            return;
+        }
+
+        VM.prank(profitSource);
+        strategyContract.injectProfit{value: assets_}(assets_);
+    }
+
+    function actionApplyStrategyLoss(uint96 lossRaw, uint96 withdrawableRaw) external {
+        if (integrationFacetInterface().strategy() != address(strategyContract)) {
+            return;
+        }
+        if (integrationFacetInterface().strategyEmergencyExit()) {
+            return;
+        }
+
+        uint256 liveAssets = integrationFacetInterface().liveStrategyAssets();
+        if (liveAssets == 0) {
+            return;
+        }
+
+        uint256 lossAssets = _boundAmount(lossRaw, _min(liveAssets, INITIAL_ASSETS));
+        uint256 remainingLiveAssets = liveAssets - lossAssets;
+        uint256 withdrawableAssets = remainingLiveAssets == 0 ? 0 : uint256(withdrawableRaw) % (remainingLiveAssets + 1);
+
+        strategyContract.applyLoss(lossAssets, withdrawableAssets);
+    }
+
+    function actionForceSendToVault(uint96 assetsRaw) external {
+        uint256 assets_ = _boundAmount(assetsRaw, forceSender.balance);
+        if (assets_ == 0) {
+            return;
+        }
+
+        _forceSendToVault(assets_);
+    }
+
+    function actionForceSendToStrategy(uint96 assetsRaw) external {
+        if (integrationFacetInterface().strategy() != address(strategyContract)) {
+            return;
+        }
+
+        uint256 assets_ = _boundAmount(assetsRaw, forceSender.balance);
+        if (assets_ == 0) {
+            return;
+        }
+
+        _forceSendToStrategy(assets_);
+    }
+
+    function actionWithdrawBeyondImmediateLiquidityAttempt(uint8 actorSeed, uint96 extraRaw) external {
+        if (controlsFacetInterface().paused()) {
+            return;
+        }
+
+        address actor = _actor(actorSeed);
+        uint256 ownerShares = coreFacetInterface().balanceOf(actor);
+        if (ownerShares == 0) {
+            return;
+        }
+
+        uint256 maxWithdraw = coreFacetInterface().maxWithdraw(actor);
+        uint256 grossEntitlement = coreFacetInterface().previewRedeem(ownerShares);
+        if (grossEntitlement <= maxWithdraw) {
+            return;
+        }
+
+        uint256 attemptAssets = maxWithdraw + _boundAmount(extraRaw, grossEntitlement - maxWithdraw);
+
+        VM.startPrank(actor);
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IERC4626VaultControls.ERC4626VaultWithdrawLimitExceeded.selector, attemptAssets, maxWithdraw
+            )
+        );
+        coreFacetInterface().withdraw(attemptAssets, actor, actor);
+        VM.stopPrank();
+    }
+
+    function invariantActualVaultBalanceCoversBookIdleAssets() public view {
+        assertTrue(address(diamond).balance >= _bookIdleAssets(), "actual vault balance should cover book idle assets");
+    }
+
+    function invariantStrategyDebtDoesNotExceedBookAssets() public view {
+        assertTrue(
+            integrationFacetInterface().strategyDebt() <= coreFacetInterface().totalManagedAssets(),
+            "strategy debt should stay within total managed assets"
+        );
+    }
+
+    function invariantBookAccountingMatchesBookIdlePlusStrategyDebt() public view {
+        assertTrue(
+            coreFacetInterface().totalManagedAssets() == _bookIdleAssets() + integrationFacetInterface().strategyDebt(),
+            "book accounting should equal book idle assets plus strategy debt"
+        );
+    }
+
+    function invariantLiveAccountingMatchesBookIdlePlusStrategyAssets() public view {
+        assertTrue(
+            coreFacetInterface().totalAssets() == _bookIdleAssets() + integrationFacetInterface().liveStrategyAssets(),
+            "live accounting should equal book idle assets plus live strategy assets"
+        );
+    }
+
+    function invariantShareSupplyMatchesTrackedActorBalances() public view {
+        assertTrue(
+            coreFacetInterface().totalSupply() == _sumTrackedShareBalances(),
+            "share supply should remain equal to tracked balances"
+        );
+    }
+
+    function invariantTrackedUnderlyingRemainsConserved() public view {
+        assertTrue(
+            _sumTrackedUnderlying() == _expectedTrackedUnderlying(),
+            "tracked underlying should remain conserved across actors, vault, strategies, sinks, and reserves"
+        );
+    }
+
+    function invariantPausedStateZeroesMutatingMaxFunctions() public view {
+        if (!controlsFacetInterface().paused()) {
+            return;
+        }
+
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            address actor = actors[i];
+            assertTrue(coreFacetInterface().maxDeposit(actor) == 0, "paused vault should expose zero maxDeposit");
+            assertTrue(coreFacetInterface().maxMint(actor) == 0, "paused vault should expose zero maxMint");
+            assertTrue(coreFacetInterface().maxWithdraw(actor) == 0, "paused vault should expose zero maxWithdraw");
+            assertTrue(coreFacetInterface().maxRedeem(actor) == 0, "paused vault should expose zero maxRedeem");
+        }
+    }
+
+    function invariantMaxWithdrawBoundedByImmediateLiquidity() public view {
+        uint256 immediateLiquidity = _immediateLiquidity();
+
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            address actor = actors[i];
+            uint256 actorBalance = coreFacetInterface().balanceOf(actor);
+            uint256 grossEntitlement = actorBalance == 0 ? 0 : coreFacetInterface().previewRedeem(actorBalance);
+            uint256 maxWithdraw = coreFacetInterface().maxWithdraw(actor);
+
+            assertTrue(maxWithdraw <= immediateLiquidity, "maxWithdraw should stay within immediate liquidity");
+            assertTrue(maxWithdraw <= grossEntitlement, "maxWithdraw should stay within live-priced entitlement");
+        }
+    }
+
+    function invariantPreviewRedeemOfMaxRedeemBoundedByImmediateLiquidity() public view {
+        uint256 immediateLiquidity = _immediateLiquidity();
+
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            address actor = actors[i];
+            uint256 maxRedeem = coreFacetInterface().maxRedeem(actor);
+            assertTrue(
+                coreFacetInterface().previewRedeem(maxRedeem) <= immediateLiquidity,
+                "previewRedeem(maxRedeem) should stay within immediate liquidity"
+            );
+        }
+    }
+
+    function invariantActualStrategyBalanceCoversReportedStrategyAssets() public view {
+        if (integrationFacetInterface().strategy() != address(strategyContract)) {
+            return;
+        }
+
+        assertTrue(
+            address(strategyContract).balance >= integrationFacetInterface().liveStrategyAssets(),
+            "actual strategy balance should cover reported strategy assets"
+        );
+    }
+
+    function _bookIdleAssets() internal view returns (uint256) {
+        uint256 totalManagedAssets = coreFacetInterface().totalManagedAssets();
+        uint256 currentStrategyDebt = integrationFacetInterface().strategyDebt();
+        if (currentStrategyDebt > totalManagedAssets) {
+            return 0;
+        }
+        return totalManagedAssets - currentStrategyDebt;
+    }
+
+    function _immediateLiquidity() internal view returns (uint256) {
+        if (integrationFacetInterface().strategyDebt() == 0) {
+            return coreFacetInterface().totalAssets();
+        }
+
+        uint256 liquidity = _bookIdleAssets();
+        if (integrationFacetInterface().strategy() == address(strategyContract)) {
+            liquidity += strategyContract.maxWithdrawableAssets();
+        }
+        return liquidity;
+    }
+}

--- a/test/DiamondVaultDeploymentIntegration.t.sol
+++ b/test/DiamondVaultDeploymentIntegration.t.sol
@@ -12,8 +12,10 @@ import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControl
 import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
 import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
 import {IERC4626VaultStrategy} from "../src/interfaces/IERC4626VaultStrategy.sol";
+import {IERC7535VaultFacet} from "../src/interfaces/IERC7535VaultFacet.sol";
 import {IOracleAdapter} from "../src/interfaces/IOracleAdapter.sol";
 import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
+import {LibVaultAsset} from "../src/vault/libraries/LibVaultAsset.sol";
 import {DiamondVaultDeploymentFixture} from "./helpers/DiamondVaultDeploymentTestHarness.sol";
 
 contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture {
@@ -180,6 +182,195 @@ contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture 
 
         assertFalse(integrationFacetInterface().strategyEmergencyExit(), "emergency exit should clear on rebind");
         assertTrue(integrationFacetInterface().strategy() == address(strategy), "strategy should be rebound");
+        assertTrue(integrationFacetInterface().strategyDebt() == 0, "strategy debt should reset to zero");
+    }
+
+    function testNativeVaultHostDeployInstallInitOracleAndStrategyWiring() public {
+        _installNativeVaultHostFacets();
+        _initializeNativeVaultHost();
+        _wireOracleAdapter();
+        _wireNativeStrategy();
+
+        IDiamondLoupe loupe = IDiamondLoupe(address(diamond));
+        address[] memory facetAddresses = loupe.facetAddresses();
+        IOracleAdapter.OracleQuote memory quotePayload = integrationFacetInterface().oracleQuote();
+
+        assertTrue(facetAddresses.length == 6, "native vault host facet count mismatch");
+        assertTrue(_containsAddress(facetAddresses, address(cutFacet)), "missing cut facet");
+        assertTrue(_containsAddress(facetAddresses, address(loupeFacet)), "missing loupe facet");
+        assertTrue(_containsAddress(facetAddresses, address(coreFacet)), "missing core facet");
+        assertTrue(_containsAddress(facetAddresses, address(nativeFacet)), "missing native facet");
+        assertTrue(_containsAddress(facetAddresses, address(controlsFacet)), "missing controls facet");
+        assertTrue(_containsAddress(facetAddresses, address(integrationFacet)), "missing integration facet");
+
+        assertTrue(
+            loupe.facetFunctionSelectors(address(coreFacet)).length
+                == LibVaultFacetSelectors.vaultCoreSelectors().length,
+            "unexpected core selector count"
+        );
+        assertTrue(
+            loupe.facetFunctionSelectors(address(nativeFacet)).length
+                == LibVaultFacetSelectors.vaultNativeSelectors().length,
+            "unexpected native selector count"
+        );
+        assertTrue(
+            loupe.facetFunctionSelectors(address(controlsFacet)).length
+                == LibVaultFacetSelectors.vaultControlsSelectors().length,
+            "unexpected controls selector count"
+        );
+        assertTrue(
+            loupe.facetFunctionSelectors(address(integrationFacet)).length
+                == LibVaultFacetSelectors.vaultIntegrationSelectors().length,
+            "unexpected integration selector count"
+        );
+
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultCoreSelectors(), address(coreFacet));
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultNativeSelectors(), address(nativeFacet));
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultControlsSelectors(), address(controlsFacet));
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultIntegrationSelectors(), address(integrationFacet));
+
+        assertTrue(loupe.facetAddress(DiamondCutFacet.diamondCut.selector) == address(cutFacet), "cut owner mismatch");
+        assertTrue(loupe.facetAddress(DiamondLoupeFacet.facets.selector) == address(loupeFacet), "loupe owner mismatch");
+        assertTrue(
+            loupe.facetAddress(IERC4626VaultFacet.initializeVault.selector) == address(coreFacet), "init owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC7535VaultFacet.depositNative.selector) == address(nativeFacet),
+            "native deposit owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC4626VaultControls.VAULT_MANAGER_ROLE.selector) == address(controlsFacet),
+            "vault manager owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC4626VaultIntegrationFacet.oracleAdapter.selector) == address(integrationFacet),
+            "oracle selector owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC4626VaultIntegrationFacet.deployToStrategy.selector) == address(integrationFacet),
+            "deploy strategy selector owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC165.supportsInterface.selector) == address(controlsFacet),
+            "supportsInterface owner mismatch"
+        );
+
+        assertTrue(coreFacetInterface().isVaultInitialized(), "vault should be initialized");
+        assertTrue(coreFacetInterface().asset() == LibVaultAsset.NATIVE_ASSET_SENTINEL, "asset mismatch");
+        assertTrue(
+            keccak256(bytes(IERC20Metadata(address(diamond)).name())) == keccak256(bytes("Native Vault Share")),
+            "name mismatch"
+        );
+        assertTrue(
+            keccak256(bytes(IERC20Metadata(address(diamond)).symbol())) == keccak256(bytes("nvSHARE")),
+            "symbol mismatch"
+        );
+
+        assertTrue(
+            controlsFacetInterface().hasRole(controlsFacetInterface().DEFAULT_ADMIN_ROLE(), admin),
+            "missing default admin"
+        );
+        assertTrue(controlsFacetInterface().hasRole(controlsFacetInterface().PAUSER_ROLE(), admin), "missing pauser");
+        assertTrue(
+            controlsFacetInterface().hasRole(controlsFacetInterface().VAULT_MANAGER_ROLE(), admin),
+            "missing vault manager"
+        );
+        (,, address feeRecipient) = controlsFacetInterface().feeConfig();
+        assertTrue(feeRecipient == admin, "fee recipient mismatch");
+
+        assertTrue(integrationFacetInterface().oracleAdapter() == address(adapter), "adapter mismatch");
+        assertTrue(integrationFacetInterface().strategy() == address(nativeStrategy), "strategy should be configured");
+        assertTrue(integrationFacetInterface().strategyDebt() == 0, "strategy debt should be zero");
+        assertFalse(integrationFacetInterface().strategyEmergencyExit(), "emergency exit should be inactive");
+        assertTrue(integrationFacetInterface().liveStrategyAssets() == 0, "live strategy assets should be zero");
+        assertTrue(
+            IERC4626VaultStrategy(address(nativeStrategy)).vault() == address(diamond), "strategy vault mismatch"
+        );
+        assertTrue(
+            IERC4626VaultStrategy(address(nativeStrategy)).asset() == LibVaultAsset.NATIVE_ASSET_SENTINEL,
+            "strategy asset mismatch"
+        );
+        assertTrue(quotePayload.value == 100_000_000, "quote value mismatch");
+        assertTrue(quotePayload.updatedAt == quoteUpdatedAt, "quote timestamp mismatch");
+        assertTrue(quotePayload.decimals == 8, "quote decimals mismatch");
+
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC4626VaultFacet).interfaceId), "missing core interface"
+        );
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC7535VaultFacet).interfaceId),
+            "missing native interface"
+        );
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC4626VaultControlsFacet).interfaceId),
+            "missing controls interface"
+        );
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC4626VaultIntegrationFacet).interfaceId),
+            "missing integration interface"
+        );
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultAlreadyInitialized.selector));
+        coreFacetInterface()
+            .initializeVault(LibVaultAsset.NATIVE_ASSET_SENTINEL, "Native Vault Share", "nvSHARE", admin);
+    }
+
+    function testNativeVaultHostSmokeCoversStrategyLifecycle() public {
+        _installNativeVaultHostFacets();
+        _initializeNativeVaultHost();
+        _wireOracleAdapter();
+        _wireNativeStrategy();
+
+        VM.deal(address(this), 1 ether);
+        VM.deal(alice, 2 ether);
+        VM.prank(alice);
+        IERC7535VaultFacet(address(diamond)).depositNative{value: 1 ether}(alice);
+
+        VM.prank(admin);
+        integrationFacetInterface().deployToStrategy(0.6 ether);
+        nativeStrategy.injectProfit{value: 0.1 ether}();
+        VM.prank(admin);
+        integrationFacetInterface().syncStrategyAssets();
+
+        assertTrue(integrationFacetInterface().strategyDebt() == 0.7 ether, "strategy debt mismatch after sync");
+        assertTrue(coreFacetInterface().totalManagedAssets() == 1.1 ether, "book value mismatch after sync");
+        assertTrue(coreFacetInterface().totalAssets() == 1.1 ether, "total assets mismatch after sync");
+
+        VM.prank(admin);
+        uint256 managerReturned = integrationFacetInterface().withdrawFromStrategy(0.15 ether);
+        assertTrue(managerReturned == 0.15 ether, "manager withdraw should return requested assets");
+        assertTrue(
+            integrationFacetInterface().strategyDebt() == 0.55 ether, "strategy debt mismatch after manager withdraw"
+        );
+
+        uint256 aliceBalanceBeforeWithdraw = alice.balance;
+        VM.prank(alice);
+        coreFacetInterface().withdraw(0.7 ether, alice, alice);
+
+        assertTrue(alice.balance == aliceBalanceBeforeWithdraw + 0.7 ether, "native withdraw payout mismatch");
+        assertTrue(
+            integrationFacetInterface().strategyDebt() == 0.4 ether, "strategy debt mismatch after user withdraw"
+        );
+        assertTrue(integrationFacetInterface().liveStrategyAssets() == 0.4 ether, "live strategy assets mismatch");
+        assertTrue(integrationFacetInterface().idleAssets() == 0, "idle assets should be exhausted after auto-pull");
+        assertTrue(coreFacetInterface().totalManagedAssets() == 0.4 ether, "book value mismatch after user withdraw");
+
+        VM.prank(admin);
+        uint256 emergencyAssets = integrationFacetInterface().emergencyExitStrategy();
+
+        assertTrue(emergencyAssets == 0.4 ether, "emergency exit should unwind remaining assets");
+        assertTrue(integrationFacetInterface().strategyEmergencyExit(), "emergency exit should be active");
+        assertTrue(integrationFacetInterface().strategyDebt() == 0, "strategy debt should be zero after unwind");
+        assertTrue(integrationFacetInterface().idleAssets() == 0.4 ether, "idle assets should contain unwound funds");
+
+        VM.prank(admin);
+        integrationFacetInterface().setStrategy(address(0));
+        VM.prank(admin);
+        integrationFacetInterface().setStrategy(address(nativeStrategy));
+
+        assertFalse(integrationFacetInterface().strategyEmergencyExit(), "emergency exit should clear on rebind");
+        assertTrue(integrationFacetInterface().strategy() == address(nativeStrategy), "strategy should be rebound");
         assertTrue(integrationFacetInterface().strategyDebt() == 0, "strategy debt should reset to zero");
     }
 

--- a/test/ERC4626VaultControlsFacetCore.t.sol
+++ b/test/ERC4626VaultControlsFacetCore.t.sol
@@ -10,9 +10,11 @@ import {IERC4626VaultBase} from "../src/interfaces/IERC4626VaultBase.sol";
 import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol";
 import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControlsFacet.sol";
 import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
+import {IERC7535VaultFacet} from "../src/interfaces/IERC7535VaultFacet.sol";
 import {IPausable} from "../src/interfaces/IPausable.sol";
 import {IReentrancyGuard} from "../src/interfaces/IReentrancyGuard.sol";
 import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
+import {LibVaultAsset} from "../src/vault/libraries/LibVaultAsset.sol";
 import {ERC4626VaultControlsFacetFixture} from "./helpers/ERC4626VaultControlsFacetTestHarness.sol";
 
 contract ERC4626VaultControlsFacetCoreTest is ERC4626VaultControlsFacetFixture {
@@ -175,7 +177,7 @@ contract ERC4626VaultControlsFacetCoreTest is ERC4626VaultControlsFacetFixture {
         assertTrue(shares == 45, "deposit shares mismatch");
         assertTrue(asset.balanceOf(eve) == INITIAL_ASSETS + 5, "fee recipient balance mismatch");
 
-        assertTrue(IERC4626VaultFacet(address(diamond)).maxDeposit(bob) == 17, "maxDeposit mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxDeposit(bob) == 16, "maxDeposit mismatch");
         assertTrue(IERC4626VaultFacet(address(diamond)).maxMint(bob) == 15, "maxMint mismatch");
         assertTrue(IERC4626VaultFacet(address(diamond)).maxWithdraw(bob) == 25, "maxWithdraw mismatch");
         assertTrue(IERC4626VaultFacet(address(diamond)).maxRedeem(bob) == 20, "maxRedeem mismatch");
@@ -183,8 +185,8 @@ contract ERC4626VaultControlsFacetCoreTest is ERC4626VaultControlsFacetFixture {
         assertTrue(IERC4626VaultFacet(address(diamond)).previewRedeem(20) == 18, "previewRedeem mismatch");
 
         VM.prank(bob);
-        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultControls.ERC4626VaultDepositLimitExceeded.selector, 18, 17));
-        IERC4626VaultFacet(address(diamond)).deposit(18, bob);
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultControls.ERC4626VaultDepositLimitExceeded.selector, 17, 16));
+        IERC4626VaultFacet(address(diamond)).deposit(17, bob);
 
         VM.prank(bob);
         VM.expectRevert(abi.encodeWithSelector(IERC4626VaultControls.ERC4626VaultMintLimitExceeded.selector, 16, 15));
@@ -243,6 +245,141 @@ contract ERC4626VaultControlsFacetCoreTest is ERC4626VaultControlsFacetFixture {
         assertTrue(IERC4626VaultFacet(address(diamond)).allowance(bob, eve) == 5, "allowance mismatch");
         assertTrue(IERC4626VaultFacet(address(diamond)).balanceOf(bob) == 25, "bob balance mismatch");
         assertTrue(IERC4626VaultFacet(address(diamond)).balanceOf(admin) == 15, "admin balance mismatch");
+    }
+
+    function testDiamondNativeDepositAppliesConfiguredFee() public {
+        _installHostedVaultNativeFacetsToDiamond();
+
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond))
+            .initializeVault(LibVaultAsset.NATIVE_ASSET_SENTINEL, "Vault Share", "vSHARE", admin);
+
+        VM.prank(admin);
+        IERC4626VaultControlsFacet(address(diamond)).setFeeConfig(1_000, 0, eve);
+
+        VM.deal(bob, 100);
+        VM.prank(bob);
+        uint256 shares = IERC7535VaultFacet(address(diamond)).depositNative{value: 100}(bob);
+
+        assertTrue(shares == 90, "native deposit shares mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 90, "native total assets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).balanceOf(bob) == 90, "native share balance mismatch");
+        assertTrue(eve.balance == 10, "native fee recipient balance mismatch");
+        assertTrue(address(diamond).balance == 90, "native vault balance mismatch");
+    }
+
+    function testDiamondNativeMintAppliesConfiguredFee() public {
+        _installHostedVaultNativeFacetsToDiamond();
+
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond))
+            .initializeVault(LibVaultAsset.NATIVE_ASSET_SENTINEL, "Vault Share", "vSHARE", admin);
+
+        VM.prank(admin);
+        IERC4626VaultControlsFacet(address(diamond)).setFeeConfig(1_000, 0, eve);
+
+        VM.deal(bob, 100);
+        VM.prank(bob);
+        uint256 assetsIn = IERC7535VaultFacet(address(diamond)).mintNative{value: 56}(50, bob);
+
+        assertTrue(assetsIn == 56, "native mint assets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 50, "native total assets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).balanceOf(bob) == 50, "native share balance mismatch");
+        assertTrue(eve.balance == 6, "native fee recipient balance mismatch");
+        assertTrue(address(diamond).balance == 50, "native vault balance mismatch");
+    }
+
+    function testDiamondNativeControlsConfigReshapesNativeRouting() public {
+        _installHostedVaultNativeFacetsToDiamond();
+
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond))
+            .initializeVault(LibVaultAsset.NATIVE_ASSET_SENTINEL, "Vault Share", "vSHARE", admin);
+
+        VM.prank(admin);
+        IERC4626VaultControlsFacet(address(diamond)).setFeeConfig(1_000, 1_000, eve);
+        VM.prank(admin);
+        IERC4626VaultControlsFacet(address(diamond)).setLimitConfig(60, 0, 15, 25, 20);
+
+        VM.deal(bob, 100);
+        VM.prank(bob);
+        uint256 shares = IERC7535VaultFacet(address(diamond)).depositNative{value: 50}(bob);
+        assertTrue(shares == 45, "native deposit shares mismatch");
+        assertTrue(eve.balance == 5, "native fee recipient balance mismatch");
+
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewDeposit(100) == 90, "native previewDeposit mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewMint(50) == 56, "native previewMint mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxDeposit(bob) == 16, "native maxDeposit mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxMint(bob) == 15, "native maxMint mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxWithdraw(bob) == 25, "native maxWithdraw mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxRedeem(bob) == 20, "native maxRedeem mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewWithdraw(20) == 22, "native previewWithdraw mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewRedeem(20) == 18, "native previewRedeem mismatch");
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultControls.ERC4626VaultDepositLimitExceeded.selector, 17, 16));
+        IERC7535VaultFacet(address(diamond)).depositNative{value: 17}(bob);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultControls.ERC4626VaultMintLimitExceeded.selector, 16, 15));
+        IERC7535VaultFacet(address(diamond)).mintNative{value: 0}(16, bob);
+
+        VM.prank(bob);
+        VM.expectRevert(
+            abi.encodeWithSelector(IERC4626VaultControls.ERC4626VaultWithdrawLimitExceeded.selector, 26, 25)
+        );
+        IERC4626VaultFacet(address(diamond)).withdraw(26, bob, bob);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultControls.ERC4626VaultRedeemLimitExceeded.selector, 21, 20));
+        IERC4626VaultFacet(address(diamond)).redeem(21, bob, bob);
+    }
+
+    function testDiamondNativeGlobalPauseBlocksVaultEntrypointsButNotShareTokenFlows() public {
+        _installHostedVaultNativeFacetsToDiamond();
+
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond))
+            .initializeVault(LibVaultAsset.NATIVE_ASSET_SENTINEL, "Vault Share", "vSHARE", admin);
+
+        VM.deal(bob, 100);
+        VM.prank(bob);
+        IERC7535VaultFacet(address(diamond)).depositNative{value: 40}(bob);
+
+        VM.prank(admin);
+        IERC4626VaultControlsFacet(address(diamond)).pause();
+
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxDeposit(bob) == 0, "native maxDeposit should pause");
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxMint(bob) == 0, "native maxMint should pause");
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxWithdraw(bob) == 0, "native maxWithdraw should pause");
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxRedeem(bob) == 0, "native maxRedeem should pause");
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+        IERC7535VaultFacet(address(diamond)).depositNative{value: 1}(bob);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+        IERC7535VaultFacet(address(diamond)).mintNative{value: 1}(1, bob);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+        IERC4626VaultFacet(address(diamond)).withdraw(1, bob, bob);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+        IERC4626VaultFacet(address(diamond)).redeem(1, bob, bob);
+
+        VM.prank(bob);
+        IERC4626VaultFacet(address(diamond)).approve(eve, 15);
+        VM.prank(eve);
+        IERC4626VaultFacet(address(diamond)).transferFrom(bob, admin, 10);
+        VM.prank(bob);
+        IERC4626VaultFacet(address(diamond)).transfer(admin, 5);
+
+        assertTrue(IERC4626VaultFacet(address(diamond)).allowance(bob, eve) == 5, "native allowance mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).balanceOf(bob) == 25, "native bob balance mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).balanceOf(admin) == 15, "native admin balance mismatch");
     }
 
     function testDiamondScopePauseRoutesButDoesNotBlockVaultEntrypoints() public {

--- a/test/ERC4626VaultFacetCore.t.sol
+++ b/test/ERC4626VaultFacetCore.t.sol
@@ -3,12 +3,20 @@ pragma solidity ^0.8.30;
 
 import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
 import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
+import {IERC165} from "../src/interfaces/IERC165.sol";
+import {IERC4626} from "../src/interfaces/IERC4626.sol";
 import {IERC4626VaultBase} from "../src/interfaces/IERC4626VaultBase.sol";
 import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
+import {IERC7535VaultFacet} from "../src/interfaces/IERC7535VaultFacet.sol";
 import {IPausable} from "../src/interfaces/IPausable.sol";
 import {ERC4626Vault} from "../src/vault/ERC4626Vault.sol";
+import {LibNativeAsset} from "../src/vault/libraries/LibNativeAsset.sol";
 import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
-import {ERC4626VaultFacetFixture, ERC4626VaultFacetHarness} from "./helpers/ERC4626VaultFacetTestHarness.sol";
+import {
+    ERC4626VaultFacetFixture,
+    ERC4626VaultFacetHarness,
+    RejectingNativeReceiver
+} from "./helpers/ERC4626VaultFacetTestHarness.sol";
 
 contract ERC4626VaultFacetCoreTest is ERC4626VaultFacetFixture {
     function testInitializeVaultSeedsMetadataAndControlPlane() public {
@@ -223,6 +231,160 @@ contract ERC4626VaultFacetCoreTest is ERC4626VaultFacetFixture {
         _installVaultCoreFacetToDiamond();
 
         _assertSelectorsUnset(LibVaultFacetSelectors.vaultControlsSelectors());
+    }
+
+    function testInitializeNativeVaultUsesSentinelAssetAndDefaultDecimals() public {
+        _initializeHostedVaultWithAsset(address(facet), LibNativeAsset.NATIVE_ASSET_SENTINEL);
+
+        assertTrue(facet.asset() == LibNativeAsset.NATIVE_ASSET_SENTINEL, "native asset sentinel mismatch");
+        assertTrue(facet.decimals() == 18, "native decimals should default to 18");
+    }
+
+    function testNativeDepositAndMintEntrypointsWorkOnFacet() public {
+        _initializeHostedVaultWithAsset(address(facet), LibNativeAsset.NATIVE_ASSET_SENTINEL);
+        VM.deal(bob, 100);
+
+        VM.prank(bob);
+        uint256 depositShares = IERC7535VaultFacet(address(facet)).depositNative{value: 40}(bob);
+
+        VM.prank(bob);
+        uint256 mintAssets = IERC7535VaultFacet(address(facet)).mintNative{value: 10}(10, bob);
+
+        assertTrue(depositShares == 40, "native deposit shares mismatch");
+        assertTrue(mintAssets == 10, "native mint assets mismatch");
+        assertTrue(facet.totalAssets() == 50, "native total assets mismatch");
+        assertTrue(facet.totalManagedAssets() == 50, "native managed assets mismatch");
+        assertTrue(facet.totalSupply() == 50, "native supply mismatch");
+        assertTrue(facet.balanceOf(bob) == 50, "native share balance mismatch");
+        assertTrue(address(facet).balance == 50, "native vault balance mismatch");
+    }
+
+    function testNativeMintRequiresExactMsgValue() public {
+        _initializeHostedVaultWithAsset(address(facet), LibNativeAsset.NATIVE_ASSET_SENTINEL);
+        VM.deal(bob, 100);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(ERC4626Vault.ERC4626VaultInvalidNativeAssetValue.selector, 9, 10));
+        IERC7535VaultFacet(address(facet)).mintNative{value: 9}(10, bob);
+    }
+
+    function testNativeEntrypointsRejectErc20Vaults() public {
+        _initializeHostedVault(address(facet));
+        VM.deal(bob, 100);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(ERC4626Vault.ERC4626VaultNativeAssetDisabled.selector));
+        IERC7535VaultFacet(address(facet)).depositNative{value: 10}(bob);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(ERC4626Vault.ERC4626VaultNativeAssetDisabled.selector));
+        IERC7535VaultFacet(address(facet)).mintNative{value: 10}(10, bob);
+    }
+
+    function testStandardDepositAndMintRejectNativeVaultMode() public {
+        _initializeHostedVaultWithAsset(address(facet), LibNativeAsset.NATIVE_ASSET_SENTINEL);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(ERC4626Vault.ERC4626VaultNativeAssetUseNativeEntrypoint.selector));
+        facet.deposit(10, bob);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(ERC4626Vault.ERC4626VaultNativeAssetUseNativeEntrypoint.selector));
+        facet.mint(10, bob);
+    }
+
+    function testErc20VaultDepositAndMintRejectMsgValue() public {
+        _initializeHostedVault(address(facet));
+        VM.deal(bob, 100);
+
+        VM.prank(bob);
+        (bool depositSuccess,) = address(facet).call{value: 1}(abi.encodeCall(IERC4626.deposit, (1, bob)));
+        assertFalse(depositSuccess, "erc20 deposit should reject native value");
+
+        VM.prank(bob);
+        (bool mintSuccess,) = address(facet).call{value: 1}(abi.encodeCall(IERC4626.mint, (1, bob)));
+        assertFalse(mintSuccess, "erc20 mint should reject native value");
+    }
+
+    function testNativeWithdrawAndRedeemTransferRawNativeAsset() public {
+        _initializeHostedVaultWithAsset(address(facet), LibNativeAsset.NATIVE_ASSET_SENTINEL);
+        VM.deal(bob, 100);
+
+        VM.prank(bob);
+        IERC7535VaultFacet(address(facet)).depositNative{value: 40}(bob);
+
+        uint256 bobBalanceBeforeWithdraw = bob.balance;
+        VM.prank(bob);
+        uint256 withdrawnShares = facet.withdraw(10, bob, bob);
+        assertTrue(withdrawnShares == 10, "native withdraw share burn mismatch");
+        assertTrue(bob.balance == bobBalanceBeforeWithdraw + 10, "native withdraw payout mismatch");
+
+        uint256 bobBalanceBeforeRedeem = bob.balance;
+        VM.prank(bob);
+        uint256 redeemedAssets = facet.redeem(5, bob, bob);
+        assertTrue(redeemedAssets == 5, "native redeem asset mismatch");
+        assertTrue(bob.balance == bobBalanceBeforeRedeem + 5, "native redeem payout mismatch");
+        assertTrue(address(facet).balance == 25, "native vault balance after payout mismatch");
+    }
+
+    function testNativePayoutFailureRevertsCleanly() public {
+        _initializeHostedVaultWithAsset(address(facet), LibNativeAsset.NATIVE_ASSET_SENTINEL);
+        VM.deal(bob, 100);
+
+        VM.prank(bob);
+        IERC7535VaultFacet(address(facet)).depositNative{value: 10}(bob);
+
+        RejectingNativeReceiver receiver = new RejectingNativeReceiver();
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(ERC4626Vault.ERC4626VaultAssetTransferFailed.selector));
+        facet.withdraw(5, address(receiver), bob);
+    }
+
+    function testForceSentNativeAssetsDoNotChangeBookAccountingOrPricing() public {
+        _initializeHostedVaultWithAsset(address(facet), LibNativeAsset.NATIVE_ASSET_SENTINEL);
+        VM.deal(bob, 100);
+
+        VM.prank(bob);
+        IERC7535VaultFacet(address(facet)).depositNative{value: 10}(bob);
+
+        VM.deal(address(facet), address(facet).balance + 7);
+
+        assertTrue(address(facet).balance == 17, "native force-send balance mismatch");
+        assertTrue(facet.totalManagedAssets() == 10, "managed assets should ignore force-send");
+        assertTrue(facet.totalAssets() == 10, "pricing should ignore force-send");
+        assertTrue(facet.convertToShares(5) == 5, "force-send should not change share pricing");
+        assertTrue(facet.convertToAssets(10) == 10, "force-send should not change asset pricing");
+    }
+
+    function testDiamondNativeRoutingReportsHostedNativeInterfaceAndTransfersRawNativeAsset() public {
+        _installHostedVaultFacetsToDiamond();
+
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond))
+            .initializeVault(LibNativeAsset.NATIVE_ASSET_SENTINEL, "Vault Share", "vSHARE", admin);
+
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC7535VaultFacet).interfaceId),
+            "native hosted interface unsupported"
+        );
+
+        VM.deal(bob, 100);
+        VM.prank(bob);
+        uint256 mintedShares = IERC7535VaultFacet(address(diamond)).depositNative{value: 25}(bob);
+        assertTrue(mintedShares == 25, "diamond native deposit shares mismatch");
+
+        uint256 bobBalanceBeforeWithdraw = bob.balance;
+        VM.prank(bob);
+        uint256 burnedShares = IERC4626VaultFacet(address(diamond)).withdraw(10, bob, bob);
+        assertTrue(burnedShares == 10, "diamond native withdraw share burn mismatch");
+        assertTrue(bob.balance == bobBalanceBeforeWithdraw + 10, "diamond native withdraw payout mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 15, "diamond native total assets mismatch");
+        assertTrue(
+            IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 15, "diamond native managed assets mismatch"
+        );
+
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultCoreSelectors(), address(facet));
     }
 
     function _assertSelectorsOwnedByFacet(bytes4[] memory selectors, address expectedFacet) internal view {

--- a/test/ERC4626VaultFacetCore.t.sol
+++ b/test/ERC4626VaultFacetCore.t.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
-import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
 import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
 import {IERC165} from "../src/interfaces/IERC165.sol";
 import {IERC4626} from "../src/interfaces/IERC4626.sol";
@@ -10,7 +9,7 @@ import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
 import {IERC7535VaultFacet} from "../src/interfaces/IERC7535VaultFacet.sol";
 import {IPausable} from "../src/interfaces/IPausable.sol";
 import {ERC4626Vault} from "../src/vault/ERC4626Vault.sol";
-import {LibNativeAsset} from "../src/vault/libraries/LibNativeAsset.sol";
+import {LibVaultAsset} from "../src/vault/libraries/LibVaultAsset.sol";
 import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {
     ERC4626VaultFacetFixture,
@@ -23,7 +22,6 @@ contract ERC4626VaultFacetCoreTest is ERC4626VaultFacetFixture {
         _initializeHostedVault(address(facet));
 
         assertTrue(facet.isVaultInitialized(), "vault should initialize");
-        assertTrue(facet.controlPlaneInitialized(), "control plane should initialize");
         assertTrue(facet.asset() == address(asset), "asset mismatch");
         assertTrue(keccak256(bytes(facet.name())) == keccak256(bytes("Vault Share")), "name mismatch");
         assertTrue(keccak256(bytes(facet.symbol())) == keccak256(bytes("vSHARE")), "symbol mismatch");
@@ -45,23 +43,6 @@ contract ERC4626VaultFacetCoreTest is ERC4626VaultFacetFixture {
 
         VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultAlreadyInitialized.selector));
         _initializeHostedVault(address(facet));
-    }
-
-    function testInitializeVaultAfterControlOnlyInitRequiresDefaultAdmin() public {
-        facet.initializeControlOnly(admin);
-
-        VM.expectRevert(
-            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, bob, facet.DEFAULT_ADMIN_ROLE())
-        );
-        VM.prank(bob);
-        facet.initializeVault(address(asset), "Vault Share", "vSHARE", admin);
-
-        VM.prank(admin);
-        facet.initializeVault(address(asset), "Vault Share", "vSHARE", admin);
-
-        assertTrue(facet.isVaultInitialized(), "vault should initialize");
-        assertTrue(facet.controlPlaneInitialized(), "control plane should stay initialized");
-        assertTrue(facet.feeRecipient() == admin, "fee recipient mismatch");
     }
 
     function testCoreFlowsAndShareTokenRoutingWorkOnFacet() public {
@@ -234,55 +215,66 @@ contract ERC4626VaultFacetCoreTest is ERC4626VaultFacetFixture {
     }
 
     function testInitializeNativeVaultUsesSentinelAssetAndDefaultDecimals() public {
-        _initializeHostedVaultWithAsset(address(facet), LibNativeAsset.NATIVE_ASSET_SENTINEL);
+        _initializeHostedVaultWithAsset(address(facet), LibVaultAsset.NATIVE_ASSET_SENTINEL);
 
-        assertTrue(facet.asset() == LibNativeAsset.NATIVE_ASSET_SENTINEL, "native asset sentinel mismatch");
+        assertTrue(facet.asset() == LibVaultAsset.NATIVE_ASSET_SENTINEL, "native asset sentinel mismatch");
         assertTrue(facet.decimals() == 18, "native decimals should default to 18");
     }
 
-    function testNativeDepositAndMintEntrypointsWorkOnFacet() public {
-        _initializeHostedVaultWithAsset(address(facet), LibNativeAsset.NATIVE_ASSET_SENTINEL);
+    function testNativeDepositAndMintEntrypointsWorkOnDiamond() public {
+        _installHostedVaultNativeFacetsToDiamond();
+
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond))
+            .initializeVault(LibVaultAsset.NATIVE_ASSET_SENTINEL, "Vault Share", "vSHARE", admin);
+
         VM.deal(bob, 100);
+        VM.prank(bob);
+        uint256 depositShares = IERC7535VaultFacet(address(diamond)).depositNative{value: 40}(bob);
 
         VM.prank(bob);
-        uint256 depositShares = IERC7535VaultFacet(address(facet)).depositNative{value: 40}(bob);
-
-        VM.prank(bob);
-        uint256 mintAssets = IERC7535VaultFacet(address(facet)).mintNative{value: 10}(10, bob);
+        uint256 mintAssets = IERC7535VaultFacet(address(diamond)).mintNative{value: 10}(10, bob);
 
         assertTrue(depositShares == 40, "native deposit shares mismatch");
         assertTrue(mintAssets == 10, "native mint assets mismatch");
-        assertTrue(facet.totalAssets() == 50, "native total assets mismatch");
-        assertTrue(facet.totalManagedAssets() == 50, "native managed assets mismatch");
-        assertTrue(facet.totalSupply() == 50, "native supply mismatch");
-        assertTrue(facet.balanceOf(bob) == 50, "native share balance mismatch");
-        assertTrue(address(facet).balance == 50, "native vault balance mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 50, "native total assets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 50, "native managed assets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalSupply() == 50, "native supply mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).balanceOf(bob) == 50, "native share balance mismatch");
+        assertTrue(address(diamond).balance == 50, "native vault balance mismatch");
     }
 
     function testNativeMintRequiresExactMsgValue() public {
-        _initializeHostedVaultWithAsset(address(facet), LibNativeAsset.NATIVE_ASSET_SENTINEL);
-        VM.deal(bob, 100);
+        _installHostedVaultNativeFacetsToDiamond();
 
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond))
+            .initializeVault(LibVaultAsset.NATIVE_ASSET_SENTINEL, "Vault Share", "vSHARE", admin);
+
+        VM.deal(bob, 100);
         VM.prank(bob);
         VM.expectRevert(abi.encodeWithSelector(ERC4626Vault.ERC4626VaultInvalidNativeAssetValue.selector, 9, 10));
-        IERC7535VaultFacet(address(facet)).mintNative{value: 9}(10, bob);
+        IERC7535VaultFacet(address(diamond)).mintNative{value: 9}(10, bob);
     }
 
-    function testNativeEntrypointsRejectErc20Vaults() public {
-        _initializeHostedVault(address(facet));
+    function testNativeEntrypointsRejectErc20VaultsOnDiamond() public {
+        _installHostedVaultNativeFacetsToDiamond();
+
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond)).initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+
         VM.deal(bob, 100);
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(ERC4626Vault.ERC4626VaultNativeAssetDisabled.selector));
+        IERC7535VaultFacet(address(diamond)).depositNative{value: 10}(bob);
 
         VM.prank(bob);
         VM.expectRevert(abi.encodeWithSelector(ERC4626Vault.ERC4626VaultNativeAssetDisabled.selector));
-        IERC7535VaultFacet(address(facet)).depositNative{value: 10}(bob);
-
-        VM.prank(bob);
-        VM.expectRevert(abi.encodeWithSelector(ERC4626Vault.ERC4626VaultNativeAssetDisabled.selector));
-        IERC7535VaultFacet(address(facet)).mintNative{value: 10}(10, bob);
+        IERC7535VaultFacet(address(diamond)).mintNative{value: 10}(10, bob);
     }
 
     function testStandardDepositAndMintRejectNativeVaultMode() public {
-        _initializeHostedVaultWithAsset(address(facet), LibNativeAsset.NATIVE_ASSET_SENTINEL);
+        _initializeHostedVaultWithAsset(address(facet), LibVaultAsset.NATIVE_ASSET_SENTINEL);
 
         VM.prank(bob);
         VM.expectRevert(abi.encodeWithSelector(ERC4626Vault.ERC4626VaultNativeAssetUseNativeEntrypoint.selector));
@@ -307,62 +299,80 @@ contract ERC4626VaultFacetCoreTest is ERC4626VaultFacetFixture {
     }
 
     function testNativeWithdrawAndRedeemTransferRawNativeAsset() public {
-        _initializeHostedVaultWithAsset(address(facet), LibNativeAsset.NATIVE_ASSET_SENTINEL);
-        VM.deal(bob, 100);
+        _installHostedVaultNativeFacetsToDiamond();
 
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond))
+            .initializeVault(LibVaultAsset.NATIVE_ASSET_SENTINEL, "Vault Share", "vSHARE", admin);
+
+        VM.deal(bob, 100);
         VM.prank(bob);
-        IERC7535VaultFacet(address(facet)).depositNative{value: 40}(bob);
+        IERC7535VaultFacet(address(diamond)).depositNative{value: 40}(bob);
 
         uint256 bobBalanceBeforeWithdraw = bob.balance;
         VM.prank(bob);
-        uint256 withdrawnShares = facet.withdraw(10, bob, bob);
+        uint256 withdrawnShares = IERC4626VaultFacet(address(diamond)).withdraw(10, bob, bob);
         assertTrue(withdrawnShares == 10, "native withdraw share burn mismatch");
         assertTrue(bob.balance == bobBalanceBeforeWithdraw + 10, "native withdraw payout mismatch");
 
         uint256 bobBalanceBeforeRedeem = bob.balance;
         VM.prank(bob);
-        uint256 redeemedAssets = facet.redeem(5, bob, bob);
+        uint256 redeemedAssets = IERC4626VaultFacet(address(diamond)).redeem(5, bob, bob);
         assertTrue(redeemedAssets == 5, "native redeem asset mismatch");
         assertTrue(bob.balance == bobBalanceBeforeRedeem + 5, "native redeem payout mismatch");
-        assertTrue(address(facet).balance == 25, "native vault balance after payout mismatch");
+        assertTrue(address(diamond).balance == 25, "native vault balance after payout mismatch");
     }
 
     function testNativePayoutFailureRevertsCleanly() public {
-        _initializeHostedVaultWithAsset(address(facet), LibNativeAsset.NATIVE_ASSET_SENTINEL);
-        VM.deal(bob, 100);
+        _installHostedVaultNativeFacetsToDiamond();
 
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond))
+            .initializeVault(LibVaultAsset.NATIVE_ASSET_SENTINEL, "Vault Share", "vSHARE", admin);
+
+        VM.deal(bob, 100);
         VM.prank(bob);
-        IERC7535VaultFacet(address(facet)).depositNative{value: 10}(bob);
+        IERC7535VaultFacet(address(diamond)).depositNative{value: 10}(bob);
 
         RejectingNativeReceiver receiver = new RejectingNativeReceiver();
 
         VM.prank(bob);
         VM.expectRevert(abi.encodeWithSelector(ERC4626Vault.ERC4626VaultAssetTransferFailed.selector));
-        facet.withdraw(5, address(receiver), bob);
+        IERC4626VaultFacet(address(diamond)).withdraw(5, address(receiver), bob);
     }
 
     function testForceSentNativeAssetsDoNotChangeBookAccountingOrPricing() public {
-        _initializeHostedVaultWithAsset(address(facet), LibNativeAsset.NATIVE_ASSET_SENTINEL);
-        VM.deal(bob, 100);
-
-        VM.prank(bob);
-        IERC7535VaultFacet(address(facet)).depositNative{value: 10}(bob);
-
-        VM.deal(address(facet), address(facet).balance + 7);
-
-        assertTrue(address(facet).balance == 17, "native force-send balance mismatch");
-        assertTrue(facet.totalManagedAssets() == 10, "managed assets should ignore force-send");
-        assertTrue(facet.totalAssets() == 10, "pricing should ignore force-send");
-        assertTrue(facet.convertToShares(5) == 5, "force-send should not change share pricing");
-        assertTrue(facet.convertToAssets(10) == 10, "force-send should not change asset pricing");
-    }
-
-    function testDiamondNativeRoutingReportsHostedNativeInterfaceAndTransfersRawNativeAsset() public {
-        _installHostedVaultFacetsToDiamond();
+        _installHostedVaultNativeFacetsToDiamond();
 
         VM.prank(admin);
         IERC4626VaultFacet(address(diamond))
-            .initializeVault(LibNativeAsset.NATIVE_ASSET_SENTINEL, "Vault Share", "vSHARE", admin);
+            .initializeVault(LibVaultAsset.NATIVE_ASSET_SENTINEL, "Vault Share", "vSHARE", admin);
+
+        VM.deal(bob, 100);
+        VM.prank(bob);
+        IERC7535VaultFacet(address(diamond)).depositNative{value: 10}(bob);
+
+        VM.deal(address(diamond), address(diamond).balance + 7);
+
+        assertTrue(address(diamond).balance == 17, "native force-send balance mismatch");
+        assertTrue(
+            IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 10, "managed assets should ignore force-send"
+        );
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 10, "pricing should ignore force-send");
+        assertTrue(
+            IERC4626VaultFacet(address(diamond)).convertToShares(5) == 5, "force-send should not change share pricing"
+        );
+        assertTrue(
+            IERC4626VaultFacet(address(diamond)).convertToAssets(10) == 10, "force-send should not change asset pricing"
+        );
+    }
+
+    function testDiamondNativeRoutingReportsHostedNativeInterfaceAndTransfersRawNativeAsset() public {
+        _installHostedVaultNativeFacetsToDiamond();
+
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond))
+            .initializeVault(LibVaultAsset.NATIVE_ASSET_SENTINEL, "Vault Share", "vSHARE", admin);
 
         assertTrue(
             IERC165(address(diamond)).supportsInterface(type(IERC7535VaultFacet).interfaceId),
@@ -385,6 +395,7 @@ contract ERC4626VaultFacetCoreTest is ERC4626VaultFacetFixture {
         );
 
         _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultCoreSelectors(), address(facet));
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultNativeSelectors(), address(nativeFacet));
     }
 
     function _assertSelectorsOwnedByFacet(bytes4[] memory selectors, address expectedFacet) internal view {

--- a/test/ERC4626VaultFacetCore.t.sol
+++ b/test/ERC4626VaultFacetCore.t.sol
@@ -257,6 +257,19 @@ contract ERC4626VaultFacetCoreTest is ERC4626VaultFacetFixture {
         IERC7535VaultFacet(address(diamond)).mintNative{value: 9}(10, bob);
     }
 
+    function testNativeMintRejectsOverpayment() public {
+        _installHostedVaultNativeFacetsToDiamond();
+
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond))
+            .initializeVault(LibVaultAsset.NATIVE_ASSET_SENTINEL, "Vault Share", "vSHARE", admin);
+
+        VM.deal(bob, 100);
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(ERC4626Vault.ERC4626VaultInvalidNativeAssetValue.selector, 11, 10));
+        IERC7535VaultFacet(address(diamond)).mintNative{value: 11}(10, bob);
+    }
+
     function testNativeEntrypointsRejectErc20VaultsOnDiamond() public {
         _installHostedVaultNativeFacetsToDiamond();
 

--- a/test/ERC4626VaultIntegrationFacetCore.t.sol
+++ b/test/ERC4626VaultIntegrationFacetCore.t.sol
@@ -7,7 +7,9 @@ import {IERC165} from "../src/interfaces/IERC165.sol";
 import {IERC4626VaultBase} from "../src/interfaces/IERC4626VaultBase.sol";
 import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
 import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
+import {IERC7535VaultFacet} from "../src/interfaces/IERC7535VaultFacet.sol";
 import {IOracleAdapter} from "../src/interfaces/IOracleAdapter.sol";
+import {LibVaultAsset} from "../src/vault/libraries/LibVaultAsset.sol";
 import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {ERC4626VaultIntegrationFacetFixture} from "./helpers/ERC4626VaultIntegrationFacetTestHarness.sol";
 
@@ -353,6 +355,137 @@ contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFix
                 "integration facet should not own initializer selector"
             );
         }
+    }
+
+    function testDiamondNativeIntegrationFacetRejectsAssetMismatchedStrategies() public {
+        _installHostedVaultNativeFacetsToDiamond();
+        _initializeDiamondNativeVault();
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IERC4626VaultIntegrationFacet.ERC4626VaultStrategyInvalidAsset.selector,
+                address(diamondProfitStrategy),
+                LibVaultAsset.NATIVE_ASSET_SENTINEL,
+                address(asset)
+            )
+        );
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(address(diamondProfitStrategy));
+    }
+
+    function testDiamondErc20IntegrationFacetRejectsNativeStrategy() public {
+        _installHostedVaultNativeFacetsToDiamond();
+        _initializeDiamondVault();
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IERC4626VaultIntegrationFacet.ERC4626VaultStrategyInvalidAsset.selector,
+                address(diamondNativeProfitStrategy),
+                address(asset),
+                LibVaultAsset.NATIVE_ASSET_SENTINEL
+            )
+        );
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(address(diamondNativeProfitStrategy));
+    }
+
+    function testDiamondNativeIntegrationFacetRunsStrategyLifecycle() public {
+        _installHostedVaultNativeFacetsToDiamond();
+        _initializeDiamondNativeVault();
+
+        VM.deal(bob, 100);
+        VM.deal(address(this), 20);
+        VM.prank(bob);
+        uint256 mintedShares = IERC7535VaultFacet(address(diamond)).depositNative{value: 100}(bob);
+
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(address(diamondNativeProfitStrategy));
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).deployToStrategy(60);
+        diamondNativeProfitStrategy.injectProfit{value: 20}();
+
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).syncStrategyAssets();
+        VM.prank(admin);
+        uint256 returnedAssets = IERC4626VaultIntegrationFacet(address(diamond)).withdrawFromStrategy(30);
+        VM.prank(admin);
+        uint256 emergencyAssets = IERC4626VaultIntegrationFacet(address(diamond)).emergencyExitStrategy();
+
+        assertTrue(mintedShares == 100, "deposit shares mismatch");
+        assertTrue(returnedAssets == 30, "partial withdraw return mismatch");
+        assertTrue(emergencyAssets == 50, "emergency exit return mismatch");
+        assertTrue(
+            IERC4626VaultIntegrationFacet(address(diamond)).strategy() == address(diamondNativeProfitStrategy),
+            "strategy mismatch"
+        );
+        assertTrue(
+            IERC4626VaultIntegrationFacet(address(diamond)).strategyEmergencyExit(),
+            "emergency exit should remain active"
+        );
+        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).strategyDebt() == 0, "strategy debt mismatch");
+        assertTrue(
+            IERC4626VaultIntegrationFacet(address(diamond)).liveStrategyAssets() == 0, "live strategy assets mismatch"
+        );
+        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).idleAssets() == 120, "idle assets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 120, "managed assets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 120, "total assets mismatch");
+        assertTrue(address(diamond).balance == 120, "diamond native balance mismatch");
+        assertTrue(address(diamondNativeProfitStrategy).balance == 0, "strategy should be fully unwound");
+    }
+
+    function testDiamondNativeIntegrationFacetSyncRealizesLoss() public {
+        _installHostedVaultNativeFacetsToDiamond();
+        _initializeDiamondNativeVault();
+
+        VM.deal(bob, 100);
+        VM.prank(bob);
+        IERC7535VaultFacet(address(diamond)).depositNative{value: 100}(bob);
+
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(address(diamondNativeLossStrategy));
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).deployToStrategy(60);
+        diamondNativeLossStrategy.applyLoss(15, 35);
+
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).syncStrategyAssets();
+
+        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).strategyDebt() == 45, "strategy debt mismatch");
+        assertTrue(
+            IERC4626VaultIntegrationFacet(address(diamond)).liveStrategyAssets() == 45, "live strategy assets mismatch"
+        );
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 85, "managed assets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 85, "total assets mismatch");
+        assertTrue(address(diamond).balance == 40, "idle balance mismatch");
+        assertTrue(address(diamondNativeLossStrategy).balance == 45, "strategy balance mismatch");
+    }
+
+    function testDiamondNativeIntegrationFacetEmergencyExitFailureDoesNotRevert() public {
+        _installHostedVaultNativeFacetsToDiamond();
+        _initializeDiamondNativeVault();
+
+        VM.deal(bob, 100);
+        VM.prank(bob);
+        IERC7535VaultFacet(address(diamond)).depositNative{value: 100}(bob);
+
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(address(diamondNativeRevertingStrategy));
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).deployToStrategy(60);
+        diamondNativeRevertingStrategy.setRevertModes(false, false, false, true);
+
+        VM.prank(admin);
+        uint256 returnedAssets = IERC4626VaultIntegrationFacet(address(diamond)).emergencyExitStrategy();
+
+        assertTrue(returnedAssets == 0, "failing emergency exit should return zero assets");
+        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).strategyEmergencyExit(), "flag should stay active");
+        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).strategyDebt() == 60, "strategy debt mismatch");
+        assertTrue(
+            IERC4626VaultIntegrationFacet(address(diamond)).liveStrategyAssets() == 60, "live strategy assets mismatch"
+        );
+        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).idleAssets() == 40, "idle assets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 100, "managed assets mismatch");
+        assertTrue(address(diamond).balance == 40, "diamond balance should remain unchanged after failed unwind");
     }
 
     function _assertSelectorsOwnedByFacet(bytes4[] memory selectors, address expectedFacet) internal view {

--- a/test/ERC4626VaultStrategyAccountingCore.t.sol
+++ b/test/ERC4626VaultStrategyAccountingCore.t.sol
@@ -37,7 +37,6 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
         _simulateStrategyDeployment(address(facet), directProfitStrategy, STRATEGY_DEBT);
         directProfitStrategy.injectProfit(20);
 
-        assertTrue(facet.strategyDebtForTest() == STRATEGY_DEBT, "strategy debt mismatch");
         assertTrue(facet.totalManagedAssets() == DEPOSIT_ASSETS, "book value should remain unchanged");
         assertTrue(facet.totalAssets() == 120, "mark-to-market assets mismatch");
         assertTrue(facet.convertToShares(12) == 10, "convertToShares profit mismatch");

--- a/test/ERC4626VaultStrategyAccountingCore.t.sol
+++ b/test/ERC4626VaultStrategyAccountingCore.t.sol
@@ -5,6 +5,7 @@ import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol
 import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControlsFacet.sol";
 import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
 import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
+import {IERC7535VaultFacet} from "../src/interfaces/IERC7535VaultFacet.sol";
 import {ERC4626VaultStrategyAccountingFixture} from "./helpers/ERC4626VaultStrategyAccountingTestHarness.sol";
 
 contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountingFixture {
@@ -181,5 +182,104 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
         );
         assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 40, "managed assets mismatch");
         assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 40, "post-withdraw totalAssets mismatch");
+    }
+
+    function testDiamondNativeHostedVaultStrategyAccountingUsesRealLifecycleAndAutoPull() public {
+        _installHostedVaultNativeFacetsToDiamond();
+        _initializeDiamondNativeVault();
+        VM.deal(bob, INITIAL_ASSETS);
+        VM.deal(address(this), 20);
+
+        VM.prank(bob);
+        IERC7535VaultFacet(address(diamond)).depositNative{value: DEPOSIT_ASSETS}(bob);
+
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(address(diamondNativeProfitStrategy));
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).deployToStrategy(60);
+        diamondNativeProfitStrategy.injectProfit{value: 20}();
+
+        VM.prank(admin);
+        IERC4626VaultControlsFacet(address(diamond)).setLimitConfig(125, 0, 0, 0, 0);
+
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == DEPOSIT_ASSETS, "book value mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 120, "diamond totalAssets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewDeposit(12) == 10, "diamond previewDeposit mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewMint(10) == 12, "diamond previewMint mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewWithdraw(12) == 10, "diamond previewWithdraw mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewRedeem(10) == 12, "diamond previewRedeem mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxDeposit(bob) == 5, "maxDeposit should use live totalAssets");
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxMint(bob) == 4, "maxMint should use live totalAssets");
+        assertTrue(
+            IERC4626VaultFacet(address(diamond)).maxWithdraw(bob) == 120,
+            "maxWithdraw should include strategy liquidity"
+        );
+        assertTrue(
+            IERC4626VaultFacet(address(diamond)).maxRedeem(bob) == 100, "maxRedeem should include strategy liquidity"
+        );
+
+        uint256 bobBalanceBeforeWithdraw = bob.balance;
+        VM.prank(bob);
+        uint256 burnedShares = IERC4626VaultFacet(address(diamond)).withdraw(80, bob, bob);
+
+        assertTrue(burnedShares == 67, "diamond withdraw should burn shares at updated price");
+        assertTrue(bob.balance == bobBalanceBeforeWithdraw + 80, "withdraw should pay raw native asset");
+        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).idleAssets() == 0, "idle assets should be zero");
+        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).strategyDebt() == 40, "strategy debt mismatch");
+        assertTrue(
+            IERC4626VaultIntegrationFacet(address(diamond)).liveStrategyAssets() == 40, "live strategy assets mismatch"
+        );
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 40, "managed assets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 40, "post-withdraw totalAssets mismatch");
+        assertTrue(address(diamond).balance == 0, "vault idle balance should be exhausted");
+    }
+
+    function testDiamondNativeRedeemAutoPullsAndReturnsCurrentShareValue() public {
+        _installHostedVaultNativeFacetsToDiamond();
+        _initializeDiamondNativeVault();
+        VM.deal(bob, INITIAL_ASSETS);
+        VM.deal(address(this), 20);
+
+        VM.prank(bob);
+        IERC7535VaultFacet(address(diamond)).depositNative{value: DEPOSIT_ASSETS}(bob);
+
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(address(diamondNativeProfitStrategy));
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).deployToStrategy(60);
+        diamondNativeProfitStrategy.injectProfit{value: 20}();
+
+        uint256 bobBalanceBeforeRedeem = bob.balance;
+        VM.prank(bob);
+        uint256 returnedAssets = IERC4626VaultFacet(address(diamond)).redeem(50, bob, bob);
+
+        assertTrue(returnedAssets == 60, "redeem should return current share value");
+        assertTrue(bob.balance == bobBalanceBeforeRedeem + 60, "redeem should pay raw native asset");
+        assertTrue(IERC4626VaultFacet(address(diamond)).balanceOf(bob) == 50, "remaining shares mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 60, "book value mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 60, "total assets mismatch");
+        assertTrue(address(diamond).balance == 0, "vault idle balance should be exhausted after redeem");
+        assertTrue(diamondNativeProfitStrategy.totalAssets() == 60, "remaining strategy assets mismatch");
+    }
+
+    function testDiamondNativeWithdrawRevertsWhenStrategyLiquidityCannotCoverExactAssets() public {
+        _installHostedVaultNativeFacetsToDiamond();
+        _initializeDiamondNativeVault();
+        VM.deal(bob, INITIAL_ASSETS);
+
+        VM.prank(bob);
+        IERC7535VaultFacet(address(diamond)).depositNative{value: DEPOSIT_ASSETS}(bob);
+
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(address(diamondNativeLossStrategy));
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).deployToStrategy(60);
+        diamondNativeLossStrategy.applyLoss(20, 10);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(IERC4626VaultControls.ERC4626VaultWithdrawLimitExceeded.selector, 70, 50)
+        );
+        VM.prank(bob);
+        IERC4626VaultFacet(address(diamond)).withdraw(70, bob, bob);
     }
 }

--- a/test/VaultFacetFoundationCore.t.sol
+++ b/test/VaultFacetFoundationCore.t.sol
@@ -5,6 +5,7 @@ import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
 import {IAccessControlTime} from "../src/interfaces/IAccessControlTime.sol";
 import {IERC165} from "../src/interfaces/IERC165.sol";
 import {IERC4626} from "../src/interfaces/IERC4626.sol";
+import {IERC7535VaultFacet} from "../src/interfaces/IERC7535VaultFacet.sol";
 import {IERC4626VaultBase} from "../src/interfaces/IERC4626VaultBase.sol";
 import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol";
 import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControlsFacet.sol";
@@ -84,12 +85,14 @@ contract VaultFacetFoundationCoreTest is VaultFacetFoundationFixture {
         bytes4[] memory coreSelectors = LibVaultFacetSelectors.vaultCoreSelectors();
         bytes4[] memory controlSelectors = LibVaultFacetSelectors.vaultControlsSelectors();
 
-        assertTrue(coreSelectors.length == 28, "unexpected core selector count");
+        assertTrue(coreSelectors.length == 30, "unexpected core selector count");
         assertTrue(controlSelectors.length == 28, "unexpected controls selector count");
 
         _assertContains(coreSelectors, IERC4626VaultFacet.initializeVault.selector);
         _assertContains(coreSelectors, IERC4626.deposit.selector);
         _assertContains(coreSelectors, IERC4626.redeem.selector);
+        _assertContains(coreSelectors, IERC7535VaultFacet.depositNative.selector);
+        _assertContains(coreSelectors, IERC7535VaultFacet.mintNative.selector);
         _assertContains(coreSelectors, IERC4626VaultBase.totalManagedAssets.selector);
 
         _assertContains(controlSelectors, IERC4626VaultControls.setFeeConfig.selector);

--- a/test/VaultFacetFoundationCore.t.sol
+++ b/test/VaultFacetFoundationCore.t.sol
@@ -83,17 +83,20 @@ contract VaultFacetFoundationCoreTest is VaultFacetFoundationFixture {
 
     function testVaultSelectorGroupsCoverExpectedHostedSplit() public pure {
         bytes4[] memory coreSelectors = LibVaultFacetSelectors.vaultCoreSelectors();
+        bytes4[] memory nativeSelectors = LibVaultFacetSelectors.vaultNativeSelectors();
         bytes4[] memory controlSelectors = LibVaultFacetSelectors.vaultControlsSelectors();
 
-        assertTrue(coreSelectors.length == 30, "unexpected core selector count");
+        assertTrue(coreSelectors.length == 28, "unexpected core selector count");
+        assertTrue(nativeSelectors.length == 2, "unexpected native selector count");
         assertTrue(controlSelectors.length == 28, "unexpected controls selector count");
 
         _assertContains(coreSelectors, IERC4626VaultFacet.initializeVault.selector);
         _assertContains(coreSelectors, IERC4626.deposit.selector);
         _assertContains(coreSelectors, IERC4626.redeem.selector);
-        _assertContains(coreSelectors, IERC7535VaultFacet.depositNative.selector);
-        _assertContains(coreSelectors, IERC7535VaultFacet.mintNative.selector);
         _assertContains(coreSelectors, IERC4626VaultBase.totalManagedAssets.selector);
+
+        _assertContains(nativeSelectors, IERC7535VaultFacet.depositNative.selector);
+        _assertContains(nativeSelectors, IERC7535VaultFacet.mintNative.selector);
 
         _assertContains(controlSelectors, IERC4626VaultControls.setFeeConfig.selector);
         _assertContains(controlSelectors, IERC4626VaultControls.setLimitConfig.selector);
@@ -102,8 +105,11 @@ contract VaultFacetFoundationCoreTest is VaultFacetFoundationFixture {
         _assertContains(controlSelectors, IERC165.supportsInterface.selector);
 
         _assertUnique(coreSelectors);
+        _assertUnique(nativeSelectors);
         _assertUnique(controlSelectors);
+        _assertDisjoint(coreSelectors, nativeSelectors);
         _assertDisjoint(coreSelectors, controlSelectors);
+        _assertDisjoint(nativeSelectors, controlSelectors);
     }
 
     function _assertContains(bytes4[] memory selectors, bytes4 target) internal pure {

--- a/test/VaultStrategyFoundationCore.t.sol
+++ b/test/VaultStrategyFoundationCore.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.30;
 
 import {IERC4626VaultStrategy} from "../src/interfaces/IERC4626VaultStrategy.sol";
+import {LibVaultAsset} from "../src/vault/libraries/LibVaultAsset.sol";
 import {
     ERC4626VaultStrategyFixture,
     MockVaultStrategyForcedRevert
@@ -108,9 +109,111 @@ contract VaultStrategyFoundationCoreTest is ERC4626VaultStrategyFixture {
         assertTrue(asset.balanceOf(vault) == 100, "vault should receive unwound assets");
     }
 
+    function testNativeMockStrategiesBindVaultAndAsset() public view {
+        _assertBinding(nativeProfitStrategy);
+        _assertBinding(nativeLossStrategy);
+        _assertBinding(nativeRevertingStrategy);
+        _assertBinding(nativeUnwindStrategy);
+    }
+
+    function testOnlyVaultCanOperateNativeStrategyLifecycle() public {
+        _assertOnlyVault(nativeProfitStrategy);
+        _assertOnlyVault(nativeLossStrategy);
+        _assertOnlyVault(nativeRevertingStrategy);
+        _assertOnlyVault(nativeUnwindStrategy);
+    }
+
+    function testNativeProfitMockReportsHigherAssetsAfterProfitInjection() public {
+        VM.deal(address(nativeProfitStrategy), 100);
+        VM.deal(address(this), 25);
+        VM.prank(vault);
+        nativeProfitStrategy.deployFunds(100);
+
+        nativeProfitStrategy.injectProfit{value: 25}();
+
+        assertTrue(nativeProfitStrategy.totalAssets() == 125, "profit should increase tracked assets");
+        assertTrue(nativeProfitStrategy.maxWithdrawableAssets() == 125, "profit should increase withdrawable assets");
+        assertTrue(address(nativeProfitStrategy).balance == 125, "strategy balance should reflect profit");
+    }
+
+    function testNativeLossShortfallMockReturnsLessThanRequestedAndShrinksAssets() public {
+        VM.deal(address(nativeLossStrategy), 100);
+        VM.prank(vault);
+        nativeLossStrategy.deployFunds(100);
+
+        nativeLossStrategy.applyLoss(40, 35);
+
+        assertTrue(nativeLossStrategy.totalAssets() == 60, "loss should reduce tracked assets");
+        assertTrue(nativeLossStrategy.maxWithdrawableAssets() == 35, "shortfall should cap withdrawable assets");
+        assertTrue(address(nativeLossStrategy).balance == 60, "strategy balance should reflect realized loss");
+
+        VM.prank(vault);
+        uint256 returnedAssets = nativeLossStrategy.withdrawToVault(50);
+
+        assertTrue(returnedAssets == 35, "withdraw should return available assets only");
+        assertTrue(nativeLossStrategy.totalAssets() == 25, "tracked assets should reduce by returned amount");
+        assertTrue(nativeLossStrategy.maxWithdrawableAssets() == 0, "withdrawable assets should be depleted");
+        assertTrue(vault.balance == 35, "vault should receive returned assets");
+    }
+
+    function testNativeRevertingMockRevertsOnConfiguredCalls() public {
+        nativeRevertingStrategy.setRevertModes(true, true, true, true);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(MockVaultStrategyForcedRevert.selector, nativeRevertingStrategy.totalAssets.selector)
+        );
+        nativeRevertingStrategy.totalAssets();
+
+        VM.deal(address(nativeRevertingStrategy), 100);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(MockVaultStrategyForcedRevert.selector, nativeRevertingStrategy.deployFunds.selector)
+        );
+        VM.prank(vault);
+        nativeRevertingStrategy.deployFunds(100);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                MockVaultStrategyForcedRevert.selector, nativeRevertingStrategy.withdrawToVault.selector
+            )
+        );
+        VM.prank(vault);
+        nativeRevertingStrategy.withdrawToVault(100);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                MockVaultStrategyForcedRevert.selector, nativeRevertingStrategy.withdrawAllToVault.selector
+            )
+        );
+        VM.prank(vault);
+        nativeRevertingStrategy.withdrawAllToVault();
+    }
+
+    function testNativeEmergencyUnwindMockReturnsAllAssetsAndClearsState() public {
+        VM.deal(address(nativeUnwindStrategy), 100);
+        VM.prank(vault);
+        nativeUnwindStrategy.deployFunds(100);
+
+        nativeUnwindStrategy.setWithdrawableAssets(40);
+
+        VM.prank(vault);
+        uint256 returnedAssets = nativeUnwindStrategy.withdrawAllToVault();
+
+        assertTrue(returnedAssets == 100, "emergency unwind should return all tracked assets");
+        assertTrue(nativeUnwindStrategy.totalAssets() == 0, "tracked assets should clear on unwind");
+        assertTrue(nativeUnwindStrategy.maxWithdrawableAssets() == 0, "withdrawable assets should clear on unwind");
+        assertTrue(vault.balance == 100, "vault should receive unwound assets");
+    }
+
     function _assertBinding(IERC4626VaultStrategy strategy_) internal view {
         assertTrue(strategy_.vault() == vault, "vault binding mismatch");
-        assertTrue(strategy_.asset() == address(asset), "asset binding mismatch");
+        address expectedAsset = address(strategy_) == address(nativeProfitStrategy)
+                || address(strategy_) == address(nativeLossStrategy)
+                || address(strategy_) == address(nativeRevertingStrategy)
+                || address(strategy_) == address(nativeUnwindStrategy)
+            ? LibVaultAsset.NATIVE_ASSET_SENTINEL
+            : address(asset);
+        assertTrue(strategy_.asset() == expectedAsset, "asset binding mismatch");
     }
 
     function _assertOnlyVault(IERC4626VaultStrategy strategy_) internal {

--- a/test/helpers/AccessControlTestHarness.sol
+++ b/test/helpers/AccessControlTestHarness.sol
@@ -9,6 +9,7 @@ interface Vm {
     function stopPrank() external;
     function assume(bool) external;
     function addr(uint256) external returns (address);
+    function deal(address who, uint256 newBalance) external;
     function sign(uint256, bytes32) external returns (uint8, bytes32, bytes32);
     function expectRevert(bytes4) external;
     function expectRevert(bytes calldata) external;

--- a/test/helpers/DiamondNativeVaultHostHardeningTestHarness.sol
+++ b/test/helpers/DiamondNativeVaultHostHardeningTestHarness.sol
@@ -2,43 +2,27 @@
 pragma solidity ^0.8.30;
 
 import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
-import {ERC4626VaultControlsFacet} from "../../src/vault/facets/ERC4626VaultControlsFacet.sol";
-import {ERC4626VaultFacet} from "../../src/vault/facets/ERC4626VaultFacet.sol";
-import {ERC4626VaultIntegrationFacet} from "../../src/vault/facets/ERC4626VaultIntegrationFacet.sol";
-import {ERC7535VaultFacet} from "../../src/vault/facets/ERC7535VaultFacet.sol";
+import {IERC7535VaultFacet} from "../../src/interfaces/IERC7535VaultFacet.sol";
 import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {DiamondVaultDeploymentFixture} from "./DiamondVaultDeploymentTestHarness.sol";
-import {MutableMockVaultStrategy} from "./ERC4626VaultStrategyTestHarness.sol";
+import {
+    ERC4626VaultControlsFacetReplacement,
+    ERC4626VaultFacetReplacement,
+    ERC4626VaultIntegrationFacetReplacement,
+    ERC7535VaultFacetReplacement,
+    IFacetVersionMarker
+} from "./DiamondVaultHostHardeningTestHarness.sol";
+import {MutableNativeMockVaultStrategy} from "./ERC4626VaultStrategyTestHarness.sol";
 
-interface IFacetVersionMarker {
-    function facetVersion() external view returns (uint256);
-}
+contract ForceSendNative {
+    constructor() payable {}
 
-contract ERC4626VaultFacetReplacement is ERC4626VaultFacet {
-    function facetVersion() external pure returns (uint256) {
-        return 2;
+    function forceSend(address payable receiver) external {
+        selfdestruct(receiver);
     }
 }
 
-contract ERC4626VaultControlsFacetReplacement is ERC4626VaultControlsFacet {
-    function facetVersion() external pure returns (uint256) {
-        return 2;
-    }
-}
-
-contract ERC4626VaultIntegrationFacetReplacement is ERC4626VaultIntegrationFacet {
-    function facetVersion() external pure returns (uint256) {
-        return 2;
-    }
-}
-
-contract ERC7535VaultFacetReplacement is ERC7535VaultFacet {
-    function facetVersion() external pure returns (uint256) {
-        return 2;
-    }
-}
-
-abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixture {
+abstract contract DiamondNativeVaultHostHardeningFixture is DiamondVaultDeploymentFixture {
     struct AccountingSnapshot {
         uint256 totalAssets;
         uint256 totalSupply;
@@ -49,6 +33,7 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
         uint256 strategyUnderlyingBalance;
         uint256 profitSourceBalance;
         uint256 lossSinkBalance;
+        uint256 forceSenderBalance;
         uint256 strategyDebt;
         uint256 liveStrategyAssets;
     }
@@ -65,16 +50,17 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
         uint256 bobMaxRedeem;
     }
 
-    uint256 internal constant INITIAL_ASSETS = 1_000_000;
-    uint256 internal constant STRATEGY_PROFIT_RESERVE = 1_000_000_000_000;
+    uint256 internal constant INITIAL_ASSETS = 100 ether;
+    uint256 internal constant STRATEGY_PROFIT_RESERVE = 100 ether;
+    uint256 internal constant FORCE_SEND_RESERVE = 25 ether;
     uint256 internal constant ACTOR_COUNT = 4;
-    uint256 internal constant BOB_DEPOSIT = 200_000;
-    uint256 internal constant CAROL_DEPOSIT = 150_000;
-    uint256 internal constant SHARE_ALLOWANCE = 25_000;
-    uint256 internal constant STRATEGY_DEPLOYED_ASSETS = 225_000;
-    uint256 internal constant STRATEGY_PROFIT_ASSETS = 25_000;
-    uint256 internal constant BOB_AUTO_PULL_WITHDRAW_ASSETS = 150_000;
-    uint256 internal constant CAROL_AUTO_PULL_REDEEM_SHARES = 50_000;
+    uint256 internal constant BOB_DEPOSIT = 20 ether;
+    uint256 internal constant CAROL_DEPOSIT = 15 ether;
+    uint256 internal constant SHARE_ALLOWANCE = 2.5 ether;
+    uint256 internal constant STRATEGY_DEPLOYED_ASSETS = 22.5 ether;
+    uint256 internal constant STRATEGY_PROFIT_ASSETS = 2.5 ether;
+    uint256 internal constant BOB_AUTO_PULL_WITHDRAW_ASSETS = 15 ether;
+    uint256 internal constant CAROL_AUTO_PULL_REDEEM_SHARES = 5 ether;
 
     address internal bob = address(0xB0B);
     address internal carol = address(0xCA11);
@@ -82,12 +68,15 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
     address internal eve = address(0xE11E);
     address internal feeSink = address(0xFEE);
     address internal profitSource = address(0xBEEF1234);
+    address internal forceSender = address(0xF0CE);
 
     address[ACTOR_COUNT] internal actors;
 
-    MutableMockVaultStrategy internal strategyContract;
+    MutableNativeMockVaultStrategy internal strategyContract;
+    MutableNativeMockVaultStrategy internal replacementStrategyContract;
 
     ERC4626VaultFacetReplacement internal coreReplacement;
+    ERC7535VaultFacetReplacement internal nativeReplacement;
     ERC4626VaultControlsFacetReplacement internal controlsReplacement;
     ERC4626VaultIntegrationFacetReplacement internal integrationReplacement;
 
@@ -95,6 +84,7 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
         super.setUp();
 
         coreReplacement = new ERC4626VaultFacetReplacement();
+        nativeReplacement = new ERC7535VaultFacetReplacement();
         controlsReplacement = new ERC4626VaultControlsFacetReplacement();
         integrationReplacement = new ERC4626VaultIntegrationFacetReplacement();
 
@@ -103,23 +93,20 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
         actors[2] = dave;
         actors[3] = eve;
 
-        strategyContract = new MutableMockVaultStrategy(address(diamond), address(asset), profitSource);
+        strategyContract = new MutableNativeMockVaultStrategy(address(diamond), profitSource);
+        replacementStrategyContract = new MutableNativeMockVaultStrategy(address(diamond), profitSource);
 
         for (uint256 i = 0; i < ACTOR_COUNT; i++) {
-            address actor = actors[i];
-            asset.mint(actor, INITIAL_ASSETS);
-            VM.prank(actor);
-            asset.approve(address(diamond), type(uint256).max);
+            VM.deal(actors[i], INITIAL_ASSETS);
         }
 
-        asset.mint(profitSource, STRATEGY_PROFIT_RESERVE);
-        VM.prank(profitSource);
-        asset.approve(address(strategyContract), type(uint256).max);
+        VM.deal(profitSource, STRATEGY_PROFIT_RESERVE);
+        VM.deal(forceSender, FORCE_SEND_RESERVE);
     }
 
-    function _installAndSeedVaultHost() internal {
-        _installVaultHostFacets();
-        _initializeVaultHost();
+    function _installAndSeedNativeVaultHost() internal {
+        _installNativeVaultHostFacets();
+        _initializeNativeVaultHost();
         _wireOracleAdapter();
         _seedCoreState();
         _seedControlsState();
@@ -128,10 +115,10 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
 
     function _seedCoreState() internal {
         VM.prank(bob);
-        coreFacetInterface().deposit(BOB_DEPOSIT, bob);
+        IERC7535VaultFacet(address(diamond)).depositNative{value: BOB_DEPOSIT}(bob);
 
         VM.prank(carol);
-        coreFacetInterface().deposit(CAROL_DEPOSIT, carol);
+        IERC7535VaultFacet(address(diamond)).depositNative{value: CAROL_DEPOSIT}(carol);
 
         VM.prank(bob);
         coreFacetInterface().approve(eve, SHARE_ALLOWANCE);
@@ -144,7 +131,7 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
         controlsFacetInterface().setFeeConfig(100, 50, feeSink);
 
         VM.prank(admin);
-        controlsFacetInterface().setLimitConfig(900_000, 300_000, 300_000, 250_000, 250_000);
+        controlsFacetInterface().setLimitConfig(90 ether, 30 ether, 30 ether, 25 ether, 25 ether);
 
         VM.prank(admin);
         controlsFacetInterface().grantRole(managerRole, eve);
@@ -163,7 +150,8 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
     }
 
     function _injectStrategyProfit(uint256 assets) internal {
-        strategyContract.injectProfit(assets);
+        VM.prank(profitSource);
+        strategyContract.injectProfit{value: assets}(assets);
     }
 
     function _applyStrategyLoss(uint256 lossAssets, uint256 withdrawableAssets) internal {
@@ -178,6 +166,10 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
         _replaceFacet(facetAddress_, LibVaultFacetSelectors.vaultCoreSelectors());
     }
 
+    function _replaceNativeFacet(address facetAddress_) internal {
+        _replaceFacet(facetAddress_, LibVaultFacetSelectors.vaultNativeSelectors());
+    }
+
     function _replaceControlsFacet(address facetAddress_) internal {
         _replaceFacet(facetAddress_, LibVaultFacetSelectors.vaultControlsSelectors());
     }
@@ -187,6 +179,10 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
     }
 
     function _addCoreReplacementMarker(address facetAddress_) internal {
+        _addFacet(facetAddress_, _markerSelectors());
+    }
+
+    function _addNativeReplacementMarker(address facetAddress_) internal {
         _addFacet(facetAddress_, _markerSelectors());
     }
 
@@ -202,6 +198,10 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
         _removeSelectors(_concat(LibVaultFacetSelectors.vaultCoreSelectors(), _markerSelectors()));
     }
 
+    function _removeNativeFacetWithMarker() internal {
+        _removeSelectors(_concat(LibVaultFacetSelectors.vaultNativeSelectors(), _markerSelectors()));
+    }
+
     function _removeControlsFacetWithMarker() internal {
         _removeSelectors(_concat(LibVaultFacetSelectors.vaultControlsSelectors(), _markerSelectors()));
     }
@@ -212,6 +212,10 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
 
     function _reAddCoreFacetWithMarker(address facetAddress_) internal {
         _addFacet(facetAddress_, _concat(LibVaultFacetSelectors.vaultCoreSelectors(), _markerSelectors()));
+    }
+
+    function _reAddNativeFacetWithMarker(address facetAddress_) internal {
+        _addFacet(facetAddress_, _concat(LibVaultFacetSelectors.vaultNativeSelectors(), _markerSelectors()));
     }
 
     function _reAddControlsFacetWithMarker(address facetAddress_) internal {
@@ -262,29 +266,36 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
 
     function _sumTrackedUnderlying() internal view returns (uint256 sum) {
         for (uint256 i = 0; i < ACTOR_COUNT; i++) {
-            sum += asset.balanceOf(actors[i]);
+            sum += actors[i].balance;
         }
 
-        sum += asset.balanceOf(address(diamond));
-        sum += asset.balanceOf(feeSink);
-        sum += asset.balanceOf(address(strategyContract));
-        sum += asset.balanceOf(profitSource);
-        sum += asset.balanceOf(strategyContract.lossSink());
+        sum += address(diamond).balance;
+        sum += feeSink.balance;
+        sum += address(strategyContract).balance;
+        sum += address(replacementStrategyContract).balance;
+        sum += profitSource.balance;
+        sum += forceSender.balance;
+        sum += strategyContract.lossSink().balance;
+    }
+
+    function _expectedTrackedUnderlying() internal pure returns (uint256) {
+        return INITIAL_ASSETS * ACTOR_COUNT + STRATEGY_PROFIT_RESERVE + FORCE_SEND_RESERVE;
     }
 
     function _snapshotAccounting() internal view returns (AccountingSnapshot memory snapshot) {
         snapshot.totalAssets = coreFacetInterface().totalAssets();
         snapshot.totalSupply = coreFacetInterface().totalSupply();
-        snapshot.vaultUnderlyingBalance = asset.balanceOf(address(diamond));
-        snapshot.feeSinkBalance = asset.balanceOf(feeSink);
-        snapshot.strategyUnderlyingBalance = asset.balanceOf(address(strategyContract));
-        snapshot.profitSourceBalance = asset.balanceOf(profitSource);
-        snapshot.lossSinkBalance = asset.balanceOf(strategyContract.lossSink());
+        snapshot.vaultUnderlyingBalance = address(diamond).balance;
+        snapshot.feeSinkBalance = feeSink.balance;
+        snapshot.strategyUnderlyingBalance = address(strategyContract).balance;
+        snapshot.profitSourceBalance = profitSource.balance;
+        snapshot.lossSinkBalance = strategyContract.lossSink().balance;
+        snapshot.forceSenderBalance = forceSender.balance;
         snapshot.strategyDebt = integrationFacetInterface().strategyDebt();
         snapshot.liveStrategyAssets = integrationFacetInterface().liveStrategyAssets();
 
         for (uint256 i = 0; i < ACTOR_COUNT; i++) {
-            snapshot.actorUnderlyingBalanceSum += asset.balanceOf(actors[i]);
+            snapshot.actorUnderlyingBalanceSum += actors[i].balance;
             snapshot.actorShareBalanceSum += coreFacetInterface().balanceOf(actors[i]);
         }
     }
@@ -300,6 +311,7 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
         assertTrue(afterSnapshot.strategyUnderlyingBalance == snapshot.strategyUnderlyingBalance, reason);
         assertTrue(afterSnapshot.profitSourceBalance == snapshot.profitSourceBalance, reason);
         assertTrue(afterSnapshot.lossSinkBalance == snapshot.lossSinkBalance, reason);
+        assertTrue(afterSnapshot.forceSenderBalance == snapshot.forceSenderBalance, reason);
         assertTrue(afterSnapshot.strategyDebt == snapshot.strategyDebt, reason);
         assertTrue(afterSnapshot.liveStrategyAssets == snapshot.liveStrategyAssets, reason);
     }
@@ -333,6 +345,28 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
         assertTrue(coreFacetInterface().totalAssets() == snapshot.totalAssets, "totalAssets mismatch");
         assertTrue(coreFacetInterface().maxWithdraw(bob) == snapshot.bobMaxWithdraw, "bob maxWithdraw mismatch");
         assertTrue(coreFacetInterface().maxRedeem(bob) == snapshot.bobMaxRedeem, "bob maxRedeem mismatch");
+    }
+
+    function _forceSendToVault(uint256 assets) internal {
+        if (assets == 0) {
+            return;
+        }
+
+        VM.startPrank(forceSender);
+        ForceSendNative sender = new ForceSendNative{value: assets}();
+        sender.forceSend(payable(address(diamond)));
+        VM.stopPrank();
+    }
+
+    function _forceSendToStrategy(uint256 assets) internal {
+        if (assets == 0) {
+            return;
+        }
+
+        VM.startPrank(forceSender);
+        ForceSendNative sender = new ForceSendNative{value: assets}();
+        sender.forceSend(payable(address(strategyContract)));
+        VM.stopPrank();
     }
 
     function _addFacet(address facetAddress_, bytes4[] memory selectors) internal {

--- a/test/helpers/DiamondVaultDeploymentTestHarness.sol
+++ b/test/helpers/DiamondVaultDeploymentTestHarness.sol
@@ -4,14 +4,16 @@ pragma solidity ^0.8.30;
 import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
 import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
 import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
+import {ERC7535VaultFacet} from "../../src/vault/facets/ERC7535VaultFacet.sol";
 import {ERC4626VaultControlsFacetHarness} from "./ERC4626VaultControlsFacetTestHarness.sol";
 import {ERC4626VaultFacetHarness} from "./ERC4626VaultFacetTestHarness.sol";
 import {ERC4626VaultIntegrationFacetHarness} from "./ERC4626VaultIntegrationFacetTestHarness.sol";
 import {MockVaultAsset} from "./ERC4626CoreTestHarness.sol";
 import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
 import {MockOracleFeed, OracleAdapterHarness} from "./OracleAdapterTestHarness.sol";
-import {ProfitMockVaultStrategy} from "./ERC4626VaultStrategyTestHarness.sol";
+import {NativeProfitMockVaultStrategy, ProfitMockVaultStrategy} from "./ERC4626VaultStrategyTestHarness.sol";
 import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
+import {LibVaultAsset} from "../../src/vault/libraries/LibVaultAsset.sol";
 import {TestBase} from "./AccessControlTestHarness.sol";
 
 abstract contract DiamondVaultDeploymentFixture is TestBase {
@@ -25,6 +27,7 @@ abstract contract DiamondVaultDeploymentFixture is TestBase {
     DiamondCutFacet internal cutFacet;
     DiamondLoupeFacet internal loupeFacet;
     ERC4626VaultFacetHarness internal coreFacet;
+    ERC7535VaultFacet internal nativeFacet;
     ERC4626VaultControlsFacetHarness internal controlsFacet;
     ERC4626VaultIntegrationFacetHarness internal integrationFacet;
     DiamondProxyHarness internal diamond;
@@ -32,6 +35,7 @@ abstract contract DiamondVaultDeploymentFixture is TestBase {
     MockOracleFeed internal feed;
     OracleAdapterHarness internal adapter;
     ProfitMockVaultStrategy internal strategy;
+    NativeProfitMockVaultStrategy internal nativeStrategy;
 
     function setUp() public virtual {
         VM.warp(currentTime);
@@ -39,6 +43,7 @@ abstract contract DiamondVaultDeploymentFixture is TestBase {
         cutFacet = new DiamondCutFacet();
         loupeFacet = new DiamondLoupeFacet();
         coreFacet = new ERC4626VaultFacetHarness();
+        nativeFacet = new ERC7535VaultFacet();
         controlsFacet = new ERC4626VaultControlsFacetHarness();
         integrationFacet = new ERC4626VaultIntegrationFacetHarness();
         diamond = new DiamondProxyHarness(admin, address(cutFacet));
@@ -47,6 +52,7 @@ abstract contract DiamondVaultDeploymentFixture is TestBase {
         feed.setLatestRoundData(1, 100_000_000, quoteUpdatedAt, quoteUpdatedAt, 1);
         adapter = new OracleAdapterHarness(admin, address(feed), maxStaleness);
         strategy = new ProfitMockVaultStrategy(address(diamond), address(asset));
+        nativeStrategy = new NativeProfitMockVaultStrategy(address(diamond));
 
         _installLoupeFacet();
     }
@@ -85,9 +91,42 @@ abstract contract DiamondVaultDeploymentFixture is TestBase {
         IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
     }
 
+    function _installNativeVaultHostFacets() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](4);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(coreFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultCoreSelectors()
+        });
+        cut[1] = IDiamondCut.FacetCut({
+            facetAddress: address(nativeFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultNativeSelectors()
+        });
+        cut[2] = IDiamondCut.FacetCut({
+            facetAddress: address(controlsFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultControlsSelectors()
+        });
+        cut[3] = IDiamondCut.FacetCut({
+            facetAddress: address(integrationFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultIntegrationSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
     function _initializeVaultHost() internal {
         VM.prank(admin);
         coreFacetInterface().initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function _initializeNativeVaultHost() internal {
+        VM.prank(admin);
+        coreFacetInterface()
+            .initializeVault(LibVaultAsset.NATIVE_ASSET_SENTINEL, "Native Vault Share", "nvSHARE", admin);
     }
 
     function _wireOracleAdapter() internal {
@@ -98,6 +137,11 @@ abstract contract DiamondVaultDeploymentFixture is TestBase {
     function _wireStrategy() internal {
         VM.prank(admin);
         integrationFacetInterface().setStrategy(address(strategy));
+    }
+
+    function _wireNativeStrategy() internal {
+        VM.prank(admin);
+        integrationFacetInterface().setStrategy(address(nativeStrategy));
     }
 
     function coreFacetInterface() internal view returns (ERC4626VaultFacetHarness) {

--- a/test/helpers/ERC4626VaultControlsFacetTestHarness.sol
+++ b/test/helpers/ERC4626VaultControlsFacetTestHarness.sol
@@ -8,6 +8,7 @@ import {IERC4626VaultControlsFacet} from "../../src/interfaces/IERC4626VaultCont
 import {IERC4626VaultFacet} from "../../src/interfaces/IERC4626VaultFacet.sol";
 import {ERC4626Vault} from "../../src/vault/ERC4626Vault.sol";
 import {ERC4626VaultControlsFacet} from "../../src/vault/facets/ERC4626VaultControlsFacet.sol";
+import {ERC7535VaultFacet} from "../../src/vault/facets/ERC7535VaultFacet.sol";
 import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
 import {ERC4626VaultFacetHarness} from "./ERC4626VaultFacetTestHarness.sol";
@@ -35,6 +36,7 @@ abstract contract ERC4626VaultControlsFacetFixture is TestBase {
 
     ReentrantMockVaultAsset internal asset;
     ERC4626VaultFacetHarness internal coreFacet;
+    ERC7535VaultFacet internal nativeFacet;
     ERC4626VaultControlsFacetHarness internal controlsFacet;
     DiamondCutFacet internal cutFacet;
     DiamondLoupeFacet internal loupeFacet;
@@ -43,6 +45,7 @@ abstract contract ERC4626VaultControlsFacetFixture is TestBase {
     function setUp() public virtual {
         asset = new ReentrantMockVaultAsset();
         coreFacet = new ERC4626VaultFacetHarness();
+        nativeFacet = new ERC7535VaultFacet();
         controlsFacet = new ERC4626VaultControlsFacetHarness();
         cutFacet = new DiamondCutFacet();
         loupeFacet = new DiamondLoupeFacet();
@@ -104,9 +107,26 @@ abstract contract ERC4626VaultControlsFacetFixture is TestBase {
         IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
     }
 
+    function _installVaultNativeFacetToDiamond() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(nativeFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultNativeSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
     function _installHostedVaultFacetsToDiamond() internal {
         _installVaultCoreFacetToDiamond();
         _installVaultControlsFacetToDiamond();
+    }
+
+    function _installHostedVaultNativeFacetsToDiamond() internal {
+        _installHostedVaultFacetsToDiamond();
+        _installVaultNativeFacetToDiamond();
     }
 
     function _loupeSelectors() internal pure returns (bytes4[] memory selectors) {

--- a/test/helpers/ERC4626VaultFacetTestHarness.sol
+++ b/test/helpers/ERC4626VaultFacetTestHarness.sol
@@ -5,6 +5,7 @@ import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
 import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
 import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
 import {IERC4626VaultFacet} from "../../src/interfaces/IERC4626VaultFacet.sol";
+import {ERC4626VaultControlsFacet} from "../../src/vault/facets/ERC4626VaultControlsFacet.sol";
 import {ERC4626VaultFacet} from "../../src/vault/facets/ERC4626VaultFacet.sol";
 import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {LibERC4626VaultStorage} from "../../src/vault/storage/LibERC4626VaultStorage.sol";
@@ -30,6 +31,12 @@ contract ERC4626VaultFacetHarness is ERC4626VaultFacet {
     }
 }
 
+contract RejectingNativeReceiver {
+    receive() external payable {
+        revert("rejecting native asset");
+    }
+}
+
 abstract contract ERC4626VaultFacetFixture is TestBase {
     uint256 internal constant INITIAL_ASSETS = 1_000_000;
 
@@ -39,6 +46,7 @@ abstract contract ERC4626VaultFacetFixture is TestBase {
 
     ReentrantMockVaultAsset internal asset;
     ERC4626VaultFacetHarness internal facet;
+    ERC4626VaultControlsFacet internal controlsFacet;
     DiamondCutFacet internal cutFacet;
     DiamondLoupeFacet internal loupeFacet;
     DiamondProxyHarness internal diamond;
@@ -46,6 +54,7 @@ abstract contract ERC4626VaultFacetFixture is TestBase {
     function setUp() public virtual {
         asset = new ReentrantMockVaultAsset();
         facet = new ERC4626VaultFacetHarness();
+        controlsFacet = new ERC4626VaultControlsFacet();
         cutFacet = new DiamondCutFacet();
         loupeFacet = new DiamondLoupeFacet();
         diamond = new DiamondProxyHarness(admin, address(cutFacet));
@@ -57,7 +66,11 @@ abstract contract ERC4626VaultFacetFixture is TestBase {
     }
 
     function _initializeHostedVault(address target) internal {
-        IERC4626VaultFacet(target).initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+        _initializeHostedVaultWithAsset(target, address(asset));
+    }
+
+    function _initializeHostedVaultWithAsset(address target, address vaultAsset) internal {
+        IERC4626VaultFacet(target).initializeVault(vaultAsset, "Vault Share", "vSHARE", admin);
     }
 
     function _approveAsset(address owner, address spender, uint256 amount) internal {
@@ -87,6 +100,23 @@ abstract contract ERC4626VaultFacetFixture is TestBase {
 
         VM.prank(admin);
         IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installVaultControlsFacetToDiamond() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(controlsFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultControlsSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installHostedVaultFacetsToDiamond() internal {
+        _installVaultCoreFacetToDiamond();
+        _installVaultControlsFacetToDiamond();
     }
 
     function _loupeSelectors() internal pure returns (bytes4[] memory selectors) {

--- a/test/helpers/ERC4626VaultFacetTestHarness.sol
+++ b/test/helpers/ERC4626VaultFacetTestHarness.sol
@@ -7,6 +7,7 @@ import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
 import {IERC4626VaultFacet} from "../../src/interfaces/IERC4626VaultFacet.sol";
 import {ERC4626VaultControlsFacet} from "../../src/vault/facets/ERC4626VaultControlsFacet.sol";
 import {ERC4626VaultFacet} from "../../src/vault/facets/ERC4626VaultFacet.sol";
+import {ERC7535VaultFacet} from "../../src/vault/facets/ERC7535VaultFacet.sol";
 import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {LibERC4626VaultStorage} from "../../src/vault/storage/LibERC4626VaultStorage.sol";
 import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
@@ -14,21 +15,11 @@ import {TestBase} from "./AccessControlTestHarness.sol";
 import {ReentrantMockVaultAsset} from "./ERC4626VaultControlsTestHarness.sol";
 
 contract ERC4626VaultFacetHarness is ERC4626VaultFacet {
-    function initializeControlOnly(address admin) external {
-        _initializeVaultFacetControl(admin);
-    }
-
     function feeRecipient() external view returns (address) {
         return LibERC4626VaultStorage.layout().fees.feeRecipient;
     }
 
-    function controlPlaneInitialized() external view returns (bool) {
-        return LibERC4626VaultStorage.layout().controlPlaneInitialized;
-    }
-
-    function probeNonReentrant() external nonReentrant returns (bool) {
-        return true;
-    }
+    function probeNonReentrant() external nonReentrant {}
 }
 
 contract RejectingNativeReceiver {
@@ -46,6 +37,7 @@ abstract contract ERC4626VaultFacetFixture is TestBase {
 
     ReentrantMockVaultAsset internal asset;
     ERC4626VaultFacetHarness internal facet;
+    ERC7535VaultFacet internal nativeFacet;
     ERC4626VaultControlsFacet internal controlsFacet;
     DiamondCutFacet internal cutFacet;
     DiamondLoupeFacet internal loupeFacet;
@@ -54,6 +46,7 @@ abstract contract ERC4626VaultFacetFixture is TestBase {
     function setUp() public virtual {
         asset = new ReentrantMockVaultAsset();
         facet = new ERC4626VaultFacetHarness();
+        nativeFacet = new ERC7535VaultFacet();
         controlsFacet = new ERC4626VaultControlsFacet();
         cutFacet = new DiamondCutFacet();
         loupeFacet = new DiamondLoupeFacet();
@@ -102,6 +95,18 @@ abstract contract ERC4626VaultFacetFixture is TestBase {
         IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
     }
 
+    function _installVaultNativeFacetToDiamond() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(nativeFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultNativeSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
     function _installVaultControlsFacetToDiamond() internal {
         IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
         cut[0] = IDiamondCut.FacetCut({
@@ -117,6 +122,11 @@ abstract contract ERC4626VaultFacetFixture is TestBase {
     function _installHostedVaultFacetsToDiamond() internal {
         _installVaultCoreFacetToDiamond();
         _installVaultControlsFacetToDiamond();
+    }
+
+    function _installHostedVaultNativeFacetsToDiamond() internal {
+        _installHostedVaultFacetsToDiamond();
+        _installVaultNativeFacetToDiamond();
     }
 
     function _loupeSelectors() internal pure returns (bytes4[] memory selectors) {

--- a/test/helpers/ERC4626VaultIntegrationFacetTestHarness.sol
+++ b/test/helpers/ERC4626VaultIntegrationFacetTestHarness.sol
@@ -5,7 +5,9 @@ import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
 import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
 import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
 import {IERC4626VaultFacet} from "../../src/interfaces/IERC4626VaultFacet.sol";
+import {ERC7535VaultFacet} from "../../src/vault/facets/ERC7535VaultFacet.sol";
 import {ERC4626VaultIntegrationFacet} from "../../src/vault/facets/ERC4626VaultIntegrationFacet.sol";
+import {LibVaultAsset} from "../../src/vault/libraries/LibVaultAsset.sol";
 import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
 import {TestBase} from "./AccessControlTestHarness.sol";
@@ -16,6 +18,9 @@ import {MockOracleFeed, OracleAdapterHarness} from "./OracleAdapterTestHarness.s
 import {MockVaultAsset} from "./ERC4626CoreTestHarness.sol";
 import {
     LossShortfallMockVaultStrategy,
+    NativeLossShortfallMockVaultStrategy,
+    NativeProfitMockVaultStrategy,
+    NativeRevertingMockVaultStrategy,
     ProfitMockVaultStrategy,
     RevertingMockVaultStrategy
 } from "./ERC4626VaultStrategyTestHarness.sol";
@@ -43,6 +48,7 @@ abstract contract ERC4626VaultIntegrationFacetFixture is TestBase {
     ReentrantMockVaultAsset internal asset;
     MockVaultAsset internal otherAsset;
     ERC4626VaultFacetHarness internal coreFacet;
+    ERC7535VaultFacet internal nativeFacet;
     ERC4626VaultControlsFacetHarness internal controlsFacet;
     ERC4626VaultIntegrationFacet internal integrationFacet;
     DiamondCutFacet internal cutFacet;
@@ -54,6 +60,9 @@ abstract contract ERC4626VaultIntegrationFacetFixture is TestBase {
     LossShortfallMockVaultStrategy internal directLossStrategy;
     RevertingMockVaultStrategy internal directRevertingStrategy;
     ProfitMockVaultStrategy internal diamondProfitStrategy;
+    NativeProfitMockVaultStrategy internal diamondNativeProfitStrategy;
+    NativeLossShortfallMockVaultStrategy internal diamondNativeLossStrategy;
+    NativeRevertingMockVaultStrategy internal diamondNativeRevertingStrategy;
     ProfitMockVaultStrategy internal wrongVaultStrategy;
     ProfitMockVaultStrategy internal directWrongAssetStrategy;
 
@@ -63,6 +72,7 @@ abstract contract ERC4626VaultIntegrationFacetFixture is TestBase {
         asset = new ReentrantMockVaultAsset();
         otherAsset = new MockVaultAsset("Other USD", "oUSD", 6);
         coreFacet = new ERC4626VaultFacetHarness();
+        nativeFacet = new ERC7535VaultFacet();
         controlsFacet = new ERC4626VaultControlsFacetHarness();
         integrationFacet = new ERC4626VaultIntegrationFacetHarness();
         cutFacet = new DiamondCutFacet();
@@ -72,6 +82,9 @@ abstract contract ERC4626VaultIntegrationFacetFixture is TestBase {
         feed.setLatestRoundData(1, 100_000_000, quoteUpdatedAt, quoteUpdatedAt, 1);
         adapter = new OracleAdapterHarness(admin, address(feed), maxStaleness);
         diamondProfitStrategy = new ProfitMockVaultStrategy(address(diamond), address(asset));
+        diamondNativeProfitStrategy = new NativeProfitMockVaultStrategy(address(diamond));
+        diamondNativeLossStrategy = new NativeLossShortfallMockVaultStrategy(address(diamond));
+        diamondNativeRevertingStrategy = new NativeRevertingMockVaultStrategy(address(diamond));
         wrongVaultStrategy = new ProfitMockVaultStrategy(address(0xBAD), address(asset));
 
         asset.mint(bob, INITIAL_ASSETS);
@@ -92,6 +105,12 @@ abstract contract ERC4626VaultIntegrationFacetFixture is TestBase {
     function _initializeDiamondVault() internal {
         VM.prank(admin);
         IERC4626VaultFacet(address(diamond)).initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function _initializeDiamondNativeVault() internal {
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond))
+            .initializeVault(LibVaultAsset.NATIVE_ASSET_SENTINEL, "Vault Share", "vSHARE", admin);
     }
 
     function _approveAsset(address owner, address spender, uint256 amount) internal {
@@ -135,6 +154,18 @@ abstract contract ERC4626VaultIntegrationFacetFixture is TestBase {
         IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
     }
 
+    function _installVaultNativeFacetToDiamond() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(nativeFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultNativeSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
     function _installVaultIntegrationFacetToDiamond() internal {
         IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
         cut[0] = IDiamondCut.FacetCut({
@@ -151,6 +182,11 @@ abstract contract ERC4626VaultIntegrationFacetFixture is TestBase {
         _installVaultCoreFacetToDiamond();
         _installVaultControlsFacetToDiamond();
         _installVaultIntegrationFacetToDiamond();
+    }
+
+    function _installHostedVaultNativeFacetsToDiamond() internal {
+        _installHostedVaultFacetsToDiamond();
+        _installVaultNativeFacetToDiamond();
     }
 
     function _loupeSelectors() internal pure returns (bytes4[] memory selectors) {

--- a/test/helpers/ERC4626VaultStrategyAccountingTestHarness.sol
+++ b/test/helpers/ERC4626VaultStrategyAccountingTestHarness.sol
@@ -23,10 +23,6 @@ contract ERC4626VaultStrategyAccountingFacetHarness is ERC4626VaultFacet {
         layout.strategy = strategy_;
         layout.strategyDebt = strategyDebt_;
     }
-
-    function strategyDebtForTest() external view returns (uint256) {
-        return LibERC4626VaultStorage.layout().strategyDebt;
-    }
 }
 
 contract ERC4626VaultStrategyAccountingInitMock {

--- a/test/helpers/ERC4626VaultStrategyAccountingTestHarness.sol
+++ b/test/helpers/ERC4626VaultStrategyAccountingTestHarness.sol
@@ -7,6 +7,8 @@ import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
 import {IERC4626VaultFacet} from "../../src/interfaces/IERC4626VaultFacet.sol";
 import {IERC4626VaultIntegrationFacet} from "../../src/interfaces/IERC4626VaultIntegrationFacet.sol";
 import {IERC4626VaultStrategy} from "../../src/interfaces/IERC4626VaultStrategy.sol";
+import {ERC7535VaultFacet} from "../../src/vault/facets/ERC7535VaultFacet.sol";
+import {LibVaultAsset} from "../../src/vault/libraries/LibVaultAsset.sol";
 import {ERC4626VaultFacet} from "../../src/vault/facets/ERC4626VaultFacet.sol";
 import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {LibERC4626VaultStorage} from "../../src/vault/storage/LibERC4626VaultStorage.sol";
@@ -15,7 +17,12 @@ import {TestBase} from "./AccessControlTestHarness.sol";
 import {ERC4626VaultControlsFacetHarness} from "./ERC4626VaultControlsFacetTestHarness.sol";
 import {ReentrantMockVaultAsset} from "./ERC4626VaultControlsTestHarness.sol";
 import {ERC4626VaultIntegrationFacetHarness} from "./ERC4626VaultIntegrationFacetTestHarness.sol";
-import {LossShortfallMockVaultStrategy, ProfitMockVaultStrategy} from "./ERC4626VaultStrategyTestHarness.sol";
+import {
+    LossShortfallMockVaultStrategy,
+    NativeLossShortfallMockVaultStrategy,
+    NativeProfitMockVaultStrategy,
+    ProfitMockVaultStrategy
+} from "./ERC4626VaultStrategyTestHarness.sol";
 
 contract ERC4626VaultStrategyAccountingFacetHarness is ERC4626VaultFacet {
     function setStrategyStateForTest(address strategy_, uint256 strategyDebt_) external {
@@ -44,6 +51,7 @@ abstract contract ERC4626VaultStrategyAccountingFixture is TestBase {
 
     ReentrantMockVaultAsset internal asset;
     ERC4626VaultStrategyAccountingFacetHarness internal facet;
+    ERC7535VaultFacet internal nativeFacet;
     ERC4626VaultControlsFacetHarness internal controlsFacet;
     ERC4626VaultIntegrationFacetHarness internal integrationFacet;
     DiamondCutFacet internal cutFacet;
@@ -53,10 +61,13 @@ abstract contract ERC4626VaultStrategyAccountingFixture is TestBase {
     ProfitMockVaultStrategy internal directProfitStrategy;
     LossShortfallMockVaultStrategy internal directLossStrategy;
     ProfitMockVaultStrategy internal diamondProfitStrategy;
+    NativeProfitMockVaultStrategy internal diamondNativeProfitStrategy;
+    NativeLossShortfallMockVaultStrategy internal diamondNativeLossStrategy;
 
     function setUp() public virtual {
         asset = new ReentrantMockVaultAsset();
         facet = new ERC4626VaultStrategyAccountingFacetHarness();
+        nativeFacet = new ERC7535VaultFacet();
         controlsFacet = new ERC4626VaultControlsFacetHarness();
         integrationFacet = new ERC4626VaultIntegrationFacetHarness();
         cutFacet = new DiamondCutFacet();
@@ -66,6 +77,8 @@ abstract contract ERC4626VaultStrategyAccountingFixture is TestBase {
         directProfitStrategy = new ProfitMockVaultStrategy(address(facet), address(asset));
         directLossStrategy = new LossShortfallMockVaultStrategy(address(facet), address(asset));
         diamondProfitStrategy = new ProfitMockVaultStrategy(address(diamond), address(asset));
+        diamondNativeProfitStrategy = new NativeProfitMockVaultStrategy(address(diamond));
+        diamondNativeLossStrategy = new NativeLossShortfallMockVaultStrategy(address(diamond));
 
         asset.mint(bob, INITIAL_ASSETS);
         asset.mint(eve, INITIAL_ASSETS);
@@ -80,6 +93,12 @@ abstract contract ERC4626VaultStrategyAccountingFixture is TestBase {
     function _initializeDiamondVault() internal {
         VM.prank(admin);
         IERC4626VaultFacet(address(diamond)).initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function _initializeDiamondNativeVault() internal {
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond))
+            .initializeVault(LibVaultAsset.NATIVE_ASSET_SENTINEL, "Vault Share", "vSHARE", admin);
     }
 
     function _approveAsset(address owner, address spender, uint256 amount) internal {
@@ -145,6 +164,18 @@ abstract contract ERC4626VaultStrategyAccountingFixture is TestBase {
         IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
     }
 
+    function _installVaultNativeFacetToDiamond() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(nativeFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultNativeSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
     function _installVaultIntegrationFacetToDiamond() internal {
         IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
         cut[0] = IDiamondCut.FacetCut({
@@ -161,6 +192,11 @@ abstract contract ERC4626VaultStrategyAccountingFixture is TestBase {
         _installVaultCoreFacetToDiamond();
         _installVaultControlsFacetToDiamond();
         _installVaultIntegrationFacetToDiamond();
+    }
+
+    function _installHostedVaultNativeFacetsToDiamond() internal {
+        _installHostedVaultFacetsToDiamond();
+        _installVaultNativeFacetToDiamond();
     }
 
     function _loupeSelectors() internal pure returns (bytes4[] memory selectors) {

--- a/test/helpers/ERC4626VaultStrategyTestHarness.sol
+++ b/test/helpers/ERC4626VaultStrategyTestHarness.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.30;
 
 import {IERC4626VaultStrategy} from "../../src/interfaces/IERC4626VaultStrategy.sol";
 import {ERC4626VaultIntegrationFacet} from "../../src/vault/facets/ERC4626VaultIntegrationFacet.sol";
+import {LibVaultAsset} from "../../src/vault/libraries/LibVaultAsset.sol";
 import {LibERC4626VaultStorage} from "../../src/vault/storage/LibERC4626VaultStorage.sol";
 import {TestBase} from "./AccessControlTestHarness.sol";
 import {MockVaultAsset} from "./ERC4626CoreTestHarness.sol";
@@ -245,6 +246,178 @@ contract MutableMockVaultStrategy is MockVaultStrategyBase {
     }
 }
 
+abstract contract MockNativeVaultStrategyBase is IERC4626VaultStrategy {
+    address internal constant LOSS_SINK = address(0x1055);
+
+    address internal immutable _vault;
+
+    uint256 internal _trackedAssets;
+    uint256 internal _withdrawableAssets;
+
+    constructor(address vault_) {
+        _vault = vault_;
+    }
+
+    receive() external payable {}
+
+    modifier onlyVault() {
+        if (msg.sender != _vault) {
+            revert ERC4626VaultStrategyOnlyVault(msg.sender, _vault);
+        }
+        _;
+    }
+
+    function vault() external view override returns (address) {
+        return _vault;
+    }
+
+    function asset() external pure override returns (address) {
+        return LibVaultAsset.NATIVE_ASSET_SENTINEL;
+    }
+
+    function totalAssets() public view virtual override returns (uint256) {
+        return _trackedAssets;
+    }
+
+    function maxWithdrawableAssets() public view virtual override returns (uint256) {
+        return _min(_trackedAssets, _withdrawableAssets);
+    }
+
+    function deployFunds(uint256 assets) external virtual override onlyVault {
+        _trackedAssets += assets;
+        _withdrawableAssets += assets;
+        require(address(this).balance >= _trackedAssets, "STRATEGY_BALANCE_UNDERFUNDED");
+    }
+
+    function withdrawToVault(uint256 assets) external virtual override onlyVault returns (uint256 assetsReturned) {
+        assetsReturned = _min(assets, maxWithdrawableAssets());
+        _trackedAssets -= assetsReturned;
+        _withdrawableAssets -= assetsReturned;
+        if (assetsReturned != 0) {
+            _transferNative(_vault, assetsReturned);
+        }
+    }
+
+    function withdrawAllToVault() external virtual override onlyVault returns (uint256 assetsReturned) {
+        assetsReturned = maxWithdrawableAssets();
+        _trackedAssets -= assetsReturned;
+        _withdrawableAssets -= assetsReturned;
+        if (assetsReturned != 0) {
+            _transferNative(_vault, assetsReturned);
+        }
+    }
+
+    function setWithdrawableAssets(uint256 assets) external {
+        _withdrawableAssets = _min(assets, _trackedAssets);
+    }
+
+    function _min(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a < b ? a : b;
+    }
+
+    function _transferNative(address to, uint256 assets) internal {
+        (bool success,) = payable(to).call{value: assets}("");
+        require(success, "STRATEGY_NATIVE_TRANSFER_FAILED");
+    }
+}
+
+contract NativeProfitMockVaultStrategy is MockNativeVaultStrategyBase {
+    constructor(address vault_) MockNativeVaultStrategyBase(vault_) {}
+
+    function injectProfit() external payable {
+        if (msg.value == 0) {
+            return;
+        }
+
+        _trackedAssets += msg.value;
+        _withdrawableAssets += msg.value;
+    }
+}
+
+contract NativeLossShortfallMockVaultStrategy is MockNativeVaultStrategyBase {
+    constructor(address vault_) MockNativeVaultStrategyBase(vault_) {}
+
+    function applyLoss(uint256 lossAssets, uint256 withdrawableAssets_) external {
+        uint256 realizedLoss = _min(lossAssets, _trackedAssets);
+        if (realizedLoss != 0) {
+            _transferNative(LOSS_SINK, realizedLoss);
+            _trackedAssets -= realizedLoss;
+        }
+        _withdrawableAssets = _min(withdrawableAssets_, _trackedAssets);
+    }
+}
+
+contract NativeRevertingMockVaultStrategy is MockNativeVaultStrategyBase {
+    bool internal _revertTotalAssets;
+    bool internal _revertDeployFunds;
+    bool internal _revertWithdrawToVault;
+    bool internal _revertWithdrawAllToVault;
+
+    constructor(address vault_) MockNativeVaultStrategyBase(vault_) {}
+
+    function setRevertModes(bool totalAssets_, bool deployFunds_, bool withdrawToVault_, bool withdrawAllToVault_)
+        external
+    {
+        _revertTotalAssets = totalAssets_;
+        _revertDeployFunds = deployFunds_;
+        _revertWithdrawToVault = withdrawToVault_;
+        _revertWithdrawAllToVault = withdrawAllToVault_;
+    }
+
+    function totalAssets() public view override returns (uint256) {
+        if (_revertTotalAssets) {
+            revert MockVaultStrategyForcedRevert(this.totalAssets.selector);
+        }
+        return super.totalAssets();
+    }
+
+    function deployFunds(uint256 assets) external override onlyVault {
+        if (_revertDeployFunds) {
+            revert MockVaultStrategyForcedRevert(this.deployFunds.selector);
+        }
+        _trackedAssets += assets;
+        _withdrawableAssets += assets;
+        require(address(this).balance >= _trackedAssets, "STRATEGY_BALANCE_UNDERFUNDED");
+    }
+
+    function withdrawToVault(uint256 assets) external override onlyVault returns (uint256 assetsReturned) {
+        if (_revertWithdrawToVault) {
+            revert MockVaultStrategyForcedRevert(this.withdrawToVault.selector);
+        }
+        assetsReturned = _min(assets, maxWithdrawableAssets());
+        _trackedAssets -= assetsReturned;
+        _withdrawableAssets -= assetsReturned;
+        if (assetsReturned != 0) {
+            _transferNative(_vault, assetsReturned);
+        }
+    }
+
+    function withdrawAllToVault() external override onlyVault returns (uint256 assetsReturned) {
+        if (_revertWithdrawAllToVault) {
+            revert MockVaultStrategyForcedRevert(this.withdrawAllToVault.selector);
+        }
+        assetsReturned = maxWithdrawableAssets();
+        _trackedAssets -= assetsReturned;
+        _withdrawableAssets -= assetsReturned;
+        if (assetsReturned != 0) {
+            _transferNative(_vault, assetsReturned);
+        }
+    }
+}
+
+contract NativeEmergencyUnwindMockVaultStrategy is MockNativeVaultStrategyBase {
+    constructor(address vault_) MockNativeVaultStrategyBase(vault_) {}
+
+    function withdrawAllToVault() external override onlyVault returns (uint256 assetsReturned) {
+        assetsReturned = _trackedAssets;
+        _trackedAssets = 0;
+        _withdrawableAssets = 0;
+        if (assetsReturned != 0) {
+            _transferNative(_vault, assetsReturned);
+        }
+    }
+}
+
 abstract contract ERC4626VaultStrategyFixture is TestBase {
     address internal admin = address(0xA11CE);
     address internal vault = address(0xA417);
@@ -256,6 +429,10 @@ abstract contract ERC4626VaultStrategyFixture is TestBase {
     LossShortfallMockVaultStrategy internal lossStrategy;
     RevertingMockVaultStrategy internal revertingStrategy;
     EmergencyUnwindMockVaultStrategy internal unwindStrategy;
+    NativeProfitMockVaultStrategy internal nativeProfitStrategy;
+    NativeLossShortfallMockVaultStrategy internal nativeLossStrategy;
+    NativeRevertingMockVaultStrategy internal nativeRevertingStrategy;
+    NativeEmergencyUnwindMockVaultStrategy internal nativeUnwindStrategy;
 
     function setUp() public virtual {
         asset = new MockVaultAsset("Mock USD", "mUSD", 6);
@@ -265,5 +442,9 @@ abstract contract ERC4626VaultStrategyFixture is TestBase {
         lossStrategy = new LossShortfallMockVaultStrategy(vault, address(asset));
         revertingStrategy = new RevertingMockVaultStrategy(vault, address(asset));
         unwindStrategy = new EmergencyUnwindMockVaultStrategy(vault, address(asset));
+        nativeProfitStrategy = new NativeProfitMockVaultStrategy(vault);
+        nativeLossStrategy = new NativeLossShortfallMockVaultStrategy(vault);
+        nativeRevertingStrategy = new NativeRevertingMockVaultStrategy(vault);
+        nativeUnwindStrategy = new NativeEmergencyUnwindMockVaultStrategy(vault);
     }
 }

--- a/test/helpers/ERC4626VaultStrategyTestHarness.sol
+++ b/test/helpers/ERC4626VaultStrategyTestHarness.sol
@@ -418,6 +418,59 @@ contract NativeEmergencyUnwindMockVaultStrategy is MockNativeVaultStrategyBase {
     }
 }
 
+contract MutableNativeMockVaultStrategy is MockNativeVaultStrategyBase {
+    address internal immutable _profitSource;
+    bool internal _revertWithdrawAllToVault;
+
+    constructor(address vault_, address profitSource_) MockNativeVaultStrategyBase(vault_) {
+        _profitSource = profitSource_;
+    }
+
+    function profitSource() external view returns (address) {
+        return _profitSource;
+    }
+
+    function lossSink() external pure returns (address) {
+        return LOSS_SINK;
+    }
+
+    function injectProfit(uint256 assets) external payable {
+        if (assets == 0) {
+            return;
+        }
+
+        require(msg.value == assets, "NATIVE_PROFIT_VALUE_MISMATCH");
+        _trackedAssets += assets;
+        _withdrawableAssets += assets;
+    }
+
+    function applyLoss(uint256 lossAssets, uint256 withdrawableAssets_) external {
+        uint256 realizedLoss = _min(lossAssets, _trackedAssets);
+        if (realizedLoss != 0) {
+            _transferNative(LOSS_SINK, realizedLoss);
+            _trackedAssets -= realizedLoss;
+        }
+        _withdrawableAssets = _min(withdrawableAssets_, _trackedAssets);
+    }
+
+    function setWithdrawAllReverts(bool shouldRevert) external {
+        _revertWithdrawAllToVault = shouldRevert;
+    }
+
+    function withdrawAllToVault() external override onlyVault returns (uint256 assetsReturned) {
+        if (_revertWithdrawAllToVault) {
+            revert MockVaultStrategyForcedRevert(this.withdrawAllToVault.selector);
+        }
+
+        assetsReturned = maxWithdrawableAssets();
+        _trackedAssets -= assetsReturned;
+        _withdrawableAssets -= assetsReturned;
+        if (assetsReturned != 0) {
+            _transferNative(_vault, assetsReturned);
+        }
+    }
+}
+
 abstract contract ERC4626VaultStrategyFixture is TestBase {
     address internal admin = address(0xA11CE);
     address internal vault = address(0xA417);
@@ -433,6 +486,7 @@ abstract contract ERC4626VaultStrategyFixture is TestBase {
     NativeLossShortfallMockVaultStrategy internal nativeLossStrategy;
     NativeRevertingMockVaultStrategy internal nativeRevertingStrategy;
     NativeEmergencyUnwindMockVaultStrategy internal nativeUnwindStrategy;
+    MutableNativeMockVaultStrategy internal mutableNativeStrategy;
 
     function setUp() public virtual {
         asset = new MockVaultAsset("Mock USD", "mUSD", 6);
@@ -446,5 +500,6 @@ abstract contract ERC4626VaultStrategyFixture is TestBase {
         nativeLossStrategy = new NativeLossShortfallMockVaultStrategy(vault);
         nativeRevertingStrategy = new NativeRevertingMockVaultStrategy(vault);
         nativeUnwindStrategy = new NativeEmergencyUnwindMockVaultStrategy(vault);
+        mutableNativeStrategy = new MutableNativeMockVaultStrategy(vault, address(0xBEEF1234));
     }
 }


### PR DESCRIPTION
## Summary
- open the milestone draft PR for ERC-7535 native asset support
- include the native hosted vault core work merged via #137
- track the remaining native-asset milestone work under the same branch and PR

## Current Included Work
- add ERC-7535-style native-asset mode to the hosted vault core
- introduce hosted native entrypoints for payable deposits and mints
- make hosted withdraw and redeem native-aware when the vault asset is the ERC-7528 sentinel
- add direct and diamond-routed native-mode coverage for init, entrypoints, payouts, and force-sent ETH behavior

## Remaining Milestone Scope
- #131 Extend hosted controls and limits for native-asset flows
- #132 Add native-asset strategy lifecycle support
- #133 Add native local deployment and operator flows
- #134 Add native-host hardening and invariant coverage
- #135 Document native-asset lifecycle and safety assumptions

## Validation So Far
- `git diff --check`
- `forge fmt --check`
- `forge test --offline --match-path test/ERC4626VaultFacetCore.t.sol`
- `forge test --offline --match-path test/VaultFacetFoundationCore.t.sol`
- `forge test --offline --match-path test/ERC4626VaultControlsFacetCore.t.sol`

## Notes
- this draft PR is the milestone integration branch targeting `main`
- follow-up child issues will update this PR as milestone work lands

Closes #128
