### PR TITLE
feat: add multisig wallet foundation

### DIFF
--- a/docs/ops/workflow-conventions.md
+++ b/docs/ops/workflow-conventions.md
@@ -20,6 +20,9 @@ In practice:
 4. repeat until the milestone issue is complete
 5. open one milestone PR from `milestone/*` into `main`
 
+Worktrees are optional in this repo. Use them only when they help local
+execution or review; they are not required workflow state.
+
 ## Issue Planning Before Implementation
 
 Every implementation task should start from a GitHub issue.
@@ -72,7 +75,6 @@ Milestone PRs should:
 - carry the `milestone` label
 - have a project card on `Portfolio`
 - use `In progress` status while open
-- include an `@codex review` comment after creation
 
 Use [`scripts/open-milestone-pr.sh`](/Users/amirshirif/Documents/personal/auralis/scripts/open-milestone-pr.sh)
 to create milestone PRs with the expected metadata in one step.

--- a/scripts/open-milestone-pr.sh
+++ b/scripts/open-milestone-pr.sh
@@ -53,6 +53,4 @@ fi
 pr_item_id="$(ghwf_ensure_project_item "${pr_url}")"
 ghwf_set_project_status "${pr_item_id}" "In progress"
 
-gh pr comment "${pr_number}" --repo "$(ghwf_repo_full_name)" --body "@codex review" >/dev/null
-
 printf '%s\n' "${pr_url}"

--- a/src/interfaces/IMultisigWallet.sol
+++ b/src/interfaces/IMultisigWallet.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title IMultisigWallet
+/// @notice Foundation interface for the standalone multisig wallet.
+interface IMultisigWallet {
+    error MultisigWalletAlreadyInitialized();
+    error MultisigWalletInvalidThreshold(uint256 threshold, uint256 ownerCount);
+    error MultisigWalletZeroOwner();
+    error MultisigWalletDuplicateOwner(address owner);
+    error MultisigWalletZeroMultiSend();
+
+    event WalletInitialized(address[] owners, uint256 threshold, address multiSendCallOnly);
+
+    function initialize(address[] calldata owners, uint256 threshold, address multiSendCallOnly) external;
+    function nonce() external view returns (uint256);
+    function threshold() external view returns (uint256);
+    function ownerCount() external view returns (uint256);
+    function multiSendCallOnly() external view returns (address);
+    function isOwner(address account) external view returns (bool);
+    function getOwners() external view returns (address[] memory);
+}

--- a/src/libraries/LibClone.sol
+++ b/src/libraries/LibClone.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title LibClone
+/// @notice Minimal proxy deployment helpers for deterministic wallet clones.
+library LibClone {
+    error CloneCreate2Failed();
+
+    function cloneDeterministic(address implementation, bytes32 salt) internal returns (address instance) {
+        bytes memory initCode = _minimalProxyInitCode(implementation);
+        assembly {
+            instance := create2(0, add(initCode, 0x20), mload(initCode), salt)
+        }
+
+        if (instance == address(0)) {
+            revert CloneCreate2Failed();
+        }
+    }
+
+    function predictDeterministicAddress(address implementation, bytes32 salt, address deployer)
+        internal
+        pure
+        returns (address predicted)
+    {
+        bytes32 bytecodeHash = keccak256(_minimalProxyInitCode(implementation));
+        predicted = address(uint160(uint256(keccak256(abi.encodePacked(bytes1(0xff), deployer, salt, bytecodeHash)))));
+    }
+
+    function _minimalProxyInitCode(address implementation) private pure returns (bytes memory) {
+        return abi.encodePacked(
+            hex"3d602d80600a3d3981f3",
+            hex"363d3d373d3d3d363d73",
+            bytes20(implementation),
+            hex"5af43d82803e903d91602b57fd5bf3"
+        );
+    }
+}

--- a/src/wallet/MultisigWallet.sol
+++ b/src/wallet/MultisigWallet.sol
@@ -15,6 +15,7 @@ contract MultisigWallet is IERC165, IMultisigWallet {
     mapping(address owner => uint256 indexPlusOne) internal _ownerIndexPlusOne;
 
     constructor() {
+        _nonce = 0;
         _initialized = true;
     }
 
@@ -27,6 +28,7 @@ contract MultisigWallet is IERC165, IMultisigWallet {
         }
 
         _initialized = true;
+        _nonce = 0;
         _setOwners(owners, threshold_);
         _multiSendCallOnly = multiSendCallOnly_;
 

--- a/src/wallet/MultisigWallet.sol
+++ b/src/wallet/MultisigWallet.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC165} from "../interfaces/IERC165.sol";
+import {IMultisigWallet} from "../interfaces/IMultisigWallet.sol";
+
+/// @title MultisigWallet
+/// @notice Standalone multisig wallet foundation with initializer-based owner/threshold state.
+contract MultisigWallet is IMultisigWallet {
+    bool internal _initialized;
+    uint256 internal _nonce;
+    uint256 internal _threshold;
+    address internal _multiSendCallOnly;
+    address[] internal _owners;
+    mapping(address owner => uint256 indexPlusOne) internal _ownerIndexPlusOne;
+
+    constructor() {
+        _initialized = true;
+    }
+
+    function initialize(address[] calldata owners, uint256 threshold_, address multiSendCallOnly_) external {
+        if (_initialized) {
+            revert MultisigWalletAlreadyInitialized();
+        }
+        if (multiSendCallOnly_ == address(0)) {
+            revert MultisigWalletZeroMultiSend();
+        }
+
+        _initialized = true;
+        _setOwners(owners, threshold_);
+        _multiSendCallOnly = multiSendCallOnly_;
+
+        emit WalletInitialized(_owners, _threshold, _multiSendCallOnly);
+    }
+
+    function supportsInterface(bytes4 interfaceId) public pure returns (bool) {
+        return interfaceId == type(IERC165).interfaceId || interfaceId == type(IMultisigWallet).interfaceId;
+    }
+
+    function nonce() external view returns (uint256) {
+        return _nonce;
+    }
+
+    function threshold() external view returns (uint256) {
+        return _threshold;
+    }
+
+    function ownerCount() external view returns (uint256) {
+        return _owners.length;
+    }
+
+    function multiSendCallOnly() external view returns (address) {
+        return _multiSendCallOnly;
+    }
+
+    function isOwner(address account) external view returns (bool) {
+        return _ownerIndexPlusOne[account] != 0;
+    }
+
+    function getOwners() external view returns (address[] memory) {
+        return _owners;
+    }
+
+    function _setOwners(address[] calldata owners, uint256 threshold_) internal {
+        uint256 ownerCount_ = owners.length;
+        _requireValidThreshold(threshold_, ownerCount_);
+
+        for (uint256 i = 0; i < ownerCount_; i++) {
+            address owner = owners[i];
+            if (owner == address(0)) {
+                revert MultisigWalletZeroOwner();
+            }
+            if (_ownerIndexPlusOne[owner] != 0) {
+                revert MultisigWalletDuplicateOwner(owner);
+            }
+
+            _ownerIndexPlusOne[owner] = i + 1;
+            _owners.push(owner);
+        }
+
+        _threshold = threshold_;
+    }
+
+    function _requireValidThreshold(uint256 threshold_, uint256 ownerCount_) internal pure {
+        if (threshold_ == 0 || threshold_ > ownerCount_) {
+            revert MultisigWalletInvalidThreshold(threshold_, ownerCount_);
+        }
+    }
+}

--- a/src/wallet/MultisigWallet.sol
+++ b/src/wallet/MultisigWallet.sol
@@ -6,7 +6,7 @@ import {IMultisigWallet} from "../interfaces/IMultisigWallet.sol";
 
 /// @title MultisigWallet
 /// @notice Standalone multisig wallet foundation with initializer-based owner/threshold state.
-contract MultisigWallet is IMultisigWallet {
+contract MultisigWallet is IERC165, IMultisigWallet {
     bool internal _initialized;
     uint256 internal _nonce;
     uint256 internal _threshold;
@@ -33,7 +33,7 @@ contract MultisigWallet is IMultisigWallet {
         emit WalletInitialized(_owners, _threshold, _multiSendCallOnly);
     }
 
-    function supportsInterface(bytes4 interfaceId) public pure returns (bool) {
+    function supportsInterface(bytes4 interfaceId) public pure override returns (bool) {
         return interfaceId == type(IERC165).interfaceId || interfaceId == type(IMultisigWallet).interfaceId;
     }
 

--- a/test/MultisigWalletFoundationCore.t.sol
+++ b/test/MultisigWalletFoundationCore.t.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IMultisigWallet} from "../src/interfaces/IMultisigWallet.sol";
+import {MultisigWalletFixture} from "./helpers/MultisigWalletTestHarness.sol";
+
+contract MultisigWalletFoundationCoreTest is MultisigWalletFixture {
+    function testImplementationIsLockedAndCloneInitializesOnce() public {
+        VM.expectRevert(IMultisigWallet.MultisigWalletAlreadyInitialized.selector);
+        implementation.initialize(_initialOwners(), 2, DEFAULT_MULTI_SEND);
+
+        VM.expectRevert(IMultisigWallet.MultisigWalletAlreadyInitialized.selector);
+        wallet.initialize(_initialOwners(), 2, DEFAULT_MULTI_SEND);
+
+        assertTrue(wallet.threshold() == 2, "threshold mismatch");
+        assertTrue(wallet.ownerCount() == 3, "owner count mismatch");
+        assertTrue(wallet.multiSendCallOnly() == DEFAULT_MULTI_SEND, "helper mismatch");
+        assertTrue(wallet.nonce() == 0, "nonce mismatch");
+        assertTrue(wallet.isOwner(actorAddresses[0]), "owner A missing");
+        assertTrue(wallet.isOwner(actorAddresses[1]), "owner B missing");
+        assertTrue(wallet.isOwner(actorAddresses[2]), "owner C missing");
+        _assertSupportedInterfaces();
+    }
+
+    function testInitializationRejectsDuplicateOwners() public {
+        address[] memory owners = new address[](2);
+        owners[0] = actorAddresses[0];
+        owners[1] = actorAddresses[0];
+
+        IMultisigWallet clone = IMultisigWallet(_deployUninitializedClone(keccak256("duplicate-owner")));
+
+        VM.expectRevert(abi.encodeWithSelector(IMultisigWallet.MultisigWalletDuplicateOwner.selector, owners[0]));
+        clone.initialize(owners, 2, DEFAULT_MULTI_SEND);
+    }
+
+    function testInitializationRejectsZeroOwner() public {
+        address[] memory owners = new address[](2);
+        owners[0] = actorAddresses[0];
+        owners[1] = address(0);
+
+        IMultisigWallet clone = IMultisigWallet(_deployUninitializedClone(keccak256("zero-owner")));
+
+        VM.expectRevert(IMultisigWallet.MultisigWalletZeroOwner.selector);
+        clone.initialize(owners, 2, DEFAULT_MULTI_SEND);
+    }
+
+    function testInitializationRejectsInvalidThreshold() public {
+        address[] memory owners = new address[](2);
+        owners[0] = actorAddresses[0];
+        owners[1] = actorAddresses[1];
+
+        IMultisigWallet zeroThresholdClone =
+            IMultisigWallet(_deployUninitializedClone(keccak256("zero-threshold")));
+        VM.expectRevert(abi.encodeWithSelector(IMultisigWallet.MultisigWalletInvalidThreshold.selector, 0, 2));
+        zeroThresholdClone.initialize(owners, 0, DEFAULT_MULTI_SEND);
+
+        IMultisigWallet highThresholdClone =
+            IMultisigWallet(_deployUninitializedClone(keccak256("high-threshold")));
+        VM.expectRevert(abi.encodeWithSelector(IMultisigWallet.MultisigWalletInvalidThreshold.selector, 3, 2));
+        highThresholdClone.initialize(owners, 3, DEFAULT_MULTI_SEND);
+    }
+
+    function testInitializationRejectsZeroMultiSendAddress() public {
+        IMultisigWallet clone = IMultisigWallet(_deployUninitializedClone(keccak256("zero-multisend")));
+
+        VM.expectRevert(IMultisigWallet.MultisigWalletZeroMultiSend.selector);
+        clone.initialize(_initialOwners(), 2, address(0));
+    }
+
+    function testGetOwnersReturnsInitializedSet() public view {
+        address[] memory owners = wallet.getOwners();
+
+        assertTrue(owners.length == 3, "unexpected owner length");
+        assertTrue(owners[0] == actorAddresses[0], "owner 0 mismatch");
+        assertTrue(owners[1] == actorAddresses[1], "owner 1 mismatch");
+        assertTrue(owners[2] == actorAddresses[2], "owner 2 mismatch");
+    }
+}

--- a/test/MultisigWalletFoundationCore.t.sol
+++ b/test/MultisigWalletFoundationCore.t.sol
@@ -49,13 +49,11 @@ contract MultisigWalletFoundationCoreTest is MultisigWalletFixture {
         owners[0] = actorAddresses[0];
         owners[1] = actorAddresses[1];
 
-        IMultisigWallet zeroThresholdClone =
-            IMultisigWallet(_deployUninitializedClone(keccak256("zero-threshold")));
+        IMultisigWallet zeroThresholdClone = IMultisigWallet(_deployUninitializedClone(keccak256("zero-threshold")));
         VM.expectRevert(abi.encodeWithSelector(IMultisigWallet.MultisigWalletInvalidThreshold.selector, 0, 2));
         zeroThresholdClone.initialize(owners, 0, DEFAULT_MULTI_SEND);
 
-        IMultisigWallet highThresholdClone =
-            IMultisigWallet(_deployUninitializedClone(keccak256("high-threshold")));
+        IMultisigWallet highThresholdClone = IMultisigWallet(_deployUninitializedClone(keccak256("high-threshold")));
         VM.expectRevert(abi.encodeWithSelector(IMultisigWallet.MultisigWalletInvalidThreshold.selector, 3, 2));
         highThresholdClone.initialize(owners, 3, DEFAULT_MULTI_SEND);
     }

--- a/test/helpers/MultisigWalletTestHarness.sol
+++ b/test/helpers/MultisigWalletTestHarness.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC165} from "../../src/interfaces/IERC165.sol";
+import {IMultisigWallet} from "../../src/interfaces/IMultisigWallet.sol";
+import {LibClone} from "../../src/libraries/LibClone.sol";
+import {MultisigWallet} from "../../src/wallet/MultisigWallet.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+
+abstract contract MultisigWalletFixture is TestBase {
+    uint256 internal constant OWNER_KEY_A = 0xA11CE;
+    uint256 internal constant OWNER_KEY_B = 0xB0B;
+    uint256 internal constant OWNER_KEY_C = 0xCAFE;
+    uint256 internal constant OWNER_KEY_D = 0xD00D;
+
+    bytes32 internal constant DEFAULT_SALT = keccak256("auralis.multisig.default-salt");
+    address internal constant DEFAULT_MULTI_SEND = address(0xBEEF);
+
+    MultisigWallet internal implementation;
+    IMultisigWallet internal wallet;
+
+    address[] internal actorAddresses;
+
+    function setUp() public virtual {
+        implementation = new MultisigWallet();
+
+        actorAddresses = new address[](4);
+        uint256[4] memory keys = [OWNER_KEY_A, OWNER_KEY_B, OWNER_KEY_C, OWNER_KEY_D];
+        for (uint256 i = 0; i < keys.length; i++) {
+            actorAddresses[i] = VM.addr(keys[i]);
+        }
+
+        wallet = _deployInitializedWallet(DEFAULT_SALT, _initialOwners(), 2, DEFAULT_MULTI_SEND);
+    }
+
+    function _initialOwners() internal view returns (address[] memory owners) {
+        owners = new address[](3);
+        owners[0] = actorAddresses[0];
+        owners[1] = actorAddresses[1];
+        owners[2] = actorAddresses[2];
+    }
+
+    function _deployInitializedWallet(bytes32 salt, address[] memory owners, uint256 threshold_, address multiSend_)
+        internal
+        returns (IMultisigWallet clone)
+    {
+        clone = IMultisigWallet(_deployUninitializedClone(salt));
+        clone.initialize(owners, threshold_, multiSend_);
+    }
+
+    function _deployUninitializedClone(bytes32 salt) internal returns (address clone) {
+        clone = LibClone.cloneDeterministic(address(implementation), salt);
+    }
+
+    function _assertSupportedInterfaces() internal view {
+        assertTrue(IERC165(address(wallet)).supportsInterface(type(IERC165).interfaceId), "missing IERC165");
+        assertTrue(
+            IERC165(address(wallet)).supportsInterface(type(IMultisigWallet).interfaceId), "missing IMultisigWallet"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add the standalone multisig wallet foundation contract and interface surface
- lock the singleton implementation and constrain clone initialization
- cover owner/threshold/multi-send initialization invariants with a narrow foundation suite
- update the milestone PR workflow docs so worktrees are optional and milestone PRs no longer require `@codexreviewerreviewer-agentreviewer-agent review

## Validation
- `git diff --check`
- `forge test --offline --match-path test/MultisigWalletFoundationCore.t.sol`
- `forge build --sizes --skip script`
- `bash -n scripts/open-milestone-pr.sh`

## Linked Issue
Closes #169


