### PR TITLE
docs: improve README onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@
 
 Security-first, diamond-ready Solidity systems.
 
-`Auralis` is a portfolio-focused Solidity repository built to show
-security-first protocol engineering, dependency-light design, and
-deployment-backed validation. The codebase is intentionally diamond-ready, so
-core modules can evolve into facetized systems without rewriting storage or
-control-plane assumptions.
+`Auralis` is a protocol-engineering portfolio repository focused on
+security-first, upgrade-aware Solidity systems. It combines modular contract
+design, deployment-backed validation, local operator flows, and hardening
+coverage so a reviewer can assess architecture and evidence together rather
+than as isolated snippets.
 
 ## Why This Repo Exists
 
@@ -23,47 +23,74 @@ shows how access control, guard rails, oracle safety, vault logic, diamond
 routing, deployment scripts, rehearsal flows, and CI checks fit together as a
 reviewable engineering system.
 
-## What It Currently Demonstrates
+## Review In 5 Minutes
 
-- A security-first control plane with RBAC, time-based permissions,
-  pausability, reentrancy protection, and upgrade guardrails.
-- Oracle safety patterns including validation bounds, stale-data handling,
-  circuit breakers, and controlled fallback behavior.
-- A diamond core with selector routing, cut/loupe support, ownership
-  introspection, and selector-integrity regression coverage.
-- Hosted ERC20 and ERC721 token facets deployed behind separate diamond hosts,
-  with init, selector ownership, Permit/metadata support, and host-level
-  hardening coverage.
-- A hosted ERC-4626 vault platform deployed behind a diamond host, split across
-  core, controls, and integration facets with deployment-backed init, oracle
-  wiring, replace/remove/re-add hardening, and diamond-routed invariant
-  coverage.
-- Operational maturity through local bootstrap, smoke validation, upgrade
-  rehearsal, system-hardening flows, and matching CI gates.
-- A local Auralis workflow for full-stack bootstrap, smoke checks, simulated
-  activity, reset flows, and unified deployment artifacts.
+- Architecture decisions: `docs/adr/README.md`
+- Canonical docs map: `docs/README.md`
+- Hosted vault architecture: `docs/vault-facets.md`
+- Security assumptions: `docs/threat-model.md`
+- Validation and CI policy: `docs/security-checks.md`
+- Local workflow and deployment artifacts: `docs/auralis-local.md`
 
-## Current Status
+## What This Repo Proves
 
-Implemented milestones so far:
+- Core architecture: diamond routing, selector ownership discipline, and
+  separate hosted token and vault deployment models.
+- Safety posture: RBAC, timed permissions, pause semantics, reentrancy
+  protection, oracle validation, and upgrade guardrails.
+- Protocol surfaces: ERC20 and ERC721 token hosts plus a hosted ERC-4626 vault
+  platform with controls, strategy integration, and native-asset support.
+- Operational maturity: local bootstrap, smoke validation, activity flows,
+  upgrade rehearsal, and matching CI/hardening gates.
 
-- Access Control + Upgrade Safety Kit
-- Oracle Adapter + Circuit Breaker
-- Diamond Core (EIP-2535)
-- System-Level Testing & Hardening
-- Diamond Token Facets
-- Diamond-Hosted Vault Platform
-- Auralis Launch Readiness
+## Evidence
 
-## Validation
+### Architecture And Design
 
-Run the highest-signal local checks with:
+- `docs/adr/README.md`: accepted architecture decisions and why the repo is
+  shaped this way.
+- `docs/diamond-core.md`: diamond routing, cut flow, selector ownership, and
+  storage discipline.
+- `docs/vault-facets.md`: hosted vault facet split, lifecycle, and deployment
+  model.
+- `docs/threat-model.md`: trust boundaries, threat assumptions, and residual
+  risks.
+
+### Validation
+
+- `test/DiamondSelectorIntegrityCore.t.sol`: selector routing and loupe
+  integrity regressions.
+- `test/DiamondVaultDeploymentIntegration.t.sol`: hosted vault deployment,
+  init, selector ownership, and oracle wiring.
+- `test/DiamondVaultHostHardening.t.sol`: replace/remove/re-add hardening
+  across the hosted vault diamond path.
+- `test/DiamondTokenDeploymentIntegration.t.sol`: ERC20 and ERC721 host
+  deployment and selector ownership.
+- `test/SystemOracleFailureScenarios.t.sol`: stale-data, breaker, fallback, and
+  recovery behavior.
+- `test/SystemVaultStressInvariant.t.sol`: higher-signal system stress coverage
+  for vault behavior under adversarial sequences.
+
+### Deployment And Operator Evidence
+
+- `docs/security-checks.md`: current CI policy and local reproduction path.
+- `docs/ops/README.md`: operator runbooks and validation flows.
+- `docs/auralis-local.md`: local bootstrap, smoke, activity, reset, and
+  artifact layout.
+
+## Validation Path
+
+Run a bounded reviewer-facing path with:
 
 ```shell
-forge test --offline
-bash script/run-local-diamond-smoke.sh
-bash script/run-local-diamond-upgrade-rehearsal.sh
-bash script/run-local-system-hardening.sh
+forge fmt --check
+forge build --sizes --skip script
+forge test --offline --match-path test/DiamondSelectorIntegrityCore.t.sol
+forge test --offline --match-path test/DiamondVaultDeploymentIntegration.t.sol
+forge test --offline --match-path test/DiamondVaultHostHardening.t.sol
+forge test --offline --match-path test/DiamondTokenDeploymentIntegration.t.sol
+forge test --offline --match-path test/SystemOracleFailureScenarios.t.sol
+forge test --offline --match-path test/SystemVaultStressInvariant.t.sol
 ```
 
 For the local Auralis workflow:
@@ -71,31 +98,20 @@ For the local Auralis workflow:
 ```shell
 bash scripts/auralis-up.sh
 bash scripts/auralis-smoke.sh
-bash scripts/auralis-activity.sh
 bash scripts/auralis-reset.sh
 ```
 
 ## Documentation
 
-Architecture and module docs live in `docs/diamond-core.md`,
-`docs/oracle-adapter.md`, `docs/erc4626-vault.md`, `docs/vault-facets.md`,
-`docs/token-facets.md`, and `docs/threat-model.md`.
+Start with `docs/README.md` for the canonical docs map.
 
-Operational guidance lives in `docs/ops/README.md`, with the end-to-end
-execution order collected in `docs/ops/runbook-system-hardening.md`.
+Recommended reviewer path:
 
-CI and local validation parity are documented in `docs/security-checks.md`.
-
-Token-host architecture and safety assumptions live in `docs/token-facets.md`,
-including the init model, selector ownership rules, separate-host deployment
-constraint, and token-host upgrade assumptions.
-
-Hosted-vault architecture and safety assumptions live in
-`docs/vault-facets.md`, including the init model, selector ownership split,
-pause behavior, deployment references, and hosted-vault upgrade assumptions.
-
-Local Auralis bootstrap, smoke, simulated activity, reset flow, and artifact
-layout are documented in `docs/auralis-local.md`.
+- Architecture decisions: `docs/adr/README.md`
+- Core architecture: `docs/diamond-core.md`, `docs/token-facets.md`,
+  `docs/vault-facets.md`, `docs/oracle-adapter.md`
+- Security and validation: `docs/threat-model.md`, `docs/security-checks.md`
+- Operations and local workflow: `docs/ops/README.md`, `docs/auralis-local.md`
 
 ## Tooling
 


### PR DESCRIPTION
## Summary
- tighten the root README for a technical reviewer first
- add a short proof path through the strongest architecture, security, and local workflow docs
- curate the strongest validation and operator evidence directly in the README

## What Changed
- replaced the broad top-level status framing with a faster reviewer-oriented intro
- added a `Review In 5 Minutes` section with the highest-signal docs entrypoints
- added an `Evidence` section grouped into architecture, validation, and operator signals
- replaced the broad validation story with a bounded reviewer-facing repro path aligned with the current CI/test philosophy

## Validation
- `git diff --check`
- path/link sweep for curated docs, tests, and local workflow script references

## Linked Issue
Closes #153
