### PR TITLE
ci: tier foundry validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   foundry-checks:
-    name: Foundry Checks
+    name: Foundry Fast PR Gate
     runs-on: ubuntu-latest
 
     steps:
@@ -46,5 +46,20 @@ jobs:
       - name: Build With Sizes
         run: forge build --sizes --skip script
 
-      - name: Run Offline Tests
-        run: forge test --offline
+      - name: Run Selector Integrity Core
+        run: forge test --offline --match-path test/DiamondSelectorIntegrityCore.t.sol
+
+      - name: Run Vault Deployment Integration
+        run: forge test --offline --match-path test/DiamondVaultDeploymentIntegration.t.sol
+
+      - name: Run Vault Host Hardening
+        run: forge test --offline --match-path test/DiamondVaultHostHardening.t.sol
+
+      - name: Run Native Vault Host Hardening
+        run: forge test --offline --match-path test/DiamondNativeVaultHostHardening.t.sol
+
+      - name: Run Token Deployment Integration
+        run: forge test --offline --match-path test/DiamondTokenDeploymentIntegration.t.sol
+
+      - name: Run System Oracle Failure Scenarios
+        run: forge test --offline --match-path test/SystemOracleFailureScenarios.t.sol

--- a/.github/workflows/system-hardening.yml
+++ b/.github/workflows/system-hardening.yml
@@ -52,9 +52,7 @@ jobs:
     if: >-
       ${{
         github.event_name == 'workflow_dispatch' ||
-        github.event_name == 'push' ||
-        (github.event_name == 'pull_request' &&
-          (github.base_ref == 'main' || startsWith(github.base_ref, 'milestone/')))
+        github.event_name == 'push'
       }}
 
     steps:


### PR DESCRIPTION
## Summary
- replace full-suite PR Foundry validation with a curated fast gate
- keep system hardening on PRs but remove the full local hardening flow from pull request runs
- preserve heavier invariant coverage outside the default PR path

Closes #157
Follow-up to #145

## PR Gate
The PR-facing Foundry workflow now keeps:
- `forge fmt --check`
- `forge build --sizes --skip script`
- `test/DiamondSelectorIntegrityCore.t.sol`
- `test/DiamondVaultDeploymentIntegration.t.sol`
- `test/DiamondVaultHostHardening.t.sol`
- `test/DiamondNativeVaultHostHardening.t.sol`
- `test/DiamondTokenDeploymentIntegration.t.sol`
- `test/SystemOracleFailureScenarios.t.sol`

The broader fuzz and invariant suites stay available outside the default PR path rather than being deleted.

## Validation
- `git diff --check`
- `forge test --offline --match-path test/DiamondSelectorIntegrityCore.t.sol`
- `forge test --offline --match-path test/DiamondVaultDeploymentIntegration.t.sol`
- `forge test --offline --match-path test/DiamondVaultHostHardening.t.sol`
- `forge test --offline --match-path test/DiamondNativeVaultHostHardening.t.sol`
- `forge test --offline --match-path test/DiamondTokenDeploymentIntegration.t.sol`
- `forge test --offline --match-path test/SystemOracleFailureScenarios.t.sol`
- `forge test --offline --match-path test/SystemVaultStressInvariant.t.sol`
- `forge test --offline --match-path test/DiamondNativeVaultHostInvariant.t.sol`

## Follow-up
- compare 2-3 PR runs against the prior ~13.5-14.5 minute Foundry baseline
- decide after measurement whether `SystemVaultStressInvariant` should remain PR-facing in system hardening or move out with the rest of the invariant family