### PR TITLE
Add multisig batch execution and factory deployment

### DIFF
--- a/src/interfaces/IMultiSendCallOnly.sol
+++ b/src/interfaces/IMultiSendCallOnly.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title IMultiSendCallOnly
+/// @notice Delegatecall helper for atomic call-only batch execution from a wallet context.
+interface IMultiSendCallOnly {
+    error MultiSendCallOnlyEmptyBatch();
+    error MultiSendCallOnlyInvalidEncoding(uint256 offset);
+    error MultiSendCallOnlyZeroTarget(uint256 transactionIndex);
+
+    /// @notice Executes concatenated call-only transactions.
+    /// @dev Each transaction is encoded as:
+    ///      - 20 bytes target
+    ///      - 32 bytes value
+    ///      - 32 bytes calldata length
+    ///      - N bytes calldata
+    function multiSend(bytes calldata transactions) external;
+}

--- a/src/interfaces/IMultisigWallet.sol
+++ b/src/interfaces/IMultisigWallet.sol
@@ -16,13 +16,16 @@ interface IMultisigWallet {
 
     event WalletInitialized(address[] owners, uint256 threshold, address multiSendCallOnly);
     event TransactionExecuted(bytes32 indexed digest, uint256 indexed nonce, address indexed target, uint256 value);
+    event BatchExecuted(bytes32 indexed digest, uint256 indexed nonce);
 
     function initialize(address[] calldata owners, uint256 threshold_, address multiSendCallOnly_) external;
     function getTransactionHash(address to, uint256 value, bytes calldata data, uint256 nonce_)
         external
         view
         returns (bytes32);
+    function getBatchHash(bytes calldata transactions, uint256 nonce_) external view returns (bytes32);
     function executeTransaction(address to, uint256 value, bytes calldata data, bytes calldata signatures) external;
+    function executeBatch(bytes calldata transactions, bytes calldata signatures) external;
     function isValidSignature(bytes32 digest, bytes calldata signatures) external view returns (bytes4);
     function nonce() external view returns (uint256);
     function threshold() external view returns (uint256);

--- a/src/interfaces/IMultisigWalletFactory.sol
+++ b/src/interfaces/IMultisigWalletFactory.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title IMultisigWalletFactory
+/// @notice Deterministic clone deployment surface for standalone multisig wallets.
+interface IMultisigWalletFactory {
+    error MultisigWalletFactoryZeroImplementation();
+
+    event WalletDeployed(address indexed wallet, address indexed implementation, bytes32 indexed salt);
+
+    function implementation() external view returns (address);
+    function deployWallet(bytes32 salt, address[] calldata owners, uint256 threshold_, address multiSendCallOnly_)
+        external
+        returns (address wallet);
+    function predictWalletAddress(bytes32 salt) external view returns (address predicted);
+}

--- a/src/wallet/MultiSendCallOnly.sol
+++ b/src/wallet/MultiSendCallOnly.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IMultiSendCallOnly} from "../interfaces/IMultiSendCallOnly.sol";
+
+/// @title MultiSendCallOnly
+/// @notice Executes atomic call-only batches when delegatecalled from a wallet.
+contract MultiSendCallOnly is IMultiSendCallOnly {
+    function multiSend(bytes calldata transactions) external {
+        uint256 totalLength = transactions.length;
+        if (totalLength == 0) {
+            revert MultiSendCallOnlyEmptyBatch();
+        }
+
+        uint256 cursor;
+        uint256 txIndex;
+        while (cursor < totalLength) {
+            if (totalLength - cursor < 84) {
+                revert MultiSendCallOnlyInvalidEncoding(cursor);
+            }
+
+            address to;
+            uint256 value;
+            uint256 dataLength;
+            assembly {
+                let base := add(transactions.offset, cursor)
+                to := shr(96, calldataload(base))
+                value := calldataload(add(base, 20))
+                dataLength := calldataload(add(base, 52))
+            }
+
+            if (to == address(0)) {
+                revert MultiSendCallOnlyZeroTarget(txIndex);
+            }
+
+            cursor += 84;
+            if (totalLength - cursor < dataLength) {
+                revert MultiSendCallOnlyInvalidEncoding(cursor);
+            }
+
+            bytes calldata data = transactions[cursor:cursor + dataLength];
+            // slither-disable-next-line arbitrary-send-eth
+            (bool success, bytes memory returndata) = to.call{value: value}(data);
+            if (!success) {
+                assembly {
+                    revert(add(returndata, 0x20), mload(returndata))
+                }
+            }
+
+            cursor += dataLength;
+            txIndex++;
+        }
+    }
+}

--- a/src/wallet/MultisigWallet.sol
+++ b/src/wallet/MultisigWallet.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.30;
 
 import {IERC165} from "../interfaces/IERC165.sol";
 import {IERC1271} from "../interfaces/IERC1271.sol";
+import {IMultiSendCallOnly} from "../interfaces/IMultiSendCallOnly.sol";
 import {IMultisigWallet} from "../interfaces/IMultisigWallet.sol";
 
 /// @title MultisigWallet
@@ -14,6 +15,7 @@ contract MultisigWallet is IERC165, IERC1271, IMultisigWallet {
         keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
     bytes32 internal constant TRANSACTION_TYPEHASH =
         keccak256("WalletTransaction(address to,uint256 value,bytes32 dataHash,uint256 nonce)");
+    bytes32 internal constant BATCH_TYPEHASH = keccak256("WalletBatch(bytes32 transactionsHash,uint256 nonce)");
     bytes32 internal constant NAME_HASH = keccak256("Auralis Multisig Wallet");
     bytes32 internal constant VERSION_HASH = keccak256("1");
     uint256 internal constant SECP256K1N_DIV_2 = 0x7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0;
@@ -61,6 +63,10 @@ contract MultisigWallet is IERC165, IERC1271, IMultisigWallet {
         return _getTransactionHash(to, value, data, nonce_);
     }
 
+    function getBatchHash(bytes calldata transactions, uint256 nonce_) external view returns (bytes32) {
+        return _getBatchHash(transactions, nonce_);
+    }
+
     // slither-disable-next-line reentrancy-events
     function executeTransaction(address to, uint256 value, bytes calldata data, bytes calldata signatures) external {
         if (to == address(0)) {
@@ -82,6 +88,26 @@ contract MultisigWallet is IERC165, IERC1271, IMultisigWallet {
         }
 
         emit TransactionExecuted(digest, currentNonce, to, value);
+    }
+
+    // slither-disable-next-line reentrancy-events
+    function executeBatch(bytes calldata transactions, bytes calldata signatures) external {
+        uint256 currentNonce = _nonce;
+        bytes32 digest = _getBatchHash(transactions, currentNonce);
+
+        _validateSignatures(digest, signatures);
+        _nonce = currentNonce + 1;
+
+        // slither-disable-next-line controlled-delegatecall
+        (bool success, bytes memory returndata) =
+            _multiSendCallOnly.delegatecall(abi.encodeCall(IMultiSendCallOnly.multiSend, (transactions)));
+        if (!success) {
+            assembly {
+                revert(add(returndata, 0x20), mload(returndata))
+            }
+        }
+
+        emit BatchExecuted(digest, currentNonce);
     }
 
     function isValidSignature(bytes32 digest, bytes calldata signatures)
@@ -156,6 +182,11 @@ contract MultisigWallet is IERC165, IERC1271, IMultisigWallet {
         returns (bytes32)
     {
         bytes32 structHash = keccak256(abi.encode(TRANSACTION_TYPEHASH, to, value, keccak256(data), nonce_));
+        return keccak256(abi.encodePacked("\x19\x01", _domainSeparator(), structHash));
+    }
+
+    function _getBatchHash(bytes calldata transactions, uint256 nonce_) internal view returns (bytes32) {
+        bytes32 structHash = keccak256(abi.encode(BATCH_TYPEHASH, keccak256(transactions), nonce_));
         return keccak256(abi.encodePacked("\x19\x01", _domainSeparator(), structHash));
     }
 

--- a/src/wallet/MultisigWalletFactory.sol
+++ b/src/wallet/MultisigWalletFactory.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IMultisigWallet} from "../interfaces/IMultisigWallet.sol";
+import {IMultisigWalletFactory} from "../interfaces/IMultisigWalletFactory.sol";
+import {LibClone} from "../libraries/LibClone.sol";
+
+/// @title MultisigWalletFactory
+/// @notice Deterministic clone deployment for standalone multisig wallets.
+contract MultisigWalletFactory is IMultisigWalletFactory {
+    address public immutable implementation;
+
+    constructor(address implementation_) {
+        if (implementation_ == address(0)) {
+            revert MultisigWalletFactoryZeroImplementation();
+        }
+
+        implementation = implementation_;
+    }
+
+    function deployWallet(bytes32 salt, address[] calldata owners, uint256 threshold_, address multiSendCallOnly_)
+        external
+        returns (address wallet)
+    {
+        wallet = LibClone.cloneDeterministic(implementation, salt);
+        IMultisigWallet(wallet).initialize(owners, threshold_, multiSendCallOnly_);
+
+        emit WalletDeployed(wallet, implementation, salt);
+    }
+
+    function predictWalletAddress(bytes32 salt) external view returns (address predicted) {
+        return LibClone.predictDeterministicAddress(implementation, salt, address(this));
+    }
+}

--- a/test/MultisigWalletFoundationCore.t.sol
+++ b/test/MultisigWalletFoundationCore.t.sol
@@ -7,14 +7,14 @@ import {MultisigWalletFixture} from "./helpers/MultisigWalletTestHarness.sol";
 contract MultisigWalletFoundationCoreTest is MultisigWalletFixture {
     function testImplementationIsLockedAndCloneInitializesOnce() public {
         VM.expectRevert(IMultisigWallet.MultisigWalletAlreadyInitialized.selector);
-        implementation.initialize(_initialOwners(), 2, DEFAULT_MULTI_SEND);
+        implementation.initialize(_initialOwners(), 2, defaultMultiSend);
 
         VM.expectRevert(IMultisigWallet.MultisigWalletAlreadyInitialized.selector);
-        wallet.initialize(_initialOwners(), 2, DEFAULT_MULTI_SEND);
+        wallet.initialize(_initialOwners(), 2, defaultMultiSend);
 
         assertTrue(wallet.threshold() == 2, "threshold mismatch");
         assertTrue(wallet.ownerCount() == 3, "owner count mismatch");
-        assertTrue(wallet.multiSendCallOnly() == DEFAULT_MULTI_SEND, "helper mismatch");
+        assertTrue(wallet.multiSendCallOnly() == defaultMultiSend, "helper mismatch");
         assertTrue(wallet.nonce() == 0, "nonce mismatch");
         assertTrue(wallet.isOwner(actorAddresses[0]), "owner A missing");
         assertTrue(wallet.isOwner(actorAddresses[1]), "owner B missing");
@@ -30,7 +30,7 @@ contract MultisigWalletFoundationCoreTest is MultisigWalletFixture {
         IMultisigWallet clone = IMultisigWallet(_deployUninitializedClone(keccak256("duplicate-owner")));
 
         VM.expectRevert(abi.encodeWithSelector(IMultisigWallet.MultisigWalletDuplicateOwner.selector, owners[0]));
-        clone.initialize(owners, 2, DEFAULT_MULTI_SEND);
+        clone.initialize(owners, 2, defaultMultiSend);
     }
 
     function testInitializationRejectsZeroOwner() public {
@@ -41,7 +41,7 @@ contract MultisigWalletFoundationCoreTest is MultisigWalletFixture {
         IMultisigWallet clone = IMultisigWallet(_deployUninitializedClone(keccak256("zero-owner")));
 
         VM.expectRevert(IMultisigWallet.MultisigWalletZeroOwner.selector);
-        clone.initialize(owners, 2, DEFAULT_MULTI_SEND);
+        clone.initialize(owners, 2, defaultMultiSend);
     }
 
     function testInitializationRejectsInvalidThreshold() public {
@@ -51,11 +51,11 @@ contract MultisigWalletFoundationCoreTest is MultisigWalletFixture {
 
         IMultisigWallet zeroThresholdClone = IMultisigWallet(_deployUninitializedClone(keccak256("zero-threshold")));
         VM.expectRevert(abi.encodeWithSelector(IMultisigWallet.MultisigWalletInvalidThreshold.selector, 0, 2));
-        zeroThresholdClone.initialize(owners, 0, DEFAULT_MULTI_SEND);
+        zeroThresholdClone.initialize(owners, 0, defaultMultiSend);
 
         IMultisigWallet highThresholdClone = IMultisigWallet(_deployUninitializedClone(keccak256("high-threshold")));
         VM.expectRevert(abi.encodeWithSelector(IMultisigWallet.MultisigWalletInvalidThreshold.selector, 3, 2));
-        highThresholdClone.initialize(owners, 3, DEFAULT_MULTI_SEND);
+        highThresholdClone.initialize(owners, 3, defaultMultiSend);
     }
 
     function testInitializationRejectsZeroMultiSendAddress() public {

--- a/test/MultisigWalletIntegration.t.sol
+++ b/test/MultisigWalletIntegration.t.sol
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IMultiSendCallOnly} from "../src/interfaces/IMultiSendCallOnly.sol";
+import {IMultisigWallet} from "../src/interfaces/IMultisigWallet.sol";
+import {IMultisigWalletFactory} from "../src/interfaces/IMultisigWalletFactory.sol";
+import {LibClone} from "../src/libraries/LibClone.sol";
+import {MultisigWalletFactory} from "../src/wallet/MultisigWalletFactory.sol";
+import {MultisigWalletFixture} from "./helpers/MultisigWalletTestHarness.sol";
+
+contract BatchExecutionTarget {
+    uint256 public storedNumber;
+    address public lastCaller;
+    uint256 public lastValue;
+
+    receive() external payable {
+        lastCaller = msg.sender;
+        lastValue = msg.value;
+    }
+
+    function setNumber(uint256 newNumber) external payable {
+        storedNumber = newNumber;
+        lastCaller = msg.sender;
+        lastValue = msg.value;
+    }
+
+    function revertWithReason() external pure {
+        revert("wallet-call-failed");
+    }
+}
+
+contract MultisigWalletIntegrationTest is MultisigWalletFixture {
+    MultisigWalletFactory internal factory;
+    BatchExecutionTarget internal firstTarget;
+    BatchExecutionTarget internal secondTarget;
+
+    function setUp() public override {
+        super.setUp();
+
+        factory = new MultisigWalletFactory(address(implementation));
+        firstTarget = new BatchExecutionTarget();
+        secondTarget = new BatchExecutionTarget();
+    }
+
+    function testBatchHashMatchesExpectedDigest() public view {
+        bytes memory transactions = bytes.concat(
+            _encodeBatchEntry(address(firstTarget), 0, abi.encodeCall(BatchExecutionTarget.setNumber, (11))),
+            _encodeBatchEntry(address(secondTarget), 0, abi.encodeCall(BatchExecutionTarget.setNumber, (22)))
+        );
+
+        assertTrue(
+            wallet.getBatchHash(transactions, 0) == _batchDigest(address(wallet), transactions, 0), "hash mismatch"
+        );
+    }
+
+    function testExecuteBatchCallsMultipleTargetsAndAdvancesNonce() public {
+        bytes memory transactions = bytes.concat(
+            _encodeBatchEntry(address(firstTarget), 0, abi.encodeCall(BatchExecutionTarget.setNumber, (11))),
+            _encodeBatchEntry(address(secondTarget), 0, abi.encodeCall(BatchExecutionTarget.setNumber, (22)))
+        );
+        bytes memory signatures = _packedSignaturesForBatch(transactions, wallet.nonce(), 2);
+
+        wallet.executeBatch(transactions, signatures);
+
+        assertTrue(firstTarget.storedNumber() == 11, "first target mismatch");
+        assertTrue(secondTarget.storedNumber() == 22, "second target mismatch");
+        assertTrue(firstTarget.lastCaller() == address(wallet), "wallet should call first target");
+        assertTrue(secondTarget.lastCaller() == address(wallet), "wallet should call second target");
+        assertTrue(wallet.nonce() == 1, "nonce should increment");
+    }
+
+    function testExecuteBatchTransfersEthToMultipleTargets() public {
+        VM.deal(address(wallet), 1 ether);
+
+        bytes memory transactions = bytes.concat(
+            _encodeBatchEntry(address(firstTarget), 0.2 ether, ""),
+            _encodeBatchEntry(address(secondTarget), 0.3 ether, "")
+        );
+        bytes memory signatures = _packedSignaturesForBatch(transactions, wallet.nonce(), 2);
+
+        wallet.executeBatch(transactions, signatures);
+
+        assertTrue(address(firstTarget).balance == 0.2 ether, "first target balance mismatch");
+        assertTrue(address(secondTarget).balance == 0.3 ether, "second target balance mismatch");
+        assertTrue(firstTarget.lastValue() == 0.2 ether, "first target value mismatch");
+        assertTrue(secondTarget.lastValue() == 0.3 ether, "second target value mismatch");
+    }
+
+    function testExecuteBatchBubblesTargetRevertAndPreservesNonce() public {
+        bytes memory transactions = bytes.concat(
+            _encodeBatchEntry(address(firstTarget), 0, abi.encodeCall(BatchExecutionTarget.setNumber, (11))),
+            _encodeBatchEntry(address(secondTarget), 0, abi.encodeCall(BatchExecutionTarget.revertWithReason, ()))
+        );
+        bytes memory signatures = _packedSignaturesForBatch(transactions, wallet.nonce(), 2);
+
+        VM.expectRevert(bytes("wallet-call-failed"));
+        wallet.executeBatch(transactions, signatures);
+
+        assertTrue(wallet.nonce() == 0, "nonce should not advance");
+        assertTrue(firstTarget.storedNumber() == 0, "batch should revert atomically");
+    }
+
+    function testExecuteBatchRejectsMalformedEncoding() public {
+        bytes memory transactions =
+            bytes.concat(bytes20(address(firstTarget)), bytes32(uint256(0)), bytes32(uint256(3)));
+        bytes memory signatures = _packedSignaturesForBatch(transactions, wallet.nonce(), 2);
+
+        VM.expectRevert();
+        wallet.executeBatch(transactions, signatures);
+    }
+
+    function testExecuteBatchRejectsZeroTargetEntry() public {
+        bytes memory transactions = _encodeBatchEntry(address(0), 0, "");
+        bytes memory signatures = _packedSignaturesForBatch(transactions, wallet.nonce(), 2);
+
+        VM.expectRevert(abi.encodeWithSelector(IMultiSendCallOnly.MultiSendCallOnlyZeroTarget.selector, 0));
+        wallet.executeBatch(transactions, signatures);
+    }
+
+    function testFactoryPredictsDeterministicAddress() public view {
+        bytes32 salt = keccak256("auralis.multisig.factory-wallet");
+        address expected = LibClone.predictDeterministicAddress(address(implementation), salt, address(factory));
+
+        assertTrue(factory.predictWalletAddress(salt) == expected, "predicted address mismatch");
+    }
+
+    function testFactoryDeploysAndInitializesWallet() public {
+        bytes32 salt = keccak256("auralis.multisig.factory-initialize");
+        address expected = factory.predictWalletAddress(salt);
+
+        address deployed = factory.deployWallet(salt, _initialOwners(), 2, defaultMultiSend);
+        IMultisigWallet deployedWallet = IMultisigWallet(deployed);
+
+        assertTrue(deployed == expected, "deployed wallet mismatch");
+        assertTrue(deployedWallet.threshold() == 2, "threshold mismatch");
+        assertTrue(deployedWallet.ownerCount() == 3, "owner count mismatch");
+        assertTrue(deployedWallet.multiSendCallOnly() == defaultMultiSend, "helper mismatch");
+    }
+
+    function testFactoryDeployedWalletExecutesSignedSingleCall() public {
+        bytes32 salt = keccak256("auralis.multisig.factory-single-call");
+        IMultisigWallet deployedWallet =
+            IMultisigWallet(factory.deployWallet(salt, _initialOwners(), 2, defaultMultiSend));
+
+        bytes memory data = abi.encodeCall(BatchExecutionTarget.setNumber, (33));
+        bytes memory signatures =
+            _packedSignaturesForTransactionAtWallet(address(deployedWallet), address(firstTarget), 0, data, 0, 2);
+
+        deployedWallet.executeTransaction(address(firstTarget), 0, data, signatures);
+
+        assertTrue(firstTarget.storedNumber() == 33, "single-call target mismatch");
+        assertTrue(deployedWallet.nonce() == 1, "single-call nonce mismatch");
+    }
+
+    function testFactoryDeployedWalletExecutesSignedBatch() public {
+        bytes32 salt = keccak256("auralis.multisig.factory-batch-call");
+        IMultisigWallet deployedWallet =
+            IMultisigWallet(factory.deployWallet(salt, _initialOwners(), 2, defaultMultiSend));
+
+        bytes memory transactions = bytes.concat(
+            _encodeBatchEntry(address(firstTarget), 0, abi.encodeCall(BatchExecutionTarget.setNumber, (44))),
+            _encodeBatchEntry(address(secondTarget), 0, abi.encodeCall(BatchExecutionTarget.setNumber, (55)))
+        );
+        bytes memory signatures = _packedSignaturesForBatchAtWallet(address(deployedWallet), transactions, 0, 2);
+
+        deployedWallet.executeBatch(transactions, signatures);
+
+        assertTrue(firstTarget.storedNumber() == 44, "first batch target mismatch");
+        assertTrue(secondTarget.storedNumber() == 55, "second batch target mismatch");
+        assertTrue(deployedWallet.nonce() == 1, "batch nonce mismatch");
+    }
+
+    function testFactoryRejectsZeroImplementation() public {
+        VM.expectRevert(IMultisigWalletFactory.MultisigWalletFactoryZeroImplementation.selector);
+        new MultisigWalletFactory(address(0));
+    }
+}

--- a/test/helpers/MultisigWalletTestHarness.sol
+++ b/test/helpers/MultisigWalletTestHarness.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.30;
 import {IERC165} from "../../src/interfaces/IERC165.sol";
 import {IERC1271} from "../../src/interfaces/IERC1271.sol";
 import {IMultisigWallet} from "../../src/interfaces/IMultisigWallet.sol";
+import {MultiSendCallOnly} from "../../src/wallet/MultiSendCallOnly.sol";
 import {LibClone} from "../../src/libraries/LibClone.sol";
 import {MultisigWallet} from "../../src/wallet/MultisigWallet.sol";
 import {TestBase} from "./AccessControlTestHarness.sol";
@@ -13,6 +14,7 @@ abstract contract MultisigWalletFixture is TestBase {
         keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
     bytes32 internal constant TRANSACTION_TYPEHASH =
         keccak256("WalletTransaction(address to,uint256 value,bytes32 dataHash,uint256 nonce)");
+    bytes32 internal constant BATCH_TYPEHASH = keccak256("WalletBatch(bytes32 transactionsHash,uint256 nonce)");
     bytes32 internal constant NAME_HASH = keccak256("Auralis Multisig Wallet");
     bytes32 internal constant VERSION_HASH = keccak256("1");
     bytes4 internal constant ERC1271_MAGIC_VALUE = 0x1626ba7e;
@@ -23,16 +25,19 @@ abstract contract MultisigWalletFixture is TestBase {
     uint256 internal constant OWNER_KEY_D = 0xD00D;
 
     bytes32 internal constant DEFAULT_SALT = keccak256("auralis.multisig.default-salt");
-    address internal constant DEFAULT_MULTI_SEND = address(0xBEEF);
 
     MultisigWallet internal implementation;
+    MultiSendCallOnly internal multiSendCallOnly;
     IMultisigWallet internal wallet;
 
     address[] internal actorAddresses;
     uint256[] internal actorKeys;
+    address internal defaultMultiSend;
 
     function setUp() public virtual {
         implementation = new MultisigWallet();
+        multiSendCallOnly = new MultiSendCallOnly();
+        defaultMultiSend = address(multiSendCallOnly);
 
         actorAddresses = new address[](4);
         actorKeys = new uint256[](4);
@@ -45,7 +50,7 @@ abstract contract MultisigWalletFixture is TestBase {
             actorAddresses[i] = VM.addr(actorKeys[i]);
         }
 
-        wallet = _deployInitializedWallet(DEFAULT_SALT, _initialOwners(), 2, DEFAULT_MULTI_SEND);
+        wallet = _deployInitializedWallet(DEFAULT_SALT, _initialOwners(), 2, defaultMultiSend);
     }
 
     function _initialOwners() internal view returns (address[] memory owners) {
@@ -88,6 +93,15 @@ abstract contract MultisigWalletFixture is TestBase {
         return keccak256(abi.encodePacked("\x19\x01", _domainSeparator(walletAddress), structHash));
     }
 
+    function _batchDigest(address walletAddress, bytes memory transactions, uint256 nonce_)
+        internal
+        view
+        returns (bytes32)
+    {
+        bytes32 structHash = keccak256(abi.encode(BATCH_TYPEHASH, keccak256(transactions), nonce_));
+        return keccak256(abi.encodePacked("\x19\x01", _domainSeparator(walletAddress), structHash));
+    }
+
     function _packedSignaturesForTransaction(
         address to,
         uint256 value,
@@ -95,7 +109,7 @@ abstract contract MultisigWalletFixture is TestBase {
         uint256 nonce_,
         uint256 signerCount
     ) internal returns (bytes memory) {
-        return _packedSignaturesForDigest(_transactionDigest(address(wallet), to, value, data, nonce_), signerCount);
+        return _packedSignaturesForTransactionAtWallet(address(wallet), to, value, data, nonce_, signerCount);
     }
 
     function _packedSignaturesForTransactionByIndexes(
@@ -105,9 +119,64 @@ abstract contract MultisigWalletFixture is TestBase {
         uint256 nonce_,
         uint256[] memory signerIndexes
     ) internal returns (bytes memory) {
+        return _packedSignaturesForTransactionByIndexesAtWallet(address(wallet), to, value, data, nonce_, signerIndexes);
+    }
+
+    function _packedSignaturesForTransactionAtWallet(
+        address walletAddress,
+        address to,
+        uint256 value,
+        bytes memory data,
+        uint256 nonce_,
+        uint256 signerCount
+    ) internal returns (bytes memory) {
+        return _packedSignaturesForDigest(_transactionDigest(walletAddress, to, value, data, nonce_), signerCount);
+    }
+
+    function _packedSignaturesForTransactionByIndexesAtWallet(
+        address walletAddress,
+        address to,
+        uint256 value,
+        bytes memory data,
+        uint256 nonce_,
+        uint256[] memory signerIndexes
+    ) internal returns (bytes memory) {
         return _packedSignaturesForDigestByIndexes(
-            _transactionDigest(address(wallet), to, value, data, nonce_), signerIndexes
+            _transactionDigest(walletAddress, to, value, data, nonce_), signerIndexes
         );
+    }
+
+    function _packedSignaturesForBatch(bytes memory transactions, uint256 nonce_, uint256 signerCount)
+        internal
+        returns (bytes memory)
+    {
+        return _packedSignaturesForBatchAtWallet(address(wallet), transactions, nonce_, signerCount);
+    }
+
+    function _packedSignaturesForBatchByIndexes(
+        bytes memory transactions,
+        uint256 nonce_,
+        uint256[] memory signerIndexes
+    ) internal returns (bytes memory) {
+        return _packedSignaturesForBatchByIndexesAtWallet(address(wallet), transactions, nonce_, signerIndexes);
+    }
+
+    function _packedSignaturesForBatchAtWallet(
+        address walletAddress,
+        bytes memory transactions,
+        uint256 nonce_,
+        uint256 signerCount
+    ) internal returns (bytes memory) {
+        return _packedSignaturesForDigest(_batchDigest(walletAddress, transactions, nonce_), signerCount);
+    }
+
+    function _packedSignaturesForBatchByIndexesAtWallet(
+        address walletAddress,
+        bytes memory transactions,
+        uint256 nonce_,
+        uint256[] memory signerIndexes
+    ) internal returns (bytes memory) {
+        return _packedSignaturesForDigestByIndexes(_batchDigest(walletAddress, transactions, nonce_), signerIndexes);
     }
 
     function _packedSignaturesForDigest(bytes32 digest, uint256 signerCount)
@@ -159,5 +228,9 @@ abstract contract MultisigWalletFixture is TestBase {
         }
 
         return indexes;
+    }
+
+    function _encodeBatchEntry(address to, uint256 value, bytes memory data) internal pure returns (bytes memory) {
+        return bytes.concat(bytes20(to), bytes32(value), bytes32(data.length), data);
     }
 }


### PR DESCRIPTION
Closes #171

## Summary
- add the call-only `MultiSendCallOnly` helper and batch execution support on the wallet
- add deterministic minimal-proxy deployment and address prediction via `MultisigWalletFactory`
- add integration coverage for batch execution, atomic failure behavior, and factory-deployed wallets

## Validation
- `git diff --check`
- `forge fmt --check`
- `forge test --offline --match-path test/MultisigWalletFoundationCore.t.sol`
- `forge test --offline --match-path test/MultisigWalletCoreExecution.t.sol`
- `forge test --offline --match-path test/MultisigWalletIntegration.t.sol`
- `forge build --sizes --skip script`
- `slither . --exclude-dependencies`