### PR TITLE
docs: add rationale comments to protocol paths

### DIFF
--- a/src/diamond/libraries/LibDiamond.sol
+++ b/src/diamond/libraries/LibDiamond.sol
@@ -189,6 +189,8 @@ library LibDiamond {
         uint256 lastSelectorPosition = selectors.length - 1;
 
         if (selectorPosition != lastSelectorPosition) {
+            // Selector arrays are swap-and-pop so loupe reads stay compact; the moved selector's stored
+            // position must be rewritten to keep future replace/remove operations sound.
             bytes4 lastSelector = selectors[lastSelectorPosition];
             selectors[selectorPosition] = lastSelector;
             diamondStorage.selectorData[lastSelector].selectorPosition = uint96(selectorPosition);
@@ -198,6 +200,8 @@ library LibDiamond {
         delete diamondStorage.selectorData[selector];
 
         if (selectors.length == 0) {
+            // Facets disappear from loupe enumeration once they own no selectors; live routing state is
+            // defined by current selector ownership, not deployment history.
             _removeFacetAddress(diamondStorage, facetAddress_);
         }
     }
@@ -242,6 +246,8 @@ library LibDiamond {
             }
         }
 
+        // Init runs after selector mutations so delegatecall setup code can immediately target the newly
+        // installed routing surface.
         initializeDiamondCut(init, initCalldata);
     }
 

--- a/src/token/TokenFacetControl.sol
+++ b/src/token/TokenFacetControl.sol
@@ -102,6 +102,7 @@ abstract contract TokenFacetControl is IAccessControl, IPausable {
     /// @param scope The scope identifier.
     /// @return True if globally paused or scope paused.
     function paused(bytes32 scope) public view returns (bool) {
+        // Global pause is the emergency override; a scoped unpause never bypasses a contract-wide stop.
         return paused() || scopePaused(scope);
     }
 
@@ -162,6 +163,8 @@ abstract contract TokenFacetControl is IAccessControl, IPausable {
     /// @dev Initializes shared access control and pausability storage when needed.
     /// @param initialAdmin The default admin and initial pauser.
     function _initializeTokenFacetControl(address initialAdmin) internal {
+        // Hosted facets share control storage, so initialization must be opportunistic and idempotent
+        // rather than assuming one dedicated initializer per facet.
         if (!_isAccessControlInitialized()) {
             _initializeAccessControl(initialAdmin);
         }

--- a/src/vault/ERC4626Vault.sol
+++ b/src/vault/ERC4626Vault.sol
@@ -26,6 +26,8 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
     /// @notice Returns total assets managed by the vault.
     /// @return The total managed asset amount.
     function totalAssets() public view virtual returns (uint256) {
+        // ERC-4626 math intentionally follows tracked managed assets instead of raw balance so direct
+        // transfers and native surplus cannot change pricing implicitly.
         return totalManagedAssets();
     }
 

--- a/src/vault/ERC4626VaultBase.sol
+++ b/src/vault/ERC4626VaultBase.sol
@@ -29,6 +29,8 @@ abstract contract ERC4626VaultBase is IERC4626VaultBase {
     /// @notice Returns currently managed asset accounting amount.
     /// @return The tracked managed asset amount.
     function totalManagedAssets() public view virtual returns (uint256) {
+        // Managed assets are the pricing source of truth; raw balances can diverge due to donations,
+        // force-sent value, or strategy timing and must not silently reprice shares.
         return LibERC4626VaultStorage.layout().totalManagedAssets;
     }
 
@@ -197,6 +199,8 @@ abstract contract ERC4626VaultBase is IERC4626VaultBase {
 
         LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
         uint256 managedAssets = layout.totalManagedAssets;
+        // Guard against tracked-accounting underflow directly so unexpected surplus cannot mask an
+        // accounting bug or let the vault spend assets it never managed.
         if (managedAssets < assets) {
             revert ERC4626VaultManagedAssetsUnderflow(managedAssets, assets);
         }
@@ -239,6 +243,8 @@ abstract contract ERC4626VaultBase is IERC4626VaultBase {
             return 0;
         }
         if (supply == 0 || managedAssets == 0) {
+            // Bootstrap 1:1 so the first liquidity provider establishes the initial price instead of
+            // inheriting an arbitrary ratio from uninitialized accounting.
             return assets;
         }
 
@@ -260,6 +266,8 @@ abstract contract ERC4626VaultBase is IERC4626VaultBase {
             return 0;
         }
         if (supply == 0 || managedAssets == 0) {
+            // Keep previews symmetric with the same 1:1 bootstrap rule before the vault has a meaningful
+            // supply-to-assets ratio.
             return shares;
         }
 

--- a/src/vault/ERC4626VaultControlLogic.sol
+++ b/src/vault/ERC4626VaultControlLogic.sol
@@ -117,6 +117,8 @@ abstract contract ERC4626VaultControlledCore is ERC4626Vault {
             }
 
             uint256 remainingAssets = maxTotalAssets_ - currentAssets;
+            // The cap is expressed in net managed assets, so the gross deposit ceiling must be fee-aware;
+            // otherwise a post-fee credit could exceed the configured cap.
             uint256 capBasedMaxAssets = LibERC4626VaultControlLogic.grossUpForDepositFee(remainingAssets);
             if (capBasedMaxAssets < maxAssets) {
                 maxAssets = capBasedMaxAssets;
@@ -160,6 +162,8 @@ abstract contract ERC4626VaultControlledCore is ERC4626Vault {
         }
 
         uint256 grossAssets = _convertToAssets(balanceOf(owner), Rounding.Down);
+        // Withdraw limits are expressed in what the receiver can actually take out, so maxWithdraw uses
+        // the net-after-fee view rather than the gross accounting assets burned.
         (uint256 netAssets,) = LibERC4626VaultControlLogic.withdrawNetFromGross(grossAssets);
 
         (,,, uint128 maxWithdraw_,) = LibERC4626VaultControlLogic.limitConfig();
@@ -201,6 +205,8 @@ abstract contract ERC4626VaultControlledCore is ERC4626Vault {
 
     function previewRedeem(uint256 shares) public view virtual override returns (uint256) {
         uint256 grossAssets = _convertToAssets(shares, Rounding.Down);
+        // Redeem previews follow the same boundary: shares map to gross accounting assets first, then
+        // withdraw fees determine the receiver's net assets.
         (uint256 netAssets,) = LibERC4626VaultControlLogic.withdrawNetFromGross(grossAssets);
         return netAssets;
     }

--- a/src/vault/facets/ERC4626VaultIntegrationFacet.sol
+++ b/src/vault/facets/ERC4626VaultIntegrationFacet.sol
@@ -39,6 +39,8 @@ contract ERC4626VaultIntegrationFacet is ERC4626Vault, VaultFacetControl, IERC46
     /// @notice Returns idle assets plus the latest reported strategy assets.
     /// @return The estimated total assets across idle vault balance and strategy reports.
     function estimatedTotalManagedAssets() public view returns (uint256) {
+        // This is an operator-facing estimate only; core ERC-4626 pricing continues to use tracked managed
+        // assets so advisory reports cannot silently redefine preview or withdraw math.
         return idleAssets() + strategyReportedAssets();
     }
 
@@ -74,6 +76,8 @@ contract ERC4626VaultIntegrationFacet is ERC4626Vault, VaultFacetControl, IERC46
         LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
         address previousStrategy = layout.strategy;
         layout.strategy = newStrategy;
+        // Reported assets belong to the previous strategy lifecycle and must be cleared so stale operator
+        // state does not survive a replacement.
         layout.strategyReportedAssets = 0;
 
         emit VaultStrategyUpdated(previousStrategy, newStrategy, msg.sender);
@@ -92,6 +96,8 @@ contract ERC4626VaultIntegrationFacet is ERC4626Vault, VaultFacetControl, IERC46
 
         LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
         uint256 previousAssets = layout.strategyReportedAssets;
+        // Reports are visibility only, not accounting truth; they inform estimates without mutating the
+        // managed-assets ledger used by ERC-4626 conversions.
         layout.strategyReportedAssets = assets;
 
         emit VaultStrategyAssetsReported(previousAssets, assets, msg.sender);


### PR DESCRIPTION
## Summary
- add a tight set of rationale comments to the most non-obvious production code paths
- clarify managed accounting, advisory strategy estimates, selector bookkeeping, and shared control semantics
- keep the diff comment-only and avoid broad comment churn

Closes #152

## Comment Targets
- `src/vault/ERC4626VaultBase.sol`
- `src/vault/ERC4626Vault.sol`
- `src/vault/ERC4626VaultControlLogic.sol`
- `src/vault/facets/ERC4626VaultIntegrationFacet.sol`
- `src/diamond/libraries/LibDiamond.sol`
- `src/token/TokenFacetControl.sol`

## Notes
- no behavior, API, or storage changes
- comments are limited to non-obvious why/boundary semantics
- this is intentionally a tight pass rather than a broad inline-doc sweep

## Validation
- `git diff --check`