### PR TITLE
Add native-asset strategy lifecycle support

### DIFF
--- a/test/ERC4626VaultIntegrationFacetCore.t.sol
+++ b/test/ERC4626VaultIntegrationFacetCore.t.sol
@@ -7,7 +7,9 @@ import {IERC165} from "../src/interfaces/IERC165.sol";
 import {IERC4626VaultBase} from "../src/interfaces/IERC4626VaultBase.sol";
 import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
 import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
+import {IERC7535VaultFacet} from "../src/interfaces/IERC7535VaultFacet.sol";
 import {IOracleAdapter} from "../src/interfaces/IOracleAdapter.sol";
+import {LibVaultAsset} from "../src/vault/libraries/LibVaultAsset.sol";
 import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {ERC4626VaultIntegrationFacetFixture} from "./helpers/ERC4626VaultIntegrationFacetTestHarness.sol";
 
@@ -353,6 +355,137 @@ contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFix
                 "integration facet should not own initializer selector"
             );
         }
+    }
+
+    function testDiamondNativeIntegrationFacetRejectsAssetMismatchedStrategies() public {
+        _installHostedVaultNativeFacetsToDiamond();
+        _initializeDiamondNativeVault();
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IERC4626VaultIntegrationFacet.ERC4626VaultStrategyInvalidAsset.selector,
+                address(diamondProfitStrategy),
+                LibVaultAsset.NATIVE_ASSET_SENTINEL,
+                address(asset)
+            )
+        );
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(address(diamondProfitStrategy));
+    }
+
+    function testDiamondErc20IntegrationFacetRejectsNativeStrategy() public {
+        _installHostedVaultNativeFacetsToDiamond();
+        _initializeDiamondVault();
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IERC4626VaultIntegrationFacet.ERC4626VaultStrategyInvalidAsset.selector,
+                address(diamondNativeProfitStrategy),
+                address(asset),
+                LibVaultAsset.NATIVE_ASSET_SENTINEL
+            )
+        );
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(address(diamondNativeProfitStrategy));
+    }
+
+    function testDiamondNativeIntegrationFacetRunsStrategyLifecycle() public {
+        _installHostedVaultNativeFacetsToDiamond();
+        _initializeDiamondNativeVault();
+
+        VM.deal(bob, 100);
+        VM.deal(address(this), 20);
+        VM.prank(bob);
+        uint256 mintedShares = IERC7535VaultFacet(address(diamond)).depositNative{value: 100}(bob);
+
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(address(diamondNativeProfitStrategy));
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).deployToStrategy(60);
+        diamondNativeProfitStrategy.injectProfit{value: 20}();
+
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).syncStrategyAssets();
+        VM.prank(admin);
+        uint256 returnedAssets = IERC4626VaultIntegrationFacet(address(diamond)).withdrawFromStrategy(30);
+        VM.prank(admin);
+        uint256 emergencyAssets = IERC4626VaultIntegrationFacet(address(diamond)).emergencyExitStrategy();
+
+        assertTrue(mintedShares == 100, "deposit shares mismatch");
+        assertTrue(returnedAssets == 30, "partial withdraw return mismatch");
+        assertTrue(emergencyAssets == 50, "emergency exit return mismatch");
+        assertTrue(
+            IERC4626VaultIntegrationFacet(address(diamond)).strategy() == address(diamondNativeProfitStrategy),
+            "strategy mismatch"
+        );
+        assertTrue(
+            IERC4626VaultIntegrationFacet(address(diamond)).strategyEmergencyExit(),
+            "emergency exit should remain active"
+        );
+        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).strategyDebt() == 0, "strategy debt mismatch");
+        assertTrue(
+            IERC4626VaultIntegrationFacet(address(diamond)).liveStrategyAssets() == 0, "live strategy assets mismatch"
+        );
+        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).idleAssets() == 120, "idle assets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 120, "managed assets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 120, "total assets mismatch");
+        assertTrue(address(diamond).balance == 120, "diamond native balance mismatch");
+        assertTrue(address(diamondNativeProfitStrategy).balance == 0, "strategy should be fully unwound");
+    }
+
+    function testDiamondNativeIntegrationFacetSyncRealizesLoss() public {
+        _installHostedVaultNativeFacetsToDiamond();
+        _initializeDiamondNativeVault();
+
+        VM.deal(bob, 100);
+        VM.prank(bob);
+        IERC7535VaultFacet(address(diamond)).depositNative{value: 100}(bob);
+
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(address(diamondNativeLossStrategy));
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).deployToStrategy(60);
+        diamondNativeLossStrategy.applyLoss(15, 35);
+
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).syncStrategyAssets();
+
+        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).strategyDebt() == 45, "strategy debt mismatch");
+        assertTrue(
+            IERC4626VaultIntegrationFacet(address(diamond)).liveStrategyAssets() == 45, "live strategy assets mismatch"
+        );
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 85, "managed assets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 85, "total assets mismatch");
+        assertTrue(address(diamond).balance == 40, "idle balance mismatch");
+        assertTrue(address(diamondNativeLossStrategy).balance == 45, "strategy balance mismatch");
+    }
+
+    function testDiamondNativeIntegrationFacetEmergencyExitFailureDoesNotRevert() public {
+        _installHostedVaultNativeFacetsToDiamond();
+        _initializeDiamondNativeVault();
+
+        VM.deal(bob, 100);
+        VM.prank(bob);
+        IERC7535VaultFacet(address(diamond)).depositNative{value: 100}(bob);
+
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(address(diamondNativeRevertingStrategy));
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).deployToStrategy(60);
+        diamondNativeRevertingStrategy.setRevertModes(false, false, false, true);
+
+        VM.prank(admin);
+        uint256 returnedAssets = IERC4626VaultIntegrationFacet(address(diamond)).emergencyExitStrategy();
+
+        assertTrue(returnedAssets == 0, "failing emergency exit should return zero assets");
+        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).strategyEmergencyExit(), "flag should stay active");
+        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).strategyDebt() == 60, "strategy debt mismatch");
+        assertTrue(
+            IERC4626VaultIntegrationFacet(address(diamond)).liveStrategyAssets() == 60, "live strategy assets mismatch"
+        );
+        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).idleAssets() == 40, "idle assets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 100, "managed assets mismatch");
+        assertTrue(address(diamond).balance == 40, "diamond balance should remain unchanged after failed unwind");
     }
 
     function _assertSelectorsOwnedByFacet(bytes4[] memory selectors, address expectedFacet) internal view {

--- a/test/ERC4626VaultStrategyAccountingCore.t.sol
+++ b/test/ERC4626VaultStrategyAccountingCore.t.sol
@@ -5,6 +5,7 @@ import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol
 import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControlsFacet.sol";
 import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
 import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
+import {IERC7535VaultFacet} from "../src/interfaces/IERC7535VaultFacet.sol";
 import {ERC4626VaultStrategyAccountingFixture} from "./helpers/ERC4626VaultStrategyAccountingTestHarness.sol";
 
 contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountingFixture {
@@ -181,5 +182,104 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
         );
         assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 40, "managed assets mismatch");
         assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 40, "post-withdraw totalAssets mismatch");
+    }
+
+    function testDiamondNativeHostedVaultStrategyAccountingUsesRealLifecycleAndAutoPull() public {
+        _installHostedVaultNativeFacetsToDiamond();
+        _initializeDiamondNativeVault();
+        VM.deal(bob, INITIAL_ASSETS);
+        VM.deal(address(this), 20);
+
+        VM.prank(bob);
+        IERC7535VaultFacet(address(diamond)).depositNative{value: DEPOSIT_ASSETS}(bob);
+
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(address(diamondNativeProfitStrategy));
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).deployToStrategy(60);
+        diamondNativeProfitStrategy.injectProfit{value: 20}();
+
+        VM.prank(admin);
+        IERC4626VaultControlsFacet(address(diamond)).setLimitConfig(125, 0, 0, 0, 0);
+
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == DEPOSIT_ASSETS, "book value mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 120, "diamond totalAssets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewDeposit(12) == 10, "diamond previewDeposit mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewMint(10) == 12, "diamond previewMint mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewWithdraw(12) == 10, "diamond previewWithdraw mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewRedeem(10) == 12, "diamond previewRedeem mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxDeposit(bob) == 5, "maxDeposit should use live totalAssets");
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxMint(bob) == 4, "maxMint should use live totalAssets");
+        assertTrue(
+            IERC4626VaultFacet(address(diamond)).maxWithdraw(bob) == 120,
+            "maxWithdraw should include strategy liquidity"
+        );
+        assertTrue(
+            IERC4626VaultFacet(address(diamond)).maxRedeem(bob) == 100, "maxRedeem should include strategy liquidity"
+        );
+
+        uint256 bobBalanceBeforeWithdraw = bob.balance;
+        VM.prank(bob);
+        uint256 burnedShares = IERC4626VaultFacet(address(diamond)).withdraw(80, bob, bob);
+
+        assertTrue(burnedShares == 67, "diamond withdraw should burn shares at updated price");
+        assertTrue(bob.balance == bobBalanceBeforeWithdraw + 80, "withdraw should pay raw native asset");
+        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).idleAssets() == 0, "idle assets should be zero");
+        assertTrue(IERC4626VaultIntegrationFacet(address(diamond)).strategyDebt() == 40, "strategy debt mismatch");
+        assertTrue(
+            IERC4626VaultIntegrationFacet(address(diamond)).liveStrategyAssets() == 40, "live strategy assets mismatch"
+        );
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 40, "managed assets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 40, "post-withdraw totalAssets mismatch");
+        assertTrue(address(diamond).balance == 0, "vault idle balance should be exhausted");
+    }
+
+    function testDiamondNativeRedeemAutoPullsAndReturnsCurrentShareValue() public {
+        _installHostedVaultNativeFacetsToDiamond();
+        _initializeDiamondNativeVault();
+        VM.deal(bob, INITIAL_ASSETS);
+        VM.deal(address(this), 20);
+
+        VM.prank(bob);
+        IERC7535VaultFacet(address(diamond)).depositNative{value: DEPOSIT_ASSETS}(bob);
+
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(address(diamondNativeProfitStrategy));
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).deployToStrategy(60);
+        diamondNativeProfitStrategy.injectProfit{value: 20}();
+
+        uint256 bobBalanceBeforeRedeem = bob.balance;
+        VM.prank(bob);
+        uint256 returnedAssets = IERC4626VaultFacet(address(diamond)).redeem(50, bob, bob);
+
+        assertTrue(returnedAssets == 60, "redeem should return current share value");
+        assertTrue(bob.balance == bobBalanceBeforeRedeem + 60, "redeem should pay raw native asset");
+        assertTrue(IERC4626VaultFacet(address(diamond)).balanceOf(bob) == 50, "remaining shares mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 60, "book value mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 60, "total assets mismatch");
+        assertTrue(address(diamond).balance == 0, "vault idle balance should be exhausted after redeem");
+        assertTrue(diamondNativeProfitStrategy.totalAssets() == 60, "remaining strategy assets mismatch");
+    }
+
+    function testDiamondNativeWithdrawRevertsWhenStrategyLiquidityCannotCoverExactAssets() public {
+        _installHostedVaultNativeFacetsToDiamond();
+        _initializeDiamondNativeVault();
+        VM.deal(bob, INITIAL_ASSETS);
+
+        VM.prank(bob);
+        IERC7535VaultFacet(address(diamond)).depositNative{value: DEPOSIT_ASSETS}(bob);
+
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(address(diamondNativeLossStrategy));
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).deployToStrategy(60);
+        diamondNativeLossStrategy.applyLoss(20, 10);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(IERC4626VaultControls.ERC4626VaultWithdrawLimitExceeded.selector, 70, 50)
+        );
+        VM.prank(bob);
+        IERC4626VaultFacet(address(diamond)).withdraw(70, bob, bob);
     }
 }

--- a/test/VaultStrategyFoundationCore.t.sol
+++ b/test/VaultStrategyFoundationCore.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.30;
 
 import {IERC4626VaultStrategy} from "../src/interfaces/IERC4626VaultStrategy.sol";
+import {LibVaultAsset} from "../src/vault/libraries/LibVaultAsset.sol";
 import {
     ERC4626VaultStrategyFixture,
     MockVaultStrategyForcedRevert
@@ -108,9 +109,111 @@ contract VaultStrategyFoundationCoreTest is ERC4626VaultStrategyFixture {
         assertTrue(asset.balanceOf(vault) == 100, "vault should receive unwound assets");
     }
 
+    function testNativeMockStrategiesBindVaultAndAsset() public view {
+        _assertBinding(nativeProfitStrategy);
+        _assertBinding(nativeLossStrategy);
+        _assertBinding(nativeRevertingStrategy);
+        _assertBinding(nativeUnwindStrategy);
+    }
+
+    function testOnlyVaultCanOperateNativeStrategyLifecycle() public {
+        _assertOnlyVault(nativeProfitStrategy);
+        _assertOnlyVault(nativeLossStrategy);
+        _assertOnlyVault(nativeRevertingStrategy);
+        _assertOnlyVault(nativeUnwindStrategy);
+    }
+
+    function testNativeProfitMockReportsHigherAssetsAfterProfitInjection() public {
+        VM.deal(address(nativeProfitStrategy), 100);
+        VM.deal(address(this), 25);
+        VM.prank(vault);
+        nativeProfitStrategy.deployFunds(100);
+
+        nativeProfitStrategy.injectProfit{value: 25}();
+
+        assertTrue(nativeProfitStrategy.totalAssets() == 125, "profit should increase tracked assets");
+        assertTrue(nativeProfitStrategy.maxWithdrawableAssets() == 125, "profit should increase withdrawable assets");
+        assertTrue(address(nativeProfitStrategy).balance == 125, "strategy balance should reflect profit");
+    }
+
+    function testNativeLossShortfallMockReturnsLessThanRequestedAndShrinksAssets() public {
+        VM.deal(address(nativeLossStrategy), 100);
+        VM.prank(vault);
+        nativeLossStrategy.deployFunds(100);
+
+        nativeLossStrategy.applyLoss(40, 35);
+
+        assertTrue(nativeLossStrategy.totalAssets() == 60, "loss should reduce tracked assets");
+        assertTrue(nativeLossStrategy.maxWithdrawableAssets() == 35, "shortfall should cap withdrawable assets");
+        assertTrue(address(nativeLossStrategy).balance == 60, "strategy balance should reflect realized loss");
+
+        VM.prank(vault);
+        uint256 returnedAssets = nativeLossStrategy.withdrawToVault(50);
+
+        assertTrue(returnedAssets == 35, "withdraw should return available assets only");
+        assertTrue(nativeLossStrategy.totalAssets() == 25, "tracked assets should reduce by returned amount");
+        assertTrue(nativeLossStrategy.maxWithdrawableAssets() == 0, "withdrawable assets should be depleted");
+        assertTrue(vault.balance == 35, "vault should receive returned assets");
+    }
+
+    function testNativeRevertingMockRevertsOnConfiguredCalls() public {
+        nativeRevertingStrategy.setRevertModes(true, true, true, true);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(MockVaultStrategyForcedRevert.selector, nativeRevertingStrategy.totalAssets.selector)
+        );
+        nativeRevertingStrategy.totalAssets();
+
+        VM.deal(address(nativeRevertingStrategy), 100);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(MockVaultStrategyForcedRevert.selector, nativeRevertingStrategy.deployFunds.selector)
+        );
+        VM.prank(vault);
+        nativeRevertingStrategy.deployFunds(100);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                MockVaultStrategyForcedRevert.selector, nativeRevertingStrategy.withdrawToVault.selector
+            )
+        );
+        VM.prank(vault);
+        nativeRevertingStrategy.withdrawToVault(100);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                MockVaultStrategyForcedRevert.selector, nativeRevertingStrategy.withdrawAllToVault.selector
+            )
+        );
+        VM.prank(vault);
+        nativeRevertingStrategy.withdrawAllToVault();
+    }
+
+    function testNativeEmergencyUnwindMockReturnsAllAssetsAndClearsState() public {
+        VM.deal(address(nativeUnwindStrategy), 100);
+        VM.prank(vault);
+        nativeUnwindStrategy.deployFunds(100);
+
+        nativeUnwindStrategy.setWithdrawableAssets(40);
+
+        VM.prank(vault);
+        uint256 returnedAssets = nativeUnwindStrategy.withdrawAllToVault();
+
+        assertTrue(returnedAssets == 100, "emergency unwind should return all tracked assets");
+        assertTrue(nativeUnwindStrategy.totalAssets() == 0, "tracked assets should clear on unwind");
+        assertTrue(nativeUnwindStrategy.maxWithdrawableAssets() == 0, "withdrawable assets should clear on unwind");
+        assertTrue(vault.balance == 100, "vault should receive unwound assets");
+    }
+
     function _assertBinding(IERC4626VaultStrategy strategy_) internal view {
         assertTrue(strategy_.vault() == vault, "vault binding mismatch");
-        assertTrue(strategy_.asset() == address(asset), "asset binding mismatch");
+        address expectedAsset = address(strategy_) == address(nativeProfitStrategy)
+                || address(strategy_) == address(nativeLossStrategy)
+                || address(strategy_) == address(nativeRevertingStrategy)
+                || address(strategy_) == address(nativeUnwindStrategy)
+            ? LibVaultAsset.NATIVE_ASSET_SENTINEL
+            : address(asset);
+        assertTrue(strategy_.asset() == expectedAsset, "asset binding mismatch");
     }
 
     function _assertOnlyVault(IERC4626VaultStrategy strategy_) internal {

--- a/test/helpers/ERC4626VaultIntegrationFacetTestHarness.sol
+++ b/test/helpers/ERC4626VaultIntegrationFacetTestHarness.sol
@@ -5,7 +5,9 @@ import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
 import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
 import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
 import {IERC4626VaultFacet} from "../../src/interfaces/IERC4626VaultFacet.sol";
+import {ERC7535VaultFacet} from "../../src/vault/facets/ERC7535VaultFacet.sol";
 import {ERC4626VaultIntegrationFacet} from "../../src/vault/facets/ERC4626VaultIntegrationFacet.sol";
+import {LibVaultAsset} from "../../src/vault/libraries/LibVaultAsset.sol";
 import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
 import {TestBase} from "./AccessControlTestHarness.sol";
@@ -16,6 +18,9 @@ import {MockOracleFeed, OracleAdapterHarness} from "./OracleAdapterTestHarness.s
 import {MockVaultAsset} from "./ERC4626CoreTestHarness.sol";
 import {
     LossShortfallMockVaultStrategy,
+    NativeLossShortfallMockVaultStrategy,
+    NativeProfitMockVaultStrategy,
+    NativeRevertingMockVaultStrategy,
     ProfitMockVaultStrategy,
     RevertingMockVaultStrategy
 } from "./ERC4626VaultStrategyTestHarness.sol";
@@ -43,6 +48,7 @@ abstract contract ERC4626VaultIntegrationFacetFixture is TestBase {
     ReentrantMockVaultAsset internal asset;
     MockVaultAsset internal otherAsset;
     ERC4626VaultFacetHarness internal coreFacet;
+    ERC7535VaultFacet internal nativeFacet;
     ERC4626VaultControlsFacetHarness internal controlsFacet;
     ERC4626VaultIntegrationFacet internal integrationFacet;
     DiamondCutFacet internal cutFacet;
@@ -54,6 +60,9 @@ abstract contract ERC4626VaultIntegrationFacetFixture is TestBase {
     LossShortfallMockVaultStrategy internal directLossStrategy;
     RevertingMockVaultStrategy internal directRevertingStrategy;
     ProfitMockVaultStrategy internal diamondProfitStrategy;
+    NativeProfitMockVaultStrategy internal diamondNativeProfitStrategy;
+    NativeLossShortfallMockVaultStrategy internal diamondNativeLossStrategy;
+    NativeRevertingMockVaultStrategy internal diamondNativeRevertingStrategy;
     ProfitMockVaultStrategy internal wrongVaultStrategy;
     ProfitMockVaultStrategy internal directWrongAssetStrategy;
 
@@ -63,6 +72,7 @@ abstract contract ERC4626VaultIntegrationFacetFixture is TestBase {
         asset = new ReentrantMockVaultAsset();
         otherAsset = new MockVaultAsset("Other USD", "oUSD", 6);
         coreFacet = new ERC4626VaultFacetHarness();
+        nativeFacet = new ERC7535VaultFacet();
         controlsFacet = new ERC4626VaultControlsFacetHarness();
         integrationFacet = new ERC4626VaultIntegrationFacetHarness();
         cutFacet = new DiamondCutFacet();
@@ -72,6 +82,9 @@ abstract contract ERC4626VaultIntegrationFacetFixture is TestBase {
         feed.setLatestRoundData(1, 100_000_000, quoteUpdatedAt, quoteUpdatedAt, 1);
         adapter = new OracleAdapterHarness(admin, address(feed), maxStaleness);
         diamondProfitStrategy = new ProfitMockVaultStrategy(address(diamond), address(asset));
+        diamondNativeProfitStrategy = new NativeProfitMockVaultStrategy(address(diamond));
+        diamondNativeLossStrategy = new NativeLossShortfallMockVaultStrategy(address(diamond));
+        diamondNativeRevertingStrategy = new NativeRevertingMockVaultStrategy(address(diamond));
         wrongVaultStrategy = new ProfitMockVaultStrategy(address(0xBAD), address(asset));
 
         asset.mint(bob, INITIAL_ASSETS);
@@ -92,6 +105,12 @@ abstract contract ERC4626VaultIntegrationFacetFixture is TestBase {
     function _initializeDiamondVault() internal {
         VM.prank(admin);
         IERC4626VaultFacet(address(diamond)).initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function _initializeDiamondNativeVault() internal {
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond))
+            .initializeVault(LibVaultAsset.NATIVE_ASSET_SENTINEL, "Vault Share", "vSHARE", admin);
     }
 
     function _approveAsset(address owner, address spender, uint256 amount) internal {
@@ -135,6 +154,18 @@ abstract contract ERC4626VaultIntegrationFacetFixture is TestBase {
         IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
     }
 
+    function _installVaultNativeFacetToDiamond() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(nativeFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultNativeSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
     function _installVaultIntegrationFacetToDiamond() internal {
         IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
         cut[0] = IDiamondCut.FacetCut({
@@ -151,6 +182,11 @@ abstract contract ERC4626VaultIntegrationFacetFixture is TestBase {
         _installVaultCoreFacetToDiamond();
         _installVaultControlsFacetToDiamond();
         _installVaultIntegrationFacetToDiamond();
+    }
+
+    function _installHostedVaultNativeFacetsToDiamond() internal {
+        _installHostedVaultFacetsToDiamond();
+        _installVaultNativeFacetToDiamond();
     }
 
     function _loupeSelectors() internal pure returns (bytes4[] memory selectors) {

--- a/test/helpers/ERC4626VaultStrategyAccountingTestHarness.sol
+++ b/test/helpers/ERC4626VaultStrategyAccountingTestHarness.sol
@@ -7,6 +7,8 @@ import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
 import {IERC4626VaultFacet} from "../../src/interfaces/IERC4626VaultFacet.sol";
 import {IERC4626VaultIntegrationFacet} from "../../src/interfaces/IERC4626VaultIntegrationFacet.sol";
 import {IERC4626VaultStrategy} from "../../src/interfaces/IERC4626VaultStrategy.sol";
+import {ERC7535VaultFacet} from "../../src/vault/facets/ERC7535VaultFacet.sol";
+import {LibVaultAsset} from "../../src/vault/libraries/LibVaultAsset.sol";
 import {ERC4626VaultFacet} from "../../src/vault/facets/ERC4626VaultFacet.sol";
 import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {LibERC4626VaultStorage} from "../../src/vault/storage/LibERC4626VaultStorage.sol";
@@ -15,7 +17,12 @@ import {TestBase} from "./AccessControlTestHarness.sol";
 import {ERC4626VaultControlsFacetHarness} from "./ERC4626VaultControlsFacetTestHarness.sol";
 import {ReentrantMockVaultAsset} from "./ERC4626VaultControlsTestHarness.sol";
 import {ERC4626VaultIntegrationFacetHarness} from "./ERC4626VaultIntegrationFacetTestHarness.sol";
-import {LossShortfallMockVaultStrategy, ProfitMockVaultStrategy} from "./ERC4626VaultStrategyTestHarness.sol";
+import {
+    LossShortfallMockVaultStrategy,
+    NativeLossShortfallMockVaultStrategy,
+    NativeProfitMockVaultStrategy,
+    ProfitMockVaultStrategy
+} from "./ERC4626VaultStrategyTestHarness.sol";
 
 contract ERC4626VaultStrategyAccountingFacetHarness is ERC4626VaultFacet {
     function setStrategyStateForTest(address strategy_, uint256 strategyDebt_) external {
@@ -44,6 +51,7 @@ abstract contract ERC4626VaultStrategyAccountingFixture is TestBase {
 
     ReentrantMockVaultAsset internal asset;
     ERC4626VaultStrategyAccountingFacetHarness internal facet;
+    ERC7535VaultFacet internal nativeFacet;
     ERC4626VaultControlsFacetHarness internal controlsFacet;
     ERC4626VaultIntegrationFacetHarness internal integrationFacet;
     DiamondCutFacet internal cutFacet;
@@ -53,10 +61,13 @@ abstract contract ERC4626VaultStrategyAccountingFixture is TestBase {
     ProfitMockVaultStrategy internal directProfitStrategy;
     LossShortfallMockVaultStrategy internal directLossStrategy;
     ProfitMockVaultStrategy internal diamondProfitStrategy;
+    NativeProfitMockVaultStrategy internal diamondNativeProfitStrategy;
+    NativeLossShortfallMockVaultStrategy internal diamondNativeLossStrategy;
 
     function setUp() public virtual {
         asset = new ReentrantMockVaultAsset();
         facet = new ERC4626VaultStrategyAccountingFacetHarness();
+        nativeFacet = new ERC7535VaultFacet();
         controlsFacet = new ERC4626VaultControlsFacetHarness();
         integrationFacet = new ERC4626VaultIntegrationFacetHarness();
         cutFacet = new DiamondCutFacet();
@@ -66,6 +77,8 @@ abstract contract ERC4626VaultStrategyAccountingFixture is TestBase {
         directProfitStrategy = new ProfitMockVaultStrategy(address(facet), address(asset));
         directLossStrategy = new LossShortfallMockVaultStrategy(address(facet), address(asset));
         diamondProfitStrategy = new ProfitMockVaultStrategy(address(diamond), address(asset));
+        diamondNativeProfitStrategy = new NativeProfitMockVaultStrategy(address(diamond));
+        diamondNativeLossStrategy = new NativeLossShortfallMockVaultStrategy(address(diamond));
 
         asset.mint(bob, INITIAL_ASSETS);
         asset.mint(eve, INITIAL_ASSETS);
@@ -80,6 +93,12 @@ abstract contract ERC4626VaultStrategyAccountingFixture is TestBase {
     function _initializeDiamondVault() internal {
         VM.prank(admin);
         IERC4626VaultFacet(address(diamond)).initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function _initializeDiamondNativeVault() internal {
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond))
+            .initializeVault(LibVaultAsset.NATIVE_ASSET_SENTINEL, "Vault Share", "vSHARE", admin);
     }
 
     function _approveAsset(address owner, address spender, uint256 amount) internal {
@@ -145,6 +164,18 @@ abstract contract ERC4626VaultStrategyAccountingFixture is TestBase {
         IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
     }
 
+    function _installVaultNativeFacetToDiamond() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(nativeFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultNativeSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
     function _installVaultIntegrationFacetToDiamond() internal {
         IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
         cut[0] = IDiamondCut.FacetCut({
@@ -161,6 +192,11 @@ abstract contract ERC4626VaultStrategyAccountingFixture is TestBase {
         _installVaultCoreFacetToDiamond();
         _installVaultControlsFacetToDiamond();
         _installVaultIntegrationFacetToDiamond();
+    }
+
+    function _installHostedVaultNativeFacetsToDiamond() internal {
+        _installHostedVaultFacetsToDiamond();
+        _installVaultNativeFacetToDiamond();
     }
 
     function _loupeSelectors() internal pure returns (bytes4[] memory selectors) {

--- a/test/helpers/ERC4626VaultStrategyTestHarness.sol
+++ b/test/helpers/ERC4626VaultStrategyTestHarness.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.30;
 
 import {IERC4626VaultStrategy} from "../../src/interfaces/IERC4626VaultStrategy.sol";
 import {ERC4626VaultIntegrationFacet} from "../../src/vault/facets/ERC4626VaultIntegrationFacet.sol";
+import {LibVaultAsset} from "../../src/vault/libraries/LibVaultAsset.sol";
 import {LibERC4626VaultStorage} from "../../src/vault/storage/LibERC4626VaultStorage.sol";
 import {TestBase} from "./AccessControlTestHarness.sol";
 import {MockVaultAsset} from "./ERC4626CoreTestHarness.sol";
@@ -245,6 +246,178 @@ contract MutableMockVaultStrategy is MockVaultStrategyBase {
     }
 }
 
+abstract contract MockNativeVaultStrategyBase is IERC4626VaultStrategy {
+    address internal constant LOSS_SINK = address(0x1055);
+
+    address internal immutable _vault;
+
+    uint256 internal _trackedAssets;
+    uint256 internal _withdrawableAssets;
+
+    constructor(address vault_) {
+        _vault = vault_;
+    }
+
+    receive() external payable {}
+
+    modifier onlyVault() {
+        if (msg.sender != _vault) {
+            revert ERC4626VaultStrategyOnlyVault(msg.sender, _vault);
+        }
+        _;
+    }
+
+    function vault() external view override returns (address) {
+        return _vault;
+    }
+
+    function asset() external pure override returns (address) {
+        return LibVaultAsset.NATIVE_ASSET_SENTINEL;
+    }
+
+    function totalAssets() public view virtual override returns (uint256) {
+        return _trackedAssets;
+    }
+
+    function maxWithdrawableAssets() public view virtual override returns (uint256) {
+        return _min(_trackedAssets, _withdrawableAssets);
+    }
+
+    function deployFunds(uint256 assets) external virtual override onlyVault {
+        _trackedAssets += assets;
+        _withdrawableAssets += assets;
+        require(address(this).balance >= _trackedAssets, "STRATEGY_BALANCE_UNDERFUNDED");
+    }
+
+    function withdrawToVault(uint256 assets) external virtual override onlyVault returns (uint256 assetsReturned) {
+        assetsReturned = _min(assets, maxWithdrawableAssets());
+        _trackedAssets -= assetsReturned;
+        _withdrawableAssets -= assetsReturned;
+        if (assetsReturned != 0) {
+            _transferNative(_vault, assetsReturned);
+        }
+    }
+
+    function withdrawAllToVault() external virtual override onlyVault returns (uint256 assetsReturned) {
+        assetsReturned = maxWithdrawableAssets();
+        _trackedAssets -= assetsReturned;
+        _withdrawableAssets -= assetsReturned;
+        if (assetsReturned != 0) {
+            _transferNative(_vault, assetsReturned);
+        }
+    }
+
+    function setWithdrawableAssets(uint256 assets) external {
+        _withdrawableAssets = _min(assets, _trackedAssets);
+    }
+
+    function _min(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a < b ? a : b;
+    }
+
+    function _transferNative(address to, uint256 assets) internal {
+        (bool success,) = payable(to).call{value: assets}("");
+        require(success, "STRATEGY_NATIVE_TRANSFER_FAILED");
+    }
+}
+
+contract NativeProfitMockVaultStrategy is MockNativeVaultStrategyBase {
+    constructor(address vault_) MockNativeVaultStrategyBase(vault_) {}
+
+    function injectProfit() external payable {
+        if (msg.value == 0) {
+            return;
+        }
+
+        _trackedAssets += msg.value;
+        _withdrawableAssets += msg.value;
+    }
+}
+
+contract NativeLossShortfallMockVaultStrategy is MockNativeVaultStrategyBase {
+    constructor(address vault_) MockNativeVaultStrategyBase(vault_) {}
+
+    function applyLoss(uint256 lossAssets, uint256 withdrawableAssets_) external {
+        uint256 realizedLoss = _min(lossAssets, _trackedAssets);
+        if (realizedLoss != 0) {
+            _transferNative(LOSS_SINK, realizedLoss);
+            _trackedAssets -= realizedLoss;
+        }
+        _withdrawableAssets = _min(withdrawableAssets_, _trackedAssets);
+    }
+}
+
+contract NativeRevertingMockVaultStrategy is MockNativeVaultStrategyBase {
+    bool internal _revertTotalAssets;
+    bool internal _revertDeployFunds;
+    bool internal _revertWithdrawToVault;
+    bool internal _revertWithdrawAllToVault;
+
+    constructor(address vault_) MockNativeVaultStrategyBase(vault_) {}
+
+    function setRevertModes(bool totalAssets_, bool deployFunds_, bool withdrawToVault_, bool withdrawAllToVault_)
+        external
+    {
+        _revertTotalAssets = totalAssets_;
+        _revertDeployFunds = deployFunds_;
+        _revertWithdrawToVault = withdrawToVault_;
+        _revertWithdrawAllToVault = withdrawAllToVault_;
+    }
+
+    function totalAssets() public view override returns (uint256) {
+        if (_revertTotalAssets) {
+            revert MockVaultStrategyForcedRevert(this.totalAssets.selector);
+        }
+        return super.totalAssets();
+    }
+
+    function deployFunds(uint256 assets) external override onlyVault {
+        if (_revertDeployFunds) {
+            revert MockVaultStrategyForcedRevert(this.deployFunds.selector);
+        }
+        _trackedAssets += assets;
+        _withdrawableAssets += assets;
+        require(address(this).balance >= _trackedAssets, "STRATEGY_BALANCE_UNDERFUNDED");
+    }
+
+    function withdrawToVault(uint256 assets) external override onlyVault returns (uint256 assetsReturned) {
+        if (_revertWithdrawToVault) {
+            revert MockVaultStrategyForcedRevert(this.withdrawToVault.selector);
+        }
+        assetsReturned = _min(assets, maxWithdrawableAssets());
+        _trackedAssets -= assetsReturned;
+        _withdrawableAssets -= assetsReturned;
+        if (assetsReturned != 0) {
+            _transferNative(_vault, assetsReturned);
+        }
+    }
+
+    function withdrawAllToVault() external override onlyVault returns (uint256 assetsReturned) {
+        if (_revertWithdrawAllToVault) {
+            revert MockVaultStrategyForcedRevert(this.withdrawAllToVault.selector);
+        }
+        assetsReturned = maxWithdrawableAssets();
+        _trackedAssets -= assetsReturned;
+        _withdrawableAssets -= assetsReturned;
+        if (assetsReturned != 0) {
+            _transferNative(_vault, assetsReturned);
+        }
+    }
+}
+
+contract NativeEmergencyUnwindMockVaultStrategy is MockNativeVaultStrategyBase {
+    constructor(address vault_) MockNativeVaultStrategyBase(vault_) {}
+
+    function withdrawAllToVault() external override onlyVault returns (uint256 assetsReturned) {
+        assetsReturned = _trackedAssets;
+        _trackedAssets = 0;
+        _withdrawableAssets = 0;
+        if (assetsReturned != 0) {
+            _transferNative(_vault, assetsReturned);
+        }
+    }
+}
+
 abstract contract ERC4626VaultStrategyFixture is TestBase {
     address internal admin = address(0xA11CE);
     address internal vault = address(0xA417);
@@ -256,6 +429,10 @@ abstract contract ERC4626VaultStrategyFixture is TestBase {
     LossShortfallMockVaultStrategy internal lossStrategy;
     RevertingMockVaultStrategy internal revertingStrategy;
     EmergencyUnwindMockVaultStrategy internal unwindStrategy;
+    NativeProfitMockVaultStrategy internal nativeProfitStrategy;
+    NativeLossShortfallMockVaultStrategy internal nativeLossStrategy;
+    NativeRevertingMockVaultStrategy internal nativeRevertingStrategy;
+    NativeEmergencyUnwindMockVaultStrategy internal nativeUnwindStrategy;
 
     function setUp() public virtual {
         asset = new MockVaultAsset("Mock USD", "mUSD", 6);
@@ -265,5 +442,9 @@ abstract contract ERC4626VaultStrategyFixture is TestBase {
         lossStrategy = new LossShortfallMockVaultStrategy(vault, address(asset));
         revertingStrategy = new RevertingMockVaultStrategy(vault, address(asset));
         unwindStrategy = new EmergencyUnwindMockVaultStrategy(vault, address(asset));
+        nativeProfitStrategy = new NativeProfitMockVaultStrategy(vault);
+        nativeLossStrategy = new NativeLossShortfallMockVaultStrategy(vault);
+        nativeRevertingStrategy = new NativeRevertingMockVaultStrategy(vault);
+        nativeUnwindStrategy = new NativeEmergencyUnwindMockVaultStrategy(vault);
     }
 }


### PR DESCRIPTION
## Summary
- add native strategy mocks that keep the existing IERC4626VaultStrategy surface and operate on raw native balances
- extend integration and accounting harnesses to install the hosted native facet and native strategies in diamond tests
- cover native strategy binding, deploy/withdraw/sync/emergency-exit, and withdraw/redeem auto-pull flows

## Testing
- forge fmt --check
- forge build --sizes --skip script
- forge test --offline --match-path test/VaultStrategyFoundationCore.t.sol
- forge test --offline --match-path test/ERC4626VaultIntegrationFacetCore.t.sol
- forge test --offline --match-path test/ERC4626VaultStrategyAccountingCore.t.sol
- forge test --offline --match-path test/ERC4626VaultFacetCore.t.sol
- forge test --offline --match-path test/DiamondVaultHostInvariant.t.sol

## Notes
- This branch does not change the production runtime path. The existing lifecycle code was already asset-agnostic; this PR makes native strategy support explicit and verified.
- linked issue: #132.

Closes #132