### PR TITLE
chore(repo): adapt workflow conventions

### DIFF
--- a/.github/workflows/main-pr-branch-guard.yml
+++ b/.github/workflows/main-pr-branch-guard.yml
@@ -14,8 +14,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  enforce-milestone-head:
-    name: Enforce milestone/* head for main
+  enforce-milestone-pr-metadata:
+    name: Enforce milestone PR metadata for main
     runs-on: ubuntu-latest
 
     steps:
@@ -31,3 +31,24 @@ jobs:
           fi
 
           echo "Branch naming rule satisfied."
+
+      - name: Validate milestone label
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          if ! jq -e '.pull_request.labels | any(.name == "milestone")' "${GITHUB_EVENT_PATH}" >/dev/null; then
+            echo "Pull requests into main must include the 'milestone' label."
+            exit 1
+          fi
+
+          echo "Milestone label present."
+
+      - name: Validate assignee
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+          assignee_count="$(jq '.pull_request.assignees | length' "${GITHUB_EVENT_PATH}")"
+          if [[ "${assignee_count}" -lt 1 ]]; then
+            echo "Pull requests into main must have an assignee set."
+            exit 1
+          fi
+
+          echo "Assignee requirement satisfied."

--- a/docs/README.md
+++ b/docs/README.md
@@ -77,6 +77,7 @@ visual model materially improves comprehension.
 ## Operations
 
 - `docs/ops/README.md`: operator-facing runbooks and validation flows.
+- `docs/ops/workflow-conventions.md`: issue, branch, PR, and milestone workflow expectations.
 
 ## Local Workflow
 

--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -6,6 +6,7 @@ validation, incident response, and release hygiene.
 ## Start Here
 
 - System hardening runbook: `docs/ops/runbook-system-hardening.md`
+- Workflow conventions: `docs/ops/workflow-conventions.md`
 
 ## Local Validation Flows
 

--- a/docs/ops/milestone-close-checklist.md
+++ b/docs/ops/milestone-close-checklist.md
@@ -11,10 +11,15 @@ Use this checklist before merging a milestone branch into `main`.
 ## 2. Branch and PR Hygiene
 
 - Milestone branch is up to date with child PR merges.
+- Milestone PR was opened with `scripts/open-milestone-pr.sh` or carries the
+  same metadata manually.
 - Final milestone PR to `main` has:
   - clear summary
   - test/security evidence
   - linked issues
+  - assignee set
+  - `milestone` label applied
+  - `@codex review` comment posted
 
 ## 3. Validation Evidence
 

--- a/docs/ops/workflow-conventions.md
+++ b/docs/ops/workflow-conventions.md
@@ -1,0 +1,115 @@
+# Workflow Conventions
+
+## Purpose
+
+These conventions keep issue planning, branch flow, PR metadata, and project
+tracking predictable across the portfolio repo.
+
+## Working Cycle
+
+- `main` only receives milestone PRs.
+- milestone branches collect the work for one GitHub milestone.
+- task branches merge into milestone branches.
+- milestone branches merge into `main` after the milestone is complete.
+
+In practice:
+
+1. plan the work on a GitHub issue before implementation starts
+2. branch from the active `milestone/*` branch
+3. open a task PR into that milestone branch
+4. repeat until the milestone issue is complete
+5. open one milestone PR from `milestone/*` into `main`
+
+## Issue Planning Before Implementation
+
+Every implementation task should start from a GitHub issue.
+
+Task issues are not treated as ready until they have:
+
+- an assignee
+- a GitHub milestone
+- a project card on `Portfolio`
+- a project `Status`
+- a parent/sub-issue relationship to the active milestone umbrella issue when
+  the work belongs to one
+
+`Portfolio` currently uses `Status` but does not have a `Track` or `Category`
+field. If one is added later, treat it as required issue/PR workflow metadata
+rather than optional bookkeeping.
+
+Once a branch and PR exist, the issue body should include a `Delivery` section:
+
+- `Branch: \`<branch>\``
+- `PR: [#<number>](<url>)`
+
+Use one canonical `PR:` line. Do not add a duplicate `PR URL:` entry.
+
+## Task PR Rules
+
+Task PRs should:
+
+- target the active `milestone/*` branch
+- have an assignee
+- copy the linked issue labels where appropriate
+- inherit the issue milestone
+- have a project card on `Portfolio`
+- carry a project `Status` of `In progress`
+- include `Closes #<issue-number>` in the PR body
+
+When GitHub `Development` links are unreliable, the issue `Delivery` section and
+the PR `Closes #...` line are treated as the canonical linkage.
+
+Use [`scripts/open-task-pr.sh`](/Users/amirshirif/Documents/personal/auralis/scripts/open-task-pr.sh)
+to create task PRs with the expected metadata and delivery links in one step.
+
+## Milestone PR Rules
+
+Milestone PRs should:
+
+- use `milestone/*` as the head branch
+- target `main`
+- have an assignee
+- carry the `milestone` label
+- have a project card on `Portfolio`
+- use `In progress` status while open
+- include an `@codex review` comment after creation
+
+Use [`scripts/open-milestone-pr.sh`](/Users/amirshirif/Documents/personal/auralis/scripts/open-milestone-pr.sh)
+to create milestone PRs with the expected metadata in one step.
+
+Main-branch guardrails in
+[`main-pr-branch-guard.yml`](/Users/amirshirif/Documents/personal/auralis/.github/workflows/main-pr-branch-guard.yml)
+enforce the parts of this checklist that GitHub Actions can verify.
+
+## Branch Naming
+
+### Milestone Branches
+
+- `milestone/<slug>`
+
+### Task Branches
+
+- `<type>/<slug>`
+
+Where `type` is typically one of:
+
+- `feat`
+- `fix`
+- `chore`
+- `docs`
+- `research`
+
+This repo already uses slug-based task branches broadly, so the workflow keeps
+that convention instead of forcing issue numbers into branch names.
+
+## Definition of Done
+
+Work is not done when the code lands but the side cards are missing.
+
+For task work, done means:
+
+- issue metadata is complete
+- issue `Delivery` section is current
+- PR metadata matches the issue
+- project cards/status are set correctly
+- the milestone branch receives the task PR, not `main`

--- a/scripts/lib/github-workflow.sh
+++ b/scripts/lib/github-workflow.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ghwf_die() {
+  echo "$*" >&2
+  exit 1
+}
+
+ghwf_repo_full_name() {
+  local remote
+  remote="$(git remote get-url origin)"
+
+  if [[ "${remote}" =~ github\.com[:/]([^/]+)/([^/.]+)(\.git)?$ ]]; then
+    printf '%s/%s\n' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+    return
+  fi
+
+  ghwf_die "unable to infer GitHub repo from origin remote: ${remote}"
+}
+
+ghwf_repo_owner() {
+  ghwf_repo_full_name | cut -d/ -f1
+}
+
+ghwf_repo_name() {
+  ghwf_repo_full_name | cut -d/ -f2
+}
+
+ghwf_login() {
+  if [[ -z "${GHWF_LOGIN:-}" ]]; then
+    GHWF_LOGIN="$(gh api user -q .login)"
+  fi
+  printf '%s\n' "${GHWF_LOGIN}"
+}
+
+ghwf_project_title() {
+  printf '%s\n' "${AURALIS_PROJECT_TITLE:-Portfolio}"
+}
+
+ghwf_project_json() {
+  if [[ -z "${GHWF_PROJECT_JSON:-}" ]]; then
+    GHWF_PROJECT_JSON="$(
+      gh project list --owner "$(ghwf_repo_owner)" --format json
+    )"
+  fi
+  printf '%s\n' "${GHWF_PROJECT_JSON}"
+}
+
+ghwf_project_number() {
+  local project_number
+  project_number="$(
+    ghwf_project_json |
+      jq -r --arg title "$(ghwf_project_title)" '.projects[] | select(.title == $title) | .number'
+  )"
+  [[ -n "${project_number}" && "${project_number}" != "null" ]] ||
+    ghwf_die "project not found: $(ghwf_project_title)"
+  printf '%s\n' "${project_number}"
+}
+
+ghwf_project_id() {
+  local project_id
+  project_id="$(
+    ghwf_project_json |
+      jq -r --arg title "$(ghwf_project_title)" '.projects[] | select(.title == $title) | .id'
+  )"
+  [[ -n "${project_id}" && "${project_id}" != "null" ]] ||
+    ghwf_die "project id not found: $(ghwf_project_title)"
+  printf '%s\n' "${project_id}"
+}
+
+ghwf_fields_json() {
+  if [[ -z "${GHWF_FIELDS_JSON:-}" ]]; then
+    GHWF_FIELDS_JSON="$(
+      gh project field-list "$(ghwf_project_number)" --owner "$(ghwf_repo_owner)" --format json
+    )"
+  fi
+  printf '%s\n' "${GHWF_FIELDS_JSON}"
+}
+
+ghwf_field_id() {
+  local field_id
+  field_id="$(
+    ghwf_fields_json |
+      jq -r --arg name "$1" '.fields[] | select(.name == $name) | .id'
+  )"
+  [[ -n "${field_id}" && "${field_id}" != "null" ]] ||
+    ghwf_die "project field not found: $1"
+  printf '%s\n' "${field_id}"
+}
+
+ghwf_field_option_id() {
+  local option_id
+  option_id="$(
+    ghwf_fields_json |
+      jq -r --arg field "$1" --arg option "$2" '
+        .fields[]
+        | select(.name == $field)
+        | .options[]?
+        | select(.name == $option)
+        | .id
+      '
+  )"
+  [[ -n "${option_id}" && "${option_id}" != "null" ]] ||
+    ghwf_die "project option not found: $1 -> $2"
+  printf '%s\n' "${option_id}"
+}
+
+ghwf_project_item_id_by_url() {
+  local url="$1"
+  gh project item-list "$(ghwf_project_number)" --owner "$(ghwf_repo_owner)" --format json |
+    jq -r --arg url "${url}" '.items[] | select(.content.url == $url) | .id' |
+    head -n1
+}
+
+ghwf_ensure_project_item() {
+  local url="$1"
+  local item_id
+
+  item_id="$(ghwf_project_item_id_by_url "${url}")"
+  if [[ -n "${item_id}" ]]; then
+    printf '%s\n' "${item_id}"
+    return
+  fi
+
+  gh project item-add "$(ghwf_project_number)" --owner "$(ghwf_repo_owner)" --url "${url}" --format json -q .id
+}
+
+ghwf_set_project_status() {
+  local item_id="$1"
+  local status_name="$2"
+
+  gh project item-edit \
+    --id "${item_id}" \
+    --project-id "$(ghwf_project_id)" \
+    --field-id "$(ghwf_field_id Status)" \
+    --single-select-option-id "$(ghwf_field_option_id Status "${status_name}")" \
+    >/dev/null
+}
+
+ghwf_issue_json() {
+  gh issue view "$1" --repo "$(ghwf_repo_full_name)" --json body,labels,milestone,projectItems,assignees,title,number,url
+}
+
+ghwf_issue_status() {
+  local issue_json="$1"
+  jq -r --arg title "$(ghwf_project_title)" '
+    .projectItems[]?
+    | select(.title == $title)
+    | .status.name // empty
+  ' <<<"${issue_json}" | head -n1
+}
+
+ghwf_issue_delivery_body() {
+  local issue_body="$1"
+  local branch="$2"
+  local pr_number="$3"
+  local pr_url="$4"
+
+  ISSUE_BODY="${issue_body}" BRANCH="${branch}" PR_NUMBER="${pr_number}" PR_URL="${pr_url}" python3 - <<'PY'
+import os
+import re
+
+body = os.environ["ISSUE_BODY"]
+branch = os.environ["BRANCH"]
+pr_number = os.environ["PR_NUMBER"]
+pr_url = os.environ["PR_URL"]
+
+clean = re.sub(r"\n## Delivery\n.*?(?=\n## |\Z)", "", body, flags=re.S).rstrip()
+
+print(
+    f"{clean}\n\n## Delivery\n"
+    f"- Branch: `{branch}`\n"
+    f"- PR: [#{pr_number}]({pr_url})\n",
+    end="",
+)
+PY
+}
+
+ghwf_update_issue_delivery() {
+  local issue_number="$1"
+  local branch="$2"
+  local pr_number="$3"
+  local pr_url="$4"
+  local issue_json
+  local issue_body_file
+
+  issue_json="$(ghwf_issue_json "${issue_number}")"
+  issue_body_file="$(mktemp)"
+  trap 'rm -f "${issue_body_file}"' RETURN
+
+  ghwf_issue_delivery_body \
+    "$(jq -r '.body' <<<"${issue_json}")" \
+    "${branch}" \
+    "${pr_number}" \
+    "${pr_url}" \
+    >"${issue_body_file}"
+
+  gh issue edit "${issue_number}" --repo "$(ghwf_repo_full_name)" --body-file "${issue_body_file}" >/dev/null
+}
+
+ghwf_ensure_label() {
+  local label_name="$1"
+  local color="$2"
+  local description="$3"
+  local repo
+
+  repo="$(ghwf_repo_full_name)"
+
+  if gh api "repos/${repo}/labels/${label_name}" >/dev/null 2>&1; then
+    return
+  fi
+
+  gh api -X POST "repos/${repo}/labels" \
+    -f name="${label_name}" \
+    -f color="${color}" \
+    -f description="${description}" \
+    >/dev/null
+}
+
+ghwf_slugify() {
+  tr '[:upper:]' '[:lower:]' <<<"$1" |
+    sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//'
+}
+
+ghwf_detect_milestone_title_from_branch() {
+  local head_branch="$1"
+  local head_slug
+
+  head_slug="${head_branch#milestone/}"
+  gh api "repos/$(ghwf_repo_full_name)/milestones?state=open&per_page=100" |
+    jq -r --arg slug "${head_slug}" '
+      .[]
+      | select((.title | ascii_downcase | gsub("[^a-z0-9]+"; "-") | gsub("(^-+|-+$)"; "")) == $slug)
+      | .title
+    ' |
+    head -n1
+}

--- a/scripts/open-milestone-pr.sh
+++ b/scripts/open-milestone-pr.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/github-workflow.sh
+source "${script_dir}/lib/github-workflow.sh"
+
+if [[ $# -lt 3 || $# -gt 4 ]]; then
+  echo "usage: $0 <head-branch> <title> <body-file> [milestone-title]" >&2
+  exit 1
+fi
+
+head_branch="$1"
+title="$2"
+body_file="$3"
+milestone_title="${4:-}"
+
+[[ -f "${body_file}" ]] || ghwf_die "body file not found: ${body_file}"
+[[ "${head_branch}" == milestone/* ]] || ghwf_die "milestone PRs must use a milestone/* head branch"
+
+login="$(ghwf_login)"
+if [[ -z "${milestone_title}" ]]; then
+  milestone_title="$(ghwf_detect_milestone_title_from_branch "${head_branch}")"
+fi
+
+pr_url="$(
+  gh pr create \
+    --repo "$(ghwf_repo_full_name)" \
+    --base main \
+    --head "${head_branch}" \
+    --title "${title}" \
+    --body-file "${body_file}"
+)"
+
+pr_number="$(gh pr view "${pr_url}" --repo "$(ghwf_repo_full_name)" --json number -q .number)"
+
+ghwf_ensure_label "milestone" "5319e7" "Milestone PR into main"
+
+pr_edit_args=(
+  gh pr edit "${pr_number}"
+  --repo "$(ghwf_repo_full_name)"
+  --add-assignee "${login}"
+  --add-label "milestone"
+)
+
+if [[ -n "${milestone_title}" ]]; then
+  pr_edit_args+=(--milestone "${milestone_title}")
+fi
+
+"${pr_edit_args[@]}" >/dev/null
+
+pr_item_id="$(ghwf_ensure_project_item "${pr_url}")"
+ghwf_set_project_status "${pr_item_id}" "In progress"
+
+gh pr comment "${pr_number}" --repo "$(ghwf_repo_full_name)" --body "@codex review" >/dev/null
+
+printf '%s\n' "${pr_url}"

--- a/scripts/open-task-pr.sh
+++ b/scripts/open-task-pr.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/github-workflow.sh
+source "${script_dir}/lib/github-workflow.sh"
+
+if [[ $# -ne 5 ]]; then
+  echo "usage: $0 <issue-number> <base-branch> <head-branch> <title> <body-file>" >&2
+  exit 1
+fi
+
+issue_number="$1"
+base_branch="$2"
+head_branch="$3"
+title="$4"
+body_file="$5"
+
+[[ -f "${body_file}" ]] || ghwf_die "body file not found: ${body_file}"
+
+issue_json="$(ghwf_issue_json "${issue_number}")"
+issue_url="$(jq -r '.url' <<<"${issue_json}")"
+issue_body="$(jq -r '.body' <<<"${issue_json}")"
+milestone_title="$(jq -r '.milestone.title // empty' <<<"${issue_json}")"
+issue_status="$(ghwf_issue_status "${issue_json}")"
+login="$(ghwf_login)"
+
+[[ -n "${milestone_title}" ]] || ghwf_die "issue #${issue_number} is missing a milestone"
+
+if [[ "$(jq '.assignees | length' <<<"${issue_json}")" -lt 1 ]]; then
+  gh issue edit "${issue_number}" --repo "$(ghwf_repo_full_name)" --add-assignee "${login}" >/dev/null
+fi
+
+issue_item_id="$(ghwf_ensure_project_item "${issue_url}")"
+ghwf_set_project_status "${issue_item_id}" "In progress"
+
+pr_body_file="$(mktemp)"
+trap 'rm -f "${pr_body_file}"' EXIT
+
+cp "${body_file}" "${pr_body_file}"
+if ! grep -Eq "Closes #${issue_number}|Fixes #${issue_number}|Resolves #${issue_number}" "${pr_body_file}"; then
+  printf '\n## Linked Issue\nCloses #%s\n' "${issue_number}" >>"${pr_body_file}"
+fi
+
+pr_url="$(
+  gh pr create \
+    --repo "$(ghwf_repo_full_name)" \
+    --base "${base_branch}" \
+    --head "${head_branch}" \
+    --title "${title}" \
+    --body-file "${pr_body_file}"
+)"
+
+pr_number="$(gh pr view "${pr_url}" --repo "$(ghwf_repo_full_name)" --json number -q .number)"
+
+pr_edit_args=(
+  gh pr edit "${pr_number}"
+  --repo "$(ghwf_repo_full_name)"
+  --add-assignee "${login}"
+  --milestone "${milestone_title}"
+)
+
+while IFS= read -r label; do
+  [[ -n "${label}" ]] || continue
+  pr_edit_args+=(--add-label "${label}")
+done < <(jq -r '.labels[].name' <<<"${issue_json}")
+
+"${pr_edit_args[@]}" >/dev/null
+
+pr_item_id="$(ghwf_ensure_project_item "${pr_url}")"
+ghwf_set_project_status "${pr_item_id}" "${issue_status:-In progress}"
+
+ghwf_update_issue_delivery "${issue_number}" "${head_branch}" "${pr_number}" "${pr_url}"
+
+printf '%s\n' "${pr_url}"


### PR DESCRIPTION
## Summary
- adapt the Mythra task and milestone workflow into Auralis without carrying over Mythra-specific project ids, names, or field assumptions
- add Auralis workflow conventions for issue planning, task PRs, milestone PRs, and required side-card hygiene
- add helper scripts that discover the Portfolio project dynamically, update delivery links, and set PR metadata consistently
- tighten the main-branch guard so `main` only accepts milestone PRs with the required metadata

## What Was Learned From Mythra
- work should flow through `milestone/*` branches rather than merging task branches directly into `main`
- implementation should start from a planned issue, not from an ad hoc branch
- issue bodies need explicit `Delivery` links because GitHub Development links are not always reliable
- side-card hygiene is part of done, not optional cleanup after merge

## How It Was Adapted For Auralis
- keep Auralis's existing branch naming style: `milestone/<slug>` and `<type>/<slug>`
- target the `Portfolio` project dynamically instead of hardcoding Mythra's project number
- require `Status`, but do not assume `Track` or `Category` because Auralis does not currently use those fields
- keep the workflow docs in `docs/ops/` and align the milestone close checklist and main-branch guard with the same expectations

## Expected Metadata / Side-Card Behavior
- task issues should have assignee, milestone, `Portfolio` card, `Status`, and a parent milestone issue when applicable
- task issues should carry a `Delivery` section with `Branch:` and `PR:` once work is underway
- task PRs should target a `milestone/*` branch, copy the issue milestone and labels, add the `Portfolio` card, and include `Closes #162`
- milestone PRs should target `main`, come from `milestone/*`, carry the `milestone` label, have an assignee, and get an `@codexreviewerreviewer-agentreviewer-agent review comment

## Files
- `docs/ops/workflow-conventions.md`
- `docs/ops/milestone-close-checklist.md`
- `docs/ops/README.md`
- `docs/README.md`
- `.github/workflows/main-pr-branch-guard.yml`
- `scripts/lib/github-workflow.sh`
- `scripts/open-task-pr.sh`
- `scripts/open-milestone-pr.sh`

## Validation
- `git diff --check`
- `bash -n scripts/open-task-pr.sh scripts/open-milestone-pr.sh scripts/lib/github-workflow.sh`


