### PR TITLE
docs: reset durable docs surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,18 +43,6 @@ reviewable engineering system.
 - A local Auralis workflow for full-stack bootstrap, smoke checks, simulated
   activity, reset flows, and unified deployment artifacts.
 
-## Current Status
-
-Implemented milestones so far:
-
-- Access Control + Upgrade Safety Kit
-- Oracle Adapter + Circuit Breaker
-- Diamond Core (EIP-2535)
-- System-Level Testing & Hardening
-- Diamond Token Facets
-- Diamond-Hosted Vault Platform
-- Auralis Launch Readiness
-
 ## Validation
 
 Run the highest-signal local checks with:
@@ -77,27 +65,15 @@ bash scripts/auralis-reset.sh
 
 ## Documentation
 
-Architecture and module docs live in `docs/diamond-core.md`,
-`docs/oracle-adapter.md`, `docs/erc4626-vault.md`, `docs/vault-facets.md`,
-`docs/token-facets.md`, and `docs/threat-model.md`.
+Start with `docs/README.md` for the canonical docs map.
 
-Durable architecture decisions live in `docs/adr/README.md`.
+Recommended reviewer path:
 
-Operational guidance lives in `docs/ops/README.md`, with the end-to-end
-execution order collected in `docs/ops/runbook-system-hardening.md`.
-
-CI and local validation parity are documented in `docs/security-checks.md`.
-
-Token-host architecture and safety assumptions live in `docs/token-facets.md`,
-including the init model, selector ownership rules, separate-host deployment
-constraint, and token-host upgrade assumptions.
-
-Hosted-vault architecture and safety assumptions live in
-`docs/vault-facets.md`, including the init model, selector ownership split,
-pause behavior, deployment references, and hosted-vault upgrade assumptions.
-
-Local Auralis bootstrap, smoke, simulated activity, reset flow, and artifact
-layout are documented in `docs/auralis-local.md`.
+- Architecture decisions: `docs/adr/README.md`
+- Core architecture: `docs/diamond-core.md`, `docs/token-facets.md`,
+  `docs/vault-facets.md`, `docs/oracle-adapter.md`
+- Security and validation: `docs/threat-model.md`, `docs/security-checks.md`
+- Operations and local workflow: `docs/ops/README.md`, `docs/auralis-local.md`
 
 ## Tooling
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,66 @@
+# Docs Map
+
+This is the canonical documentation map for `Auralis`.
+
+Use this surface to understand the current architecture, the major design
+decisions behind it, how safety is validated, and where operator-facing
+runbooks live.
+
+## Start Here
+
+- Architecture decisions: `docs/adr/README.md`
+- Diamond core architecture: `docs/diamond-core.md`
+- Hosted token architecture: `docs/token-facets.md`
+- Hosted vault architecture: `docs/vault-facets.md`
+- Security assumptions: `docs/threat-model.md`
+- Validation and CI policy: `docs/security-checks.md`
+
+## Architecture
+
+- `docs/diamond-core.md`: diamond routing, cut flow, selector ownership, and
+  storage discipline.
+- `docs/token-facets.md`: separate ERC20 and ERC721 host model, initialization,
+  role surface, and upgrade assumptions.
+- `docs/vault-facets.md`: hosted vault facet split, selector ownership, and
+  deployment model.
+- `docs/erc4626-vault.md`: standalone ERC-4626 module semantics, math, fees,
+  limits, and native-mode accounting assumptions.
+- `docs/oracle-adapter.md`: oracle adapter validation, breaker behavior, and
+  fallback policy.
+- `docs/access-control.md`: RBAC hierarchy and time-window access model.
+- `docs/pausable.md`: global and scoped pause behavior.
+- `docs/reentrancy-guard.md`: reentrancy protection model.
+- `docs/upgrade-guardrails.md`: queued upgrade intent model and execution
+  constraints.
+
+## ADRs
+
+- `docs/adr/README.md`: accepted architecture decisions and their consequences.
+
+## Security And Validation
+
+- `docs/threat-model.md`: trust assumptions, threat boundaries, and residual
+  risks.
+- `docs/security-checks.md`: CI gates and local reproduction entrypoints.
+- `docs/system-hardening.md`: system-level hardening coverage and what it
+  intentionally simulates.
+- `docs/testing-conventions.md`: test layout and naming conventions.
+
+## Operations
+
+- `docs/ops/README.md`: operator-facing runbooks and validation flows.
+
+## Local Workflow
+
+- `docs/auralis-local.md`: local bootstrap, smoke, activity, reset flow, and
+  artifact layout.
+
+## Legacy / Transient References
+
+These docs still exist because they can be operationally useful, but they are
+not part of the primary reviewer path and will be handled more aggressively in
+`#155`.
+
+- `docs/ops/milestone-close-checklist.md`
+- `docs/ops/release-checklist.md`
+- `docs/ops/release-notes-template.md`

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -1,7 +1,7 @@
 # Operations Docs
 
 This folder is the operator-facing guide set for deployment rehearsal,
-validation, incident response, and milestone hygiene.
+validation, incident response, and release hygiene.
 
 ## Start Here
 
@@ -20,7 +20,7 @@ validation, incident response, and milestone hygiene.
 - Pause/unpause runbook: `docs/ops/runbook-pause-unpause.md`
 - Upgrade execution runbook: `docs/ops/runbook-upgrade-execution.md`
 
-## Release And Milestone Hygiene
+## Secondary Release / Milestone References
 
 - Release checklist: `docs/ops/release-checklist.md`
 - Release notes template: `docs/ops/release-notes-template.md`

--- a/docs/ops/runbook-system-hardening.md
+++ b/docs/ops/runbook-system-hardening.md
@@ -1,6 +1,6 @@
 # Runbook: System Hardening Validation
 
-Use this runbook when validating a milestone branch, reproducing CI failures, or
+Use this runbook when validating a branch, reproducing CI failures, or
 reviewing the repository's deployment-backed safety checks end to end.
 
 ## Recommended Local Execution Order
@@ -65,8 +65,8 @@ bash script/run-local-system-hardening.sh
 
 ## CI Equivalents
 
-- `Foundry CI / Foundry Checks`
-  - baseline formatting, build, and full offline test suite
+- `Foundry CI / Foundry Fast PR Gate`
+  - baseline formatting, build, and curated high-signal PR-facing suites
 - `System Hardening / Targeted System Suites`
   - targeted vault/oracle system suites
 - `System Hardening / Full Local Hardening Flow`
@@ -79,7 +79,7 @@ or after a failing run.
 
 - The flows assume deterministic local Anvil defaults unless environment
   variables override them.
-- The operator sequence here is for the current diamond/system-hardening
-  milestone, not a future multi-module production deployment.
+- The operator sequence here is for the current repository architecture, not a
+  future multi-module production deployment.
 - Remaining out-of-scope and trust assumptions are tracked in
   `docs/system-hardening.md`.

--- a/docs/oracle-adapter.md
+++ b/docs/oracle-adapter.md
@@ -1,7 +1,6 @@
 # Oracle Adapter
 
-This module defines the oracle adapter and breaker controls for the oracle
-milestone:
+This module defines the oracle adapter and breaker controls used in `Auralis`:
 - provider-facing feed interface
 - normalized quote read interface
 - validation guardrails for live reads

--- a/docs/security-checks.md
+++ b/docs/security-checks.md
@@ -12,7 +12,8 @@ This repository runs security-focused CI checks in addition to baseline Foundry 
   - `Targeted System Suites` runs on every workflow trigger and executes:
     - `forge test --offline --match-path test/SystemVaultStressInvariant.t.sol`
     - `forge test --offline --match-path test/SystemOracleFailureScenarios.t.sol`
-  - `Full Local Hardening Flow` runs on pushes to `main`/`milestone/**`, on manual dispatch, and on pull requests targeting `main` or `milestone/**`.
+  - `Full Local Hardening Flow` runs on pushes to `main`/`milestone/**` and on
+    manual dispatch.
 - Scope: deployment bootstrap, smoke flow, upgrade rehearsal, vault stress invariants, and oracle failure scenarios.
 - Operational execution order and local reproduction context:
   `docs/ops/runbook-system-hardening.md`
@@ -50,8 +51,8 @@ Use the targeted suites for faster iteration and the full hardening runner for t
 
 ### Token Hosts
 
-The diamond token milestone also has reviewer-facing validation suites for the
-separate ERC20-host and ERC721-host deployment model:
+The token hosts have reviewer-facing validation suites for the separate
+ERC20-host and ERC721-host deployment model:
 
 ```bash
 forge test --offline --match-path test/DiamondTokenDeploymentIntegration.t.sol
@@ -65,7 +66,7 @@ reinstall persistence, and diamond-routed invariant coverage locally.
 
 ### Hosted Vault
 
-The hosted vault milestone has matching deployment, hardening, and invariant
+The hosted vault architecture has matching deployment, hardening, and invariant
 coverage for the supported three-facet vault host:
 
 ```bash

--- a/docs/system-hardening.md
+++ b/docs/system-hardening.md
@@ -1,7 +1,7 @@
 # System Hardening
 
-This note defines the reproducible system-level hardening coverage added for
-issue `#69`.
+This note defines the reproducible system-level hardening coverage used in
+`Auralis`.
 
 For the operator-facing execution order and failure interpretation, see
 `docs/ops/runbook-system-hardening.md`.

--- a/docs/token-facets.md
+++ b/docs/token-facets.md
@@ -1,12 +1,12 @@
 # Diamond Token Facets
 
-This document is the canonical guide for the hosted token model implemented in
-the `Diamond Token Facets` milestone.
+This document is the canonical guide for the hosted token architecture in
+`Auralis`.
 
 For the decision to deploy separate hosts instead of a single shared token host,
 see `docs/adr/0002-separate-diamond-hosts.md`.
 
-The current supported deployment model is:
+The supported deployment model is:
 
 - one ERC20-hosted diamond
 - one ERC721-hosted diamond
@@ -217,7 +217,7 @@ The ERC721 host exposes:
 
 ## Safety Notes For Reviewers
 
-- Separate-host deployment is the supported model for this milestone.
+- Separate-host deployment is the supported model in this repository.
 - No selector namespacing is used.
 - Re-initialization is not part of replace/remove/re-add flows.
 - Facet upgrades must preserve storage layout and hosted selector intent.

--- a/docs/vault-facets.md
+++ b/docs/vault-facets.md
@@ -1,7 +1,7 @@
 # Diamond Vault Facets
 
-This document is the canonical guide for the hosted vault model implemented in
-the `Diamond-Hosted Vault Platform` milestone.
+This document is the canonical guide for the hosted vault architecture in
+`Auralis`.
 
 For the durable architecture decisions behind the hosted vault shape, see
 `docs/adr/0002-separate-diamond-hosts.md`,
@@ -147,7 +147,7 @@ Asset helpers:
 
 That means strategy reports are visible to operators and reviewers, but they do
 not automatically change `withdraw`, `redeem`, preview math, or live liquidity
-semantics in this milestone.
+semantics in the current implementation.
 
 ## Selector Ownership Model
 


### PR DESCRIPTION
## Summary
- add a canonical `docs/README.md` as the durable docs map
- remove milestone-era framing from the primary docs surface
- demote transient milestone/release docs from primary navigation without archiving or deleting them

Closes #154

## What Changed
- `README.md` now points to the durable docs map instead of milestone history
- `docs/README.md` now organizes the docs surface into architecture, ADRs, security and validation, operations, local workflow, and legacy/transient references
- `docs/ops/README.md` now treats release and milestone hygiene docs as secondary references
- durable subsystem docs no longer lead with milestone-era wording

## Notes
- this PR does not archive or delete docs; that remains `#155`
- this PR does not add diagrams; that remains `#148`

## Validation
- `git diff --check`
- milestone-era phrasing scan over `README.md` and `docs/` for the targeted patterns