### PR TITLE
Document multisig wallet reviewer surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@
 [![Foundry CI](https://github.com/amshirif/Auralis/actions/workflows/ci.yml/badge.svg)](https://github.com/amshirif/Auralis/actions/workflows/ci.yml)
 ![License](https://img.shields.io/github/license/amshirif/Auralis)
 
-Security-first, diamond-ready Solidity systems.
+Security-first Solidity systems.
 
 `Auralis` is a protocol-engineering portfolio repository focused on
 security-first, upgrade-aware Solidity systems. It combines modular contract
-design, deployment-backed validation, local operator flows, and hardening
-coverage so a reviewer can assess architecture and evidence together rather
-than as isolated snippets.
+design, deployment-backed validation, local operator flows, hardening
+coverage, and standalone smart-wallet execution so a reviewer can assess
+architecture and evidence together rather than as isolated snippets.
 
 ## Why This Repo Exists
 
@@ -28,6 +28,7 @@ reviewable engineering system.
 - Architecture decisions: `docs/adr/README.md`
 - Canonical docs map: `docs/README.md`
 - Hosted vault architecture: `docs/vault-facets.md`
+- Smart-wallet architecture: `docs/multisig-wallet.md`
 - Security assumptions: `docs/threat-model.md`
 - Validation and CI policy: `docs/security-checks.md`
 - Local workflow and deployment artifacts: `docs/auralis-local.md`
@@ -35,11 +36,15 @@ reviewable engineering system.
 ## What This Repo Proves
 
 - Core architecture: diamond routing, selector ownership discipline, and
-  separate hosted token and vault deployment models.
+  separate hosted token and vault deployment models plus a standalone
+  smart-wallet track.
 - Safety posture: RBAC, timed permissions, pause semantics, reentrancy
-  protection, oracle validation, and upgrade guardrails.
+  protection, oracle validation, upgrade guardrails, and threshold-based wallet
+  execution.
 - Protocol surfaces: ERC20 and ERC721 token hosts plus a hosted ERC-4626 vault
-  platform with controls, strategy integration, and native-asset support.
+  platform with controls, strategy integration, and native-asset support, plus
+  a standalone multisig wallet with single-call, batch, and self-managed
+  configuration flows.
 - Operational maturity: local bootstrap, smoke validation, activity flows,
   upgrade rehearsal, and matching CI/hardening gates.
 
@@ -53,6 +58,8 @@ reviewable engineering system.
   storage discipline.
 - `docs/vault-facets.md`: hosted vault facet split, lifecycle, and deployment
   model.
+- `docs/multisig-wallet.md`: wallet deployment model, signature semantics,
+  replay protection, and self-managed configuration surface.
 - `docs/threat-model.md`: trust boundaries, threat assumptions, and residual
   risks.
 
@@ -70,6 +77,16 @@ reviewable engineering system.
   recovery behavior.
 - `test/SystemVaultStressInvariant.t.sol`: higher-signal system stress coverage
   for vault behavior under adversarial sequences.
+- `test/MultisigWalletFoundationCore.t.sol`: initializer, owner-set, and clone
+  foundation checks.
+- `test/MultisigWalletCoreExecution.t.sol`: EIP-712 signing, nonce, ERC-1271,
+  and single-call execution behavior.
+- `test/MultisigWalletIntegration.t.sol`: batch execution and deterministic
+  factory deployment coverage.
+- `test/MultisigWalletManagement.t.sol`: self-managed owner and threshold
+  mutation coverage.
+- `test/MultisigWalletInvariant.t.sol`: owner uniqueness, threshold bounds, and
+  nonce progression invariants.
 
 ### Deployment And Operator Evidence
 
@@ -93,6 +110,16 @@ forge test --offline --match-path test/SystemOracleFailureScenarios.t.sol
 forge test --offline --match-path test/SystemVaultStressInvariant.t.sol
 ```
 
+For the wallet track:
+
+```shell
+forge test --offline --match-path test/MultisigWalletFoundationCore.t.sol
+forge test --offline --match-path test/MultisigWalletCoreExecution.t.sol
+forge test --offline --match-path test/MultisigWalletIntegration.t.sol
+forge test --offline --match-path test/MultisigWalletManagement.t.sol
+forge test --offline --match-path test/MultisigWalletInvariant.t.sol
+```
+
 For the local Auralis workflow:
 
 ```shell
@@ -109,7 +136,7 @@ Recommended reviewer path:
 
 - Architecture decisions: `docs/adr/README.md`
 - Core architecture: `docs/diamond-core.md`, `docs/token-facets.md`,
-  `docs/vault-facets.md`, `docs/oracle-adapter.md`
+  `docs/vault-facets.md`, `docs/multisig-wallet.md`, `docs/oracle-adapter.md`
 - Security and validation: `docs/threat-model.md`, `docs/security-checks.md`
 - Operations and local workflow: `docs/ops/README.md`, `docs/auralis-local.md`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,12 @@ Use this surface to understand the current architecture, the major design
 decisions behind it, how safety is validated, and where operator-facing
 runbooks live.
 
+The repo currently has three major protocol surfaces:
+
+- diamond-hosted token systems
+- diamond-hosted vault systems
+- a standalone multisig wallet track
+
 ## Architecture Overview
 
 ```mermaid
@@ -14,6 +20,7 @@ flowchart TD
     Core["Diamond Core<br/>routing and upgrade base"]
     Token["Token Hosts<br/>ERC20 and ERC721 diamonds"]
     Vault["Vault Hosts<br/>hosted ERC-4626 platform"]
+    Wallet["Wallet Track<br/>standalone multisig system"]
     Oracle["Oracle Adapter<br/>validation and breaker policy"]
     Security["Threat Model and Security Checks"]
     Ops["Ops and Local Workflow"]
@@ -21,6 +28,7 @@ flowchart TD
     ADR --> Core
     ADR --> Token
     ADR --> Vault
+    Wallet --> Security
     ADR --> Oracle
     Core --> Token
     Core --> Vault
@@ -37,6 +45,7 @@ flowchart TD
 - Diamond core architecture: `docs/diamond-core.md`
 - Hosted token architecture: `docs/token-facets.md`
 - Hosted vault architecture: `docs/vault-facets.md`
+- Smart-wallet architecture: `docs/multisig-wallet.md`
 - Security assumptions: `docs/threat-model.md`
 - Validation and CI policy: `docs/security-checks.md`
 
@@ -51,6 +60,8 @@ visual model materially improves comprehension.
   role surface, and upgrade assumptions.
 - `docs/vault-facets.md`: hosted vault facet split, selector ownership, and
   deployment model.
+- `docs/multisig-wallet.md`: standalone multisig wallet deployment,
+  authorization, and configuration model.
 - `docs/erc4626-vault.md`: standalone ERC-4626 module semantics, math, fees,
   limits, and native-mode accounting assumptions.
 - `docs/oracle-adapter.md`: oracle adapter validation, breaker behavior, and

--- a/docs/multisig-wallet.md
+++ b/docs/multisig-wallet.md
@@ -1,0 +1,130 @@
+# Multisig Wallet
+
+This document is the canonical guide for the standalone multisig wallet
+architecture in `Auralis`.
+
+The wallet track is intentionally separate from the repo's diamond-hosted token
+and vault systems. It exists to show a second security-oriented protocol shape:
+an account-style execution surface built around threshold approvals, replay
+protection, deterministic deployment, and self-managed configuration.
+
+## Supported Model
+
+The current wallet track supports:
+
+- one `MultisigWallet` singleton implementation
+- one `MultisigWalletFactory` for deterministic clone deployment
+- one fixed `MultiSendCallOnly` helper for atomic call-only batching
+- EOA owners only
+- one monotonic nonce shared across single-call and batch execution
+
+```mermaid
+flowchart LR
+    Owners["Owners<br/>packed EOA signatures"]
+    Factory["MultisigWalletFactory<br/>deterministic clones"]
+    Impl["MultisigWallet<br/>singleton implementation"]
+    Wallet["Wallet Clone<br/>owners, threshold, nonce"]
+    Batch["MultiSendCallOnly<br/>call-only batch helper"]
+    Targets["External Targets"]
+
+    Impl --> Factory
+    Factory --> Wallet
+    Owners --> Wallet
+    Wallet --> Targets
+    Wallet --> Batch
+    Batch --> Targets
+```
+
+## Deployment Model
+
+Wallet instances are deployed as deterministic clones of the singleton
+implementation.
+
+Initialization sets:
+
+- the initial owner set
+- the threshold
+- the fixed `MultiSendCallOnly` helper address
+- the wallet nonce at `0`
+
+The implementation contract is constructor-locked so only clones can be
+initialized.
+
+## Authorization Model
+
+Single-call execution uses an EIP-712 typed payload containing:
+
+- `to`
+- `value`
+- `dataHash`
+- `nonce`
+
+Batch execution uses an EIP-712 typed payload containing:
+
+- `transactionsHash`
+- `nonce`
+
+Approvals are provided as one packed `bytes signatures` blob:
+
+- one 65-byte ECDSA signature per approving owner
+- exactly `threshold` signatures
+- recovered signer addresses must be strictly increasing
+
+This gives the wallet an explicit duplicate-signer and signer-order check
+without relying on per-call deduplication storage.
+
+## Execution And Replay Protection
+
+The wallet exposes two execution surfaces:
+
+- `executeTransaction(...)` for one external `call`
+- `executeBatch(...)` for atomic call-only batching through the fixed helper
+
+Replay protection is nonce-based:
+
+- the current nonce is part of the signed payload
+- signatures authorize only the current nonce
+- nonce is advanced before external execution, so successful calls consume the
+  approval and reverted calls cannot partially execute
+
+The batch path does not expose arbitrary user delegatecall. The wallet
+delegatecalls only into the fixed `MultiSendCallOnly` helper, which then issues
+plain external calls to the batched targets.
+
+## Configuration Model
+
+Wallet configuration is self-managed.
+
+The wallet exposes direct configuration methods:
+
+- `addOwner(address)`
+- `removeOwner(address)`
+- `replaceOwner(address,address)`
+- `changeThreshold(uint256)`
+
+Those methods are only callable by the wallet itself. In practice, that means
+configuration changes must be executed through an already-authorized
+`executeTransaction(...)` or `executeBatch(...)` call.
+
+Removal uses swap-and-pop on the owner array. Owner ordering is not part of the
+public contract guarantee.
+
+## Out Of Scope For V1
+
+The current wallet track does not include:
+
+- modules or guards
+- fallback handlers
+- contract-owner signatures
+- ERC-4337 integration
+- passkeys
+- gas refund machinery
+- generic user delegatecall execution
+
+## Related Tests
+
+- `test/MultisigWalletFoundationCore.t.sol`
+- `test/MultisigWalletCoreExecution.t.sol`
+- `test/MultisigWalletIntegration.t.sol`
+- `test/MultisigWalletManagement.t.sol`
+- `test/MultisigWalletInvariant.t.sol`

--- a/docs/security-checks.md
+++ b/docs/security-checks.md
@@ -84,6 +84,24 @@ strategy-aware accounting, loss and emergency-exit behavior, selector
 ownership, facet replacement persistence, and diamond-routed vault invariants
 locally.
 
+### Multisig Wallet
+
+The standalone wallet track has a bounded reviewer-facing suite set for
+foundation, execution, batch/factory, management, and invariant coverage:
+
+```bash
+forge test --offline --match-path test/MultisigWalletFoundationCore.t.sol
+forge test --offline --match-path test/MultisigWalletCoreExecution.t.sol
+forge test --offline --match-path test/MultisigWalletIntegration.t.sol
+forge test --offline --match-path test/MultisigWalletManagement.t.sol
+forge test --offline --match-path test/MultisigWalletInvariant.t.sol
+```
+
+Use these to reproduce initializer behavior, EIP-712 signing, ERC-1271
+verification, deterministic clone deployment, call-only batch execution,
+self-managed owner/threshold changes, and the wallet invariants around owner
+uniqueness, threshold bounds, and nonce progression.
+
 ### Slither
 
 Install and run the same high-severity gate locally:

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,7 +1,7 @@
 # Threat Model
 
 This summary covers security assumptions and guard rails for access, oracle,
-upgrade, and vault modules.
+upgrade, vault, and wallet modules.
 
 For the accepted architecture decisions that shape these assumptions, see
 `docs/adr/README.md`.
@@ -15,6 +15,9 @@ For the accepted architecture decisions that shape these assumptions, see
 - `Pausable`
 - `ReentrancyGuard`
 - `UpgradeGuardrails`
+- `MultisigWallet`
+- `MultisigWalletFactory`
+- `MultiSendCallOnly`
 
 ## Security Goals
 
@@ -25,12 +28,17 @@ For the accepted architecture decisions that shape these assumptions, see
 - Reentrant state-changing entrypoints are blocked.
 - Upgrade execution follows explicit authorization and guardrail checks.
 - Vault share/accounting behavior remains explicit under rounding and low-liquidity edge conditions.
+- Wallet execution requires the configured threshold of valid owner signatures.
+- Wallet replay protection prevents nonce reuse across signed transactions.
+- Wallet configuration changes require wallet-authorized self-calls.
 
 ## Trust Assumptions
 
 - Initial admin/upgrader/pauser assignments are correct at initialization.
 - Oracle feed sources are configured to trusted contracts with expected ABI behavior.
 - Governance/operator keys are managed securely off-chain.
+- Wallet owners review and approve transaction payloads securely off-chain.
+- The configured `MultiSendCallOnly` helper is the intended fixed batch helper for deployed wallets.
 - Deployed contracts integrate `_applyUpgrade` correctly for their proxy/diamond mechanism.
 - Time-based checks rely on `block.timestamp` and accept normal timestamp variance.
 
@@ -66,6 +74,18 @@ For the accepted architecture decisions that shape these assumptions, see
 10. Emergency response lag on vault write paths
 - Mitigation: pausable controls block `deposit`, `mint`, `withdraw`, and `redeem` when paused.
 
+11. Wallet replay or stale approval reuse
+- Mitigation: every signed wallet transaction includes the current monotonic nonce, and nonce advances on successful wallet execution.
+
+12. Duplicate or malformed threshold approvals
+- Mitigation: wallet signatures are packed at fixed length, recovered signers must be valid owners, and signer addresses must be strictly increasing.
+
+13. Unauthorized wallet reconfiguration
+- Mitigation: owner and threshold mutation methods require `msg.sender == address(this)` and can only be reached through an already-authorized wallet execution.
+
+14. Batch execution widening into arbitrary delegatecall
+- Mitigation: batch execution delegatecalls only into the fixed `MultiSendCallOnly` helper, which performs plain external calls to the encoded targets.
+
 ## Residual Risks / Out of Scope
 
 - Compromised privileged keys can still perform privileged actions.
@@ -74,6 +94,9 @@ For the accepted architecture decisions that shape these assumptions, see
 - Diamond `diamondCut` flows include core guardrails, but governance policy (timelocks/multisig approvals) remains an integration responsibility.
 - The current upgrade guardrails check nonzero implementation; deeper bytecode/interface validation is protocol-specific and should be added where needed.
 - Direct token donations to vault addresses can create untracked surplus unless explicitly reconciled by integration policy.
+- Compromised wallet owner keys can still authorize malicious transactions.
+- Off-chain signing and transaction review policy for multisig owners remains an operational responsibility.
+- The wallet does not yet include modules, guards, fallback handlers, contract owners, or ERC-4337 integration.
 
 ## Operational Guidance
 


### PR DESCRIPTION
## Summary
- add a dedicated multisig wallet architecture doc with a small reviewer-facing diagram
- thread the wallet track into the root README, canonical docs map, and reviewer validation path
- update the threat model and security checks so the wallet is represented as a first-class subsystem

Closes #173