### PR TITLE
Add native-host hardening and invariant coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ reviewable engineering system.
   with init, selector ownership, Permit/metadata support, and host-level
   hardening coverage.
 - A hosted ERC-4626 vault platform deployed behind a diamond host, split across
-  core, controls, and integration facets with active strategy lifecycle
-  management, live strategy-aware accounting, loss-aware withdrawals,
-  emergency-exit safety, deployment-backed init, and diamond-routed hardening
-  plus invariant coverage.
+  core, native, controls, and integration facets with ERC20 and native-asset
+  modes, active strategy lifecycle management, live strategy-aware accounting,
+  loss-aware withdrawals, emergency-exit safety, deployment-backed init, and
+  diamond-routed hardening plus invariant coverage.
 - Operational maturity through local bootstrap, smoke validation, upgrade
   rehearsal, system-hardening flows, and matching CI gates.
 - A local Auralis workflow for full-stack bootstrap, smoke checks, simulated
@@ -94,8 +94,9 @@ constraint, and token-host upgrade assumptions.
 
 Hosted-vault architecture and safety assumptions live in
 `docs/vault-facets.md`, including the init model, selector ownership split,
-live strategy lifecycle, accounting model, emergency-exit behavior, deployment
-references, and hosted-vault upgrade assumptions.
+live strategy lifecycle, native-asset behavior, accounting model,
+emergency-exit behavior, deployment references, and hosted-vault upgrade
+assumptions.
 
 Local Auralis bootstrap, smoke, simulated activity, reset flow, and artifact
 layout are documented in `docs/auralis-local.md`.

--- a/docs/auralis-local.md
+++ b/docs/auralis-local.md
@@ -45,13 +45,15 @@ bash scripts/auralis-reset.sh
 `auralis-up.sh`
 - starts Anvil if one is not already available
 - deploys the ERC20 host, ERC721 host, ERC20 vault host, and native vault host
-- writes `deployments/auralis.local.json`
+- writes the host-specific vault artifacts and `deployments/auralis.local.json`
 
 `auralis-smoke.sh`
 - checks deployed code is present
 - runs token and NFT happy-path transactions
 - runs ERC20 vault deposit, strategy deploy, profit sync, manager pull, user auto-pull, and emergency-exit flows
-- runs native vault deposit, strategy deploy, profit sync, manager pull, user auto-pull, and emergency-exit flows
+- runs native vault exact-value deposit and mint, strategy deploy, payable
+  profit sync, manager pull, user auto-pull, emergency-exit, and strategy
+  rebind flows
 - restores both local vaults to a ready state by re-binding the configured strategy after the emergency-exit smoke
 - verifies both vault oracle quote paths are live
 
@@ -79,8 +81,33 @@ and records:
 - native vault host addresses
 - configured vault strategy addresses and zeroed initial strategy state
 
+The host-specific vault artifacts are:
+
+- `deployments/diamond-vault.local.json`
+- `deployments/diamond-native-vault.local.json`
+
+Each vault artifact records:
+
+- `assetMode` as `erc20` or `native`
+- the installed facet addresses, including `vaultNativeFacet`
+- the configured strategy and zeroed initial strategy state
+
+For backward compatibility:
+
+- `vaultHost` in `deployments/auralis.local.json` remains the ERC20 hosted
+  vault
+- `nativeVaultHost` is the parallel native hosted vault entry
+
 ## Simulated Activity
 
 The activity script is explicitly demo traffic for local development and review.
 It is meant to create realistic event history and state transitions, not to
 model production usage or strategy execution.
+
+For the native hosted vault specifically, the local workflow assumes:
+
+- asset-in flows use `depositNative` and `mintNative`
+- `mintNative` must be funded with exact `msg.value`
+- exits use standard `withdraw` and `redeem` and pay raw native asset
+- strategy profit injection is payable and uses raw ETH
+- force-sent ETH is not treated as managed assets by the vault accounting model

--- a/docs/erc4626-vault.md
+++ b/docs/erc4626-vault.md
@@ -9,6 +9,9 @@ repository:
 It covers the standalone vault modules and their math/control behavior. For the
 diamond-hosted vault platform, see `docs/vault-facets.md`.
 
+Native-asset mode is only supported through the diamond-hosted vault platform.
+The standalone `ERC4626Vault` module remains an ERC-20 asset vault surface.
+
 ## Contract Roles
 
 - `ERC4626VaultBase`: initializer + share/asset accounting primitives.
@@ -132,6 +135,19 @@ vault entrypoints. This is the primary emergency stop for vault write paths.
 - No native slippage parameters are present on ERC-4626 functions; integrators
   should pre-check previews and enforce client-side constraints.
 - The controls layer applies global limits, not per-user risk limits.
+
+## Hosted Native-Mode Boundary
+
+The hosted platform extends this ERC-20 vault model with an ERC-7535-style
+native entry surface, but the native behavior is not part of the standalone
+module contract described here.
+
+Implications:
+- `deposit` and `mint` remain ERC-20 entrypoints only.
+- native funding, exact `msg.value` validation, and raw native payouts are
+  documented in `docs/vault-facets.md`.
+- forced native transfers are a hosted-vault accounting concern, not a
+  standalone ERC-20 vault concern.
 
 ## Test References
 

--- a/docs/vault-facets.md
+++ b/docs/vault-facets.md
@@ -7,6 +7,7 @@ It covers the supported diamond-hosted vault deployment:
 
 - one diamond
 - one `ERC4626VaultFacet`
+- one `ERC7535VaultFacet` for native mode
 - one `ERC4626VaultControlsFacet`
 - one `ERC4626VaultIntegrationFacet`
 - one active strategy per vault
@@ -33,6 +34,24 @@ The core facet also owns runtime liquidity sourcing for user withdrawals and
 redemptions. When idle vault liquidity is insufficient, it will pull
 immediately withdrawable assets from the configured strategy before finishing
 `withdraw` or `redeem`.
+
+### Native Facet
+
+`ERC7535VaultFacet` owns the native-only selector group:
+
+- `depositNative(address receiver)`
+- `mintNative(uint256 shares, address receiver)`
+
+It exists only for hosted vaults initialized with the native asset sentinel:
+
+- `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE`
+
+Native mode keeps the standard ERC-4626 surface unchanged:
+
+- `deposit` and `mint` remain installed on the core facet but revert for native
+  vaults
+- `withdraw` and `redeem` stay on the core facet and pay raw native asset in
+  native mode
 
 ### Controls Facet
 
@@ -67,11 +86,12 @@ Initialization sequence:
 
 1. Install loupe selectors.
 2. Install the core, controls, and integration selector groups.
-3. Call
+3. For native mode, also install the native selector group.
+4. Call
    `initializeVault(address vaultAsset, string vaultName, string vaultSymbol, address admin)`
    through the diamond.
-4. Call `setOracleAdapter(address newAdapter)` through the integration facet.
-5. Call `setStrategy(address newStrategy)` through the integration facet.
+5. Call `setOracleAdapter(address newAdapter)` through the integration facet.
+6. Call `setStrategy(address newStrategy)` through the integration facet.
 
 Initialization behavior:
 
@@ -93,6 +113,10 @@ state with:
 - `strategyEmergencyExit() == false`
 
 No funds are deployed to strategy during deployment.
+
+The native local reference deployment in `script/DeployDiamondNativeVaultHost.s.sol`
+uses the same init model, but passes the native asset sentinel as
+`vaultAsset` and installs the native selector group.
 
 ## Role Model And Pause Behavior
 
@@ -123,6 +147,8 @@ Global pause blocks:
 
 - `deposit`
 - `mint`
+- `depositNative`
+- `mintNative`
 - `withdraw`
 - `redeem`
 
@@ -153,6 +179,9 @@ A strategy must satisfy `IERC4626VaultStrategy` and report:
 
 `setStrategy(...)` validates those bindings and requires `strategyDebt() == 0`
 before a strategy can be cleared or replaced.
+
+For native hosted vaults, `asset()` on both the vault and the strategy must be
+the native sentinel. No separate native-only strategy interface exists.
 
 ### Lifecycle Surface
 
@@ -214,6 +243,52 @@ while still keeping explicit book accounting for deployed debt.
 
 ## User-Facing Withdraw And Redeem Semantics
 
+### Native-Asset User Flows
+
+Native hosted vaults use the ERC-7535-style entry surface for asset-in flows.
+
+#### `depositNative(receiver)`
+
+- caller sends raw native asset as `msg.value`
+- shares are minted from the same fee/limit/pause logic used by hosted
+  `deposit`
+- the vault asset remains the sentinel address, not wrapped native token state
+
+#### `mintNative(shares, receiver)`
+
+- caller requests exact `shares`
+- the vault computes the gross native assets required under current fee logic
+- `msg.value` must equal that required gross amount exactly
+- underpayment reverts
+- overpayment also reverts
+- no refund path, excess credit, or donation semantics are supported
+
+#### `withdraw(assets)` and `redeem(shares)` in native mode
+
+- user exits remain on the standard ERC-4626 core facet
+- payouts are sent as raw native asset
+- if idle liquidity is short, the vault may auto-pull immediately withdrawable
+  native liquidity from strategy before paying the receiver
+
+## Native-Asset Accounting And Safety Assumptions
+
+Hosted native vaults still use tracked managed assets rather than raw
+`address(this).balance`.
+
+Implications:
+- force-sent ETH does not increase `totalManagedAssets()`
+- force-sent ETH does not increase share price through `totalAssets()` pricing
+- force-sent ETH does not increase hosted `maxWithdraw()` or `maxRedeem()`
+- if a native exit is satisfied partly or fully from untracked force-sent ETH,
+  book accounting only burns the tracked portion of assets
+
+This is an explicit safety choice:
+- untracked native surplus is treated as non-canonical balance
+- native integrators should not rely on arbitrary ETH transfers into the vault
+  to represent managed assets
+- the vault does not attempt to reconcile unsolicited ETH into strategy debt or
+  book value automatically
+
 `withdraw(assets)` and `redeem(shares)` remain core-facet entrypoints, but they
 are strategy-aware.
 
@@ -239,6 +314,8 @@ are strategy-aware.
   pricing and limit shaping
 - `maxWithdraw()` and `maxRedeem()` are bounded by immediate liquidity, not by
   total mark-to-market assets alone
+- in native mode, immediate liquidity excludes untracked force-sent ETH above
+  tracked idle assets
 - `maxWithdraw()` and `maxRedeem()` are zero when `totalAssets() == 0`, even if
   residual dust shares still exist after a full loss event
 
@@ -249,6 +326,8 @@ For the supported hosted vault deployment:
 - `diamondCut` is owned by `DiamondCutFacet`
 - loupe and ownership-introspection selectors are owned by `DiamondLoupeFacet`
 - core selectors are owned by `ERC4626VaultFacet`
+- native selectors are owned by `ERC7535VaultFacet` when native mode is
+  installed
 - controls selectors and `supportsInterface(bytes4)` are owned by
   `ERC4626VaultControlsFacet`
 - integration selectors are owned by `ERC4626VaultIntegrationFacet`
@@ -257,6 +336,8 @@ One important implication:
 
 - support for `IERC4626VaultFacet` and `IERC4626VaultIntegrationFacet` is
   reported through the controls facet
+- support for `IERC7535VaultFacet` is only reported when native selectors are
+  installed
 - those interface IDs are only reported when the corresponding core or
   integration selectors are installed
 
@@ -282,6 +363,7 @@ Current hardening coverage explicitly validates persistence for:
 Reference local deployment flow:
 
 - `script/DeployDiamondVaultHost.s.sol`
+- `script/DeployDiamondNativeVaultHost.s.sol`
 
 Reference deployment-backed validation:
 
@@ -291,6 +373,8 @@ Reference deployment-backed validation:
 - `test/VaultStrategyFoundationCore.t.sol`
 - `test/DiamondVaultHostHardening.t.sol`
 - `test/DiamondVaultHostInvariant.t.sol`
+- `test/DiamondNativeVaultHostHardening.t.sol`
+- `test/DiamondNativeVaultHostInvariant.t.sol`
 
 ## Out Of Scope
 
@@ -299,4 +383,6 @@ The current hosted strategy model does not include:
 - multi-strategy allocation
 - async or queued withdrawals
 - automatic harvest or keeper-driven execution
+- wrapping native balances into WETH or another canonical ERC-20 asset inside
+  the hosted vault
 - extension-standard work deferred to `#24 Advanced Extensions`

--- a/src/vault/ERC4626Vault.sol
+++ b/src/vault/ERC4626Vault.sol
@@ -170,7 +170,7 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
         }
 
         _burnShares(owner, shares);
-        _decreaseManagedAssets(assets);
+        _decreaseManagedAssetsForAssetExit(assets);
         _safeTransferAsset(receiver, assets);
 
         emit Withdraw(msg.sender, receiver, owner, assets, shares);
@@ -216,7 +216,7 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
         }
 
         _burnShares(owner, shares);
-        _decreaseManagedAssets(assets);
+        _decreaseManagedAssetsForAssetExit(assets);
         _safeTransferAsset(receiver, assets);
 
         emit Withdraw(msg.sender, receiver, owner, assets, shares);
@@ -274,6 +274,26 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
         }
     }
 
+    /// @dev Decreases managed assets for a user exit while ignoring untracked native surplus.
+    /// @dev Forced ETH can increase `address(this).balance` without increasing managed assets. When a native
+    ///      withdrawal is satisfied from that surplus, book accounting must only burn the tracked portion.
+    function _decreaseManagedAssetsForAssetExit(uint256 assets) internal {
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        if (LibVaultAsset.isNativeAsset(layout.asset) && layout.strategyDebt != 0) {
+            uint256 nativeSurplus =
+                LibVaultAsset.balanceOfSelf(layout.asset) - (layout.totalManagedAssets - layout.strategyDebt);
+            if (nativeSurplus >= assets) {
+                return;
+            }
+
+            unchecked {
+                assets -= nativeSurplus;
+            }
+        }
+
+        _decreaseManagedAssets(assets);
+    }
+
     /// @dev Returns the vault's immediately idle asset balance.
     function _idleAssetBalance() internal view returns (uint256) {
         return LibVaultAsset.balanceOfSelf(asset());
@@ -282,7 +302,7 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
     /// @dev Returns the configured strategy's immediately withdrawable assets.
     function _strategyWithdrawableAssets() internal view returns (uint256) {
         LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
-        if (layout.strategy == address(0) || layout.strategyDebt == 0) {
+        if (layout.strategyDebt == 0) {
             return 0;
         }
 

--- a/src/vault/ERC4626VaultControlLogic.sol
+++ b/src/vault/ERC4626VaultControlLogic.sol
@@ -364,7 +364,7 @@ abstract contract ERC4626VaultControlledCore is ERC4626Vault {
         }
 
         _burnShares(owner, shares);
-        _decreaseManagedAssets(grossAssets);
+        _decreaseManagedAssetsForAssetExit(grossAssets);
         _safeTransferAsset(receiver, assets);
         _payoutFee(feeAssets);
 
@@ -396,7 +396,7 @@ abstract contract ERC4626VaultControlledCore is ERC4626Vault {
         }
 
         _burnShares(owner, shares);
-        _decreaseManagedAssets(grossAssets);
+        _decreaseManagedAssetsForAssetExit(grossAssets);
         _safeTransferAsset(receiver, assets);
         _payoutFee(feeAssets);
 

--- a/src/vault/facets/ERC4626VaultFacet.sol
+++ b/src/vault/facets/ERC4626VaultFacet.sol
@@ -134,7 +134,7 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
         }
 
         _burnShares(owner, shares);
-        _decreaseManagedAssets(grossAssets);
+        _decreaseManagedAssetsForAssetExit(grossAssets);
         _safeTransferAsset(receiver, assets);
         _payoutFee(feeAssets);
 
@@ -185,7 +185,7 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
         }
 
         _burnShares(owner, shares);
-        _decreaseManagedAssets(grossAssets);
+        _decreaseManagedAssetsForAssetExit(grossAssets);
         _safeTransferAsset(receiver, assets);
         _payoutFee(feeAssets);
 
@@ -194,7 +194,7 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
 
     function _managedAssetsForPricing() internal view virtual override returns (uint256) {
         LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
-        if (layout.strategy == address(0) || layout.strategyDebt == 0) {
+        if (layout.strategyDebt == 0) {
             return layout.totalManagedAssets;
         }
 
@@ -205,11 +205,14 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
 
     function _withdrawLiquidityCapAssets() internal view virtual override returns (uint256) {
         LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
-        if (layout.strategy == address(0) || layout.strategyDebt == 0) {
+        if (layout.strategyDebt == 0) {
             return type(uint256).max;
         }
 
-        return _idleAssetBalance() + _strategyWithdrawableAssets();
+        uint256 actualIdleAssets = _idleAssetBalance();
+        uint256 idleBookAssets = layout.totalManagedAssets - layout.strategyDebt;
+        uint256 trackedIdleAssets = actualIdleAssets < idleBookAssets ? actualIdleAssets : idleBookAssets;
+        return trackedIdleAssets + _strategyWithdrawableAssets();
     }
 
     function _vaultOperationsPaused() internal view virtual override returns (bool) {
@@ -222,7 +225,7 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
         }
 
         LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
-        if (layout.strategy == address(0) || layout.strategyDebt == 0) {
+        if (layout.strategyDebt == 0) {
             return;
         }
 

--- a/test/DiamondNativeVaultHostHardening.t.sol
+++ b/test/DiamondNativeVaultHostHardening.t.sol
@@ -1,0 +1,388 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
+import {IERC165} from "../src/interfaces/IERC165.sol";
+import {IERC20Metadata} from "../src/interfaces/IERC20Metadata.sol";
+import {IERC4626} from "../src/interfaces/IERC4626.sol";
+import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol";
+import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
+import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
+import {IERC7535VaultFacet} from "../src/interfaces/IERC7535VaultFacet.sol";
+import {IPausable} from "../src/interfaces/IPausable.sol";
+import {LibVaultAsset} from "../src/vault/libraries/LibVaultAsset.sol";
+import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
+import {DiamondNativeVaultHostHardeningFixture} from "./helpers/DiamondNativeVaultHostHardeningTestHarness.sol";
+import {IFacetVersionMarker} from "./helpers/DiamondVaultHostHardeningTestHarness.sol";
+
+contract DiamondNativeVaultHostHardeningTest is DiamondNativeVaultHostHardeningFixture {
+    function testNativeCoreFacetReplaceRemoveReAddPreservesState() public {
+        _installAndSeedNativeVaultHost();
+        _injectStrategyProfit(STRATEGY_PROFIT_ASSETS);
+
+        StrategyStateSnapshot memory initialState = _snapshotStrategyState();
+
+        _replaceCoreFacet(address(coreReplacement));
+        _addCoreReplacementMarker(address(coreReplacement));
+
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultCoreSelectors(), address(coreReplacement));
+        assertTrue(
+            IDiamondLoupe(address(diamond)).facetAddress(IFacetVersionMarker.facetVersion.selector)
+                == address(coreReplacement),
+            "core marker owner mismatch"
+        );
+        assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "core replacement marker mismatch");
+        assertTrue(coreFacetInterface().asset() == LibVaultAsset.NATIVE_ASSET_SENTINEL, "core asset mismatch");
+        assertTrue(
+            keccak256(bytes(IERC20Metadata(address(diamond)).name())) == keccak256(bytes("Native Vault Share")),
+            "core name mismatch after replace"
+        );
+        assertTrue(
+            keccak256(bytes(IERC20Metadata(address(diamond)).symbol())) == keccak256(bytes("nvSHARE")),
+            "core symbol mismatch after replace"
+        );
+        assertTrue(coreFacetInterface().balanceOf(bob) == BOB_DEPOSIT, "bob balance mismatch");
+        assertTrue(coreFacetInterface().balanceOf(carol) == CAROL_DEPOSIT, "carol balance mismatch");
+        assertTrue(coreFacetInterface().allowance(bob, eve) == SHARE_ALLOWANCE, "share allowance mismatch");
+        _assertStrategyState(initialState);
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC4626VaultFacet).interfaceId),
+            "core interface missing after replace"
+        );
+
+        _removeCoreFacetWithMarker();
+
+        _assertMissingSelector(abi.encodeWithSelector(IERC4626.asset.selector), "core asset selector should be missing");
+        _assertMissingSelector(
+            abi.encodeWithSelector(IERC20Metadata.name.selector), "core metadata selector should be missing"
+        );
+        assertTrue(
+            !IERC165(address(diamond)).supportsInterface(type(IERC4626VaultFacet).interfaceId),
+            "core interface should be absent when selectors removed"
+        );
+        (,, address feeRecipient) = controlsFacetInterface().feeConfig();
+        assertTrue(feeRecipient == feeSink, "controls should still route after core removal");
+        assertTrue(
+            integrationFacetInterface().oracleAdapter() == address(adapter),
+            "integration should still route after core removal"
+        );
+
+        _reAddCoreFacetWithMarker(address(coreReplacement));
+
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultCoreSelectors(), address(coreReplacement));
+        assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "core marker mismatch after re-add");
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC4626VaultFacet).interfaceId),
+            "core interface missing after re-add"
+        );
+        assertTrue(coreFacetInterface().asset() == LibVaultAsset.NATIVE_ASSET_SENTINEL, "core asset mismatch");
+        assertTrue(coreFacetInterface().balanceOf(bob) == BOB_DEPOSIT, "bob balance mismatch after re-add");
+        assertTrue(coreFacetInterface().balanceOf(carol) == CAROL_DEPOSIT, "carol balance mismatch after re-add");
+        assertTrue(coreFacetInterface().allowance(bob, eve) == SHARE_ALLOWANCE, "allowance mismatch after re-add");
+        _assertStrategyState(initialState);
+    }
+
+    function testNativeFacetReplaceRemoveReAddPreservesState() public {
+        _installAndSeedNativeVaultHost();
+
+        StrategyStateSnapshot memory initialState = _snapshotStrategyState();
+
+        _replaceNativeFacet(address(nativeReplacement));
+        _addNativeReplacementMarker(address(nativeReplacement));
+
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultNativeSelectors(), address(nativeReplacement));
+        assertTrue(
+            IDiamondLoupe(address(diamond)).facetAddress(IFacetVersionMarker.facetVersion.selector)
+                == address(nativeReplacement),
+            "native marker owner mismatch"
+        );
+        assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "native replacement marker mismatch");
+        _assertStrategyState(initialState);
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC7535VaultFacet).interfaceId),
+            "native interface missing after replace"
+        );
+
+        _removeNativeFacetWithMarker();
+
+        _assertMissingSelector(
+            abi.encodeWithSelector(IERC7535VaultFacet.depositNative.selector, bob),
+            "native deposit selector should be missing"
+        );
+        assertTrue(coreFacetInterface().asset() == LibVaultAsset.NATIVE_ASSET_SENTINEL, "core should still route");
+        assertTrue(
+            !IERC165(address(diamond)).supportsInterface(type(IERC7535VaultFacet).interfaceId),
+            "native interface should be absent when selectors removed"
+        );
+
+        _reAddNativeFacetWithMarker(address(nativeReplacement));
+
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultNativeSelectors(), address(nativeReplacement));
+        assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "native marker mismatch after re-add");
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC7535VaultFacet).interfaceId),
+            "native interface missing after re-add"
+        );
+        _assertStrategyState(initialState);
+    }
+
+    function testNativeControlsFacetReplaceRemoveReAddPreservesControlState() public {
+        _installAndSeedNativeVaultHost();
+        _pauseVault();
+
+        StrategyStateSnapshot memory initialState = _snapshotStrategyState();
+
+        _replaceControlsFacet(address(controlsReplacement));
+        _addControlsReplacementMarker(address(controlsReplacement));
+
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultControlsSelectors(), address(controlsReplacement));
+        assertTrue(
+            IDiamondLoupe(address(diamond)).facetAddress(IERC165.supportsInterface.selector)
+                == address(controlsReplacement),
+            "supportsInterface owner mismatch after controls replace"
+        );
+        assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "controls replacement marker mismatch");
+        _assertControlsState();
+        _assertStrategyState(initialState);
+        assertTrue(controlsFacetInterface().paused(), "paused state should persist after replace");
+        assertFalse(controlsFacetInterface().reentrancyGuardEntered(), "reentrancy should not be entered");
+
+        _removeControlsFacetWithMarker();
+
+        _assertMissingSelector(
+            abi.encodeWithSelector(IERC4626VaultControls.feeConfig.selector),
+            "controls fee config selector should be missing"
+        );
+        _assertMissingSelector(
+            abi.encodeWithSelector(IERC165.supportsInterface.selector, type(IERC4626VaultFacet).interfaceId),
+            "supportsInterface selector should be missing"
+        );
+        assertTrue(
+            coreFacetInterface().asset() == LibVaultAsset.NATIVE_ASSET_SENTINEL,
+            "core should still route after controls removal"
+        );
+        assertTrue(
+            integrationFacetInterface().strategyDebt() == initialState.strategyDebt,
+            "integration should still route after controls removal"
+        );
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+        IERC7535VaultFacet(address(diamond)).depositNative{value: 1 ether}(bob);
+
+        _reAddControlsFacetWithMarker(address(controlsReplacement));
+
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultControlsSelectors(), address(controlsReplacement));
+        assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "controls marker mismatch after re-add");
+        _assertControlsState();
+        _assertStrategyState(initialState);
+        assertTrue(controlsFacetInterface().paused(), "paused state should persist after re-add");
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC7535VaultFacet).interfaceId),
+            "native interface should be reported after controls re-add"
+        );
+        _unpauseVault();
+
+        uint256 expectedShares = coreFacetInterface().previewDeposit(1 ether);
+        VM.prank(dave);
+        uint256 mintedShares = IERC7535VaultFacet(address(diamond)).depositNative{value: 1 ether}(dave);
+        assertTrue(mintedShares == expectedShares, "dave should receive previewed shares after unpause");
+    }
+
+    function testNativeIntegrationFacetReplaceRemoveReAddPreservesIntegrationState() public {
+        _installAndSeedNativeVaultHost();
+
+        StrategyStateSnapshot memory initialState = _snapshotStrategyState();
+
+        _replaceIntegrationFacet(address(integrationReplacement));
+        _addIntegrationReplacementMarker(address(integrationReplacement));
+
+        _assertSelectorsOwnedByFacet(
+            LibVaultFacetSelectors.vaultIntegrationSelectors(), address(integrationReplacement)
+        );
+        assertTrue(
+            IDiamondLoupe(address(diamond)).facetAddress(IFacetVersionMarker.facetVersion.selector)
+                == address(integrationReplacement),
+            "integration marker owner mismatch"
+        );
+        assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "integration replacement marker mismatch");
+        _assertStrategyState(initialState);
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC4626VaultIntegrationFacet).interfaceId),
+            "integration interface missing after replace"
+        );
+
+        _removeIntegrationFacetWithMarker();
+
+        _assertMissingSelector(
+            abi.encodeWithSelector(IERC4626VaultIntegrationFacet.oracleAdapter.selector),
+            "integration oracle selector should be missing"
+        );
+        assertTrue(
+            coreFacetInterface().asset() == LibVaultAsset.NATIVE_ASSET_SENTINEL,
+            "core should still route after integration removal"
+        );
+        assertTrue(
+            controlsFacetInterface().hasRole(controlsFacetInterface().VAULT_MANAGER_ROLE(), eve),
+            "controls should still route after integration removal"
+        );
+        assertTrue(
+            !IERC165(address(diamond)).supportsInterface(type(IERC4626VaultIntegrationFacet).interfaceId),
+            "integration interface should be absent when selectors removed"
+        );
+
+        uint256 expectedBobSharesBurned = coreFacetInterface().previewWithdraw(BOB_AUTO_PULL_WITHDRAW_ASSETS);
+        uint256 bobBalanceBefore = bob.balance;
+        VM.prank(bob);
+        uint256 burnedShares = coreFacetInterface().withdraw(BOB_AUTO_PULL_WITHDRAW_ASSETS, bob, bob);
+        assertTrue(
+            burnedShares == expectedBobSharesBurned, "withdraw should use previewWithdraw semantics while removed"
+        );
+        assertTrue(bob.balance == bobBalanceBefore + BOB_AUTO_PULL_WITHDRAW_ASSETS, "bob native payout mismatch");
+
+        uint256 expectedCarolAssetsReturned = coreFacetInterface().previewRedeem(CAROL_AUTO_PULL_REDEEM_SHARES);
+        uint256 carolBalanceBefore = carol.balance;
+        VM.prank(carol);
+        uint256 returnedAssets = coreFacetInterface().redeem(CAROL_AUTO_PULL_REDEEM_SHARES, carol, carol);
+        assertTrue(
+            returnedAssets == expectedCarolAssetsReturned, "redeem should use previewRedeem semantics while removed"
+        );
+        assertTrue(carol.balance == carolBalanceBefore + expectedCarolAssetsReturned, "carol native payout mismatch");
+
+        uint256 expectedIdleAssets = address(diamond).balance;
+        uint256 expectedLiveStrategyAssets = strategyContract.totalAssets();
+        uint256 expectedTotalManagedAssets = coreFacetInterface().totalManagedAssets();
+        uint256 expectedTotalAssets = coreFacetInterface().totalAssets();
+        uint256 expectedBobBalance = coreFacetInterface().balanceOf(bob);
+        uint256 expectedCarolBalance = coreFacetInterface().balanceOf(carol);
+
+        _reAddIntegrationFacetWithMarker(address(integrationReplacement));
+
+        _assertSelectorsOwnedByFacet(
+            LibVaultFacetSelectors.vaultIntegrationSelectors(), address(integrationReplacement)
+        );
+        assertTrue(
+            IFacetVersionMarker(address(diamond)).facetVersion() == 2, "integration marker mismatch after re-add"
+        );
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC4626VaultIntegrationFacet).interfaceId),
+            "integration interface missing after re-add"
+        );
+        assertTrue(
+            integrationFacetInterface().strategy() == address(strategyContract), "strategy mismatch after re-add"
+        );
+        assertTrue(
+            integrationFacetInterface().strategyDebt() == expectedTotalManagedAssets - expectedIdleAssets,
+            "strategy debt mismatch after re-add"
+        );
+        assertTrue(
+            integrationFacetInterface().liveStrategyAssets() == expectedLiveStrategyAssets,
+            "live strategy assets mismatch after re-add"
+        );
+        assertTrue(integrationFacetInterface().idleAssets() == expectedIdleAssets, "idle assets mismatch after re-add");
+        assertFalse(integrationFacetInterface().strategyEmergencyExit(), "emergency exit should stay inactive");
+        assertTrue(
+            coreFacetInterface().totalManagedAssets() == expectedTotalManagedAssets, "book value mismatch after re-add"
+        );
+        assertTrue(coreFacetInterface().totalAssets() == expectedTotalAssets, "total assets mismatch after re-add");
+        assertTrue(coreFacetInterface().balanceOf(bob) == expectedBobBalance, "bob balance mismatch after re-add");
+        assertTrue(coreFacetInterface().balanceOf(carol) == expectedCarolBalance, "carol balance mismatch after re-add");
+    }
+
+    function testNativeIntegrationEmergencyExitStatePersistsAcrossFacetChurnAndRebind() public {
+        _installAndSeedNativeVaultHost();
+
+        VM.prank(admin);
+        uint256 emergencyAssets = integrationFacetInterface().emergencyExitStrategy();
+        assertTrue(emergencyAssets == STRATEGY_DEPLOYED_ASSETS, "emergency exit should unwind deployed assets");
+
+        _replaceIntegrationFacet(address(integrationReplacement));
+        _addIntegrationReplacementMarker(address(integrationReplacement));
+        _replaceNativeFacet(address(nativeReplacement));
+        _removeIntegrationFacetWithMarker();
+        _removeSelectors(LibVaultFacetSelectors.vaultNativeSelectors());
+        _reAddIntegrationFacetWithMarker(address(integrationReplacement));
+        _addFacet(address(nativeReplacement), LibVaultFacetSelectors.vaultNativeSelectors());
+
+        assertTrue(
+            IFacetVersionMarker(address(diamond)).facetVersion() == 2,
+            "replacement marker mismatch after emergency re-add"
+        );
+        assertTrue(integrationFacetInterface().strategy() == address(strategyContract), "strategy mismatch after churn");
+        assertTrue(integrationFacetInterface().strategyEmergencyExit(), "emergency exit should persist after churn");
+        assertTrue(integrationFacetInterface().strategyDebt() == 0, "strategy debt should remain zero after churn");
+        assertTrue(integrationFacetInterface().liveStrategyAssets() == 0, "live strategy assets should remain zero");
+        assertTrue(integrationFacetInterface().idleAssets() == BOB_DEPOSIT + CAROL_DEPOSIT, "idle assets mismatch");
+
+        VM.expectRevert(IERC4626VaultIntegrationFacet.ERC4626VaultStrategyEmergencyExitActive.selector);
+        VM.prank(admin);
+        integrationFacetInterface().deployToStrategy(1);
+
+        VM.prank(admin);
+        integrationFacetInterface().setStrategy(address(0));
+        VM.prank(admin);
+        integrationFacetInterface().setStrategy(address(replacementStrategyContract));
+
+        assertFalse(integrationFacetInterface().strategyEmergencyExit(), "emergency exit should clear on rebind");
+
+        VM.prank(admin);
+        integrationFacetInterface().deployToStrategy(1 ether);
+        assertTrue(integrationFacetInterface().strategyDebt() == 1 ether, "deploy should work after strategy rebind");
+        assertTrue(
+            integrationFacetInterface().strategy() == address(replacementStrategyContract),
+            "replacement strategy should bind"
+        );
+    }
+
+    function testForceSentNativeAssetsDoNotChangeAccountingOrMaxFunctions() public {
+        _installAndSeedNativeVaultHost();
+        _injectStrategyProfit(STRATEGY_PROFIT_ASSETS);
+
+        StrategyStateSnapshot memory beforeState = _snapshotStrategyState();
+        uint256 expectedVaultBalance = address(diamond).balance + 3 ether;
+        uint256 expectedStrategyBalance = address(strategyContract).balance + 2 ether;
+
+        _forceSendToVault(3 ether);
+        _forceSendToStrategy(2 ether);
+
+        assertTrue(address(diamond).balance == expectedVaultBalance, "vault force-send balance mismatch");
+        assertTrue(address(strategyContract).balance == expectedStrategyBalance, "strategy force-send balance mismatch");
+        assertTrue(coreFacetInterface().totalManagedAssets() == beforeState.totalManagedAssets, "book assets changed");
+        assertTrue(coreFacetInterface().totalAssets() == beforeState.totalAssets, "pricing assets changed");
+        assertTrue(coreFacetInterface().maxWithdraw(bob) == beforeState.bobMaxWithdraw, "maxWithdraw changed");
+        assertTrue(coreFacetInterface().maxRedeem(bob) == beforeState.bobMaxRedeem, "maxRedeem changed");
+        assertTrue(
+            integrationFacetInterface().liveStrategyAssets() == beforeState.liveStrategyAssets, "live assets changed"
+        );
+    }
+
+    function _assertSelectorsOwnedByFacet(bytes4[] memory selectors, address expectedFacet) internal view {
+        for (uint256 i = 0; i < selectors.length; i++) {
+            assertTrue(
+                IDiamondLoupe(address(diamond)).facetAddress(selectors[i]) == expectedFacet, "selector owner mismatch"
+            );
+        }
+    }
+
+    function _assertControlsState() internal view {
+        bytes32 managerRole = controlsFacetInterface().VAULT_MANAGER_ROLE();
+        (uint16 depositFeeBps, uint16 withdrawFeeBps, address feeRecipient) = controlsFacetInterface().feeConfig();
+        (uint128 maxTotalAssets, uint128 maxDeposit, uint128 maxMint, uint128 maxWithdraw, uint128 maxRedeem) =
+            controlsFacetInterface().limitConfig();
+        (uint64 start, uint64 end, bool exists) = controlsFacetInterface().getRoleWindow(managerRole, dave);
+
+        assertTrue(depositFeeBps == 100, "deposit fee mismatch");
+        assertTrue(withdrawFeeBps == 50, "withdraw fee mismatch");
+        assertTrue(feeRecipient == feeSink, "fee recipient mismatch");
+        assertTrue(maxTotalAssets == 90 ether, "max total assets mismatch");
+        assertTrue(maxDeposit == 30 ether, "max deposit mismatch");
+        assertTrue(maxMint == 30 ether, "max mint mismatch");
+        assertTrue(maxWithdraw == 25 ether, "max withdraw mismatch");
+        assertTrue(maxRedeem == 25 ether, "max redeem mismatch");
+        assertTrue(controlsFacetInterface().hasRole(managerRole, eve), "eve manager role mismatch");
+        assertTrue(start == uint64(currentTime - 100), "role window start mismatch");
+        assertTrue(end == uint64(currentTime + 1_000), "role window end mismatch");
+        assertTrue(exists, "role window should exist");
+        assertTrue(controlsFacetInterface().hasActiveRole(managerRole, dave), "dave active manager role mismatch");
+    }
+}

--- a/test/DiamondNativeVaultHostInvariant.t.sol
+++ b/test/DiamondNativeVaultHostInvariant.t.sol
@@ -1,0 +1,481 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol";
+import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
+import {IERC7535VaultFacet} from "../src/interfaces/IERC7535VaultFacet.sol";
+import {IPausable} from "../src/interfaces/IPausable.sol";
+import {DiamondNativeVaultHostHardeningFixture} from "./helpers/DiamondNativeVaultHostHardeningTestHarness.sol";
+
+contract DiamondNativeVaultHostInvariantTest is DiamondNativeVaultHostHardeningFixture {
+    function setUp() public override {
+        super.setUp();
+        _installNativeVaultHostFacets();
+        _initializeNativeVaultHost();
+        _wireOracleAdapter();
+        _wireNativeStrategy();
+
+        VM.prank(admin);
+        controlsFacetInterface().setFeeConfig(0, 0, feeSink);
+    }
+
+    function targetContracts() external view returns (address[] memory contracts) {
+        contracts = new address[](1);
+        contracts[0] = address(this);
+    }
+
+    function actionDepositNative(uint8 actorSeed, uint96 assetsRaw) external {
+        address actor = _actor(actorSeed);
+        uint256 maxAssets = _min(coreFacetInterface().maxDeposit(actor), actor.balance);
+        uint256 assets_ = _boundAmount(assetsRaw, maxAssets);
+        if (assets_ == 0 || coreFacetInterface().previewDeposit(assets_) == 0) {
+            return;
+        }
+
+        if (controlsFacetInterface().paused()) {
+            VM.startPrank(actor);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+            IERC7535VaultFacet(address(diamond)).depositNative{value: assets_}(actor);
+            VM.stopPrank();
+            return;
+        }
+
+        VM.prank(actor);
+        IERC7535VaultFacet(address(diamond)).depositNative{value: assets_}(actor);
+    }
+
+    function actionMintNative(uint8 actorSeed, uint96 sharesRaw) external {
+        address actor = _actor(actorSeed);
+        uint256 feasibleShares = coreFacetInterface().previewDeposit(actor.balance);
+        uint256 maxShares = _min(coreFacetInterface().maxMint(actor), feasibleShares);
+        uint256 shares = _boundAmount(sharesRaw, maxShares);
+        if (shares == 0) {
+            return;
+        }
+
+        uint256 requiredAssets = coreFacetInterface().previewMint(shares);
+        if (requiredAssets == 0 || requiredAssets > actor.balance) {
+            return;
+        }
+
+        if (controlsFacetInterface().paused()) {
+            VM.startPrank(actor);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+            IERC7535VaultFacet(address(diamond)).mintNative{value: requiredAssets}(shares, actor);
+            VM.stopPrank();
+            return;
+        }
+
+        VM.prank(actor);
+        IERC7535VaultFacet(address(diamond)).mintNative{value: requiredAssets}(shares, actor);
+    }
+
+    function actionWithdraw(uint8 actorSeed, uint96 assetsRaw) external {
+        address actor = _actor(actorSeed);
+        uint256 assets_ = _boundAmount(assetsRaw, coreFacetInterface().maxWithdraw(actor));
+        if (assets_ == 0) {
+            return;
+        }
+
+        if (controlsFacetInterface().paused()) {
+            VM.startPrank(actor);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+            coreFacetInterface().withdraw(assets_, actor, actor);
+            VM.stopPrank();
+            return;
+        }
+
+        VM.prank(actor);
+        coreFacetInterface().withdraw(assets_, actor, actor);
+    }
+
+    function actionRedeem(uint8 actorSeed, uint96 sharesRaw) external {
+        address actor = _actor(actorSeed);
+        uint256 shares = _boundAmount(sharesRaw, coreFacetInterface().maxRedeem(actor));
+        if (shares == 0 || coreFacetInterface().previewRedeem(shares) == 0) {
+            return;
+        }
+
+        if (controlsFacetInterface().paused()) {
+            VM.startPrank(actor);
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableEnforcedPause.selector));
+            coreFacetInterface().redeem(shares, actor, actor);
+            VM.stopPrank();
+            return;
+        }
+
+        VM.prank(actor);
+        coreFacetInterface().redeem(shares, actor, actor);
+    }
+
+    function actionApprove(uint8 ownerSeed, uint8 spenderSeed, uint96 sharesRaw) external {
+        address owner = _actor(ownerSeed);
+        address spender = _actorExcluding(owner, spenderSeed);
+
+        VM.prank(owner);
+        coreFacetInterface().approve(spender, uint256(sharesRaw));
+    }
+
+    function actionTransfer(uint8 fromSeed, uint8 toSeed, uint96 sharesRaw) external {
+        address from = _actor(fromSeed);
+        address to = _actorExcluding(from, toSeed);
+        uint256 shares = _boundAmount(sharesRaw, coreFacetInterface().balanceOf(from));
+        if (shares == 0) {
+            return;
+        }
+
+        VM.prank(from);
+        coreFacetInterface().transfer(to, shares);
+    }
+
+    function actionTransferFrom(uint8 spenderSeed, uint8 ownerSeed, uint8 toSeed, uint96 sharesRaw) external {
+        address spender = _actor(spenderSeed);
+        address owner = _actor(ownerSeed);
+        if (spender == owner) {
+            return;
+        }
+
+        address to = _actorExcluding(owner, toSeed);
+        uint256 allowance = coreFacetInterface().allowance(owner, spender);
+        uint256 balance = coreFacetInterface().balanceOf(owner);
+        uint256 shares = _boundAmount(sharesRaw, allowance < balance ? allowance : balance);
+        if (shares == 0) {
+            return;
+        }
+
+        VM.prank(spender);
+        coreFacetInterface().transferFrom(owner, to, shares);
+    }
+
+    function actionPauseToggle(bool shouldPause) external {
+        bool isPaused = controlsFacetInterface().paused();
+        if (shouldPause && !isPaused) {
+            _pauseVault();
+        } else if (!shouldPause && isPaused) {
+            _unpauseVault();
+        }
+    }
+
+    function actionSetFeeConfig(uint16 depositFeeRaw, uint16 withdrawFeeRaw) external {
+        AccountingSnapshot memory snapshot = _snapshotAccounting();
+        uint16 depositFeeBps = uint16(uint256(depositFeeRaw) % 2_001);
+        uint16 withdrawFeeBps = uint16(uint256(withdrawFeeRaw) % 2_001);
+
+        VM.prank(admin);
+        controlsFacetInterface().setFeeConfig(depositFeeBps, withdrawFeeBps, feeSink);
+
+        _assertAccountingUnchanged(snapshot, "fee config updates should not mutate accounting");
+    }
+
+    function actionSetLimitConfig(
+        uint96 totalCapRaw,
+        uint96 depositRaw,
+        uint96 mintRaw,
+        uint96 withdrawRaw,
+        uint96 redeemRaw
+    ) external {
+        AccountingSnapshot memory snapshot = _snapshotAccounting();
+
+        uint256 currentAssets = coreFacetInterface().totalAssets();
+        uint128 maxTotalAssets = totalCapRaw % 4 == 0
+            ? 0
+            : uint128(currentAssets + (uint256(totalCapRaw) % _expectedTrackedUnderlying()) + 1);
+        uint128 maxDeposit = depositRaw % 4 == 0 ? 0 : uint128((uint256(depositRaw) % INITIAL_ASSETS) + 1);
+        uint128 maxMint = mintRaw % 4 == 0 ? 0 : uint128((uint256(mintRaw) % INITIAL_ASSETS) + 1);
+        uint128 maxWithdraw = withdrawRaw % 4 == 0 ? 0 : uint128((uint256(withdrawRaw) % INITIAL_ASSETS) + 1);
+        uint128 maxRedeem = redeemRaw % 4 == 0 ? 0 : uint128((uint256(redeemRaw) % INITIAL_ASSETS) + 1);
+
+        VM.prank(admin);
+        controlsFacetInterface().setLimitConfig(maxTotalAssets, maxDeposit, maxMint, maxWithdraw, maxRedeem);
+
+        _assertAccountingUnchanged(snapshot, "limit config updates should not mutate accounting");
+    }
+
+    function actionSetOracleAdapter(bool configured) external {
+        AccountingSnapshot memory snapshot = _snapshotAccounting();
+
+        VM.prank(admin);
+        integrationFacetInterface().setOracleAdapter(configured ? address(adapter) : address(0));
+
+        _assertAccountingUnchanged(snapshot, "oracle adapter updates should not mutate accounting");
+    }
+
+    function actionSetStrategy(bool configured) external {
+        if (integrationFacetInterface().strategyDebt() != 0) {
+            return;
+        }
+
+        AccountingSnapshot memory snapshot = _snapshotAccounting();
+
+        if (!configured && integrationFacetInterface().strategy() != address(0)) {
+            VM.prank(admin);
+            integrationFacetInterface().setStrategy(address(0));
+            _assertAccountingUnchanged(snapshot, "strategy clear should not mutate accounting");
+            return;
+        }
+
+        if (configured && integrationFacetInterface().strategy() == address(0)) {
+            strategyContract.setWithdrawAllReverts(false);
+            VM.prank(admin);
+            integrationFacetInterface().setStrategy(address(strategyContract));
+            _assertAccountingUnchanged(snapshot, "strategy rebind should not mutate accounting");
+        }
+    }
+
+    function actionDeployToStrategy(uint96 assetsRaw) external {
+        if (integrationFacetInterface().strategy() != address(strategyContract)) {
+            return;
+        }
+
+        uint256 assets_ = _boundAmount(assetsRaw, integrationFacetInterface().idleAssets());
+        if (assets_ == 0) {
+            return;
+        }
+
+        if (integrationFacetInterface().strategyEmergencyExit()) {
+            VM.expectRevert(IERC4626VaultIntegrationFacet.ERC4626VaultStrategyEmergencyExitActive.selector);
+            VM.prank(admin);
+            integrationFacetInterface().deployToStrategy(assets_);
+            return;
+        }
+
+        VM.prank(admin);
+        integrationFacetInterface().deployToStrategy(assets_);
+    }
+
+    function actionWithdrawFromStrategy(uint96 assetsRaw) external {
+        if (integrationFacetInterface().strategy() != address(strategyContract)) {
+            return;
+        }
+
+        uint256 strategyDebt = integrationFacetInterface().strategyDebt();
+        uint256 assets_ = _boundAmount(assetsRaw, strategyDebt);
+        if (assets_ == 0) {
+            return;
+        }
+
+        VM.prank(admin);
+        integrationFacetInterface().withdrawFromStrategy(assets_);
+    }
+
+    function actionSyncStrategyAssets() external {
+        if (integrationFacetInterface().strategy() != address(strategyContract)) {
+            return;
+        }
+
+        VM.prank(admin);
+        integrationFacetInterface().syncStrategyAssets();
+    }
+
+    function actionEmergencyExitStrategy(bool forceFailure) external {
+        if (integrationFacetInterface().strategy() != address(strategyContract)) {
+            return;
+        }
+
+        strategyContract.setWithdrawAllReverts(forceFailure && integrationFacetInterface().strategyDebt() != 0);
+
+        VM.prank(admin);
+        integrationFacetInterface().emergencyExitStrategy();
+    }
+
+    function actionInjectStrategyProfit(uint96 assetsRaw) external {
+        if (integrationFacetInterface().strategy() != address(strategyContract)) {
+            return;
+        }
+        if (integrationFacetInterface().strategyDebt() == 0 || integrationFacetInterface().strategyEmergencyExit()) {
+            return;
+        }
+
+        uint256 available = _min(profitSource.balance, INITIAL_ASSETS);
+        uint256 assets_ = _boundAmount(assetsRaw, available);
+        if (assets_ == 0) {
+            return;
+        }
+
+        VM.prank(profitSource);
+        strategyContract.injectProfit{value: assets_}(assets_);
+    }
+
+    function actionApplyStrategyLoss(uint96 lossRaw, uint96 withdrawableRaw) external {
+        if (integrationFacetInterface().strategy() != address(strategyContract)) {
+            return;
+        }
+        if (integrationFacetInterface().strategyEmergencyExit()) {
+            return;
+        }
+
+        uint256 liveAssets = integrationFacetInterface().liveStrategyAssets();
+        if (liveAssets == 0) {
+            return;
+        }
+
+        uint256 lossAssets = _boundAmount(lossRaw, _min(liveAssets, INITIAL_ASSETS));
+        uint256 remainingLiveAssets = liveAssets - lossAssets;
+        uint256 withdrawableAssets = remainingLiveAssets == 0 ? 0 : uint256(withdrawableRaw) % (remainingLiveAssets + 1);
+
+        strategyContract.applyLoss(lossAssets, withdrawableAssets);
+    }
+
+    function actionForceSendToVault(uint96 assetsRaw) external {
+        uint256 assets_ = _boundAmount(assetsRaw, forceSender.balance);
+        if (assets_ == 0) {
+            return;
+        }
+
+        _forceSendToVault(assets_);
+    }
+
+    function actionForceSendToStrategy(uint96 assetsRaw) external {
+        if (integrationFacetInterface().strategy() != address(strategyContract)) {
+            return;
+        }
+
+        uint256 assets_ = _boundAmount(assetsRaw, forceSender.balance);
+        if (assets_ == 0) {
+            return;
+        }
+
+        _forceSendToStrategy(assets_);
+    }
+
+    function actionWithdrawBeyondImmediateLiquidityAttempt(uint8 actorSeed, uint96 extraRaw) external {
+        if (controlsFacetInterface().paused()) {
+            return;
+        }
+
+        address actor = _actor(actorSeed);
+        uint256 ownerShares = coreFacetInterface().balanceOf(actor);
+        if (ownerShares == 0) {
+            return;
+        }
+
+        uint256 maxWithdraw = coreFacetInterface().maxWithdraw(actor);
+        uint256 grossEntitlement = coreFacetInterface().previewRedeem(ownerShares);
+        if (grossEntitlement <= maxWithdraw) {
+            return;
+        }
+
+        uint256 attemptAssets = maxWithdraw + _boundAmount(extraRaw, grossEntitlement - maxWithdraw);
+
+        VM.startPrank(actor);
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IERC4626VaultControls.ERC4626VaultWithdrawLimitExceeded.selector, attemptAssets, maxWithdraw
+            )
+        );
+        coreFacetInterface().withdraw(attemptAssets, actor, actor);
+        VM.stopPrank();
+    }
+
+    function invariantActualVaultBalanceCoversBookIdleAssets() public view {
+        assertTrue(address(diamond).balance >= _bookIdleAssets(), "actual vault balance should cover book idle assets");
+    }
+
+    function invariantStrategyDebtDoesNotExceedBookAssets() public view {
+        assertTrue(
+            integrationFacetInterface().strategyDebt() <= coreFacetInterface().totalManagedAssets(),
+            "strategy debt should stay within total managed assets"
+        );
+    }
+
+    function invariantBookAccountingMatchesBookIdlePlusStrategyDebt() public view {
+        assertTrue(
+            coreFacetInterface().totalManagedAssets() == _bookIdleAssets() + integrationFacetInterface().strategyDebt(),
+            "book accounting should equal book idle assets plus strategy debt"
+        );
+    }
+
+    function invariantLiveAccountingMatchesBookIdlePlusStrategyAssets() public view {
+        assertTrue(
+            coreFacetInterface().totalAssets() == _bookIdleAssets() + integrationFacetInterface().liveStrategyAssets(),
+            "live accounting should equal book idle assets plus live strategy assets"
+        );
+    }
+
+    function invariantShareSupplyMatchesTrackedActorBalances() public view {
+        assertTrue(
+            coreFacetInterface().totalSupply() == _sumTrackedShareBalances(),
+            "share supply should remain equal to tracked balances"
+        );
+    }
+
+    function invariantTrackedUnderlyingRemainsConserved() public view {
+        assertTrue(
+            _sumTrackedUnderlying() == _expectedTrackedUnderlying(),
+            "tracked underlying should remain conserved across actors, vault, strategies, sinks, and reserves"
+        );
+    }
+
+    function invariantPausedStateZeroesMutatingMaxFunctions() public view {
+        if (!controlsFacetInterface().paused()) {
+            return;
+        }
+
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            address actor = actors[i];
+            assertTrue(coreFacetInterface().maxDeposit(actor) == 0, "paused vault should expose zero maxDeposit");
+            assertTrue(coreFacetInterface().maxMint(actor) == 0, "paused vault should expose zero maxMint");
+            assertTrue(coreFacetInterface().maxWithdraw(actor) == 0, "paused vault should expose zero maxWithdraw");
+            assertTrue(coreFacetInterface().maxRedeem(actor) == 0, "paused vault should expose zero maxRedeem");
+        }
+    }
+
+    function invariantMaxWithdrawBoundedByImmediateLiquidity() public view {
+        uint256 immediateLiquidity = _immediateLiquidity();
+
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            address actor = actors[i];
+            uint256 actorBalance = coreFacetInterface().balanceOf(actor);
+            uint256 grossEntitlement = actorBalance == 0 ? 0 : coreFacetInterface().previewRedeem(actorBalance);
+            uint256 maxWithdraw = coreFacetInterface().maxWithdraw(actor);
+
+            assertTrue(maxWithdraw <= immediateLiquidity, "maxWithdraw should stay within immediate liquidity");
+            assertTrue(maxWithdraw <= grossEntitlement, "maxWithdraw should stay within live-priced entitlement");
+        }
+    }
+
+    function invariantPreviewRedeemOfMaxRedeemBoundedByImmediateLiquidity() public view {
+        uint256 immediateLiquidity = _immediateLiquidity();
+
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            address actor = actors[i];
+            uint256 maxRedeem = coreFacetInterface().maxRedeem(actor);
+            assertTrue(
+                coreFacetInterface().previewRedeem(maxRedeem) <= immediateLiquidity,
+                "previewRedeem(maxRedeem) should stay within immediate liquidity"
+            );
+        }
+    }
+
+    function invariantActualStrategyBalanceCoversReportedStrategyAssets() public view {
+        if (integrationFacetInterface().strategy() != address(strategyContract)) {
+            return;
+        }
+
+        assertTrue(
+            address(strategyContract).balance >= integrationFacetInterface().liveStrategyAssets(),
+            "actual strategy balance should cover reported strategy assets"
+        );
+    }
+
+    function _bookIdleAssets() internal view returns (uint256) {
+        uint256 totalManagedAssets = coreFacetInterface().totalManagedAssets();
+        uint256 currentStrategyDebt = integrationFacetInterface().strategyDebt();
+        if (currentStrategyDebt > totalManagedAssets) {
+            return 0;
+        }
+        return totalManagedAssets - currentStrategyDebt;
+    }
+
+    function _immediateLiquidity() internal view returns (uint256) {
+        if (integrationFacetInterface().strategyDebt() == 0) {
+            return coreFacetInterface().totalAssets();
+        }
+
+        uint256 liquidity = _bookIdleAssets();
+        if (integrationFacetInterface().strategy() == address(strategyContract)) {
+            liquidity += strategyContract.maxWithdrawableAssets();
+        }
+        return liquidity;
+    }
+}

--- a/test/helpers/DiamondNativeVaultHostHardeningTestHarness.sol
+++ b/test/helpers/DiamondNativeVaultHostHardeningTestHarness.sol
@@ -2,43 +2,27 @@
 pragma solidity ^0.8.30;
 
 import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
-import {ERC4626VaultControlsFacet} from "../../src/vault/facets/ERC4626VaultControlsFacet.sol";
-import {ERC4626VaultFacet} from "../../src/vault/facets/ERC4626VaultFacet.sol";
-import {ERC4626VaultIntegrationFacet} from "../../src/vault/facets/ERC4626VaultIntegrationFacet.sol";
-import {ERC7535VaultFacet} from "../../src/vault/facets/ERC7535VaultFacet.sol";
+import {IERC7535VaultFacet} from "../../src/interfaces/IERC7535VaultFacet.sol";
 import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {DiamondVaultDeploymentFixture} from "./DiamondVaultDeploymentTestHarness.sol";
-import {MutableMockVaultStrategy} from "./ERC4626VaultStrategyTestHarness.sol";
+import {
+    ERC4626VaultControlsFacetReplacement,
+    ERC4626VaultFacetReplacement,
+    ERC4626VaultIntegrationFacetReplacement,
+    ERC7535VaultFacetReplacement,
+    IFacetVersionMarker
+} from "./DiamondVaultHostHardeningTestHarness.sol";
+import {MutableNativeMockVaultStrategy} from "./ERC4626VaultStrategyTestHarness.sol";
 
-interface IFacetVersionMarker {
-    function facetVersion() external view returns (uint256);
-}
+contract ForceSendNative {
+    constructor() payable {}
 
-contract ERC4626VaultFacetReplacement is ERC4626VaultFacet {
-    function facetVersion() external pure returns (uint256) {
-        return 2;
+    function forceSend(address payable receiver) external {
+        selfdestruct(receiver);
     }
 }
 
-contract ERC4626VaultControlsFacetReplacement is ERC4626VaultControlsFacet {
-    function facetVersion() external pure returns (uint256) {
-        return 2;
-    }
-}
-
-contract ERC4626VaultIntegrationFacetReplacement is ERC4626VaultIntegrationFacet {
-    function facetVersion() external pure returns (uint256) {
-        return 2;
-    }
-}
-
-contract ERC7535VaultFacetReplacement is ERC7535VaultFacet {
-    function facetVersion() external pure returns (uint256) {
-        return 2;
-    }
-}
-
-abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixture {
+abstract contract DiamondNativeVaultHostHardeningFixture is DiamondVaultDeploymentFixture {
     struct AccountingSnapshot {
         uint256 totalAssets;
         uint256 totalSupply;
@@ -49,6 +33,7 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
         uint256 strategyUnderlyingBalance;
         uint256 profitSourceBalance;
         uint256 lossSinkBalance;
+        uint256 forceSenderBalance;
         uint256 strategyDebt;
         uint256 liveStrategyAssets;
     }
@@ -65,16 +50,17 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
         uint256 bobMaxRedeem;
     }
 
-    uint256 internal constant INITIAL_ASSETS = 1_000_000;
-    uint256 internal constant STRATEGY_PROFIT_RESERVE = 1_000_000_000_000;
+    uint256 internal constant INITIAL_ASSETS = 100 ether;
+    uint256 internal constant STRATEGY_PROFIT_RESERVE = 100 ether;
+    uint256 internal constant FORCE_SEND_RESERVE = 25 ether;
     uint256 internal constant ACTOR_COUNT = 4;
-    uint256 internal constant BOB_DEPOSIT = 200_000;
-    uint256 internal constant CAROL_DEPOSIT = 150_000;
-    uint256 internal constant SHARE_ALLOWANCE = 25_000;
-    uint256 internal constant STRATEGY_DEPLOYED_ASSETS = 225_000;
-    uint256 internal constant STRATEGY_PROFIT_ASSETS = 25_000;
-    uint256 internal constant BOB_AUTO_PULL_WITHDRAW_ASSETS = 150_000;
-    uint256 internal constant CAROL_AUTO_PULL_REDEEM_SHARES = 50_000;
+    uint256 internal constant BOB_DEPOSIT = 20 ether;
+    uint256 internal constant CAROL_DEPOSIT = 15 ether;
+    uint256 internal constant SHARE_ALLOWANCE = 2.5 ether;
+    uint256 internal constant STRATEGY_DEPLOYED_ASSETS = 22.5 ether;
+    uint256 internal constant STRATEGY_PROFIT_ASSETS = 2.5 ether;
+    uint256 internal constant BOB_AUTO_PULL_WITHDRAW_ASSETS = 15 ether;
+    uint256 internal constant CAROL_AUTO_PULL_REDEEM_SHARES = 5 ether;
 
     address internal bob = address(0xB0B);
     address internal carol = address(0xCA11);
@@ -82,12 +68,15 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
     address internal eve = address(0xE11E);
     address internal feeSink = address(0xFEE);
     address internal profitSource = address(0xBEEF1234);
+    address internal forceSender = address(0xF0CE);
 
     address[ACTOR_COUNT] internal actors;
 
-    MutableMockVaultStrategy internal strategyContract;
+    MutableNativeMockVaultStrategy internal strategyContract;
+    MutableNativeMockVaultStrategy internal replacementStrategyContract;
 
     ERC4626VaultFacetReplacement internal coreReplacement;
+    ERC7535VaultFacetReplacement internal nativeReplacement;
     ERC4626VaultControlsFacetReplacement internal controlsReplacement;
     ERC4626VaultIntegrationFacetReplacement internal integrationReplacement;
 
@@ -95,6 +84,7 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
         super.setUp();
 
         coreReplacement = new ERC4626VaultFacetReplacement();
+        nativeReplacement = new ERC7535VaultFacetReplacement();
         controlsReplacement = new ERC4626VaultControlsFacetReplacement();
         integrationReplacement = new ERC4626VaultIntegrationFacetReplacement();
 
@@ -103,23 +93,20 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
         actors[2] = dave;
         actors[3] = eve;
 
-        strategyContract = new MutableMockVaultStrategy(address(diamond), address(asset), profitSource);
+        strategyContract = new MutableNativeMockVaultStrategy(address(diamond), profitSource);
+        replacementStrategyContract = new MutableNativeMockVaultStrategy(address(diamond), profitSource);
 
         for (uint256 i = 0; i < ACTOR_COUNT; i++) {
-            address actor = actors[i];
-            asset.mint(actor, INITIAL_ASSETS);
-            VM.prank(actor);
-            asset.approve(address(diamond), type(uint256).max);
+            VM.deal(actors[i], INITIAL_ASSETS);
         }
 
-        asset.mint(profitSource, STRATEGY_PROFIT_RESERVE);
-        VM.prank(profitSource);
-        asset.approve(address(strategyContract), type(uint256).max);
+        VM.deal(profitSource, STRATEGY_PROFIT_RESERVE);
+        VM.deal(forceSender, FORCE_SEND_RESERVE);
     }
 
-    function _installAndSeedVaultHost() internal {
-        _installVaultHostFacets();
-        _initializeVaultHost();
+    function _installAndSeedNativeVaultHost() internal {
+        _installNativeVaultHostFacets();
+        _initializeNativeVaultHost();
         _wireOracleAdapter();
         _seedCoreState();
         _seedControlsState();
@@ -128,10 +115,10 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
 
     function _seedCoreState() internal {
         VM.prank(bob);
-        coreFacetInterface().deposit(BOB_DEPOSIT, bob);
+        IERC7535VaultFacet(address(diamond)).depositNative{value: BOB_DEPOSIT}(bob);
 
         VM.prank(carol);
-        coreFacetInterface().deposit(CAROL_DEPOSIT, carol);
+        IERC7535VaultFacet(address(diamond)).depositNative{value: CAROL_DEPOSIT}(carol);
 
         VM.prank(bob);
         coreFacetInterface().approve(eve, SHARE_ALLOWANCE);
@@ -144,7 +131,7 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
         controlsFacetInterface().setFeeConfig(100, 50, feeSink);
 
         VM.prank(admin);
-        controlsFacetInterface().setLimitConfig(900_000, 300_000, 300_000, 250_000, 250_000);
+        controlsFacetInterface().setLimitConfig(90 ether, 30 ether, 30 ether, 25 ether, 25 ether);
 
         VM.prank(admin);
         controlsFacetInterface().grantRole(managerRole, eve);
@@ -163,7 +150,8 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
     }
 
     function _injectStrategyProfit(uint256 assets) internal {
-        strategyContract.injectProfit(assets);
+        VM.prank(profitSource);
+        strategyContract.injectProfit{value: assets}(assets);
     }
 
     function _applyStrategyLoss(uint256 lossAssets, uint256 withdrawableAssets) internal {
@@ -178,6 +166,10 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
         _replaceFacet(facetAddress_, LibVaultFacetSelectors.vaultCoreSelectors());
     }
 
+    function _replaceNativeFacet(address facetAddress_) internal {
+        _replaceFacet(facetAddress_, LibVaultFacetSelectors.vaultNativeSelectors());
+    }
+
     function _replaceControlsFacet(address facetAddress_) internal {
         _replaceFacet(facetAddress_, LibVaultFacetSelectors.vaultControlsSelectors());
     }
@@ -187,6 +179,10 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
     }
 
     function _addCoreReplacementMarker(address facetAddress_) internal {
+        _addFacet(facetAddress_, _markerSelectors());
+    }
+
+    function _addNativeReplacementMarker(address facetAddress_) internal {
         _addFacet(facetAddress_, _markerSelectors());
     }
 
@@ -202,6 +198,10 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
         _removeSelectors(_concat(LibVaultFacetSelectors.vaultCoreSelectors(), _markerSelectors()));
     }
 
+    function _removeNativeFacetWithMarker() internal {
+        _removeSelectors(_concat(LibVaultFacetSelectors.vaultNativeSelectors(), _markerSelectors()));
+    }
+
     function _removeControlsFacetWithMarker() internal {
         _removeSelectors(_concat(LibVaultFacetSelectors.vaultControlsSelectors(), _markerSelectors()));
     }
@@ -212,6 +212,10 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
 
     function _reAddCoreFacetWithMarker(address facetAddress_) internal {
         _addFacet(facetAddress_, _concat(LibVaultFacetSelectors.vaultCoreSelectors(), _markerSelectors()));
+    }
+
+    function _reAddNativeFacetWithMarker(address facetAddress_) internal {
+        _addFacet(facetAddress_, _concat(LibVaultFacetSelectors.vaultNativeSelectors(), _markerSelectors()));
     }
 
     function _reAddControlsFacetWithMarker(address facetAddress_) internal {
@@ -262,29 +266,36 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
 
     function _sumTrackedUnderlying() internal view returns (uint256 sum) {
         for (uint256 i = 0; i < ACTOR_COUNT; i++) {
-            sum += asset.balanceOf(actors[i]);
+            sum += actors[i].balance;
         }
 
-        sum += asset.balanceOf(address(diamond));
-        sum += asset.balanceOf(feeSink);
-        sum += asset.balanceOf(address(strategyContract));
-        sum += asset.balanceOf(profitSource);
-        sum += asset.balanceOf(strategyContract.lossSink());
+        sum += address(diamond).balance;
+        sum += feeSink.balance;
+        sum += address(strategyContract).balance;
+        sum += address(replacementStrategyContract).balance;
+        sum += profitSource.balance;
+        sum += forceSender.balance;
+        sum += strategyContract.lossSink().balance;
+    }
+
+    function _expectedTrackedUnderlying() internal pure returns (uint256) {
+        return INITIAL_ASSETS * ACTOR_COUNT + STRATEGY_PROFIT_RESERVE + FORCE_SEND_RESERVE;
     }
 
     function _snapshotAccounting() internal view returns (AccountingSnapshot memory snapshot) {
         snapshot.totalAssets = coreFacetInterface().totalAssets();
         snapshot.totalSupply = coreFacetInterface().totalSupply();
-        snapshot.vaultUnderlyingBalance = asset.balanceOf(address(diamond));
-        snapshot.feeSinkBalance = asset.balanceOf(feeSink);
-        snapshot.strategyUnderlyingBalance = asset.balanceOf(address(strategyContract));
-        snapshot.profitSourceBalance = asset.balanceOf(profitSource);
-        snapshot.lossSinkBalance = asset.balanceOf(strategyContract.lossSink());
+        snapshot.vaultUnderlyingBalance = address(diamond).balance;
+        snapshot.feeSinkBalance = feeSink.balance;
+        snapshot.strategyUnderlyingBalance = address(strategyContract).balance;
+        snapshot.profitSourceBalance = profitSource.balance;
+        snapshot.lossSinkBalance = strategyContract.lossSink().balance;
+        snapshot.forceSenderBalance = forceSender.balance;
         snapshot.strategyDebt = integrationFacetInterface().strategyDebt();
         snapshot.liveStrategyAssets = integrationFacetInterface().liveStrategyAssets();
 
         for (uint256 i = 0; i < ACTOR_COUNT; i++) {
-            snapshot.actorUnderlyingBalanceSum += asset.balanceOf(actors[i]);
+            snapshot.actorUnderlyingBalanceSum += actors[i].balance;
             snapshot.actorShareBalanceSum += coreFacetInterface().balanceOf(actors[i]);
         }
     }
@@ -300,6 +311,7 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
         assertTrue(afterSnapshot.strategyUnderlyingBalance == snapshot.strategyUnderlyingBalance, reason);
         assertTrue(afterSnapshot.profitSourceBalance == snapshot.profitSourceBalance, reason);
         assertTrue(afterSnapshot.lossSinkBalance == snapshot.lossSinkBalance, reason);
+        assertTrue(afterSnapshot.forceSenderBalance == snapshot.forceSenderBalance, reason);
         assertTrue(afterSnapshot.strategyDebt == snapshot.strategyDebt, reason);
         assertTrue(afterSnapshot.liveStrategyAssets == snapshot.liveStrategyAssets, reason);
     }
@@ -333,6 +345,28 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
         assertTrue(coreFacetInterface().totalAssets() == snapshot.totalAssets, "totalAssets mismatch");
         assertTrue(coreFacetInterface().maxWithdraw(bob) == snapshot.bobMaxWithdraw, "bob maxWithdraw mismatch");
         assertTrue(coreFacetInterface().maxRedeem(bob) == snapshot.bobMaxRedeem, "bob maxRedeem mismatch");
+    }
+
+    function _forceSendToVault(uint256 assets) internal {
+        if (assets == 0) {
+            return;
+        }
+
+        VM.startPrank(forceSender);
+        ForceSendNative sender = new ForceSendNative{value: assets}();
+        sender.forceSend(payable(address(diamond)));
+        VM.stopPrank();
+    }
+
+    function _forceSendToStrategy(uint256 assets) internal {
+        if (assets == 0) {
+            return;
+        }
+
+        VM.startPrank(forceSender);
+        ForceSendNative sender = new ForceSendNative{value: assets}();
+        sender.forceSend(payable(address(strategyContract)));
+        VM.stopPrank();
     }
 
     function _addFacet(address facetAddress_, bytes4[] memory selectors) internal {

--- a/test/helpers/ERC4626VaultStrategyTestHarness.sol
+++ b/test/helpers/ERC4626VaultStrategyTestHarness.sol
@@ -418,6 +418,59 @@ contract NativeEmergencyUnwindMockVaultStrategy is MockNativeVaultStrategyBase {
     }
 }
 
+contract MutableNativeMockVaultStrategy is MockNativeVaultStrategyBase {
+    address internal immutable _profitSource;
+    bool internal _revertWithdrawAllToVault;
+
+    constructor(address vault_, address profitSource_) MockNativeVaultStrategyBase(vault_) {
+        _profitSource = profitSource_;
+    }
+
+    function profitSource() external view returns (address) {
+        return _profitSource;
+    }
+
+    function lossSink() external pure returns (address) {
+        return LOSS_SINK;
+    }
+
+    function injectProfit(uint256 assets) external payable {
+        if (assets == 0) {
+            return;
+        }
+
+        require(msg.value == assets, "NATIVE_PROFIT_VALUE_MISMATCH");
+        _trackedAssets += assets;
+        _withdrawableAssets += assets;
+    }
+
+    function applyLoss(uint256 lossAssets, uint256 withdrawableAssets_) external {
+        uint256 realizedLoss = _min(lossAssets, _trackedAssets);
+        if (realizedLoss != 0) {
+            _transferNative(LOSS_SINK, realizedLoss);
+            _trackedAssets -= realizedLoss;
+        }
+        _withdrawableAssets = _min(withdrawableAssets_, _trackedAssets);
+    }
+
+    function setWithdrawAllReverts(bool shouldRevert) external {
+        _revertWithdrawAllToVault = shouldRevert;
+    }
+
+    function withdrawAllToVault() external override onlyVault returns (uint256 assetsReturned) {
+        if (_revertWithdrawAllToVault) {
+            revert MockVaultStrategyForcedRevert(this.withdrawAllToVault.selector);
+        }
+
+        assetsReturned = maxWithdrawableAssets();
+        _trackedAssets -= assetsReturned;
+        _withdrawableAssets -= assetsReturned;
+        if (assetsReturned != 0) {
+            _transferNative(_vault, assetsReturned);
+        }
+    }
+}
+
 abstract contract ERC4626VaultStrategyFixture is TestBase {
     address internal admin = address(0xA11CE);
     address internal vault = address(0xA417);
@@ -433,6 +486,7 @@ abstract contract ERC4626VaultStrategyFixture is TestBase {
     NativeLossShortfallMockVaultStrategy internal nativeLossStrategy;
     NativeRevertingMockVaultStrategy internal nativeRevertingStrategy;
     NativeEmergencyUnwindMockVaultStrategy internal nativeUnwindStrategy;
+    MutableNativeMockVaultStrategy internal mutableNativeStrategy;
 
     function setUp() public virtual {
         asset = new MockVaultAsset("Mock USD", "mUSD", 6);
@@ -446,5 +500,6 @@ abstract contract ERC4626VaultStrategyFixture is TestBase {
         nativeLossStrategy = new NativeLossShortfallMockVaultStrategy(vault);
         nativeRevertingStrategy = new NativeRevertingMockVaultStrategy(vault);
         nativeUnwindStrategy = new NativeEmergencyUnwindMockVaultStrategy(vault);
+        mutableNativeStrategy = new MutableNativeMockVaultStrategy(vault, address(0xBEEF1234));
     }
 }


### PR DESCRIPTION
## Summary
- add native-host facet churn and emergency-exit hardening coverage
- add native-host invariant coverage for deposits, exits, strategy lifecycle, pause/limit changes, and force-sent ETH
- fix native exit accounting and liquidity-cap handling when untracked ETH is force-sent into the vault

## Details
This branch adds a native-only hardening harness plus invariant suite around the hosted diamond path. The new coverage exercises native depositNative and mintNative, standard ERC-4626 withdraw and redeem, strategy deploy, pull, sync, emergency-exit, facet replacement and removal flows, and forced ETH delivery into both the vault and the strategy.

The invariant work exposed two runtime bugs that are fixed here:
- native exits could decrement tracked managed assets even when the withdrawal was satisfied by untracked force-sent ETH
- hosted native maxWithdraw and maxRedeem could be overstated by untracked idle ETH because the liquidity cap used actual idle balance instead of tracked idle balance

## Validation
- forge fmt --check
- forge build --sizes --skip script
- forge test --offline --match-path test/DiamondNativeVaultHostHardening.t.sol
- forge test --offline --match-path test/DiamondNativeVaultHostInvariant.t.sol
- forge test --offline --match-path test/DiamondVaultHostInvariant.t.sol

Closes #134