### PR TITLE
Add multisig wallet management flows

### DIFF
--- a/src/interfaces/IMultisigWallet.sol
+++ b/src/interfaces/IMultisigWallet.sol
@@ -5,9 +5,14 @@ pragma solidity ^0.8.30;
 /// @notice Foundation interface for the standalone multisig wallet.
 interface IMultisigWallet {
     error MultisigWalletAlreadyInitialized();
+    error MultisigWalletCallerNotSelf();
     error MultisigWalletInvalidThreshold(uint256 threshold, uint256 ownerCount);
     error MultisigWalletZeroOwner();
     error MultisigWalletDuplicateOwner(address owner);
+    error MultisigWalletOwnerNotFound(address owner);
+    error MultisigWalletReplaceOwnerNoop(address owner);
+    error MultisigWalletCannotRemoveLastOwner();
+    error MultisigWalletRemovalInvalidatesThreshold(uint256 threshold, uint256 newOwnerCount);
     error MultisigWalletZeroMultiSend();
     error MultisigWalletInvalidSignaturesLength(uint256 providedLength, uint256 requiredLength);
     error MultisigWalletInvalidSigner(address signer);
@@ -17,6 +22,10 @@ interface IMultisigWallet {
     event WalletInitialized(address[] owners, uint256 threshold, address multiSendCallOnly);
     event TransactionExecuted(bytes32 indexed digest, uint256 indexed nonce, address indexed target, uint256 value);
     event BatchExecuted(bytes32 indexed digest, uint256 indexed nonce);
+    event OwnerAdded(address indexed owner);
+    event OwnerRemoved(address indexed owner);
+    event OwnerReplaced(address indexed oldOwner, address indexed newOwner);
+    event ThresholdChanged(uint256 threshold);
 
     function initialize(address[] calldata owners, uint256 threshold_, address multiSendCallOnly_) external;
     function getTransactionHash(address to, uint256 value, bytes calldata data, uint256 nonce_)
@@ -26,6 +35,10 @@ interface IMultisigWallet {
     function getBatchHash(bytes calldata transactions, uint256 nonce_) external view returns (bytes32);
     function executeTransaction(address to, uint256 value, bytes calldata data, bytes calldata signatures) external;
     function executeBatch(bytes calldata transactions, bytes calldata signatures) external;
+    function addOwner(address owner) external;
+    function removeOwner(address owner) external;
+    function replaceOwner(address oldOwner, address newOwner) external;
+    function changeThreshold(uint256 newThreshold) external;
     function isValidSignature(bytes32 digest, bytes calldata signatures) external view returns (bytes4);
     function nonce() external view returns (uint256);
     function threshold() external view returns (uint256);

--- a/src/wallet/MultisigWallet.sol
+++ b/src/wallet/MultisigWallet.sol
@@ -110,6 +110,29 @@ contract MultisigWallet is IERC165, IERC1271, IMultisigWallet {
         emit BatchExecuted(digest, currentNonce);
     }
 
+    function addOwner(address owner) external {
+        _requireSelfCall();
+        _addOwner(owner);
+    }
+
+    function removeOwner(address owner) external {
+        _requireSelfCall();
+        _removeOwner(owner);
+    }
+
+    function replaceOwner(address oldOwner, address newOwner) external {
+        _requireSelfCall();
+        _replaceOwner(oldOwner, newOwner);
+    }
+
+    function changeThreshold(uint256 newThreshold) external {
+        _requireSelfCall();
+        _requireValidThreshold(newThreshold, _owners.length);
+        _threshold = newThreshold;
+
+        emit ThresholdChanged(newThreshold);
+    }
+
     function isValidSignature(bytes32 digest, bytes calldata signatures)
         external
         view
@@ -146,6 +169,12 @@ contract MultisigWallet is IERC165, IERC1271, IMultisigWallet {
         return _owners;
     }
 
+    function _requireSelfCall() internal view {
+        if (msg.sender != address(this)) {
+            revert MultisigWalletCallerNotSelf();
+        }
+    }
+
     function _setOwners(address[] calldata owners, uint256 threshold_) internal {
         uint256 ownerCount_ = owners.length;
         _requireValidThreshold(threshold_, ownerCount_);
@@ -164,6 +193,73 @@ contract MultisigWallet is IERC165, IERC1271, IMultisigWallet {
         }
 
         _threshold = threshold_;
+    }
+
+    function _addOwner(address owner) internal {
+        if (owner == address(0)) {
+            revert MultisigWalletZeroOwner();
+        }
+        if (_ownerIndexPlusOne[owner] != 0) {
+            revert MultisigWalletDuplicateOwner(owner);
+        }
+
+        _ownerIndexPlusOne[owner] = _owners.length + 1;
+        _owners.push(owner);
+
+        emit OwnerAdded(owner);
+    }
+
+    function _removeOwner(address owner) internal {
+        uint256 ownerIndexPlusOne = _ownerIndexPlusOne[owner];
+        if (ownerIndexPlusOne == 0) {
+            revert MultisigWalletOwnerNotFound(owner);
+        }
+
+        uint256 ownerCount_ = _owners.length;
+        if (ownerCount_ == 1) {
+            revert MultisigWalletCannotRemoveLastOwner();
+        }
+
+        uint256 newOwnerCount = ownerCount_ - 1;
+        if (_threshold > newOwnerCount) {
+            revert MultisigWalletRemovalInvalidatesThreshold(_threshold, newOwnerCount);
+        }
+
+        uint256 ownerIndex = ownerIndexPlusOne - 1;
+        uint256 lastOwnerIndex = ownerCount_ - 1;
+        if (ownerIndex != lastOwnerIndex) {
+            address lastOwner = _owners[lastOwnerIndex];
+            _owners[ownerIndex] = lastOwner;
+            _ownerIndexPlusOne[lastOwner] = ownerIndex + 1;
+        }
+
+        _owners.pop();
+        delete _ownerIndexPlusOne[owner];
+
+        emit OwnerRemoved(owner);
+    }
+
+    function _replaceOwner(address oldOwner, address newOwner) internal {
+        uint256 oldOwnerIndexPlusOne = _ownerIndexPlusOne[oldOwner];
+        if (oldOwnerIndexPlusOne == 0) {
+            revert MultisigWalletOwnerNotFound(oldOwner);
+        }
+        if (oldOwner == newOwner) {
+            revert MultisigWalletReplaceOwnerNoop(oldOwner);
+        }
+        if (newOwner == address(0)) {
+            revert MultisigWalletZeroOwner();
+        }
+        if (_ownerIndexPlusOne[newOwner] != 0) {
+            revert MultisigWalletDuplicateOwner(newOwner);
+        }
+
+        uint256 ownerIndex = oldOwnerIndexPlusOne - 1;
+        _owners[ownerIndex] = newOwner;
+        delete _ownerIndexPlusOne[oldOwner];
+        _ownerIndexPlusOne[newOwner] = oldOwnerIndexPlusOne;
+
+        emit OwnerReplaced(oldOwner, newOwner);
     }
 
     function _requireValidThreshold(uint256 threshold_, uint256 ownerCount_) internal pure {

--- a/test/MultisigWalletInvariant.t.sol
+++ b/test/MultisigWalletInvariant.t.sol
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IMultisigWallet} from "../src/interfaces/IMultisigWallet.sol";
+import {MultisigWalletFixture} from "./helpers/MultisigWalletTestHarness.sol";
+
+contract MultisigWalletInvariantTest is MultisigWalletFixture {
+    uint256 internal successfulExecutions;
+
+    function setUp() public override {
+        super.setUp();
+        successfulExecutions = wallet.nonce();
+    }
+
+    function targetContracts() external view returns (address[] memory contracts) {
+        contracts = new address[](1);
+        contracts[0] = address(this);
+    }
+
+    function actionAddOwner(uint8 candidateSeed) external {
+        address candidate = actorAddresses[uint256(candidateSeed) % actorAddresses.length];
+        if (wallet.isOwner(candidate)) {
+            return;
+        }
+
+        _executeSelfTransaction(wallet, abi.encodeCall(IMultisigWallet.addOwner, (candidate)));
+        successfulExecutions++;
+    }
+
+    function actionRemoveOwner(uint8 ownerSeed) external {
+        address[] memory owners = wallet.getOwners();
+        uint256 ownerCount_ = owners.length;
+        if (ownerCount_ <= 1 || wallet.threshold() > ownerCount_ - 1) {
+            return;
+        }
+
+        address owner = owners[uint256(ownerSeed) % ownerCount_];
+        _executeSelfTransaction(wallet, abi.encodeCall(IMultisigWallet.removeOwner, (owner)));
+        successfulExecutions++;
+    }
+
+    function actionReplaceOwner(uint8 ownerSeed, uint8 candidateSeed) external {
+        address[] memory owners = wallet.getOwners();
+        uint256 ownerCount_ = owners.length;
+        if (ownerCount_ == 0) {
+            return;
+        }
+
+        address oldOwner = owners[uint256(ownerSeed) % ownerCount_];
+        address newOwner = actorAddresses[uint256(candidateSeed) % actorAddresses.length];
+        if (newOwner == oldOwner || wallet.isOwner(newOwner)) {
+            return;
+        }
+
+        _executeSelfTransaction(wallet, abi.encodeCall(IMultisigWallet.replaceOwner, (oldOwner, newOwner)));
+        successfulExecutions++;
+    }
+
+    function actionChangeThreshold(uint8 thresholdSeed) external {
+        uint256 ownerCount_ = wallet.ownerCount();
+        uint256 newThreshold = (uint256(thresholdSeed) % ownerCount_) + 1;
+        if (newThreshold == wallet.threshold()) {
+            return;
+        }
+
+        _executeSelfTransaction(wallet, abi.encodeCall(IMultisigWallet.changeThreshold, (newThreshold)));
+        successfulExecutions++;
+    }
+
+    function actionBatchChangeThresholdAndRemoveOwner(uint8 ownerSeed, uint8 thresholdSeed) external {
+        address[] memory owners = wallet.getOwners();
+        uint256 ownerCount_ = owners.length;
+        if (ownerCount_ <= 1) {
+            return;
+        }
+
+        uint256 newOwnerCount = ownerCount_ - 1;
+        uint256 newThreshold = (uint256(thresholdSeed) % newOwnerCount) + 1;
+        if (wallet.threshold() <= newOwnerCount && newThreshold == wallet.threshold()) {
+            return;
+        }
+
+        address owner = owners[uint256(ownerSeed) % ownerCount_];
+        bytes memory transactions = bytes.concat(
+            _encodeBatchEntry(address(wallet), 0, abi.encodeCall(IMultisigWallet.changeThreshold, (newThreshold))),
+            _encodeBatchEntry(address(wallet), 0, abi.encodeCall(IMultisigWallet.removeOwner, (owner)))
+        );
+
+        _executeSelfBatch(wallet, transactions);
+        successfulExecutions++;
+    }
+
+    function actionUnauthorizedMutationAttempt(uint8 methodSeed, uint8 actorSeed) external {
+        uint256 beforeThreshold = wallet.threshold();
+        uint256 beforeOwnerCount = wallet.ownerCount();
+        bool[] memory beforeFlags = new bool[](actorAddresses.length);
+        for (uint256 i = 0; i < actorAddresses.length; i++) {
+            beforeFlags[i] = wallet.isOwner(actorAddresses[i]);
+        }
+
+        uint256 method = uint256(methodSeed) % 4;
+        address actor = actorAddresses[uint256(actorSeed) % actorAddresses.length];
+        VM.expectRevert(IMultisigWallet.MultisigWalletCallerNotSelf.selector);
+        if (method == 0) {
+            wallet.addOwner(actor);
+        } else if (method == 1) {
+            wallet.removeOwner(actor);
+        } else if (method == 2) {
+            wallet.replaceOwner(actorAddresses[0], actor);
+        } else {
+            wallet.changeThreshold((uint256(actorSeed) % 6) + 1);
+        }
+
+        assertTrue(wallet.threshold() == beforeThreshold, "unauthorized attempt changed threshold");
+        assertTrue(wallet.ownerCount() == beforeOwnerCount, "unauthorized attempt changed owner count");
+        for (uint256 i = 0; i < actorAddresses.length; i++) {
+            assertTrue(wallet.isOwner(actorAddresses[i]) == beforeFlags[i], "unauthorized attempt changed ownership");
+        }
+    }
+
+    function invariantThresholdWithinOwnerCount() public view {
+        uint256 ownerCount_ = wallet.ownerCount();
+        uint256 threshold_ = wallet.threshold();
+
+        assertTrue(ownerCount_ >= 1, "owner count must stay positive");
+        assertTrue(threshold_ >= 1, "threshold must stay positive");
+        assertTrue(threshold_ <= ownerCount_, "threshold must not exceed owner count");
+    }
+
+    function invariantOwnersRemainUniqueAndNonZero() public view {
+        address[] memory owners = wallet.getOwners();
+        for (uint256 i = 0; i < owners.length; i++) {
+            assertTrue(owners[i] != address(0), "owner must be nonzero");
+            for (uint256 j = i + 1; j < owners.length; j++) {
+                assertTrue(owners[i] != owners[j], "owners must remain unique");
+            }
+        }
+    }
+
+    function invariantOwnerViewsRemainConsistent() public view {
+        address[] memory owners = wallet.getOwners();
+        assertTrue(owners.length == wallet.ownerCount(), "owner count must match owners array");
+
+        uint256 actorOwnerCount;
+        for (uint256 i = 0; i < actorAddresses.length; i++) {
+            if (wallet.isOwner(actorAddresses[i])) {
+                actorOwnerCount++;
+            }
+        }
+
+        assertTrue(actorOwnerCount == owners.length, "isOwner view must match owner set");
+        for (uint256 i = 0; i < owners.length; i++) {
+            assertTrue(wallet.isOwner(owners[i]), "owner list entries must report as owners");
+        }
+    }
+
+    function invariantNonceTracksSuccessfulWalletExecutions() public view {
+        assertTrue(wallet.nonce() == successfulExecutions, "nonce must track successful wallet executions");
+    }
+}

--- a/test/MultisigWalletManagement.t.sol
+++ b/test/MultisigWalletManagement.t.sol
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IMultisigWallet} from "../src/interfaces/IMultisigWallet.sol";
+import {MultisigWalletFixture} from "./helpers/MultisigWalletTestHarness.sol";
+
+contract MultisigWalletManagementTest is MultisigWalletFixture {
+    function testDirectManagementCallsRequireSelfCall() public {
+        VM.expectRevert(IMultisigWallet.MultisigWalletCallerNotSelf.selector);
+        wallet.addOwner(actorAddresses[3]);
+
+        VM.expectRevert(IMultisigWallet.MultisigWalletCallerNotSelf.selector);
+        wallet.removeOwner(actorAddresses[0]);
+
+        VM.expectRevert(IMultisigWallet.MultisigWalletCallerNotSelf.selector);
+        wallet.replaceOwner(actorAddresses[0], actorAddresses[3]);
+
+        VM.expectRevert(IMultisigWallet.MultisigWalletCallerNotSelf.selector);
+        wallet.changeThreshold(1);
+    }
+
+    function testSignedSelfCallCanAddOwner() public {
+        _executeSelfTransaction(wallet, abi.encodeCall(IMultisigWallet.addOwner, (actorAddresses[3])));
+
+        assertTrue(wallet.ownerCount() == 4, "owner count mismatch");
+        assertTrue(wallet.threshold() == 2, "threshold should remain unchanged");
+        assertTrue(wallet.isOwner(actorAddresses[3]), "new owner missing");
+
+        address[] memory owners = wallet.getOwners();
+        assertTrue(owners.length == 4, "owners length mismatch");
+        assertTrue(owners[3] == actorAddresses[3], "new owner should append");
+    }
+
+    function testAddOwnerRejectsZeroOwner() public {
+        bytes memory data = abi.encodeCall(IMultisigWallet.addOwner, (address(0)));
+        bytes memory signatures = _packedCurrentThresholdSignaturesForTransaction(wallet, address(wallet), 0, data);
+
+        VM.expectRevert(IMultisigWallet.MultisigWalletZeroOwner.selector);
+        wallet.executeTransaction(address(wallet), 0, data, signatures);
+
+        assertTrue(wallet.ownerCount() == 3, "owner count should remain unchanged");
+        assertTrue(wallet.nonce() == 0, "nonce should remain unchanged");
+    }
+
+    function testAddOwnerRejectsDuplicateOwner() public {
+        bytes memory data = abi.encodeCall(IMultisigWallet.addOwner, (actorAddresses[0]));
+        bytes memory signatures = _packedCurrentThresholdSignaturesForTransaction(wallet, address(wallet), 0, data);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(IMultisigWallet.MultisigWalletDuplicateOwner.selector, actorAddresses[0])
+        );
+        wallet.executeTransaction(address(wallet), 0, data, signatures);
+
+        assertTrue(wallet.ownerCount() == 3, "owner count should remain unchanged");
+        assertTrue(wallet.nonce() == 0, "nonce should remain unchanged");
+    }
+
+    function testSignedSelfCallCanRemoveOwnerAndSwapPop() public {
+        _executeSelfTransaction(wallet, abi.encodeCall(IMultisigWallet.removeOwner, (actorAddresses[0])));
+
+        assertTrue(wallet.ownerCount() == 2, "owner count mismatch");
+        assertTrue(wallet.threshold() == 2, "threshold should remain unchanged");
+        assertFalse(wallet.isOwner(actorAddresses[0]), "removed owner should be absent");
+        assertTrue(wallet.isOwner(actorAddresses[1]), "second owner missing");
+        assertTrue(wallet.isOwner(actorAddresses[2]), "third owner missing");
+
+        address[] memory owners = wallet.getOwners();
+        assertTrue(owners.length == 2, "owners length mismatch");
+        assertTrue(owners[0] == actorAddresses[2], "swap-and-pop should move last owner into removed slot");
+        assertTrue(owners[1] == actorAddresses[1], "middle owner should remain");
+    }
+
+    function testRemoveOwnerRejectsMissingOwner() public {
+        bytes memory data = abi.encodeCall(IMultisigWallet.removeOwner, (actorAddresses[5]));
+        bytes memory signatures = _packedCurrentThresholdSignaturesForTransaction(wallet, address(wallet), 0, data);
+
+        VM.expectRevert(abi.encodeWithSelector(IMultisigWallet.MultisigWalletOwnerNotFound.selector, actorAddresses[5]));
+        wallet.executeTransaction(address(wallet), 0, data, signatures);
+    }
+
+    function testRemoveOwnerRejectsLastOwner() public {
+        address[] memory singleOwner = new address[](1);
+        singleOwner[0] = actorAddresses[0];
+        IMultisigWallet singleOwnerWallet =
+            _deployInitializedWallet(keccak256("auralis.multisig.single-owner"), singleOwner, 1, defaultMultiSend);
+
+        bytes memory data = abi.encodeCall(IMultisigWallet.removeOwner, (actorAddresses[0]));
+        bytes memory signatures =
+            _packedCurrentThresholdSignaturesForTransaction(singleOwnerWallet, address(singleOwnerWallet), 0, data);
+
+        VM.expectRevert(IMultisigWallet.MultisigWalletCannotRemoveLastOwner.selector);
+        singleOwnerWallet.executeTransaction(address(singleOwnerWallet), 0, data, signatures);
+
+        assertTrue(singleOwnerWallet.ownerCount() == 1, "single-owner wallet should remain unchanged");
+        assertTrue(singleOwnerWallet.nonce() == 0, "nonce should remain unchanged");
+    }
+
+    function testRemoveOwnerRejectsThresholdInvalidatingRemoval() public {
+        address[] memory twoOwners = new address[](2);
+        twoOwners[0] = actorAddresses[0];
+        twoOwners[1] = actorAddresses[1];
+        IMultisigWallet twoOwnerWallet =
+            _deployInitializedWallet(keccak256("auralis.multisig.two-owner"), twoOwners, 2, defaultMultiSend);
+
+        bytes memory data = abi.encodeCall(IMultisigWallet.removeOwner, (actorAddresses[0]));
+        bytes memory signatures =
+            _packedCurrentThresholdSignaturesForTransaction(twoOwnerWallet, address(twoOwnerWallet), 0, data);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(IMultisigWallet.MultisigWalletRemovalInvalidatesThreshold.selector, 2, 1)
+        );
+        twoOwnerWallet.executeTransaction(address(twoOwnerWallet), 0, data, signatures);
+    }
+
+    function testSignedSelfCallCanReplaceOwner() public {
+        _executeSelfTransaction(
+            wallet, abi.encodeCall(IMultisigWallet.replaceOwner, (actorAddresses[0], actorAddresses[3]))
+        );
+
+        assertTrue(wallet.ownerCount() == 3, "owner count should remain unchanged");
+        assertTrue(wallet.threshold() == 2, "threshold should remain unchanged");
+        assertFalse(wallet.isOwner(actorAddresses[0]), "old owner should be absent");
+        assertTrue(wallet.isOwner(actorAddresses[3]), "replacement owner missing");
+
+        address[] memory owners = wallet.getOwners();
+        assertTrue(owners[0] == actorAddresses[3], "replacement should preserve slot");
+    }
+
+    function testReplaceOwnerRejectsMissingOwner() public {
+        bytes memory data = abi.encodeCall(IMultisigWallet.replaceOwner, (actorAddresses[5], actorAddresses[3]));
+        bytes memory signatures = _packedCurrentThresholdSignaturesForTransaction(wallet, address(wallet), 0, data);
+
+        VM.expectRevert(abi.encodeWithSelector(IMultisigWallet.MultisigWalletOwnerNotFound.selector, actorAddresses[5]));
+        wallet.executeTransaction(address(wallet), 0, data, signatures);
+    }
+
+    function testReplaceOwnerRejectsZeroReplacement() public {
+        bytes memory data = abi.encodeCall(IMultisigWallet.replaceOwner, (actorAddresses[0], address(0)));
+        bytes memory signatures = _packedCurrentThresholdSignaturesForTransaction(wallet, address(wallet), 0, data);
+
+        VM.expectRevert(IMultisigWallet.MultisigWalletZeroOwner.selector);
+        wallet.executeTransaction(address(wallet), 0, data, signatures);
+    }
+
+    function testReplaceOwnerRejectsDuplicateReplacement() public {
+        bytes memory data = abi.encodeCall(IMultisigWallet.replaceOwner, (actorAddresses[0], actorAddresses[1]));
+        bytes memory signatures = _packedCurrentThresholdSignaturesForTransaction(wallet, address(wallet), 0, data);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(IMultisigWallet.MultisigWalletDuplicateOwner.selector, actorAddresses[1])
+        );
+        wallet.executeTransaction(address(wallet), 0, data, signatures);
+    }
+
+    function testReplaceOwnerRejectsSameAddressNoop() public {
+        bytes memory data = abi.encodeCall(IMultisigWallet.replaceOwner, (actorAddresses[0], actorAddresses[0]));
+        bytes memory signatures = _packedCurrentThresholdSignaturesForTransaction(wallet, address(wallet), 0, data);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(IMultisigWallet.MultisigWalletReplaceOwnerNoop.selector, actorAddresses[0])
+        );
+        wallet.executeTransaction(address(wallet), 0, data, signatures);
+    }
+
+    function testSignedSelfCallCanChangeThreshold() public {
+        _executeSelfTransaction(wallet, abi.encodeCall(IMultisigWallet.changeThreshold, (3)));
+
+        assertTrue(wallet.threshold() == 3, "threshold should update");
+        assertTrue(wallet.ownerCount() == 3, "owner count should remain unchanged");
+    }
+
+    function testChangeThresholdRejectsZero() public {
+        bytes memory data = abi.encodeCall(IMultisigWallet.changeThreshold, (0));
+        bytes memory signatures = _packedCurrentThresholdSignaturesForTransaction(wallet, address(wallet), 0, data);
+
+        VM.expectRevert(abi.encodeWithSelector(IMultisigWallet.MultisigWalletInvalidThreshold.selector, 0, 3));
+        wallet.executeTransaction(address(wallet), 0, data, signatures);
+    }
+
+    function testChangeThresholdRejectsAboveOwnerCount() public {
+        bytes memory data = abi.encodeCall(IMultisigWallet.changeThreshold, (4));
+        bytes memory signatures = _packedCurrentThresholdSignaturesForTransaction(wallet, address(wallet), 0, data);
+
+        VM.expectRevert(abi.encodeWithSelector(IMultisigWallet.MultisigWalletInvalidThreshold.selector, 4, 3));
+        wallet.executeTransaction(address(wallet), 0, data, signatures);
+    }
+
+    function testBatchChangeThresholdAndRemoveOwnerWorks() public {
+        IMultisigWallet threeOfThreeWallet = _deployInitializedWallet(
+            keccak256("auralis.multisig.three-of-three"), _initialOwners(), 3, defaultMultiSend
+        );
+
+        bytes memory transactions = bytes.concat(
+            _encodeBatchEntry(address(threeOfThreeWallet), 0, abi.encodeCall(IMultisigWallet.changeThreshold, (2))),
+            _encodeBatchEntry(
+                address(threeOfThreeWallet), 0, abi.encodeCall(IMultisigWallet.removeOwner, (actorAddresses[0]))
+            )
+        );
+
+        _executeSelfBatch(threeOfThreeWallet, transactions);
+
+        assertTrue(threeOfThreeWallet.threshold() == 2, "threshold mismatch");
+        assertTrue(threeOfThreeWallet.ownerCount() == 2, "owner count mismatch");
+        assertFalse(threeOfThreeWallet.isOwner(actorAddresses[0]), "removed owner should be absent");
+        assertTrue(threeOfThreeWallet.nonce() == 1, "batch should consume exactly one nonce");
+    }
+}

--- a/test/helpers/MultisigWalletTestHarness.sol
+++ b/test/helpers/MultisigWalletTestHarness.sol
@@ -23,6 +23,8 @@ abstract contract MultisigWalletFixture is TestBase {
     uint256 internal constant OWNER_KEY_B = 0xB0B;
     uint256 internal constant OWNER_KEY_C = 0xCAFE;
     uint256 internal constant OWNER_KEY_D = 0xD00D;
+    uint256 internal constant OWNER_KEY_E = 0xE11E;
+    uint256 internal constant OWNER_KEY_F = 0xF00D;
 
     bytes32 internal constant DEFAULT_SALT = keccak256("auralis.multisig.default-salt");
 
@@ -39,12 +41,14 @@ abstract contract MultisigWalletFixture is TestBase {
         multiSendCallOnly = new MultiSendCallOnly();
         defaultMultiSend = address(multiSendCallOnly);
 
-        actorAddresses = new address[](4);
-        actorKeys = new uint256[](4);
+        actorAddresses = new address[](6);
+        actorKeys = new uint256[](6);
         actorKeys[0] = OWNER_KEY_A;
         actorKeys[1] = OWNER_KEY_B;
         actorKeys[2] = OWNER_KEY_C;
         actorKeys[3] = OWNER_KEY_D;
+        actorKeys[4] = OWNER_KEY_E;
+        actorKeys[5] = OWNER_KEY_F;
 
         for (uint256 i = 0; i < actorKeys.length; i++) {
             actorAddresses[i] = VM.addr(actorKeys[i]);
@@ -179,6 +183,60 @@ abstract contract MultisigWalletFixture is TestBase {
         return _packedSignaturesForDigestByIndexes(_batchDigest(walletAddress, transactions, nonce_), signerIndexes);
     }
 
+    function _packedCurrentThresholdSignaturesForTransaction(
+        IMultisigWallet wallet_,
+        address to,
+        uint256 value,
+        bytes memory data
+    ) internal returns (bytes memory) {
+        return _packedCurrentThresholdSignaturesForTransactionAtWallet(address(wallet_), to, value, data);
+    }
+
+    function _packedCurrentThresholdSignaturesForTransactionAtWallet(
+        address walletAddress,
+        address to,
+        uint256 value,
+        bytes memory data
+    ) internal returns (bytes memory) {
+        return _packedSignaturesForTransactionByIndexesAtWallet(
+            walletAddress,
+            to,
+            value,
+            data,
+            IMultisigWallet(walletAddress).nonce(),
+            _currentThresholdSignerIndexes(walletAddress)
+        );
+    }
+
+    function _packedCurrentThresholdSignaturesForBatch(IMultisigWallet wallet_, bytes memory transactions)
+        internal
+        returns (bytes memory)
+    {
+        return _packedCurrentThresholdSignaturesForBatchAtWallet(address(wallet_), transactions);
+    }
+
+    function _packedCurrentThresholdSignaturesForBatchAtWallet(address walletAddress, bytes memory transactions)
+        internal
+        returns (bytes memory)
+    {
+        return _packedSignaturesForBatchByIndexesAtWallet(
+            walletAddress,
+            transactions,
+            IMultisigWallet(walletAddress).nonce(),
+            _currentThresholdSignerIndexes(walletAddress)
+        );
+    }
+
+    function _executeSelfTransaction(IMultisigWallet wallet_, bytes memory data) internal {
+        bytes memory signatures = _packedCurrentThresholdSignaturesForTransaction(wallet_, address(wallet_), 0, data);
+        wallet_.executeTransaction(address(wallet_), 0, data, signatures);
+    }
+
+    function _executeSelfBatch(IMultisigWallet wallet_, bytes memory transactions) internal {
+        bytes memory signatures = _packedCurrentThresholdSignaturesForBatch(wallet_, transactions);
+        wallet_.executeBatch(transactions, signatures);
+    }
+
     function _packedSignaturesForDigest(bytes32 digest, uint256 signerCount)
         internal
         returns (bytes memory signatures)
@@ -232,5 +290,35 @@ abstract contract MultisigWalletFixture is TestBase {
 
     function _encodeBatchEntry(address to, uint256 value, bytes memory data) internal pure returns (bytes memory) {
         return bytes.concat(bytes20(to), bytes32(value), bytes32(data.length), data);
+    }
+
+    function _currentThresholdSignerIndexes(address walletAddress)
+        internal
+        view
+        returns (uint256[] memory signerIndexes)
+    {
+        address[] memory owners = IMultisigWallet(walletAddress).getOwners();
+        uint256[] memory ownerIndexes = new uint256[](owners.length);
+
+        for (uint256 i = 0; i < owners.length; i++) {
+            ownerIndexes[i] = _actorIndex(owners[i]);
+        }
+
+        ownerIndexes = _sortedIndexesByAddress(ownerIndexes);
+        uint256 signerCount = IMultisigWallet(walletAddress).threshold();
+        signerIndexes = new uint256[](signerCount);
+        for (uint256 i = 0; i < signerCount; i++) {
+            signerIndexes[i] = ownerIndexes[i];
+        }
+    }
+
+    function _actorIndex(address actor) internal view returns (uint256) {
+        for (uint256 i = 0; i < actorAddresses.length; i++) {
+            if (actorAddresses[i] == actor) {
+                return i;
+            }
+        }
+
+        revert("unknown actor");
     }
 }


### PR DESCRIPTION
## Summary
- add self-call-only owner and threshold management flows to the multisig wallet
- add a dedicated management test suite plus invariant coverage for owner/threshold safety properties
- preserve prior execution, batch, and factory behavior while hardening mutation edge cases

Closes #172