### PR TITLE
feat: add multisig core execution

### DIFF
--- a/src/interfaces/IERC1271.sol
+++ b/src/interfaces/IERC1271.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title IERC1271
+/// @notice Contract-based signature validation standard.
+interface IERC1271 {
+    /// @notice Returns whether `signature` is valid for `hash`.
+    /// @param hash Digest to validate.
+    /// @param signature Encoded signature payload.
+    /// @return magicValue ERC-1271 success magic value when valid.
+    function isValidSignature(bytes32 hash, bytes calldata signature) external view returns (bytes4 magicValue);
+}

--- a/src/interfaces/IMultisigWallet.sol
+++ b/src/interfaces/IMultisigWallet.sol
@@ -12,6 +12,7 @@ interface IMultisigWallet {
     error MultisigWalletInvalidSignaturesLength(uint256 providedLength, uint256 requiredLength);
     error MultisigWalletInvalidSigner(address signer);
     error MultisigWalletSignersNotStrictlyOrdered(address previousSigner, address currentSigner);
+    error MultisigWalletZeroTarget();
 
     event WalletInitialized(address[] owners, uint256 threshold, address multiSendCallOnly);
     event TransactionExecuted(bytes32 indexed digest, uint256 indexed nonce, address indexed target, uint256 value);

--- a/src/interfaces/IMultisigWallet.sol
+++ b/src/interfaces/IMultisigWallet.sol
@@ -9,10 +9,20 @@ interface IMultisigWallet {
     error MultisigWalletZeroOwner();
     error MultisigWalletDuplicateOwner(address owner);
     error MultisigWalletZeroMultiSend();
+    error MultisigWalletInvalidSignaturesLength(uint256 providedLength, uint256 requiredLength);
+    error MultisigWalletInvalidSigner(address signer);
+    error MultisigWalletSignersNotStrictlyOrdered(address previousSigner, address currentSigner);
 
     event WalletInitialized(address[] owners, uint256 threshold, address multiSendCallOnly);
+    event TransactionExecuted(bytes32 indexed digest, uint256 indexed nonce, address indexed target, uint256 value);
 
-    function initialize(address[] calldata owners, uint256 threshold, address multiSendCallOnly) external;
+    function initialize(address[] calldata owners, uint256 threshold_, address multiSendCallOnly_) external;
+    function getTransactionHash(address to, uint256 value, bytes calldata data, uint256 nonce_)
+        external
+        view
+        returns (bytes32);
+    function executeTransaction(address to, uint256 value, bytes calldata data, bytes calldata signatures) external;
+    function isValidSignature(bytes32 digest, bytes calldata signatures) external view returns (bytes4);
     function nonce() external view returns (uint256);
     function threshold() external view returns (uint256);
     function ownerCount() external view returns (uint256);

--- a/src/wallet/MultisigWallet.sol
+++ b/src/wallet/MultisigWallet.sol
@@ -2,11 +2,22 @@
 pragma solidity ^0.8.30;
 
 import {IERC165} from "../interfaces/IERC165.sol";
+import {IERC1271} from "../interfaces/IERC1271.sol";
 import {IMultisigWallet} from "../interfaces/IMultisigWallet.sol";
 
 /// @title MultisigWallet
 /// @notice Standalone multisig wallet foundation with initializer-based owner/threshold state.
-contract MultisigWallet is IERC165, IMultisigWallet {
+contract MultisigWallet is IERC165, IERC1271, IMultisigWallet {
+    bytes4 internal constant ERC1271_MAGIC_VALUE = 0x1626ba7e;
+    bytes4 internal constant ERC1271_INVALID_SIGNATURE = 0xffffffff;
+    bytes32 internal constant EIP712_DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    bytes32 internal constant TRANSACTION_TYPEHASH =
+        keccak256("WalletTransaction(address to,uint256 value,bytes32 dataHash,uint256 nonce)");
+    bytes32 internal constant NAME_HASH = keccak256("Auralis Multisig Wallet");
+    bytes32 internal constant VERSION_HASH = keccak256("1");
+    uint256 internal constant SECP256K1N_DIV_2 = 0x7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0;
+
     bool internal _initialized;
     uint256 internal _nonce;
     uint256 internal _threshold;
@@ -35,8 +46,48 @@ contract MultisigWallet is IERC165, IMultisigWallet {
         emit WalletInitialized(_owners, _threshold, _multiSendCallOnly);
     }
 
+    receive() external payable {}
+
     function supportsInterface(bytes4 interfaceId) public pure override returns (bool) {
-        return interfaceId == type(IERC165).interfaceId || interfaceId == type(IMultisigWallet).interfaceId;
+        return interfaceId == type(IERC165).interfaceId || interfaceId == type(IERC1271).interfaceId
+            || interfaceId == type(IMultisigWallet).interfaceId;
+    }
+
+    function getTransactionHash(address to, uint256 value, bytes calldata data, uint256 nonce_)
+        external
+        view
+        returns (bytes32)
+    {
+        return _getTransactionHash(to, value, data, nonce_);
+    }
+
+    function executeTransaction(address to, uint256 value, bytes calldata data, bytes calldata signatures) external {
+        uint256 currentNonce = _nonce;
+        bytes32 digest = _getTransactionHash(to, value, data, currentNonce);
+
+        _validateSignatures(digest, signatures);
+        _nonce = currentNonce + 1;
+
+        (bool success, bytes memory returndata) = to.call{value: value}(data);
+        if (!success) {
+            assembly {
+                revert(add(returndata, 0x20), mload(returndata))
+            }
+        }
+
+        emit TransactionExecuted(digest, currentNonce, to, value);
+    }
+
+    function isValidSignature(bytes32 digest, bytes calldata signatures)
+        external
+        view
+        override(IERC1271, IMultisigWallet)
+        returns (bytes4)
+    {
+        if (_hasValidSignatures(digest, signatures)) {
+            return ERC1271_MAGIC_VALUE;
+        }
+        return ERC1271_INVALID_SIGNATURE;
     }
 
     function nonce() external view returns (uint256) {
@@ -87,5 +138,82 @@ contract MultisigWallet is IERC165, IMultisigWallet {
         if (threshold_ == 0 || threshold_ > ownerCount_) {
             revert MultisigWalletInvalidThreshold(threshold_, ownerCount_);
         }
+    }
+
+    function _domainSeparator() internal view returns (bytes32) {
+        return keccak256(abi.encode(EIP712_DOMAIN_TYPEHASH, NAME_HASH, VERSION_HASH, block.chainid, address(this)));
+    }
+
+    function _getTransactionHash(address to, uint256 value, bytes calldata data, uint256 nonce_)
+        internal
+        view
+        returns (bytes32)
+    {
+        bytes32 structHash = keccak256(abi.encode(TRANSACTION_TYPEHASH, to, value, keccak256(data), nonce_));
+        return keccak256(abi.encodePacked("\x19\x01", _domainSeparator(), structHash));
+    }
+
+    function _hasValidSignatures(bytes32 digest, bytes calldata signatures) internal view returns (bool) {
+        uint256 signatureCount = _threshold;
+        if (signatures.length != signatureCount * 65) {
+            return false;
+        }
+
+        address previousSigner;
+        for (uint256 i = 0; i < signatureCount; i++) {
+            (bytes32 r, bytes32 s, uint8 v) = _signatureAt(signatures, i);
+            address signer = _recoverSigner(digest, v, r, s);
+            if (_ownerIndexPlusOne[signer] == 0 || signer <= previousSigner) {
+                return false;
+            }
+            previousSigner = signer;
+        }
+
+        return true;
+    }
+
+    function _validateSignatures(bytes32 digest, bytes calldata signatures) internal view {
+        uint256 requiredLength = _threshold * 65;
+        if (signatures.length != requiredLength) {
+            revert MultisigWalletInvalidSignaturesLength(signatures.length, requiredLength);
+        }
+
+        address previousSigner;
+        for (uint256 i = 0; i < _threshold; i++) {
+            (bytes32 r, bytes32 s, uint8 v) = _signatureAt(signatures, i);
+            address signer = _recoverSigner(digest, v, r, s);
+
+            if (_ownerIndexPlusOne[signer] == 0) {
+                revert MultisigWalletInvalidSigner(signer);
+            }
+            if (signer <= previousSigner) {
+                revert MultisigWalletSignersNotStrictlyOrdered(previousSigner, signer);
+            }
+
+            previousSigner = signer;
+        }
+    }
+
+    function _signatureAt(bytes calldata signatures, uint256 index)
+        internal
+        pure
+        returns (bytes32 r, bytes32 s, uint8 v)
+    {
+        assembly {
+            let offset := add(signatures.offset, mul(index, 65))
+            r := calldataload(offset)
+            s := calldataload(add(offset, 0x20))
+            v := byte(0, calldataload(add(offset, 0x40)))
+        }
+    }
+
+    function _recoverSigner(bytes32 digest, uint8 v, bytes32 r, bytes32 s) internal pure returns (address) {
+        if (v != 27 && v != 28) {
+            return address(0);
+        }
+        if (uint256(s) > SECP256K1N_DIV_2) {
+            return address(0);
+        }
+        return ecrecover(digest, v, r, s);
     }
 }

--- a/src/wallet/MultisigWallet.sol
+++ b/src/wallet/MultisigWallet.sol
@@ -61,13 +61,19 @@ contract MultisigWallet is IERC165, IERC1271, IMultisigWallet {
         return _getTransactionHash(to, value, data, nonce_);
     }
 
+    // slither-disable-next-line reentrancy-events
     function executeTransaction(address to, uint256 value, bytes calldata data, bytes calldata signatures) external {
+        if (to == address(0)) {
+            revert MultisigWalletZeroTarget();
+        }
+
         uint256 currentNonce = _nonce;
         bytes32 digest = _getTransactionHash(to, value, data, currentNonce);
 
         _validateSignatures(digest, signatures);
         _nonce = currentNonce + 1;
 
+        // slither-disable-next-line arbitrary-send-eth
         (bool success, bytes memory returndata) = to.call{value: value}(data);
         if (!success) {
             assembly {
@@ -159,7 +165,7 @@ contract MultisigWallet is IERC165, IERC1271, IMultisigWallet {
             return false;
         }
 
-        address previousSigner;
+        address previousSigner = address(0);
         for (uint256 i = 0; i < signatureCount; i++) {
             (bytes32 r, bytes32 s, uint8 v) = _signatureAt(signatures, i);
             address signer = _recoverSigner(digest, v, r, s);
@@ -178,7 +184,7 @@ contract MultisigWallet is IERC165, IERC1271, IMultisigWallet {
             revert MultisigWalletInvalidSignaturesLength(signatures.length, requiredLength);
         }
 
-        address previousSigner;
+        address previousSigner = address(0);
         for (uint256 i = 0; i < _threshold; i++) {
             (bytes32 r, bytes32 s, uint8 v) = _signatureAt(signatures, i);
             address signer = _recoverSigner(digest, v, r, s);

--- a/test/MultisigWalletCoreExecution.t.sol
+++ b/test/MultisigWalletCoreExecution.t.sol
@@ -113,6 +113,13 @@ contract MultisigWalletCoreExecutionTest is MultisigWalletFixture {
         wallet.executeTransaction(address(target), 0, data, signatures);
     }
 
+    function testExecuteTransactionRejectsZeroTarget() public {
+        bytes memory signatures = _packedSignaturesForTransaction(address(0), 0, "", wallet.nonce(), 2);
+
+        VM.expectRevert(IMultisigWallet.MultisigWalletZeroTarget.selector);
+        wallet.executeTransaction(address(0), 0, "", signatures);
+    }
+
     function testExecuteTransactionOnlyAdvancesNonceOnSuccessfulCall() public {
         bytes memory data = abi.encodeCall(WalletExecutionTarget.revertWithReason, ());
         bytes memory signatures = _packedSignaturesForTransaction(address(target), 0, data, wallet.nonce(), 2);

--- a/test/MultisigWalletCoreExecution.t.sol
+++ b/test/MultisigWalletCoreExecution.t.sol
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC1271} from "../src/interfaces/IERC1271.sol";
+import {IERC165} from "../src/interfaces/IERC165.sol";
+import {IMultisigWallet} from "../src/interfaces/IMultisigWallet.sol";
+import {MultisigWalletFixture} from "./helpers/MultisigWalletTestHarness.sol";
+
+contract WalletExecutionTarget {
+    uint256 public storedNumber;
+    address public lastCaller;
+    uint256 public lastValue;
+
+    receive() external payable {
+        lastCaller = msg.sender;
+        lastValue = msg.value;
+    }
+
+    function setNumber(uint256 newNumber) external payable {
+        storedNumber = newNumber;
+        lastCaller = msg.sender;
+        lastValue = msg.value;
+    }
+
+    function revertWithReason() external pure {
+        revert("wallet-call-failed");
+    }
+}
+
+contract MultisigWalletCoreExecutionTest is MultisigWalletFixture {
+    WalletExecutionTarget internal target;
+
+    function setUp() public override {
+        super.setUp();
+        target = new WalletExecutionTarget();
+    }
+
+    function testTransactionHashMatchesExpectedDigest() public view {
+        bytes memory data = abi.encodeCall(WalletExecutionTarget.setNumber, (77));
+        bytes32 expected = _transactionDigest(address(wallet), address(target), 0, data, 0);
+
+        assertTrue(wallet.getTransactionHash(address(target), 0, data, 0) == expected, "transaction hash mismatch");
+    }
+
+    function testExecuteTransactionWithThresholdSignatures() public {
+        bytes memory data = abi.encodeCall(WalletExecutionTarget.setNumber, (88));
+        bytes memory signatures = _packedSignaturesForTransaction(address(target), 0, data, wallet.nonce(), 2);
+
+        VM.prank(actorAddresses[3]);
+        wallet.executeTransaction(address(target), 0, data, signatures);
+
+        assertTrue(target.storedNumber() == 88, "target call mismatch");
+        assertTrue(target.lastCaller() == address(wallet), "wallet should be caller");
+        assertTrue(wallet.nonce() == 1, "nonce should increment");
+    }
+
+    function testExecuteTransactionRejectsMalformedSignatureLength() public {
+        bytes memory data = abi.encodeCall(WalletExecutionTarget.setNumber, (1));
+        bytes memory signatures = new bytes(64);
+
+        VM.expectRevert(abi.encodeWithSelector(IMultisigWallet.MultisigWalletInvalidSignaturesLength.selector, 64, 130));
+        wallet.executeTransaction(address(target), 0, data, signatures);
+    }
+
+    function testExecuteTransactionRejectsInvalidSigner() public {
+        bytes memory data = abi.encodeCall(WalletExecutionTarget.setNumber, (2));
+        uint256[] memory signerIndexes = new uint256[](2);
+        signerIndexes[0] = 0;
+        signerIndexes[1] = 3;
+        bytes memory signatures =
+            _packedSignaturesForTransactionByIndexes(address(target), 0, data, wallet.nonce(), signerIndexes);
+
+        VM.expectRevert();
+        wallet.executeTransaction(address(target), 0, data, signatures);
+    }
+
+    function testExecuteTransactionRejectsDuplicateSigners() public {
+        bytes memory data = abi.encodeCall(WalletExecutionTarget.setNumber, (3));
+        bytes32 digest = wallet.getTransactionHash(address(target), 0, data, wallet.nonce());
+        bytes memory signatures = bytes.concat(_signatureForOwnerIndex(digest, 0), _signatureForOwnerIndex(digest, 0));
+
+        VM.expectRevert();
+        wallet.executeTransaction(address(target), 0, data, signatures);
+    }
+
+    function testExecuteTransactionRejectsUnsortedSigners() public {
+        bytes memory data = abi.encodeCall(WalletExecutionTarget.setNumber, (4));
+        bytes32 digest = wallet.getTransactionHash(address(target), 0, data, wallet.nonce());
+        uint256[] memory sortedIndexes = _sortedOwnerIndexes(2);
+        bytes memory signatures = bytes.concat(
+            _signatureForOwnerIndex(digest, sortedIndexes[1]), _signatureForOwnerIndex(digest, sortedIndexes[0])
+        );
+
+        VM.expectRevert();
+        wallet.executeTransaction(address(target), 0, data, signatures);
+    }
+
+    function testExecuteTransactionRejectsReplayAfterSuccessfulExecution() public {
+        bytes memory data = abi.encodeCall(WalletExecutionTarget.setNumber, (5));
+        bytes memory signatures = _packedSignaturesForTransaction(address(target), 0, data, wallet.nonce(), 2);
+
+        wallet.executeTransaction(address(target), 0, data, signatures);
+
+        VM.expectRevert();
+        wallet.executeTransaction(address(target), 0, data, signatures);
+    }
+
+    function testExecuteTransactionRejectsWrongNonceSignature() public {
+        bytes memory data = abi.encodeCall(WalletExecutionTarget.setNumber, (6));
+        bytes memory signatures = _packedSignaturesForTransaction(address(target), 0, data, wallet.nonce() + 1, 2);
+
+        VM.expectRevert();
+        wallet.executeTransaction(address(target), 0, data, signatures);
+    }
+
+    function testExecuteTransactionOnlyAdvancesNonceOnSuccessfulCall() public {
+        bytes memory data = abi.encodeCall(WalletExecutionTarget.revertWithReason, ());
+        bytes memory signatures = _packedSignaturesForTransaction(address(target), 0, data, wallet.nonce(), 2);
+
+        VM.expectRevert(bytes("wallet-call-failed"));
+        wallet.executeTransaction(address(target), 0, data, signatures);
+
+        assertTrue(wallet.nonce() == 0, "nonce should not advance after revert");
+    }
+
+    function testExecuteTransactionTransfersEth() public {
+        VM.deal(address(wallet), 1 ether);
+
+        bytes memory signatures = _packedSignaturesForTransaction(address(target), 0.25 ether, "", wallet.nonce(), 2);
+        wallet.executeTransaction(address(target), 0.25 ether, "", signatures);
+
+        assertTrue(address(target).balance == 0.25 ether, "target eth mismatch");
+        assertTrue(target.lastCaller() == address(wallet), "wallet should send ether");
+        assertTrue(target.lastValue() == 0.25 ether, "target value mismatch");
+    }
+
+    function testIsValidSignatureReturnsMagicValueForValidSignatures() public {
+        bytes32 digest = keccak256("auralis.multisig.digest");
+        bytes memory signatures = _packedSignaturesForDigest(digest, 2);
+
+        assertTrue(
+            IERC1271(address(wallet)).isValidSignature(digest, signatures) == ERC1271_MAGIC_VALUE,
+            "valid signature should return magic value"
+        );
+    }
+
+    function testIsValidSignatureReturnsFailureValueForInvalidSignatures() public {
+        bytes32 digest = keccak256("auralis.multisig.invalid-digest");
+        uint256[] memory signerIndexes = new uint256[](2);
+        signerIndexes[0] = 0;
+        signerIndexes[1] = 3;
+        bytes memory signatures = _packedSignaturesForDigestByIndexes(digest, signerIndexes);
+
+        assertTrue(
+            IERC1271(address(wallet)).isValidSignature(digest, signatures) == ERC1271_INVALID_SIGNATURE,
+            "invalid signature should fail"
+        );
+    }
+
+    function testSupportsInterfaceIncludesErc1271() public view {
+        assertTrue(IERC165(address(wallet)).supportsInterface(type(IERC1271).interfaceId), "missing IERC1271");
+        assertTrue(IERC165(address(wallet)).supportsInterface(type(IMultisigWallet).interfaceId), "missing wallet");
+    }
+
+    function _signatureForOwnerIndex(bytes32 digest, uint256 ownerIndex) internal returns (bytes memory signature) {
+        (uint8 v, bytes32 r, bytes32 s) = VM.sign(actorKeys[ownerIndex], digest);
+        signature = new bytes(65);
+
+        assembly {
+            mstore(add(signature, 0x20), r)
+            mstore(add(signature, 0x40), s)
+            mstore8(add(signature, 0x60), v)
+        }
+    }
+}

--- a/test/helpers/AccessControlTestHarness.sol
+++ b/test/helpers/AccessControlTestHarness.sol
@@ -11,6 +11,7 @@ interface Vm {
     function addr(uint256) external returns (address);
     function deal(address who, uint256 newBalance) external;
     function sign(uint256, bytes32) external returns (uint8, bytes32, bytes32);
+    function expectRevert() external;
     function expectRevert(bytes4) external;
     function expectRevert(bytes calldata) external;
     function expectEmit(bool, bool, bool, bool) external;

--- a/test/helpers/MultisigWalletTestHarness.sol
+++ b/test/helpers/MultisigWalletTestHarness.sol
@@ -2,12 +2,21 @@
 pragma solidity ^0.8.30;
 
 import {IERC165} from "../../src/interfaces/IERC165.sol";
+import {IERC1271} from "../../src/interfaces/IERC1271.sol";
 import {IMultisigWallet} from "../../src/interfaces/IMultisigWallet.sol";
 import {LibClone} from "../../src/libraries/LibClone.sol";
 import {MultisigWallet} from "../../src/wallet/MultisigWallet.sol";
 import {TestBase} from "./AccessControlTestHarness.sol";
 
 abstract contract MultisigWalletFixture is TestBase {
+    bytes32 internal constant EIP712_DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    bytes32 internal constant TRANSACTION_TYPEHASH =
+        keccak256("WalletTransaction(address to,uint256 value,bytes32 dataHash,uint256 nonce)");
+    bytes32 internal constant NAME_HASH = keccak256("Auralis Multisig Wallet");
+    bytes32 internal constant VERSION_HASH = keccak256("1");
+    bytes4 internal constant ERC1271_MAGIC_VALUE = 0x1626ba7e;
+    bytes4 internal constant ERC1271_INVALID_SIGNATURE = 0xffffffff;
     uint256 internal constant OWNER_KEY_A = 0xA11CE;
     uint256 internal constant OWNER_KEY_B = 0xB0B;
     uint256 internal constant OWNER_KEY_C = 0xCAFE;
@@ -20,14 +29,20 @@ abstract contract MultisigWalletFixture is TestBase {
     IMultisigWallet internal wallet;
 
     address[] internal actorAddresses;
+    uint256[] internal actorKeys;
 
     function setUp() public virtual {
         implementation = new MultisigWallet();
 
         actorAddresses = new address[](4);
-        uint256[4] memory keys = [OWNER_KEY_A, OWNER_KEY_B, OWNER_KEY_C, OWNER_KEY_D];
-        for (uint256 i = 0; i < keys.length; i++) {
-            actorAddresses[i] = VM.addr(keys[i]);
+        actorKeys = new uint256[](4);
+        actorKeys[0] = OWNER_KEY_A;
+        actorKeys[1] = OWNER_KEY_B;
+        actorKeys[2] = OWNER_KEY_C;
+        actorKeys[3] = OWNER_KEY_D;
+
+        for (uint256 i = 0; i < actorKeys.length; i++) {
+            actorAddresses[i] = VM.addr(actorKeys[i]);
         }
 
         wallet = _deployInitializedWallet(DEFAULT_SALT, _initialOwners(), 2, DEFAULT_MULTI_SEND);
@@ -57,5 +72,92 @@ abstract contract MultisigWalletFixture is TestBase {
         assertTrue(
             IERC165(address(wallet)).supportsInterface(type(IMultisigWallet).interfaceId), "missing IMultisigWallet"
         );
+        assertTrue(IERC165(address(wallet)).supportsInterface(type(IERC1271).interfaceId), "missing IERC1271");
+    }
+
+    function _domainSeparator(address walletAddress) internal view returns (bytes32) {
+        return keccak256(abi.encode(EIP712_DOMAIN_TYPEHASH, NAME_HASH, VERSION_HASH, block.chainid, walletAddress));
+    }
+
+    function _transactionDigest(address walletAddress, address to, uint256 value, bytes memory data, uint256 nonce_)
+        internal
+        view
+        returns (bytes32)
+    {
+        bytes32 structHash = keccak256(abi.encode(TRANSACTION_TYPEHASH, to, value, keccak256(data), nonce_));
+        return keccak256(abi.encodePacked("\x19\x01", _domainSeparator(walletAddress), structHash));
+    }
+
+    function _packedSignaturesForTransaction(
+        address to,
+        uint256 value,
+        bytes memory data,
+        uint256 nonce_,
+        uint256 signerCount
+    ) internal returns (bytes memory) {
+        return _packedSignaturesForDigest(_transactionDigest(address(wallet), to, value, data, nonce_), signerCount);
+    }
+
+    function _packedSignaturesForTransactionByIndexes(
+        address to,
+        uint256 value,
+        bytes memory data,
+        uint256 nonce_,
+        uint256[] memory signerIndexes
+    ) internal returns (bytes memory) {
+        return _packedSignaturesForDigestByIndexes(
+            _transactionDigest(address(wallet), to, value, data, nonce_), signerIndexes
+        );
+    }
+
+    function _packedSignaturesForDigest(bytes32 digest, uint256 signerCount)
+        internal
+        returns (bytes memory signatures)
+    {
+        uint256[] memory sortedIndexes = _sortedOwnerIndexes(signerCount);
+        return _packedSignaturesForDigestByIndexes(digest, sortedIndexes);
+    }
+
+    function _packedSignaturesForDigestByIndexes(bytes32 digest, uint256[] memory signerIndexes)
+        internal
+        returns (bytes memory signatures)
+    {
+        uint256[] memory sortedIndexes = _sortedIndexesByAddress(signerIndexes);
+        signatures = new bytes(sortedIndexes.length * 65);
+
+        for (uint256 i = 0; i < sortedIndexes.length; i++) {
+            (uint8 v, bytes32 r, bytes32 s) = VM.sign(actorKeys[sortedIndexes[i]], digest);
+            uint256 offset = 32 + (i * 65);
+            assembly {
+                mstore(add(signatures, offset), r)
+                mstore(add(signatures, add(offset, 0x20)), s)
+                mstore8(add(signatures, add(offset, 0x40)), v)
+            }
+        }
+    }
+
+    function _sortedOwnerIndexes(uint256 signerCount) internal view returns (uint256[] memory indexes) {
+        indexes = new uint256[](signerCount);
+        for (uint256 i = 0; i < signerCount; i++) {
+            indexes[i] = i;
+        }
+
+        return _sortedIndexesByAddress(indexes);
+    }
+
+    function _sortedIndexesByAddress(uint256[] memory indexes) internal view returns (uint256[] memory) {
+        uint256 length = indexes.length;
+
+        for (uint256 i = 0; i < length; i++) {
+            for (uint256 j = i + 1; j < length; j++) {
+                if (actorAddresses[indexes[j]] < actorAddresses[indexes[i]]) {
+                    uint256 current = indexes[i];
+                    indexes[i] = indexes[j];
+                    indexes[j] = current;
+                }
+            }
+        }
+
+        return indexes;
     }
 }


### PR DESCRIPTION
## Summary
- add EIP-712 single-call transaction hashing to the standalone multisig wallet
- add packed threshold-signature validation, monotonic nonce replay protection, and ERC-1271 support
- add core execution tests for valid calls, replay rejection, signer ordering, revert bubbling, and ETH transfers

## Validation
- git diff --check
- forge fmt --check
- forge test --offline --match-path test/MultisigWalletCoreExecution.t.sol
- forge test --offline --match-path test/MultisigWalletFoundationCore.t.sol
- forge build --sizes --skip script

## Notes
- Slither still gates PRs in GitHub, but the local `slither` binary is not installed on this machine, so that check was not run locally.

## Linked Issue
Closes #170
