### PR TITLE
Add native local deployment and operator flows

### DIFF
--- a/docs/auralis-local.md
+++ b/docs/auralis-local.md
@@ -1,7 +1,8 @@
 # Auralis Local Workflow
 
 `Auralis` ships with a local-first workflow for bootstrapping the token hosts,
-vault host, and a small amount of simulated protocol activity on Anvil.
+ERC20 vault host, native vault host, and a small amount of simulated protocol
+activity on Anvil.
 
 ## Prerequisites
 
@@ -43,25 +44,26 @@ bash scripts/auralis-reset.sh
 
 `auralis-up.sh`
 - starts Anvil if one is not already available
-- deploys the ERC20 host, ERC721 host, and strategy-enabled vault host
+- deploys the ERC20 host, ERC721 host, ERC20 vault host, and native vault host
 - writes `deployments/auralis.local.json`
 
 `auralis-smoke.sh`
 - checks deployed code is present
 - runs token and NFT happy-path transactions
-- runs vault deposit, strategy deploy, profit sync, manager pull, user auto-pull, and emergency-exit flows
-- restores the local vault to a ready state by re-binding the configured strategy after the emergency-exit smoke
-- verifies the vault oracle quote path is live
+- runs ERC20 vault deposit, strategy deploy, profit sync, manager pull, user auto-pull, and emergency-exit flows
+- runs native vault deposit, strategy deploy, profit sync, manager pull, user auto-pull, and emergency-exit flows
+- restores both local vaults to a ready state by re-binding the configured strategy after the emergency-exit smoke
+- verifies both vault oracle quote paths are live
 
 `auralis-activity.sh`
 - generates deterministic demo traffic across the deployed hosts
 - mints and transfers ERC20 balances
 - mints and moves an ERC721 token
-- deposits into the vault, deploys capital to strategy, syncs profit, pulls funds back, moves shares, redeems shares, updates the oracle, and toggles pause state
+- deposits into the ERC20 vault and native vault, deploys capital to strategy, syncs profit, pulls funds back, moves shares, redeems shares, updates the oracle, and toggles pause state
 
 `auralis-reset.sh`
 - stops the managed Anvil process if `auralis-up.sh` started it
-- removes the Auralis deployment artifacts
+- removes the Auralis deployment artifacts, including the native vault artifact
 
 ## Artifact Layout
 
@@ -73,8 +75,9 @@ and records:
 - owner/alice actor addresses
 - ERC20 host addresses
 - ERC721 host addresses
-- vault host addresses
-- configured vault strategy address and zeroed initial strategy state
+- ERC20 vault host addresses
+- native vault host addresses
+- configured vault strategy addresses and zeroed initial strategy state
 
 ## Simulated Activity
 

--- a/script/DeployDiamondNativeVaultHost.s.sol
+++ b/script/DeployDiamondNativeVaultHost.s.sol
@@ -12,27 +12,30 @@ import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControl
 import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
 import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
 import {IERC4626VaultStrategy} from "../src/interfaces/IERC4626VaultStrategy.sol";
+import {IERC7535VaultFacet} from "../src/interfaces/IERC7535VaultFacet.sol";
 import {IOracleAdapter} from "../src/interfaces/IOracleAdapter.sol";
 import {ERC4626VaultControlsFacet} from "../src/vault/facets/ERC4626VaultControlsFacet.sol";
 import {ERC4626VaultFacet} from "../src/vault/facets/ERC4626VaultFacet.sol";
 import {ERC4626VaultIntegrationFacet} from "../src/vault/facets/ERC4626VaultIntegrationFacet.sol";
+import {ERC7535VaultFacet} from "../src/vault/facets/ERC7535VaultFacet.sol";
+import {LibVaultAsset} from "../src/vault/libraries/LibVaultAsset.sol";
 import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {DiamondVaultHostScriptBase} from "./common/DiamondVaultHostScriptBase.sol";
 import {
-    LocalHappyPathVaultStrategy,
-    LocalMintableVaultAsset,
     LocalMockOracleFeed,
+    LocalNativeHappyPathVaultStrategy,
     LocalOracleAdapterHarness
 } from "./mocks/LocalVaultDeploymentMocks.sol";
 
-/// @title DeployDiamondVaultHostScript
-/// @notice Reference local deployment flow for the hosted vault diamond.
-contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
-    struct VaultHostDeploymentState {
+/// @title DeployDiamondNativeVaultHostScript
+/// @notice Reference local deployment flow for the native hosted vault diamond.
+contract DeployDiamondNativeVaultHostScript is DiamondVaultHostScriptBase {
+    struct NativeVaultHostDeploymentState {
         address diamondAddress;
         address cutFacetAddress;
         address loupeFacetAddress;
         address vaultCoreFacetAddress;
+        address vaultNativeFacetAddress;
         address vaultControlsFacetAddress;
         address vaultIntegrationFacetAddress;
         address vaultAssetAddress;
@@ -41,10 +44,10 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
         address strategyAddress;
     }
 
-    string internal constant VAULT_OBJECT = "diamondVaultHost";
-    string internal constant VAULT_OUTPUT_RELATIVE_PATH = "/deployments/diamond-vault.local.json";
-    string internal constant VAULT_NAME = "Vault Share";
-    string internal constant VAULT_SYMBOL = "vSHARE";
+    string internal constant VAULT_OBJECT = "diamondNativeVaultHost";
+    string internal constant VAULT_OUTPUT_RELATIVE_PATH = "/deployments/diamond-native-vault.local.json";
+    string internal constant VAULT_NAME = "Native Vault Share";
+    string internal constant VAULT_SYMBOL = "nvSHARE";
     uint64 internal constant MAX_STALENESS = 1 hours;
     uint8 internal constant ORACLE_DECIMALS = 8;
     int256 internal constant ORACLE_ANSWER = 100_000_000;
@@ -54,13 +57,14 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
         returns (
             address diamondAddress,
             address vaultCoreFacetAddress,
+            address vaultNativeFacetAddress,
             address vaultControlsFacetAddress,
             address vaultIntegrationFacetAddress
         )
     {
         uint256 deployerPrivateKey = VM.envUint("PRIVATE_KEY");
         address owner = VM.addr(deployerPrivateKey);
-        VaultHostDeploymentState memory state;
+        NativeVaultHostDeploymentState memory state;
 
         VM.startBroadcast(deployerPrivateKey);
 
@@ -84,7 +88,7 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
                 diamondCutFacet: state.cutFacetAddress,
                 diamondLoupeFacet: state.loupeFacetAddress,
                 vaultCoreFacet: state.vaultCoreFacetAddress,
-                vaultNativeFacet: address(0),
+                vaultNativeFacet: state.vaultNativeFacetAddress,
                 vaultControlsFacet: state.vaultControlsFacetAddress,
                 vaultIntegrationFacet: state.vaultIntegrationFacetAddress,
                 vaultAsset: state.vaultAssetAddress,
@@ -96,7 +100,7 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
                 strategyDebt: 0,
                 liveStrategyAssets: 0,
                 strategyEmergencyExit: false,
-                assetMode: "erc20",
+                assetMode: "native",
                 vaultName: VAULT_NAME,
                 vaultSymbol: VAULT_SYMBOL
             })
@@ -104,38 +108,45 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
 
         diamondAddress = state.diamondAddress;
         vaultCoreFacetAddress = state.vaultCoreFacetAddress;
+        vaultNativeFacetAddress = state.vaultNativeFacetAddress;
         vaultControlsFacetAddress = state.vaultControlsFacetAddress;
         vaultIntegrationFacetAddress = state.vaultIntegrationFacetAddress;
     }
 
-    function _deployVaultSupportContracts(VaultHostDeploymentState memory state, address owner)
+    function _deployVaultSupportContracts(NativeVaultHostDeploymentState memory state, address owner)
         internal
-        returns (VaultHostDeploymentState memory)
+        returns (NativeVaultHostDeploymentState memory)
     {
         state.vaultCoreFacetAddress = address(new ERC4626VaultFacet());
+        state.vaultNativeFacetAddress = address(new ERC7535VaultFacet());
         state.vaultControlsFacetAddress = address(new ERC4626VaultControlsFacet());
         state.vaultIntegrationFacetAddress = address(new ERC4626VaultIntegrationFacet());
-        state.vaultAssetAddress = address(new LocalMintableVaultAsset("Mock USD", "mUSD", 6));
+        state.vaultAssetAddress = LibVaultAsset.NATIVE_ASSET_SENTINEL;
         state.oracleFeedAddress = address(new LocalMockOracleFeed(ORACLE_DECIMALS, ORACLE_ANSWER, block.timestamp - 1));
         state.oracleAdapterAddress =
             address(new LocalOracleAdapterHarness(owner, state.oracleFeedAddress, MAX_STALENESS));
-        state.strategyAddress = address(new LocalHappyPathVaultStrategy(state.diamondAddress, state.vaultAssetAddress));
+        state.strategyAddress = address(new LocalNativeHappyPathVaultStrategy(state.diamondAddress));
         return state;
     }
 
-    function _installVaultHostFacets(VaultHostDeploymentState memory state) internal {
-        IDiamondCut.FacetCut[] memory vaultCut = new IDiamondCut.FacetCut[](3);
+    function _installVaultHostFacets(NativeVaultHostDeploymentState memory state) internal {
+        IDiamondCut.FacetCut[] memory vaultCut = new IDiamondCut.FacetCut[](4);
         vaultCut[0] = IDiamondCut.FacetCut({
             facetAddress: state.vaultCoreFacetAddress,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: LibVaultFacetSelectors.vaultCoreSelectors()
         });
         vaultCut[1] = IDiamondCut.FacetCut({
+            facetAddress: state.vaultNativeFacetAddress,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultNativeSelectors()
+        });
+        vaultCut[2] = IDiamondCut.FacetCut({
             facetAddress: state.vaultControlsFacetAddress,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: LibVaultFacetSelectors.vaultControlsSelectors()
         });
-        vaultCut[2] = IDiamondCut.FacetCut({
+        vaultCut[3] = IDiamondCut.FacetCut({
             facetAddress: state.vaultIntegrationFacetAddress,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: LibVaultFacetSelectors.vaultIntegrationSelectors()
@@ -143,7 +154,7 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
         IDiamondCut(state.diamondAddress).diamondCut(vaultCut, address(0), "");
     }
 
-    function _validateVaultHost(VaultHostDeploymentState memory state, address owner) internal view {
+    function _validateVaultHost(NativeVaultHostDeploymentState memory state, address owner) internal view {
         _validateDiamondCore(state.diamondAddress, owner, state.cutFacetAddress, state.loupeFacetAddress);
 
         IDiamondLoupe loupe = IDiamondLoupe(state.diamondAddress);
@@ -153,99 +164,125 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
         IERC4626VaultStrategy strategy = IERC4626VaultStrategy(state.strategyAddress);
         address[] memory facetAddresses = loupe.facetAddresses();
 
-        require(facetAddresses.length == 5, "vault host facet count mismatch");
-        require(_containsAddress(facetAddresses, state.cutFacetAddress), "vault host missing cut facet");
-        require(_containsAddress(facetAddresses, state.loupeFacetAddress), "vault host missing loupe facet");
-        require(_containsAddress(facetAddresses, state.vaultCoreFacetAddress), "vault host missing core facet");
-        require(_containsAddress(facetAddresses, state.vaultControlsFacetAddress), "vault host missing controls facet");
+        require(facetAddresses.length == 6, "native vault host facet count mismatch");
+        require(_containsAddress(facetAddresses, state.cutFacetAddress), "native vault host missing cut facet");
+        require(_containsAddress(facetAddresses, state.loupeFacetAddress), "native vault host missing loupe facet");
+        require(_containsAddress(facetAddresses, state.vaultCoreFacetAddress), "native vault host missing core facet");
         require(
-            _containsAddress(facetAddresses, state.vaultIntegrationFacetAddress), "vault host missing integration facet"
+            _containsAddress(facetAddresses, state.vaultNativeFacetAddress), "native vault host missing native facet"
+        );
+        require(
+            _containsAddress(facetAddresses, state.vaultControlsFacetAddress),
+            "native vault host missing controls facet"
+        );
+        require(
+            _containsAddress(facetAddresses, state.vaultIntegrationFacetAddress),
+            "native vault host missing integration facet"
         );
 
         require(
             loupe.facetFunctionSelectors(state.vaultCoreFacetAddress).length
                 == LibVaultFacetSelectors.vaultCoreSelectors().length,
-            "vault host core selector count mismatch"
+            "native vault host core selector count mismatch"
+        );
+        require(
+            loupe.facetFunctionSelectors(state.vaultNativeFacetAddress).length
+                == LibVaultFacetSelectors.vaultNativeSelectors().length,
+            "native vault host native selector count mismatch"
         );
         require(
             loupe.facetFunctionSelectors(state.vaultControlsFacetAddress).length
                 == LibVaultFacetSelectors.vaultControlsSelectors().length,
-            "vault host controls selector count mismatch"
+            "native vault host controls selector count mismatch"
         );
         require(
             loupe.facetFunctionSelectors(state.vaultIntegrationFacetAddress).length
                 == LibVaultFacetSelectors.vaultIntegrationSelectors().length,
-            "vault host integration selector count mismatch"
+            "native vault host integration selector count mismatch"
         );
 
-        require(vaultCore.isVaultInitialized(), "vault host not initialized");
-        require(vaultCore.asset() == state.vaultAssetAddress, "vault host asset mismatch");
+        require(vaultCore.isVaultInitialized(), "native vault host not initialized");
+        require(vaultCore.asset() == state.vaultAssetAddress, "native vault host asset mismatch");
         require(
             keccak256(bytes(IERC20Metadata(state.diamondAddress).name())) == keccak256(bytes(VAULT_NAME)),
-            "vault name mismatch"
+            "native vault name mismatch"
         );
         require(
             keccak256(bytes(IERC20Metadata(state.diamondAddress).symbol())) == keccak256(bytes(VAULT_SYMBOL)),
-            "vault symbol mismatch"
+            "native vault symbol mismatch"
         );
-        require(vaultControls.hasRole(vaultControls.DEFAULT_ADMIN_ROLE(), owner), "vault default admin missing");
-        require(vaultControls.hasRole(vaultControls.PAUSER_ROLE(), owner), "vault pauser missing");
-        require(vaultControls.hasRole(vaultControls.VAULT_MANAGER_ROLE(), owner), "vault manager missing");
+        require(vaultControls.hasRole(vaultControls.DEFAULT_ADMIN_ROLE(), owner), "native vault default admin missing");
+        require(vaultControls.hasRole(vaultControls.PAUSER_ROLE(), owner), "native vault pauser missing");
+        require(vaultControls.hasRole(vaultControls.VAULT_MANAGER_ROLE(), owner), "native vault manager missing");
 
         (,, address feeRecipient) = vaultControls.feeConfig();
-        require(feeRecipient == owner, "vault fee recipient mismatch");
+        require(feeRecipient == owner, "native vault fee recipient mismatch");
 
-        require(vaultIntegration.oracleAdapter() == state.oracleAdapterAddress, "vault oracle adapter mismatch");
-        require(vaultIntegration.strategy() == state.strategyAddress, "vault strategy mismatch");
-        require(vaultIntegration.strategyDebt() == 0, "vault strategy debt should be zero");
-        require(!vaultIntegration.strategyEmergencyExit(), "vault emergency exit should be inactive");
-        require(vaultIntegration.liveStrategyAssets() == 0, "vault live strategy assets should be zero");
-        require(strategy.vault() == state.diamondAddress, "strategy vault binding mismatch");
-        require(strategy.asset() == state.vaultAssetAddress, "strategy asset binding mismatch");
+        require(vaultIntegration.oracleAdapter() == state.oracleAdapterAddress, "native vault oracle adapter mismatch");
+        require(vaultIntegration.strategy() == state.strategyAddress, "native vault strategy mismatch");
+        require(vaultIntegration.strategyDebt() == 0, "native vault strategy debt should be zero");
+        require(!vaultIntegration.strategyEmergencyExit(), "native vault emergency exit should be inactive");
+        require(vaultIntegration.liveStrategyAssets() == 0, "native vault live strategy assets should be zero");
+        require(strategy.vault() == state.diamondAddress, "native strategy vault binding mismatch");
+        require(strategy.asset() == state.vaultAssetAddress, "native strategy asset binding mismatch");
 
         IOracleAdapter.OracleQuote memory quotePayload = vaultIntegration.oracleQuote();
-        require(quotePayload.value == ORACLE_ANSWER, "vault quote value mismatch");
-        require(quotePayload.decimals == ORACLE_DECIMALS, "vault quote decimals mismatch");
-        require(quotePayload.updatedAt != 0, "vault quote timestamp missing");
+        require(quotePayload.value == ORACLE_ANSWER, "native vault quote value mismatch");
+        require(quotePayload.decimals == ORACLE_DECIMALS, "native vault quote decimals mismatch");
+        require(quotePayload.updatedAt != 0, "native vault quote timestamp missing");
 
         require(
             IERC165(state.diamondAddress).supportsInterface(type(IERC4626VaultFacet).interfaceId),
-            "vault host missing core interface"
+            "native vault host missing core interface"
+        );
+        require(
+            IERC165(state.diamondAddress).supportsInterface(type(IERC7535VaultFacet).interfaceId),
+            "native vault host missing native interface"
         );
         require(
             IERC165(state.diamondAddress).supportsInterface(type(IERC4626VaultControlsFacet).interfaceId),
-            "vault host missing controls interface"
+            "native vault host missing controls interface"
         );
         require(
             IERC165(state.diamondAddress).supportsInterface(type(IERC4626VaultIntegrationFacet).interfaceId),
-            "vault host missing integration interface"
+            "native vault host missing integration interface"
         );
 
-        _requireSelectorOwner(loupe, DiamondCutFacet.diamondCut.selector, state.cutFacetAddress, "vault cut owner");
-        _requireSelectorOwner(loupe, DiamondLoupeFacet.facets.selector, state.loupeFacetAddress, "vault loupe owner");
         _requireSelectorOwner(
-            loupe, IERC4626VaultFacet.initializeVault.selector, state.vaultCoreFacetAddress, "vault init owner"
+            loupe, DiamondCutFacet.diamondCut.selector, state.cutFacetAddress, "native vault cut owner"
+        );
+        _requireSelectorOwner(
+            loupe, DiamondLoupeFacet.facets.selector, state.loupeFacetAddress, "native vault loupe owner"
+        );
+        _requireSelectorOwner(
+            loupe, IERC4626VaultFacet.initializeVault.selector, state.vaultCoreFacetAddress, "native vault init owner"
+        );
+        _requireSelectorOwner(
+            loupe,
+            IERC7535VaultFacet.depositNative.selector,
+            state.vaultNativeFacetAddress,
+            "native vault deposit owner"
         );
         _requireSelectorOwner(
             loupe,
             IERC4626VaultControls.VAULT_MANAGER_ROLE.selector,
             state.vaultControlsFacetAddress,
-            "vault manager owner"
+            "native vault manager owner"
         );
         _requireSelectorOwner(
             loupe,
             IERC4626VaultIntegrationFacet.oracleAdapter.selector,
             state.vaultIntegrationFacetAddress,
-            "vault oracle owner"
+            "native vault oracle owner"
         );
         _requireSelectorOwner(
             loupe,
             IERC4626VaultIntegrationFacet.deployToStrategy.selector,
             state.vaultIntegrationFacetAddress,
-            "vault deploy strategy owner"
+            "native vault deploy strategy owner"
         );
         _requireSelectorOwner(
-            loupe, IERC165.supportsInterface.selector, state.vaultControlsFacetAddress, "vault erc165 owner"
+            loupe, IERC165.supportsInterface.selector, state.vaultControlsFacetAddress, "native vault erc165 owner"
         );
     }
 

--- a/script/common/DiamondVaultHostScriptBase.sol
+++ b/script/common/DiamondVaultHostScriptBase.sol
@@ -18,6 +18,7 @@ abstract contract DiamondVaultHostScriptBase is DiamondCoreScriptBase {
         address diamondCutFacet;
         address diamondLoupeFacet;
         address vaultCoreFacet;
+        address vaultNativeFacet;
         address vaultControlsFacet;
         address vaultIntegrationFacet;
         address vaultAsset;
@@ -29,6 +30,7 @@ abstract contract DiamondVaultHostScriptBase is DiamondCoreScriptBase {
         uint256 strategyDebt;
         uint256 liveStrategyAssets;
         bool strategyEmergencyExit;
+        string assetMode;
         string vaultName;
         string vaultSymbol;
     }
@@ -86,6 +88,7 @@ abstract contract DiamondVaultHostScriptBase is DiamondCoreScriptBase {
         json = VM.serializeAddress(objectKey, "diamondCutFacet", artifact.diamondCutFacet);
         json = VM.serializeAddress(objectKey, "diamondLoupeFacet", artifact.diamondLoupeFacet);
         json = VM.serializeAddress(objectKey, "vaultCoreFacet", artifact.vaultCoreFacet);
+        json = VM.serializeAddress(objectKey, "vaultNativeFacet", artifact.vaultNativeFacet);
         json = VM.serializeAddress(objectKey, "vaultControlsFacet", artifact.vaultControlsFacet);
         json = VM.serializeAddress(objectKey, "vaultIntegrationFacet", artifact.vaultIntegrationFacet);
         json = VM.serializeAddress(objectKey, "vaultAsset", artifact.vaultAsset);
@@ -95,6 +98,7 @@ abstract contract DiamondVaultHostScriptBase is DiamondCoreScriptBase {
         json = VM.serializeUint(objectKey, "strategyDebt", artifact.strategyDebt);
         json = VM.serializeUint(objectKey, "liveStrategyAssets", artifact.liveStrategyAssets);
         json = VM.serializeBool(objectKey, "strategyEmergencyExit", artifact.strategyEmergencyExit);
+        json = VM.serializeString(objectKey, "assetMode", artifact.assetMode);
         json = VM.serializeString(objectKey, "vaultName", artifact.vaultName);
         json = VM.serializeString(objectKey, "vaultSymbol", artifact.vaultSymbol);
         VM.writeJson(json, string.concat(VM.projectRoot(), outputRelativePath));

--- a/script/mocks/LocalVaultDeploymentMocks.sol
+++ b/script/mocks/LocalVaultDeploymentMocks.sol
@@ -5,6 +5,7 @@ import {IERC20Metadata} from "../../src/interfaces/IERC20Metadata.sol";
 import {IOracleFeed} from "../../src/interfaces/IOracleFeed.sol";
 import {IERC4626VaultStrategy} from "../../src/interfaces/IERC4626VaultStrategy.sol";
 import {OracleAdapter} from "../../src/oracle/OracleAdapter.sol";
+import {LibVaultAsset} from "../../src/vault/libraries/LibVaultAsset.sol";
 
 /// @title LocalMintableVaultAsset
 /// @notice Minimal mintable ERC20 used for local hosted-vault deployment rehearsal.
@@ -192,6 +193,75 @@ contract LocalHappyPathVaultStrategy is IERC4626VaultStrategy {
         }
 
         LocalMintableVaultAsset(ASSET).mint(address(this), assets);
+        _trackedAssets += assets;
+    }
+}
+
+/// @title LocalNativeHappyPathVaultStrategy
+/// @notice Simple native vault-bound strategy used for local hosted-vault deployment and smoke flows.
+contract LocalNativeHappyPathVaultStrategy is IERC4626VaultStrategy {
+    address internal immutable VAULT;
+    uint256 internal _trackedAssets;
+
+    constructor(address vault_) {
+        VAULT = vault_;
+    }
+
+    receive() external payable {}
+
+    modifier onlyVault() {
+        if (msg.sender != VAULT) {
+            revert ERC4626VaultStrategyOnlyVault(msg.sender, VAULT);
+        }
+        _;
+    }
+
+    function vault() external view returns (address) {
+        return VAULT;
+    }
+
+    function asset() external pure returns (address) {
+        return LibVaultAsset.NATIVE_ASSET_SENTINEL;
+    }
+
+    function totalAssets() external view returns (uint256) {
+        return _trackedAssets;
+    }
+
+    function maxWithdrawableAssets() external view returns (uint256) {
+        return _trackedAssets;
+    }
+
+    function deployFunds(uint256 assets) external onlyVault {
+        _trackedAssets += assets;
+        require(address(this).balance >= _trackedAssets, "STRATEGY_UNDERFUNDED");
+    }
+
+    function withdrawToVault(uint256 assets) external onlyVault returns (uint256 assetsReturned) {
+        assetsReturned = assets > _trackedAssets ? _trackedAssets : assets;
+        _trackedAssets -= assetsReturned;
+        if (assetsReturned != 0) {
+            (bool success,) = payable(VAULT).call{value: assetsReturned}("");
+            require(success, "STRATEGY_TRANSFER_FAILED");
+        }
+    }
+
+    function withdrawAllToVault() external onlyVault returns (uint256 assetsReturned) {
+        assetsReturned = _trackedAssets;
+        _trackedAssets = 0;
+        if (assetsReturned != 0) {
+            (bool success,) = payable(VAULT).call{value: assetsReturned}("");
+            require(success, "STRATEGY_TRANSFER_FAILED");
+        }
+    }
+
+    function injectProfit(uint256 assets) external payable {
+        if (assets == 0) {
+            require(msg.value == 0, "STRATEGY_PROFIT_VALUE_MISMATCH");
+            return;
+        }
+
+        require(msg.value == assets, "STRATEGY_PROFIT_VALUE_MISMATCH");
         _trackedAssets += assets;
     }
 }

--- a/scripts/auralis-activity.sh
+++ b/scripts/auralis-activity.sh
@@ -12,6 +12,9 @@ vault_diamond="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.diamond)"
 vault_asset="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.vaultAsset)"
 oracle_feed="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.oracleFeed)"
 strategy="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.strategy)"
+native_vault_diamond="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" nativeVaultHost.diamond)"
+native_oracle_feed="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" nativeVaultHost.oracleFeed)"
+native_strategy="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" nativeVaultHost.strategy)"
 
 now_ts="$(date +%s)"
 
@@ -59,11 +62,38 @@ cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_
 cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
   "${vault_diamond}" "unpause()" >/dev/null
 
+auralis_note "Generating native vault and strategy activity"
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_ALICE_PRIVATE_KEY}" --value 1250000000000000000 \
+  "${native_vault_diamond}" "depositNative(address)(uint256)" "${AURALIS_ALICE_ADDRESS}" >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${native_vault_diamond}" "deployToStrategy(uint256)" 750000000000000000 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" --value 125000000000000000 \
+  "${native_strategy}" "injectProfit(uint256)" 125000000000000000 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${native_vault_diamond}" "syncStrategyAssets()" >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${native_vault_diamond}" "withdrawFromStrategy(uint256)(uint256)" 200000000000000000 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_ALICE_PRIVATE_KEY}" \
+  "${native_vault_diamond}" "transfer(address,uint256)" "${AURALIS_OWNER_ADDRESS}" 250000000000000000 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${native_vault_diamond}" "redeem(uint256,address,address)(uint256)" 100000000000000000 "${AURALIS_OWNER_ADDRESS}" "${AURALIS_OWNER_ADDRESS}" >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${native_oracle_feed}" "setRoundData(int256,uint256)" 102000000 "${now_ts}" >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${native_vault_diamond}" "pause()" >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${native_vault_diamond}" "unpause()" >/dev/null
+
 idle_assets="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "idleAssets()(uint256)" | awk '{print $1}')"
 strategy_debt="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "strategyDebt()(uint256)" | awk '{print $1}')"
 live_strategy_assets="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "liveStrategyAssets()(uint256)" | awk '{print $1}')"
 total_assets="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "totalAssets()(uint256)" | awk '{print $1}')"
 quote_tuple="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "oracleQuote()((int256,uint64,uint8))")"
+native_idle_assets="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${native_vault_diamond}" "idleAssets()(uint256)" | awk '{print $1}')"
+native_strategy_debt="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${native_vault_diamond}" "strategyDebt()(uint256)" | awk '{print $1}')"
+native_live_strategy_assets="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${native_vault_diamond}" "liveStrategyAssets()(uint256)" | awk '{print $1}')"
+native_total_assets="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${native_vault_diamond}" "totalAssets()(uint256)" | awk '{print $1}')"
+native_quote_tuple="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${native_vault_diamond}" "oracleQuote()((int256,uint64,uint8))")"
 
 cat <<MSG
 Auralis simulated activity complete.
@@ -74,5 +104,11 @@ Live strategy assets: ${live_strategy_assets}
 Total assets: ${total_assets}
 Oracle quote tuple: ${quote_tuple}
 
-The local chain now has representative token, NFT, vault, oracle, and live strategy lifecycle activity.
+Native idle assets: ${native_idle_assets}
+Native strategy debt: ${native_strategy_debt}
+Native live strategy assets: ${native_live_strategy_assets}
+Native total assets: ${native_total_assets}
+Native oracle quote tuple: ${native_quote_tuple}
+
+The local chain now has representative token, NFT, ERC20 vault, native vault, oracle, and live strategy lifecycle activity.
 MSG

--- a/scripts/auralis-smoke.sh
+++ b/scripts/auralis-smoke.sh
@@ -9,11 +9,35 @@ auralis_require_artifact
 erc20_diamond="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" erc20Host.diamond)"
 erc721_diamond="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" erc721Host.diamond)"
 vault_diamond="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.diamond)"
+vault_asset_mode="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.assetMode)"
 vault_asset="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.vaultAsset)"
 oracle_adapter="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.oracleAdapter)"
 strategy="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.strategy)"
+native_vault_diamond="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" nativeVaultHost.diamond)"
+native_vault_asset_mode="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" nativeVaultHost.assetMode)"
+native_vault_native_facet="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" nativeVaultHost.vaultNativeFacet)"
+native_oracle_adapter="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" nativeVaultHost.oracleAdapter)"
+native_strategy="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" nativeVaultHost.strategy)"
+
+if [[ "${vault_asset_mode}" != "erc20" ]]; then
+  echo "Expected vaultHost.assetMode to be erc20, got ${vault_asset_mode}." >&2
+  exit 1
+fi
+
+if [[ "${native_vault_asset_mode}" != "native" ]]; then
+  echo "Expected nativeVaultHost.assetMode to be native, got ${native_vault_asset_mode}." >&2
+  exit 1
+fi
 
 for address in "${erc20_diamond}" "${erc721_diamond}" "${vault_diamond}" "${vault_asset}" "${oracle_adapter}" "${strategy}"; do
+  code="$(cast code --rpc-url "${AURALIS_RPC_URL}" "${address}")"
+  if [[ "${code}" == "0x" ]]; then
+    echo "Expected deployed code at ${address}, found empty code." >&2
+    exit 1
+  fi
+done
+
+for address in "${native_vault_diamond}" "${native_vault_native_facet}" "${native_oracle_adapter}" "${native_strategy}"; do
   code="$(cast code --rpc-url "${AURALIS_RPC_URL}" "${address}")"
   if [[ "${code}" == "0x" ]]; then
     echo "Expected deployed code at ${address}, found empty code." >&2
@@ -85,6 +109,47 @@ fi
 quote_tuple="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${vault_diamond}" "oracleQuote()((int256,uint64,uint8))")"
 if [[ -z "${quote_tuple}" ]]; then
   echo "oracleQuote() returned empty output." >&2
+  exit 1
+fi
+
+auralis_note "Native vault host smoke: strategy-enabled lifecycle"
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_ALICE_PRIVATE_KEY}" --value 1000000000000000000 \
+  "${native_vault_diamond}" "depositNative(address)(uint256)" "${AURALIS_ALICE_ADDRESS}" >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${native_vault_diamond}" "deployToStrategy(uint256)" 600000000000000000 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" --value 100000000000000000 \
+  "${native_strategy}" "injectProfit(uint256)" 100000000000000000 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${native_vault_diamond}" "syncStrategyAssets()" >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${native_vault_diamond}" "withdrawFromStrategy(uint256)(uint256)" 150000000000000000 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_ALICE_PRIVATE_KEY}" \
+  "${native_vault_diamond}" "withdraw(uint256,address,address)(uint256)" 700000000000000000 "${AURALIS_ALICE_ADDRESS}" "${AURALIS_ALICE_ADDRESS}" >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${native_vault_diamond}" "emergencyExitStrategy()(uint256)" >/dev/null
+
+native_strategy_debt="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${native_vault_diamond}" "strategyDebt()(uint256)" | awk '{print $1}')"
+native_strategy_exit="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${native_vault_diamond}" "strategyEmergencyExit()(bool)")"
+if [[ "${native_strategy_debt}" != "0" || "${native_strategy_exit}" != "true" ]]; then
+  echo "Unexpected native strategy state after emergency exit: debt=${native_strategy_debt}, emergency=${native_strategy_exit}" >&2
+  exit 1
+fi
+
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${native_vault_diamond}" "setStrategy(address)" 0x0000000000000000000000000000000000000000 >/dev/null
+cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" \
+  "${native_vault_diamond}" "setStrategy(address)" "${native_strategy}" >/dev/null
+
+native_strategy_rebound="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${native_vault_diamond}" "strategy()(address)")"
+native_strategy_exit="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${native_vault_diamond}" "strategyEmergencyExit()(bool)")"
+if [[ "${native_strategy_rebound,,}" != "${native_strategy,,}" || "${native_strategy_exit}" != "false" ]]; then
+  echo "Native strategy was not rebound cleanly after smoke flow." >&2
+  exit 1
+fi
+
+native_quote_tuple="$(cast call --rpc-url "${AURALIS_RPC_URL}" "${native_vault_diamond}" "oracleQuote()((int256,uint64,uint8))")"
+if [[ -z "${native_quote_tuple}" ]]; then
+  echo "native oracleQuote() returned empty output." >&2
   exit 1
 fi
 

--- a/scripts/auralis-up.sh
+++ b/scripts/auralis-up.sh
@@ -8,7 +8,7 @@ auralis_start_anvil_if_needed
 auralis_remove_artifacts
 
 auralis_note "Funding local actor accounts"
-auralis_fund_actor "${AURALIS_ALICE_ADDRESS}"
+auralis_fund_actor "${AURALIS_ALICE_ADDRESS}" 10000000000000000000
 
 auralis_note "Deploying ERC20 host"
 (
@@ -28,10 +28,17 @@ auralis_note "Deploying strategy-enabled vault host"
   forge script script/DeployDiamondVaultHost.s.sol:DeployDiamondVaultHostScript --rpc-url "${AURALIS_RPC_URL}" --broadcast
 )
 
+auralis_note "Deploying native strategy-enabled vault host"
+(
+  cd "${AURALIS_ROOT}"
+  forge script script/DeployDiamondNativeVaultHost.s.sol:DeployDiamondNativeVaultHostScript --rpc-url "${AURALIS_RPC_URL}" --broadcast
+)
+
 auralis_note "Writing unified Auralis artifact"
 auralis_write_unified_artifact
 
 vault_strategy="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" vaultHost.strategy)"
+native_vault_strategy="$(auralis_json_get "${AURALIS_ARTIFACT_PATH}" nativeVaultHost.strategy)"
 
 cat <<MSG
 Auralis local environment is ready.
@@ -41,6 +48,7 @@ Artifact: ${AURALIS_ARTIFACT_PATH}
 Owner: ${AURALIS_OWNER_ADDRESS}
 Alice: ${AURALIS_ALICE_ADDRESS}
 Vault strategy: ${vault_strategy}
+Native vault strategy: ${native_vault_strategy}
 
 Next steps:
 - bash scripts/auralis-smoke.sh

--- a/scripts/lib/auralis.sh
+++ b/scripts/lib/auralis.sh
@@ -7,6 +7,7 @@ AURALIS_ARTIFACT_PATH="${AURALIS_DEPLOYMENTS_DIR}/auralis.local.json"
 AURALIS_ERC20_ARTIFACT_PATH="${AURALIS_DEPLOYMENTS_DIR}/diamond-erc20.local.json"
 AURALIS_ERC721_ARTIFACT_PATH="${AURALIS_DEPLOYMENTS_DIR}/diamond-erc721.local.json"
 AURALIS_VAULT_ARTIFACT_PATH="${AURALIS_DEPLOYMENTS_DIR}/diamond-vault.local.json"
+AURALIS_NATIVE_VAULT_ARTIFACT_PATH="${AURALIS_DEPLOYMENTS_DIR}/diamond-native-vault.local.json"
 AURALIS_ANVIL_PID_PATH="${AURALIS_STATE_DIR}/anvil.pid"
 AURALIS_ANVIL_LOG_PATH="${ANVIL_LOG_PATH:-${AURALIS_STATE_DIR}/anvil.log}"
 AURALIS_OWNER_PRIVATE_KEY="${PRIVATE_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}"
@@ -122,11 +123,12 @@ auralis_remove_artifacts() {
     "${AURALIS_ARTIFACT_PATH}" \
     "${AURALIS_ERC20_ARTIFACT_PATH}" \
     "${AURALIS_ERC721_ARTIFACT_PATH}" \
-    "${AURALIS_VAULT_ARTIFACT_PATH}"
+    "${AURALIS_VAULT_ARTIFACT_PATH}" \
+    "${AURALIS_NATIVE_VAULT_ARTIFACT_PATH}"
 }
 
 auralis_write_unified_artifact() {
-  python3 - "${AURALIS_ERC20_ARTIFACT_PATH}" "${AURALIS_ERC721_ARTIFACT_PATH}" "${AURALIS_VAULT_ARTIFACT_PATH}" "${AURALIS_ARTIFACT_PATH}" "${AURALIS_RPC_URL}" "${AURALIS_OWNER_ADDRESS}" "${AURALIS_ALICE_ADDRESS}" <<'PY'
+  python3 - "${AURALIS_ERC20_ARTIFACT_PATH}" "${AURALIS_ERC721_ARTIFACT_PATH}" "${AURALIS_VAULT_ARTIFACT_PATH}" "${AURALIS_NATIVE_VAULT_ARTIFACT_PATH}" "${AURALIS_ARTIFACT_PATH}" "${AURALIS_RPC_URL}" "${AURALIS_OWNER_ADDRESS}" "${AURALIS_ALICE_ADDRESS}" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -134,10 +136,11 @@ from pathlib import Path
 erc20 = json.load(open(sys.argv[1], 'r', encoding='utf-8'))
 erc721 = json.load(open(sys.argv[2], 'r', encoding='utf-8'))
 vault = json.load(open(sys.argv[3], 'r', encoding='utf-8'))
-out_path = Path(sys.argv[4])
-rpc_url = sys.argv[5]
-owner = sys.argv[6]
-alice = sys.argv[7]
+native_vault = json.load(open(sys.argv[4], 'r', encoding='utf-8'))
+out_path = Path(sys.argv[5])
+rpc_url = sys.argv[6]
+owner = sys.argv[7]
+alice = sys.argv[8]
 
 artifact = {
     'project': 'Auralis',
@@ -158,7 +161,11 @@ artifact = {
     },
     'vaultHost': {
         **vault,
-        'label': 'Vault host',
+        'label': 'ERC20 vault host',
+    },
+    'nativeVaultHost': {
+        **native_vault,
+        'label': 'Native vault host',
     },
 }
 
@@ -171,4 +178,3 @@ auralis_fund_actor() {
   local value_wei="${2:-1000000000000000000}"
   cast send --rpc-url "${AURALIS_RPC_URL}" --private-key "${AURALIS_OWNER_PRIVATE_KEY}" --value "${value_wei}" "${recipient}" >/dev/null
 }
-

--- a/test/DiamondVaultDeploymentIntegration.t.sol
+++ b/test/DiamondVaultDeploymentIntegration.t.sol
@@ -12,8 +12,10 @@ import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControl
 import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
 import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
 import {IERC4626VaultStrategy} from "../src/interfaces/IERC4626VaultStrategy.sol";
+import {IERC7535VaultFacet} from "../src/interfaces/IERC7535VaultFacet.sol";
 import {IOracleAdapter} from "../src/interfaces/IOracleAdapter.sol";
 import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
+import {LibVaultAsset} from "../src/vault/libraries/LibVaultAsset.sol";
 import {DiamondVaultDeploymentFixture} from "./helpers/DiamondVaultDeploymentTestHarness.sol";
 
 contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture {
@@ -180,6 +182,195 @@ contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture 
 
         assertFalse(integrationFacetInterface().strategyEmergencyExit(), "emergency exit should clear on rebind");
         assertTrue(integrationFacetInterface().strategy() == address(strategy), "strategy should be rebound");
+        assertTrue(integrationFacetInterface().strategyDebt() == 0, "strategy debt should reset to zero");
+    }
+
+    function testNativeVaultHostDeployInstallInitOracleAndStrategyWiring() public {
+        _installNativeVaultHostFacets();
+        _initializeNativeVaultHost();
+        _wireOracleAdapter();
+        _wireNativeStrategy();
+
+        IDiamondLoupe loupe = IDiamondLoupe(address(diamond));
+        address[] memory facetAddresses = loupe.facetAddresses();
+        IOracleAdapter.OracleQuote memory quotePayload = integrationFacetInterface().oracleQuote();
+
+        assertTrue(facetAddresses.length == 6, "native vault host facet count mismatch");
+        assertTrue(_containsAddress(facetAddresses, address(cutFacet)), "missing cut facet");
+        assertTrue(_containsAddress(facetAddresses, address(loupeFacet)), "missing loupe facet");
+        assertTrue(_containsAddress(facetAddresses, address(coreFacet)), "missing core facet");
+        assertTrue(_containsAddress(facetAddresses, address(nativeFacet)), "missing native facet");
+        assertTrue(_containsAddress(facetAddresses, address(controlsFacet)), "missing controls facet");
+        assertTrue(_containsAddress(facetAddresses, address(integrationFacet)), "missing integration facet");
+
+        assertTrue(
+            loupe.facetFunctionSelectors(address(coreFacet)).length
+                == LibVaultFacetSelectors.vaultCoreSelectors().length,
+            "unexpected core selector count"
+        );
+        assertTrue(
+            loupe.facetFunctionSelectors(address(nativeFacet)).length
+                == LibVaultFacetSelectors.vaultNativeSelectors().length,
+            "unexpected native selector count"
+        );
+        assertTrue(
+            loupe.facetFunctionSelectors(address(controlsFacet)).length
+                == LibVaultFacetSelectors.vaultControlsSelectors().length,
+            "unexpected controls selector count"
+        );
+        assertTrue(
+            loupe.facetFunctionSelectors(address(integrationFacet)).length
+                == LibVaultFacetSelectors.vaultIntegrationSelectors().length,
+            "unexpected integration selector count"
+        );
+
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultCoreSelectors(), address(coreFacet));
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultNativeSelectors(), address(nativeFacet));
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultControlsSelectors(), address(controlsFacet));
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultIntegrationSelectors(), address(integrationFacet));
+
+        assertTrue(loupe.facetAddress(DiamondCutFacet.diamondCut.selector) == address(cutFacet), "cut owner mismatch");
+        assertTrue(loupe.facetAddress(DiamondLoupeFacet.facets.selector) == address(loupeFacet), "loupe owner mismatch");
+        assertTrue(
+            loupe.facetAddress(IERC4626VaultFacet.initializeVault.selector) == address(coreFacet), "init owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC7535VaultFacet.depositNative.selector) == address(nativeFacet),
+            "native deposit owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC4626VaultControls.VAULT_MANAGER_ROLE.selector) == address(controlsFacet),
+            "vault manager owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC4626VaultIntegrationFacet.oracleAdapter.selector) == address(integrationFacet),
+            "oracle selector owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC4626VaultIntegrationFacet.deployToStrategy.selector) == address(integrationFacet),
+            "deploy strategy selector owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC165.supportsInterface.selector) == address(controlsFacet),
+            "supportsInterface owner mismatch"
+        );
+
+        assertTrue(coreFacetInterface().isVaultInitialized(), "vault should be initialized");
+        assertTrue(coreFacetInterface().asset() == LibVaultAsset.NATIVE_ASSET_SENTINEL, "asset mismatch");
+        assertTrue(
+            keccak256(bytes(IERC20Metadata(address(diamond)).name())) == keccak256(bytes("Native Vault Share")),
+            "name mismatch"
+        );
+        assertTrue(
+            keccak256(bytes(IERC20Metadata(address(diamond)).symbol())) == keccak256(bytes("nvSHARE")),
+            "symbol mismatch"
+        );
+
+        assertTrue(
+            controlsFacetInterface().hasRole(controlsFacetInterface().DEFAULT_ADMIN_ROLE(), admin),
+            "missing default admin"
+        );
+        assertTrue(controlsFacetInterface().hasRole(controlsFacetInterface().PAUSER_ROLE(), admin), "missing pauser");
+        assertTrue(
+            controlsFacetInterface().hasRole(controlsFacetInterface().VAULT_MANAGER_ROLE(), admin),
+            "missing vault manager"
+        );
+        (,, address feeRecipient) = controlsFacetInterface().feeConfig();
+        assertTrue(feeRecipient == admin, "fee recipient mismatch");
+
+        assertTrue(integrationFacetInterface().oracleAdapter() == address(adapter), "adapter mismatch");
+        assertTrue(integrationFacetInterface().strategy() == address(nativeStrategy), "strategy should be configured");
+        assertTrue(integrationFacetInterface().strategyDebt() == 0, "strategy debt should be zero");
+        assertFalse(integrationFacetInterface().strategyEmergencyExit(), "emergency exit should be inactive");
+        assertTrue(integrationFacetInterface().liveStrategyAssets() == 0, "live strategy assets should be zero");
+        assertTrue(
+            IERC4626VaultStrategy(address(nativeStrategy)).vault() == address(diamond), "strategy vault mismatch"
+        );
+        assertTrue(
+            IERC4626VaultStrategy(address(nativeStrategy)).asset() == LibVaultAsset.NATIVE_ASSET_SENTINEL,
+            "strategy asset mismatch"
+        );
+        assertTrue(quotePayload.value == 100_000_000, "quote value mismatch");
+        assertTrue(quotePayload.updatedAt == quoteUpdatedAt, "quote timestamp mismatch");
+        assertTrue(quotePayload.decimals == 8, "quote decimals mismatch");
+
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC4626VaultFacet).interfaceId), "missing core interface"
+        );
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC7535VaultFacet).interfaceId),
+            "missing native interface"
+        );
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC4626VaultControlsFacet).interfaceId),
+            "missing controls interface"
+        );
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC4626VaultIntegrationFacet).interfaceId),
+            "missing integration interface"
+        );
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultAlreadyInitialized.selector));
+        coreFacetInterface()
+            .initializeVault(LibVaultAsset.NATIVE_ASSET_SENTINEL, "Native Vault Share", "nvSHARE", admin);
+    }
+
+    function testNativeVaultHostSmokeCoversStrategyLifecycle() public {
+        _installNativeVaultHostFacets();
+        _initializeNativeVaultHost();
+        _wireOracleAdapter();
+        _wireNativeStrategy();
+
+        VM.deal(address(this), 1 ether);
+        VM.deal(alice, 2 ether);
+        VM.prank(alice);
+        IERC7535VaultFacet(address(diamond)).depositNative{value: 1 ether}(alice);
+
+        VM.prank(admin);
+        integrationFacetInterface().deployToStrategy(0.6 ether);
+        nativeStrategy.injectProfit{value: 0.1 ether}();
+        VM.prank(admin);
+        integrationFacetInterface().syncStrategyAssets();
+
+        assertTrue(integrationFacetInterface().strategyDebt() == 0.7 ether, "strategy debt mismatch after sync");
+        assertTrue(coreFacetInterface().totalManagedAssets() == 1.1 ether, "book value mismatch after sync");
+        assertTrue(coreFacetInterface().totalAssets() == 1.1 ether, "total assets mismatch after sync");
+
+        VM.prank(admin);
+        uint256 managerReturned = integrationFacetInterface().withdrawFromStrategy(0.15 ether);
+        assertTrue(managerReturned == 0.15 ether, "manager withdraw should return requested assets");
+        assertTrue(
+            integrationFacetInterface().strategyDebt() == 0.55 ether, "strategy debt mismatch after manager withdraw"
+        );
+
+        uint256 aliceBalanceBeforeWithdraw = alice.balance;
+        VM.prank(alice);
+        coreFacetInterface().withdraw(0.7 ether, alice, alice);
+
+        assertTrue(alice.balance == aliceBalanceBeforeWithdraw + 0.7 ether, "native withdraw payout mismatch");
+        assertTrue(
+            integrationFacetInterface().strategyDebt() == 0.4 ether, "strategy debt mismatch after user withdraw"
+        );
+        assertTrue(integrationFacetInterface().liveStrategyAssets() == 0.4 ether, "live strategy assets mismatch");
+        assertTrue(integrationFacetInterface().idleAssets() == 0, "idle assets should be exhausted after auto-pull");
+        assertTrue(coreFacetInterface().totalManagedAssets() == 0.4 ether, "book value mismatch after user withdraw");
+
+        VM.prank(admin);
+        uint256 emergencyAssets = integrationFacetInterface().emergencyExitStrategy();
+
+        assertTrue(emergencyAssets == 0.4 ether, "emergency exit should unwind remaining assets");
+        assertTrue(integrationFacetInterface().strategyEmergencyExit(), "emergency exit should be active");
+        assertTrue(integrationFacetInterface().strategyDebt() == 0, "strategy debt should be zero after unwind");
+        assertTrue(integrationFacetInterface().idleAssets() == 0.4 ether, "idle assets should contain unwound funds");
+
+        VM.prank(admin);
+        integrationFacetInterface().setStrategy(address(0));
+        VM.prank(admin);
+        integrationFacetInterface().setStrategy(address(nativeStrategy));
+
+        assertFalse(integrationFacetInterface().strategyEmergencyExit(), "emergency exit should clear on rebind");
+        assertTrue(integrationFacetInterface().strategy() == address(nativeStrategy), "strategy should be rebound");
         assertTrue(integrationFacetInterface().strategyDebt() == 0, "strategy debt should reset to zero");
     }
 

--- a/test/helpers/DiamondVaultDeploymentTestHarness.sol
+++ b/test/helpers/DiamondVaultDeploymentTestHarness.sol
@@ -4,14 +4,16 @@ pragma solidity ^0.8.30;
 import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
 import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
 import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
+import {ERC7535VaultFacet} from "../../src/vault/facets/ERC7535VaultFacet.sol";
 import {ERC4626VaultControlsFacetHarness} from "./ERC4626VaultControlsFacetTestHarness.sol";
 import {ERC4626VaultFacetHarness} from "./ERC4626VaultFacetTestHarness.sol";
 import {ERC4626VaultIntegrationFacetHarness} from "./ERC4626VaultIntegrationFacetTestHarness.sol";
 import {MockVaultAsset} from "./ERC4626CoreTestHarness.sol";
 import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
 import {MockOracleFeed, OracleAdapterHarness} from "./OracleAdapterTestHarness.sol";
-import {ProfitMockVaultStrategy} from "./ERC4626VaultStrategyTestHarness.sol";
+import {NativeProfitMockVaultStrategy, ProfitMockVaultStrategy} from "./ERC4626VaultStrategyTestHarness.sol";
 import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
+import {LibVaultAsset} from "../../src/vault/libraries/LibVaultAsset.sol";
 import {TestBase} from "./AccessControlTestHarness.sol";
 
 abstract contract DiamondVaultDeploymentFixture is TestBase {
@@ -25,6 +27,7 @@ abstract contract DiamondVaultDeploymentFixture is TestBase {
     DiamondCutFacet internal cutFacet;
     DiamondLoupeFacet internal loupeFacet;
     ERC4626VaultFacetHarness internal coreFacet;
+    ERC7535VaultFacet internal nativeFacet;
     ERC4626VaultControlsFacetHarness internal controlsFacet;
     ERC4626VaultIntegrationFacetHarness internal integrationFacet;
     DiamondProxyHarness internal diamond;
@@ -32,6 +35,7 @@ abstract contract DiamondVaultDeploymentFixture is TestBase {
     MockOracleFeed internal feed;
     OracleAdapterHarness internal adapter;
     ProfitMockVaultStrategy internal strategy;
+    NativeProfitMockVaultStrategy internal nativeStrategy;
 
     function setUp() public virtual {
         VM.warp(currentTime);
@@ -39,6 +43,7 @@ abstract contract DiamondVaultDeploymentFixture is TestBase {
         cutFacet = new DiamondCutFacet();
         loupeFacet = new DiamondLoupeFacet();
         coreFacet = new ERC4626VaultFacetHarness();
+        nativeFacet = new ERC7535VaultFacet();
         controlsFacet = new ERC4626VaultControlsFacetHarness();
         integrationFacet = new ERC4626VaultIntegrationFacetHarness();
         diamond = new DiamondProxyHarness(admin, address(cutFacet));
@@ -47,6 +52,7 @@ abstract contract DiamondVaultDeploymentFixture is TestBase {
         feed.setLatestRoundData(1, 100_000_000, quoteUpdatedAt, quoteUpdatedAt, 1);
         adapter = new OracleAdapterHarness(admin, address(feed), maxStaleness);
         strategy = new ProfitMockVaultStrategy(address(diamond), address(asset));
+        nativeStrategy = new NativeProfitMockVaultStrategy(address(diamond));
 
         _installLoupeFacet();
     }
@@ -85,9 +91,42 @@ abstract contract DiamondVaultDeploymentFixture is TestBase {
         IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
     }
 
+    function _installNativeVaultHostFacets() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](4);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(coreFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultCoreSelectors()
+        });
+        cut[1] = IDiamondCut.FacetCut({
+            facetAddress: address(nativeFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultNativeSelectors()
+        });
+        cut[2] = IDiamondCut.FacetCut({
+            facetAddress: address(controlsFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultControlsSelectors()
+        });
+        cut[3] = IDiamondCut.FacetCut({
+            facetAddress: address(integrationFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultIntegrationSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
     function _initializeVaultHost() internal {
         VM.prank(admin);
         coreFacetInterface().initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function _initializeNativeVaultHost() internal {
+        VM.prank(admin);
+        coreFacetInterface()
+            .initializeVault(LibVaultAsset.NATIVE_ASSET_SENTINEL, "Native Vault Share", "nvSHARE", admin);
     }
 
     function _wireOracleAdapter() internal {
@@ -98,6 +137,11 @@ abstract contract DiamondVaultDeploymentFixture is TestBase {
     function _wireStrategy() internal {
         VM.prank(admin);
         integrationFacetInterface().setStrategy(address(strategy));
+    }
+
+    function _wireNativeStrategy() internal {
+        VM.prank(admin);
+        integrationFacetInterface().setStrategy(address(nativeStrategy));
     }
 
     function coreFacetInterface() internal view returns (ERC4626VaultFacetHarness) {


### PR DESCRIPTION
## Summary
- add a parallel native hosted-vault local deployment flow and artifact output
- extend local smoke and activity scripts to exercise native deposit and strategy lifecycle paths
- add deployment integration coverage and local-operator docs for the native vault host

## Testing
- `forge test --offline --match-path test/DiamondVaultDeploymentIntegration.t.sol`
- `bash scripts/auralis-up.sh`
- `bash scripts/auralis-smoke.sh`
- `bash scripts/auralis-activity.sh`
- `bash scripts/auralis-reset.sh`

Closes #133