### PR TITLE
docs: add architecture decision records

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Architecture and module docs live in `docs/diamond-core.md`,
 `docs/oracle-adapter.md`, `docs/erc4626-vault.md`, `docs/vault-facets.md`,
 `docs/token-facets.md`, and `docs/threat-model.md`.
 
+Durable architecture decisions live in `docs/adr/README.md`.
+
 Operational guidance lives in `docs/ops/README.md`, with the end-to-end
 execution order collected in `docs/ops/runbook-system-hardening.md`.
 

--- a/docs/adr/0001-diamond-foundation.md
+++ b/docs/adr/0001-diamond-foundation.md
@@ -1,0 +1,40 @@
+# ADR 0001: Use diamond architecture as the upgrade and composition foundation
+
+## Status
+
+Accepted
+
+## Context
+
+`Auralis` is meant to demonstrate systems that evolve from standalone modules
+into reviewable hosted platforms. That requires upgradeable composition without
+collapsing storage discipline, selector ownership, or operational review into a
+single monolithic contract.
+
+## Decision
+
+Use EIP-2535 diamond architecture as the repository's upgrade and composition
+foundation.
+
+The repository keeps mutable state in namespaced storage libraries and treats
+selector ownership as an explicit review surface. Feature groups that need to
+evolve independently are expressed as facets behind diamond hosts rather than
+being merged into one large upgradeable implementation.
+
+## Consequences
+
+- New hosted systems can reuse the same cut, loupe, and selector-integrity
+  review model.
+- Upgrade safety depends on strict storage discipline and explicit post-cut
+  validation.
+- Facet boundaries become part of the architecture and must stay legible to
+  reviewers.
+- Some complexity moves from inheritance and constructor flow into deployment,
+  routing, and selector bookkeeping.
+
+## Related Docs/Tests
+
+- `docs/diamond-core.md`
+- `docs/vault-facets.md`
+- `test/DiamondSelectorIntegrityCore.t.sol`
+- `test/DiamondVaultDeploymentIntegration.t.sol`

--- a/docs/adr/0002-separate-diamond-hosts.md
+++ b/docs/adr/0002-separate-diamond-hosts.md
@@ -1,0 +1,36 @@
+# ADR 0002: Deploy separate diamond hosts instead of a single mega-host
+
+## Status
+
+Accepted
+
+## Context
+
+The repository hosts multiple standards and protocol surfaces, including ERC20,
+ERC721, and ERC-4626-based vault flows. Trying to expose all of them from one
+diamond would create selector collisions, blur upgrade intent, and make review
+of supported surfaces harder.
+
+## Decision
+
+Deploy separate diamond hosts for materially different external surfaces instead
+of building one shared mega-host.
+
+ERC20, ERC721, and vault deployments remain distinct hosts even when they share
+supporting control-plane or diamond-core patterns.
+
+## Consequences
+
+- Standard selector surfaces stay unchanged and do not require namespacing.
+- Deployment artifacts, upgrade review, and hardening coverage remain scoped to
+  one host type at a time.
+- Shared logic must be reused through libraries, patterns, and scripts rather
+  than a single catch-all host contract.
+- Cross-host composition is explicit and easier to reason about operationally.
+
+## Related Docs/Tests
+
+- `docs/token-facets.md`
+- `docs/vault-facets.md`
+- `test/DiamondTokenDeploymentIntegration.t.sol`
+- `test/DiamondVaultDeploymentIntegration.t.sol`

--- a/docs/adr/0003-tracked-managed-assets.md
+++ b/docs/adr/0003-tracked-managed-assets.md
@@ -1,0 +1,40 @@
+# ADR 0003: Base hosted vault accounting on tracked managed assets
+
+## Status
+
+Accepted
+
+## Context
+
+Raw asset balances are not a safe source of truth for vault pricing. Direct
+donations, accidental transfers, and raw native balance changes can distort
+share pricing or liquidity calculations if conversion math reads underlying
+balances directly.
+
+## Decision
+
+Base hosted vault accounting and pricing on tracked managed assets rather than
+raw token or ETH balances.
+
+The vault treats managed accounting as the source of truth for ERC-4626
+conversions, previews, and share pricing. Raw balance reads are still useful
+for immediate liquidity checks and operator visibility, but they do not define
+pricing.
+
+## Consequences
+
+- Donation-style price manipulation is reduced because direct surplus does not
+  automatically reprice shares.
+- Strategy, native-asset, and emergency-liquidity logic must reconcile with
+  managed accounting instead of assuming raw balance truth.
+- Integrators and reviewers need to distinguish accounting state from idle
+  balance state.
+- Some flows become more explicit and less automatic, which is safer but less
+  implicit than raw-balance-based vaults.
+
+## Related Docs/Tests
+
+- `docs/erc4626-vault.md`
+- `docs/vault-facets.md`
+- `docs/threat-model.md`
+- `test/ERC4626VaultAccountingInvariant.t.sol`

--- a/docs/adr/0004-native-sentinel-and-facet.md
+++ b/docs/adr/0004-native-sentinel-and-facet.md
@@ -1,0 +1,36 @@
+# ADR 0004: Add native asset support with a sentinel and dedicated facet
+
+## Status
+
+Accepted
+
+## Context
+
+The hosted vault platform needed native-asset support without breaking the
+standard ERC-4626 surface or overloading existing selectors with asset-mode
+specific semantics. The native work also had to fit within facet size limits and
+preserve a clear selector ownership model.
+
+## Decision
+
+Represent native mode with the native asset sentinel and expose native-only
+entrypoints through a dedicated facet instead of overloading the standard
+ERC-4626 selectors.
+
+Standard ERC-4626 selectors remain on the core vault facet. Native-only
+entrypoints such as `depositNative` and `mintNative` live on the native facet.
+
+## Consequences
+
+- The ERC-4626 surface stays standard for ERC20-backed vaults.
+- Native mode remains explicit in routing, selector ownership, and review.
+- Native-specific semantics such as exact `msg.value` handling do not leak into
+  the standard selector surface.
+- Hosted native deployments must install and validate one additional facet.
+
+## Related Docs/Tests
+
+- `docs/vault-facets.md`
+- `docs/auralis-local.md`
+- `test/ERC4626VaultFacetCore.t.sol`
+- `test/DiamondNativeVaultHostHardening.t.sol`

--- a/docs/adr/0005-exclude-force-sent-eth.md
+++ b/docs/adr/0005-exclude-force-sent-eth.md
@@ -1,0 +1,35 @@
+# ADR 0005: Exclude force-sent ETH from managed accounting and pricing
+
+## Status
+
+Accepted
+
+## Context
+
+Native-asset hosts can receive ETH outside the intended control flow through
+`selfdestruct` or other forced-send patterns. If that surplus is treated as
+managed capital automatically, pricing, limits, and withdrawals can become
+misleading or manipulable.
+
+## Decision
+
+Exclude force-sent ETH from managed accounting and pricing by default.
+
+Raw native surplus may improve immediate exit liquidity in some cases, but it is
+not treated as managed vault assets for pricing, accounting, or share issuance.
+
+## Consequences
+
+- Forced ETH cannot inflate share price or mint pricing.
+- Native liquidity checks must distinguish between immediate raw balance and
+  tracked managed assets.
+- Reviewers must treat force-sent surplus as untracked balance, not protocol
+  yield.
+- Reconciliation, if ever desired, must be explicit rather than automatic.
+
+## Related Docs/Tests
+
+- `docs/erc4626-vault.md`
+- `docs/threat-model.md`
+- `test/DiamondNativeVaultHostInvariant.t.sol`
+- `test/DiamondNativeVaultHostHardening.t.sol`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,22 @@
+# Architecture Decision Records
+
+This directory captures durable architecture decisions for `Auralis`.
+
+ADRs explain why the repository is shaped the way it is. They are intentionally
+short and decision-focused. Module behavior, operational flows, and validation
+details continue to live in the subsystem docs and test suites.
+
+## Status Vocabulary
+
+- `Accepted`: the decision is in force for the current repository shape.
+- `Superseded`: the decision was replaced by a later ADR.
+- `Proposed`: the decision is under consideration and not yet the documented
+  baseline.
+
+## Current ADRs
+
+- [0001 - Use diamond architecture as the upgrade and composition foundation](0001-diamond-foundation.md)
+- [0002 - Deploy separate diamond hosts instead of a single mega-host](0002-separate-diamond-hosts.md)
+- [0003 - Base hosted vault accounting on tracked managed assets](0003-tracked-managed-assets.md)
+- [0004 - Add native asset support with a sentinel and dedicated facet](0004-native-sentinel-and-facet.md)
+- [0005 - Exclude force-sent ETH from managed accounting and pricing](0005-exclude-force-sent-eth.md)

--- a/docs/diamond-core.md
+++ b/docs/diamond-core.md
@@ -4,6 +4,9 @@ This document describes the diamond core behavior implemented in this repository
 including bootstrap expectations, `diamondCut` init flow, selector ownership
 rules, and upgrade review guidance.
 
+For the decision to use diamonds as the repository's upgrade and composition
+foundation, see `docs/adr/0001-diamond-foundation.md`.
+
 ## Contracts
 
 - `src/diamond/Diamond.sol`: base proxy with owner bootstrap and selector routing fallback.

--- a/docs/erc4626-vault.md
+++ b/docs/erc4626-vault.md
@@ -6,6 +6,11 @@ repository:
 - `ERC4626Vault`
 - `ERC4626VaultControls`
 
+For the accounting and native-asset decisions behind this module family, see
+`docs/adr/0003-tracked-managed-assets.md`,
+`docs/adr/0004-native-sentinel-and-facet.md`, and
+`docs/adr/0005-exclude-force-sent-eth.md`.
+
 It covers the standalone vault modules and their math/control behavior. For the
 diamond-hosted vault platform, see `docs/vault-facets.md`.
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -3,6 +3,9 @@
 This summary covers security assumptions and guard rails for access, oracle,
 upgrade, and vault modules.
 
+For the accepted architecture decisions that shape these assumptions, see
+`docs/adr/README.md`.
+
 ## In-Scope Modules
 
 - `AccessControl`

--- a/docs/token-facets.md
+++ b/docs/token-facets.md
@@ -3,6 +3,9 @@
 This document is the canonical guide for the hosted token model implemented in
 the `Diamond Token Facets` milestone.
 
+For the decision to deploy separate hosts instead of a single shared token host,
+see `docs/adr/0002-separate-diamond-hosts.md`.
+
 The current supported deployment model is:
 
 - one ERC20-hosted diamond

--- a/docs/vault-facets.md
+++ b/docs/vault-facets.md
@@ -3,6 +3,12 @@
 This document is the canonical guide for the hosted vault model implemented in
 the `Diamond-Hosted Vault Platform` milestone.
 
+For the durable architecture decisions behind the hosted vault shape, see
+`docs/adr/0002-separate-diamond-hosts.md`,
+`docs/adr/0003-tracked-managed-assets.md`,
+`docs/adr/0004-native-sentinel-and-facet.md`, and
+`docs/adr/0005-exclude-force-sent-eth.md`.
+
 It covers the supported diamond-hosted vault deployment:
 
 - one diamond


### PR DESCRIPTION
## Summary
- add a first-class ADR surface under `docs/adr/`
- capture five accepted architecture decisions that shape the current repo
- add minimal cross-links from the docs front door and key architecture docs

Closes #146

## Included ADRs
- `0001` diamond architecture as the upgrade and composition foundation
- `0002` separate diamond hosts instead of a single mega-host
- `0003` tracked managed assets for hosted vault accounting
- `0004` native asset support via sentinel plus dedicated native facet
- `0005` force-sent ETH excluded from managed accounting and pricing

## Notes
- this PR does not reorganize the broader docs tree
- it is intentionally limited to durable decision capture plus minimal linking
- the larger docs reset remains in `#154`

## Validation
- `git diff --check`