### PR TITLE
docs: add reviewer onboarding diagrams

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,31 @@ Use this surface to understand the current architecture, the major design
 decisions behind it, how safety is validated, and where operator-facing
 runbooks live.
 
+## Architecture Overview
+
+```mermaid
+flowchart TD
+    ADR["ADRs<br/>accepted design choices"]
+    Core["Diamond Core<br/>routing and upgrade base"]
+    Token["Token Hosts<br/>ERC20 and ERC721 diamonds"]
+    Vault["Vault Hosts<br/>hosted ERC-4626 platform"]
+    Oracle["Oracle Adapter<br/>validation and breaker policy"]
+    Security["Threat Model and Security Checks"]
+    Ops["Ops and Local Workflow"]
+
+    ADR --> Core
+    ADR --> Token
+    ADR --> Vault
+    ADR --> Oracle
+    Core --> Token
+    Core --> Vault
+    Oracle --> Vault
+    Vault --> Security
+    Token --> Security
+    Core --> Security
+    Security --> Ops
+```
+
 ## Start Here
 
 - Architecture decisions: `docs/adr/README.md`
@@ -16,6 +41,9 @@ runbooks live.
 - Validation and CI policy: `docs/security-checks.md`
 
 ## Architecture
+
+The linked architecture docs include structure and lifecycle diagrams where the
+visual model materially improves comprehension.
 
 - `docs/diamond-core.md`: diamond routing, cut flow, selector ownership, and
   storage discipline.

--- a/docs/auralis-local.md
+++ b/docs/auralis-local.md
@@ -39,6 +39,17 @@ Reset local artifacts and stop the managed Anvil process:
 bash scripts/auralis-reset.sh
 ```
 
+## Workflow Overview
+
+```mermaid
+flowchart LR
+    Up["auralis-up"] --> Artifact["deployments/auralis.local.json"]
+    Artifact --> Smoke["auralis-smoke"]
+    Smoke --> Activity["auralis-activity"]
+    Activity --> Reset["auralis-reset"]
+    Reset --> Clean["artifacts removed and managed Anvil stopped"]
+```
+
 ## What The Scripts Do
 
 `auralis-up.sh`

--- a/docs/erc4626-vault.md
+++ b/docs/erc4626-vault.md
@@ -14,6 +14,26 @@ For the accounting and native-asset decisions behind this module family, see
 It covers the standalone vault modules and their math/control behavior. For the
 diamond-hosted vault platform, see `docs/vault-facets.md`.
 
+## Accounting Model
+
+```mermaid
+flowchart TD
+    Idle["Idle underlying balance"]
+    Managed["Tracked managed assets"]
+    Strategy["Strategy-reported / estimated assets"]
+    Surplus["Raw surplus<br/>direct transfers or force-sent native balance"]
+    Pricing["convert / preview / share pricing"]
+    Liquidity["Immediate exit liquidity checks"]
+
+    Idle --> Managed
+    Managed --> Pricing
+    Idle --> Liquidity
+    Strategy --> Liquidity
+    Strategy -. estimate only .-> Managed
+    Surplus -. not auto-accounted .-> Managed
+    Surplus --> Liquidity
+```
+
 ## Contract Roles
 
 - `ERC4626VaultBase`: initializer + share/asset accounting primitives.

--- a/docs/vault-facets.md
+++ b/docs/vault-facets.md
@@ -24,6 +24,24 @@ For the standalone ERC-4626 module behavior and math reference, see
 The hosted vault diamond preserves a split between user-facing vault flows,
 control-plane selectors, and integration/config selectors.
 
+### Host Structure
+
+```mermaid
+flowchart TD
+    Diamond["Vault Diamond"]
+    Cut["DiamondCutFacet<br/>diamondCut"]
+    Loupe["DiamondLoupeFacet<br/>loupe and owner reads"]
+    Core["ERC4626VaultFacet<br/>user flows and max/preview helpers"]
+    Controls["ERC4626VaultControlsFacet<br/>fees, limits, roles, pause"]
+    Integration["ERC4626VaultIntegrationFacet<br/>oracle and strategy config"]
+
+    Diamond --> Cut
+    Diamond --> Loupe
+    Diamond --> Core
+    Diamond --> Controls
+    Diamond --> Integration
+```
+
 ### Core Facet
 
 `ERC4626VaultFacet` owns the ERC-4626/share-token selector group:
@@ -124,6 +142,21 @@ vault does not currently use per-scope pause behavior for ERC-4626 entrypoints.
 
 The integration facet is config/report infrastructure, not an active strategy
 engine.
+
+### Runtime Flow
+
+```mermaid
+flowchart LR
+    Init["initializeVault"] --> Roles["grant admin, manager, pauser roles"]
+    Roles --> Oracle["optional setOracleAdapter"]
+    Oracle --> Strategy["optional setStrategy"]
+    Strategy --> Users["deposit / mint / withdraw / redeem"]
+    Strategy --> Reports["reportStrategyAssets"]
+    Reports --> Estimate["estimatedTotalManagedAssets"]
+    Users --> Managed["totalManagedAssets and ERC-4626 math"]
+
+    Reports -. advisory only .-> Managed
+```
 
 Oracle behavior:
 


### PR DESCRIPTION
## Summary
- add Mermaid diagrams to the durable docs surface for faster reviewer onboarding
- visualize the repo architecture, hosted vault structure and runtime flow, vault accounting model, and local workflow sequence
- keep the diagrams embedded directly in the docs that own the concepts

Closes #148

## Included Diagrams
- repo-level architecture overview in `docs/README.md`
- hosted-vault structure diagram in `docs/vault-facets.md`
- hosted-vault runtime/lifecycle diagram in `docs/vault-facets.md`
- vault accounting model diagram in `docs/erc4626-vault.md`
- local workflow diagram in `docs/auralis-local.md`

## Notes
- Mermaid is used directly in Markdown; no SVG or image assets were added
- this PR supplements the existing prose docs rather than replacing them
- README onboarding polish remains in `#153`

## Validation
- `git diff --check`
- Mermaid block sanity check across the four updated docs