### PR TITLE
feat: add AMM foundation layer

### DIFF
--- a/src/amm/AMMLpToken.sol
+++ b/src/amm/AMMLpToken.sol
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAMMLpToken} from "../interfaces/IAMMLpToken.sol";
+
+/// @title AMMLpToken
+/// @notice Abstract ERC-20 + permit base for AMM LP shares.
+abstract contract AMMLpToken is IAMMLpToken {
+    bytes32 internal constant EIP712_DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    bytes32 internal constant PERMIT_TYPEHASH =
+        keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+    bytes32 internal constant NAME_HASH = keccak256("Auralis V2 LP");
+    bytes32 internal constant VERSION_HASH = keccak256("1");
+    uint256 internal constant SECP256K1N_DIV_2 = 0x7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0;
+
+    bool internal _ammLpInitialized;
+    uint256 internal _ammLpTotalSupply;
+    mapping(address account => uint256 balance) internal _ammLpBalances;
+    mapping(address owner => mapping(address spender => uint256 allowance_)) internal _ammLpAllowances;
+    mapping(address owner => uint256 nonce_) internal _permitNonces;
+    bytes32 internal _hashedName;
+    uint256 internal _cachedChainId;
+    bytes32 internal _cachedDomainSeparator;
+
+    function name() public pure virtual returns (string memory) {
+        return "Auralis V2 LP";
+    }
+
+    function symbol() public pure virtual returns (string memory) {
+        return "AUR-V2-LP";
+    }
+
+    function decimals() public pure virtual returns (uint8) {
+        return 18;
+    }
+
+    function totalSupply() public view virtual returns (uint256) {
+        return _ammLpTotalSupply;
+    }
+
+    function balanceOf(address account) public view virtual returns (uint256) {
+        return _ammLpBalances[account];
+    }
+
+    function allowance(address owner, address spender) public view virtual returns (uint256) {
+        return _ammLpAllowances[owner][spender];
+    }
+
+    function approve(address spender, uint256 value) external virtual returns (bool) {
+        _requireInitialized();
+        _approveLp(msg.sender, spender, value);
+        return true;
+    }
+
+    function transfer(address to, uint256 value) external virtual returns (bool) {
+        _transferLp(msg.sender, to, value);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 value) external virtual returns (bool) {
+        _spendAllowance(from, msg.sender, value);
+        _transferLp(from, to, value);
+        return true;
+    }
+
+    function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s)
+        external
+        virtual
+    {
+        _requireInitialized();
+
+        if (block.timestamp > deadline) {
+            revert AMMLpPermitExpired(deadline, block.timestamp);
+        }
+
+        uint256 nonce_ = _permitNonces[owner];
+        // forge-lint: disable-next-line(asm-keccak256)
+        bytes32 structHash = keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, nonce_, deadline));
+        // forge-lint: disable-next-line(asm-keccak256)
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR(), structHash));
+        address signer = _recoverSigner(digest, v, r, s);
+        if (signer != owner) {
+            revert AMMLpPermitInvalidSigner(signer, owner);
+        }
+
+        _permitNonces[owner] = nonce_ + 1;
+        _approveLp(owner, spender, value);
+    }
+
+    function nonces(address owner) external view virtual returns (uint256) {
+        return _permitNonces[owner];
+    }
+
+    // forge-lint: disable-next-line(mixed-case-function)
+    function DOMAIN_SEPARATOR() public view virtual returns (bytes32) {
+        bytes32 hashedName = _hashedName == bytes32(0) ? NAME_HASH : _hashedName;
+        if (_cachedChainId == block.chainid && _cachedDomainSeparator != bytes32(0)) {
+            return _cachedDomainSeparator;
+        }
+        return _buildDomainSeparator(hashedName, block.chainid);
+    }
+
+    function _initializeAmmLpToken() internal {
+        if (_ammLpInitialized) {
+            revert AMMLpAlreadyInitialized();
+        }
+
+        _ammLpInitialized = true;
+        _hashedName = NAME_HASH;
+        _cachedChainId = block.chainid;
+        _cachedDomainSeparator = _buildDomainSeparator(NAME_HASH, block.chainid);
+    }
+
+    function _mintLp(address to, uint256 value) internal {
+        _requireInitialized();
+        _requireNonZeroAddress(to);
+
+        _ammLpTotalSupply += value;
+        _ammLpBalances[to] += value;
+
+        emit Transfer(address(0), to, value);
+    }
+
+    function _burnLp(address from, uint256 value) internal {
+        _requireInitialized();
+        _requireNonZeroAddress(from);
+
+        uint256 fromBalance = _ammLpBalances[from];
+        if (fromBalance < value) {
+            revert AMMLpInsufficientBalance(from, fromBalance, value);
+        }
+
+        unchecked {
+            _ammLpBalances[from] = fromBalance - value;
+            _ammLpTotalSupply -= value;
+        }
+
+        emit Transfer(from, address(0), value);
+    }
+
+    function _transferLp(address from, address to, uint256 value) internal {
+        _requireInitialized();
+        _requireNonZeroAddress(from);
+        _requireNonZeroAddress(to);
+
+        uint256 fromBalance = _ammLpBalances[from];
+        if (fromBalance < value) {
+            revert AMMLpInsufficientBalance(from, fromBalance, value);
+        }
+
+        unchecked {
+            _ammLpBalances[from] = fromBalance - value;
+        }
+        _ammLpBalances[to] += value;
+
+        emit Transfer(from, to, value);
+    }
+
+    function _approveLp(address owner, address spender, uint256 value) internal {
+        _requireInitialized();
+        _requireNonZeroAddress(owner);
+
+        _ammLpAllowances[owner][spender] = value;
+        emit Approval(owner, spender, value);
+    }
+
+    function _spendAllowance(address owner, address spender, uint256 value) internal {
+        _requireInitialized();
+        _requireNonZeroAddress(owner);
+
+        uint256 currentAllowance = allowance(owner, spender);
+        if (currentAllowance == type(uint256).max) {
+            return;
+        }
+        if (currentAllowance < value) {
+            revert AMMLpInsufficientAllowance(owner, spender, currentAllowance, value);
+        }
+
+        unchecked {
+            _approveLp(owner, spender, currentAllowance - value);
+        }
+    }
+
+    function _buildDomainSeparator(bytes32 hashedName, uint256 chainId) internal view returns (bytes32) {
+        // forge-lint: disable-next-line(asm-keccak256)
+        return keccak256(abi.encode(EIP712_DOMAIN_TYPEHASH, hashedName, VERSION_HASH, chainId, address(this)));
+    }
+
+    function _recoverSigner(bytes32 digest, uint8 v, bytes32 r, bytes32 s) internal pure returns (address) {
+        if (v != 27 && v != 28) {
+            return address(0);
+        }
+        if (uint256(s) > SECP256K1N_DIV_2) {
+            return address(0);
+        }
+
+        return ecrecover(digest, v, r, s);
+    }
+
+    function _requireInitialized() internal view {
+        if (!_ammLpInitialized) {
+            revert AMMLpNotInitialized();
+        }
+    }
+
+    function _requireNonZeroAddress(address account) internal pure {
+        if (account == address(0)) {
+            revert AMMLpZeroAddress();
+        }
+    }
+}

--- a/src/amm/libraries/AMMFixedPoint.sol
+++ b/src/amm/libraries/AMMFixedPoint.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title AMMFixedPoint
+/// @notice Minimal UQ112x112 fixed-point helpers for V2-style price accumulation.
+library AMMFixedPoint {
+    uint224 internal constant Q112 = uint224(1) << 112;
+
+    struct UQ112x112 {
+        uint224 value;
+    }
+
+    function encode(uint112 value) internal pure returns (UQ112x112 memory) {
+        return UQ112x112(uint224(value) * Q112);
+    }
+
+    function uqdiv(UQ112x112 memory self, uint112 value) internal pure returns (UQ112x112 memory) {
+        return UQ112x112(self.value / uint224(value));
+    }
+}

--- a/src/amm/libraries/AMMMath.sol
+++ b/src/amm/libraries/AMMMath.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title AMMMath
+/// @notice Shared math helpers for the standalone AMM subsystem.
+library AMMMath {
+    function min(uint256 x, uint256 y) internal pure returns (uint256) {
+        return x < y ? x : y;
+    }
+
+    function sqrt(uint256 y) internal pure returns (uint256 z) {
+        if (y == 0) {
+            return 0;
+        }
+        if (y <= 3) {
+            return 1;
+        }
+
+        z = y;
+        uint256 x = (y / 2) + 1;
+        while (x < z) {
+            z = x;
+            x = ((y / x) + x) / 2;
+        }
+    }
+}

--- a/src/interfaces/IAMMFactory.sol
+++ b/src/interfaces/IAMMFactory.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title IAMMFactory
+/// @notice Factory and registry surface for deterministic AMM pair deployment.
+interface IAMMFactory {
+    event PairCreated(address indexed token0, address indexed token1, address pair, uint256 pairIndex);
+
+    function feeTo() external view returns (address);
+    function feeToSetter() external view returns (address);
+    function getPair(address tokenA, address tokenB) external view returns (address);
+    function allPairs(uint256 index) external view returns (address);
+    function allPairsLength() external view returns (uint256);
+
+    function createPair(address tokenA, address tokenB) external returns (address pair);
+    function setFeeTo(address feeTo_) external;
+    function setFeeToSetter(address feeToSetter_) external;
+}

--- a/src/interfaces/IAMMLpToken.sol
+++ b/src/interfaces/IAMMLpToken.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC20Metadata} from "./IERC20Metadata.sol";
+import {IERC20Permit} from "./IERC20Permit.sol";
+
+/// @title IAMMLpToken
+/// @notice ERC-20 + permit surface for the standalone AMM LP token.
+interface IAMMLpToken is IERC20Metadata, IERC20Permit {
+    error AMMLpAlreadyInitialized();
+    error AMMLpNotInitialized();
+    error AMMLpZeroAddress();
+    error AMMLpInsufficientBalance(address account, uint256 available, uint256 required);
+    error AMMLpInsufficientAllowance(address owner, address spender, uint256 available, uint256 required);
+    error AMMLpPermitExpired(uint256 deadline, uint256 currentTimestamp);
+    error AMMLpPermitInvalidSigner(address signer, address owner);
+}

--- a/src/interfaces/IAMMPair.sol
+++ b/src/interfaces/IAMMPair.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAMMLpToken} from "./IAMMLpToken.sol";
+
+/// @title IAMMPair
+/// @notice Constant-product AMM pair surface, including LP token behavior.
+interface IAMMPair is IAMMLpToken {
+    event Mint(address indexed sender, uint256 amount0, uint256 amount1);
+    event Burn(address indexed sender, uint256 amount0, uint256 amount1, address indexed to);
+    event Swap(
+        address indexed sender,
+        uint256 amount0In,
+        uint256 amount1In,
+        uint256 amount0Out,
+        uint256 amount1Out,
+        address indexed to
+    );
+    event Sync(uint112 reserve0, uint112 reserve1);
+
+    function factory() external view returns (address);
+    function token0() external view returns (address);
+    function token1() external view returns (address);
+    function MINIMUM_LIQUIDITY() external pure returns (uint256);
+    function getReserves() external view returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast);
+    function price0CumulativeLast() external view returns (uint256);
+    function price1CumulativeLast() external view returns (uint256);
+    function kLast() external view returns (uint256);
+
+    function initialize(address token0_, address token1_) external;
+    function mint(address to) external returns (uint256 liquidity);
+    function burn(address to) external returns (uint256 amount0, uint256 amount1);
+    function swap(uint256 amount0Out, uint256 amount1Out, address to, bytes calldata data) external;
+    function skim(address to) external;
+    function sync() external;
+}

--- a/src/interfaces/IAMMRouter.sol
+++ b/src/interfaces/IAMMRouter.sol
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title IAMMRouter
+/// @notice User-facing router and quoting surface for the standalone AMM subsystem.
+interface IAMMRouter {
+    function factory() external view returns (address);
+    function wrappedNative() external view returns (address);
+
+    function quote(uint256 amountA, uint256 reserveA, uint256 reserveB) external pure returns (uint256 amountB);
+    function getAmountOut(uint256 amountIn, uint256 reserveIn, uint256 reserveOut) external pure returns (uint256);
+    function getAmountIn(uint256 amountOut, uint256 reserveIn, uint256 reserveOut) external pure returns (uint256);
+    function getAmountsOut(uint256 amountIn, address[] calldata path) external view returns (uint256[] memory amounts);
+    function getAmountsIn(uint256 amountOut, address[] calldata path) external view returns (uint256[] memory amounts);
+
+    function addLiquidity(
+        address tokenA,
+        address tokenB,
+        uint256 amountADesired,
+        uint256 amountBDesired,
+        uint256 amountAMin,
+        uint256 amountBMin,
+        address to,
+        uint256 deadline
+    ) external returns (uint256 amountA, uint256 amountB, uint256 liquidity);
+
+    function addLiquidityNative(
+        address token,
+        uint256 amountTokenDesired,
+        uint256 amountTokenMin,
+        uint256 amountNativeMin,
+        address to,
+        uint256 deadline
+    ) external payable returns (uint256 amountToken, uint256 amountNative, uint256 liquidity);
+
+    function removeLiquidity(
+        address tokenA,
+        address tokenB,
+        uint256 liquidity,
+        uint256 amountAMin,
+        uint256 amountBMin,
+        address to,
+        uint256 deadline
+    ) external returns (uint256 amountA, uint256 amountB);
+
+    function removeLiquidityNative(
+        address token,
+        uint256 liquidity,
+        uint256 amountTokenMin,
+        uint256 amountNativeMin,
+        address to,
+        uint256 deadline
+    ) external returns (uint256 amountToken, uint256 amountNative);
+
+    function removeLiquidityWithPermit(
+        address tokenA,
+        address tokenB,
+        uint256 liquidity,
+        uint256 amountAMin,
+        uint256 amountBMin,
+        address to,
+        uint256 deadline,
+        bool approveMax,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external returns (uint256 amountA, uint256 amountB);
+
+    function removeLiquidityNativeWithPermit(
+        address token,
+        uint256 liquidity,
+        uint256 amountTokenMin,
+        uint256 amountNativeMin,
+        address to,
+        uint256 deadline,
+        bool approveMax,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external returns (uint256 amountToken, uint256 amountNative);
+
+    function swapExactTokensForTokens(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external returns (uint256[] memory amounts);
+
+    function swapTokensForExactTokens(
+        uint256 amountOut,
+        uint256 amountInMax,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external returns (uint256[] memory amounts);
+
+    function swapExactNativeForTokens(uint256 amountOutMin, address[] calldata path, address to, uint256 deadline)
+        external
+        payable
+        returns (uint256[] memory amounts);
+
+    function swapTokensForExactNative(
+        uint256 amountOut,
+        uint256 amountInMax,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external returns (uint256[] memory amounts);
+
+    function swapExactTokensForNative(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external returns (uint256[] memory amounts);
+
+    function swapNativeForExactTokens(uint256 amountOut, address[] calldata path, address to, uint256 deadline)
+        external
+        payable
+        returns (uint256[] memory amounts);
+}

--- a/test/AMMFoundationCore.t.sol
+++ b/test/AMMFoundationCore.t.sol
@@ -111,7 +111,8 @@ contract AMMFoundationCoreTest is AMMFoundationFixture {
         lpToken.mint(alice, 10);
 
         VM.prank(alice);
-        (bool success, bytes memory returndata) = address(lpToken).call(abi.encodeCall(lpToken.transfer, (address(0), 1)));
+        (bool success, bytes memory returndata) =
+            address(lpToken).call(abi.encodeCall(lpToken.transfer, (address(0), 1)));
         assertFalse(success, "zero-address transfer should revert");
 
         bytes4 revertSelector;

--- a/test/AMMFoundationCore.t.sol
+++ b/test/AMMFoundationCore.t.sol
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAMMLpToken} from "../src/interfaces/IAMMLpToken.sol";
+import {AMMFoundationFixture} from "./helpers/AMMTestHarness.sol";
+
+contract AMMFoundationCoreTest is AMMFoundationFixture {
+    function testInitializationSucceedsOnceAndCachesDomainSeparator() public {
+        lpToken.initializeAmmLpToken();
+
+        assertTrue(lpToken.initialized(), "lp token should initialize");
+        assertTrue(keccak256(bytes(lpToken.name())) == keccak256(bytes("Auralis V2 LP")), "name mismatch");
+        assertTrue(keccak256(bytes(lpToken.symbol())) == keccak256(bytes("AUR-V2-LP")), "symbol mismatch");
+        assertTrue(lpToken.decimals() == 18, "decimals mismatch");
+        assertTrue(lpToken.DOMAIN_SEPARATOR() == _domainSeparator(address(lpToken)), "domain separator mismatch");
+
+        VM.expectRevert(IAMMLpToken.AMMLpAlreadyInitialized.selector);
+        lpToken.initializeAmmLpToken();
+    }
+
+    function testMintTransferApproveTransferFromAndBurn() public {
+        lpToken.initializeAmmLpToken();
+
+        lpToken.mint(alice, 100);
+        assertTrue(lpToken.totalSupply() == 100, "total supply mismatch");
+        assertTrue(lpToken.balanceOf(alice) == 100, "alice balance mismatch");
+
+        VM.prank(alice);
+        assertTrue(lpToken.transfer(bob, 40), "transfer should succeed");
+        assertTrue(lpToken.balanceOf(alice) == 60, "alice post-transfer mismatch");
+        assertTrue(lpToken.balanceOf(bob) == 40, "bob post-transfer mismatch");
+
+        VM.prank(alice);
+        assertTrue(lpToken.approve(bob, 25), "approve should succeed");
+        assertTrue(lpToken.allowance(alice, bob) == 25, "allowance mismatch");
+
+        VM.prank(bob);
+        assertTrue(lpToken.transferFrom(alice, carol, 20), "transferFrom should succeed");
+        assertTrue(lpToken.balanceOf(carol) == 20, "carol balance mismatch");
+        assertTrue(lpToken.allowance(alice, bob) == 5, "allowance post-transferFrom mismatch");
+
+        lpToken.burn(carol, 10);
+        assertTrue(lpToken.balanceOf(carol) == 10, "carol post-burn mismatch");
+        assertTrue(lpToken.totalSupply() == 90, "total supply post-burn mismatch");
+    }
+
+    function testPermitSetsAllowanceAndIncrementsNonce() public {
+        lpToken.initializeAmmLpToken();
+
+        uint256 deadline = block.timestamp + 1 days;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(ALICE_PK, address(lpToken), alice, bob, 55, 0, deadline);
+
+        lpToken.permit(alice, bob, 55, deadline, v, r, s);
+
+        assertTrue(lpToken.allowance(alice, bob) == 55, "permit allowance mismatch");
+        assertTrue(lpToken.nonces(alice) == 1, "permit nonce mismatch");
+    }
+
+    function testPermitReplayReverts() public {
+        lpToken.initializeAmmLpToken();
+
+        uint256 deadline = block.timestamp + 1 days;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(ALICE_PK, address(lpToken), alice, bob, 55, 0, deadline);
+
+        lpToken.permit(alice, bob, 55, deadline, v, r, s);
+
+        address replaySigner = _recoverPermitSigner(address(lpToken), alice, bob, 55, 1, deadline, v, r, s);
+        VM.expectRevert(abi.encodeWithSelector(IAMMLpToken.AMMLpPermitInvalidSigner.selector, replaySigner, alice));
+        lpToken.permit(alice, bob, 55, deadline, v, r, s);
+    }
+
+    function testPermitRevertsOnExpiredDeadline() public {
+        lpToken.initializeAmmLpToken();
+
+        uint256 deadline = block.timestamp;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(ALICE_PK, address(lpToken), alice, bob, 33, 0, deadline);
+
+        VM.warp(deadline + 1);
+        VM.expectRevert(abi.encodeWithSelector(IAMMLpToken.AMMLpPermitExpired.selector, deadline, block.timestamp));
+        lpToken.permit(alice, bob, 33, deadline, v, r, s);
+    }
+
+    function testPermitRevertsOnWrongPayload() public {
+        lpToken.initializeAmmLpToken();
+
+        uint256 deadline = block.timestamp + 1 days;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(ALICE_PK, address(lpToken), alice, bob, 55, 0, deadline);
+
+        address wrongSpenderSigner = _recoverPermitSigner(address(lpToken), alice, carol, 55, 0, deadline, v, r, s);
+        VM.expectRevert(
+            abi.encodeWithSelector(IAMMLpToken.AMMLpPermitInvalidSigner.selector, wrongSpenderSigner, alice)
+        );
+        lpToken.permit(alice, carol, 55, deadline, v, r, s);
+    }
+
+    function testPermitRejectsInvalidVAndHighS() public {
+        lpToken.initializeAmmLpToken();
+
+        uint256 deadline = block.timestamp + 1 days;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(ALICE_PK, address(lpToken), alice, bob, 77, 0, deadline);
+
+        VM.expectRevert(abi.encodeWithSelector(IAMMLpToken.AMMLpPermitInvalidSigner.selector, address(0), alice));
+        lpToken.permit(alice, bob, 77, deadline, v + 2, r, s);
+
+        VM.expectRevert(abi.encodeWithSelector(IAMMLpToken.AMMLpPermitInvalidSigner.selector, address(0), alice));
+        lpToken.permit(alice, bob, 77, deadline, v, r, _invalidHighS(s));
+    }
+
+    function testZeroAddressTransferRevertsAndZeroSpenderApproveIsAllowed() public {
+        lpToken.initializeAmmLpToken();
+        lpToken.mint(alice, 10);
+
+        VM.prank(alice);
+        (bool success, bytes memory returndata) = address(lpToken).call(abi.encodeCall(lpToken.transfer, (address(0), 1)));
+        assertFalse(success, "zero-address transfer should revert");
+
+        bytes4 revertSelector;
+        assembly {
+            revertSelector := mload(add(returndata, 0x20))
+        }
+        assertTrue(revertSelector == IAMMLpToken.AMMLpZeroAddress.selector, "unexpected revert selector");
+
+        VM.prank(alice);
+        assertTrue(lpToken.approve(address(0), 7), "approve zero spender should succeed");
+        assertTrue(lpToken.allowance(alice, address(0)) == 7, "zero spender allowance mismatch");
+    }
+
+    function testMutatingActionsRevertBeforeInitialization() public {
+        VM.expectRevert(IAMMLpToken.AMMLpNotInitialized.selector);
+        lpToken.mint(alice, 1);
+
+        VM.prank(alice);
+        VM.expectRevert(IAMMLpToken.AMMLpNotInitialized.selector);
+        lpToken.approve(bob, 1);
+    }
+
+    function testMathHelpersMatchExpectedValues() public pure {
+        assertTrue(_mathMin(4, 9) == 4, "min mismatch");
+        assertTrue(_mathSqrt(0) == 0, "sqrt(0) mismatch");
+        assertTrue(_mathSqrt(1) == 1, "sqrt(1) mismatch");
+        assertTrue(_mathSqrt(2) == 1, "sqrt(2) mismatch");
+        assertTrue(_mathSqrt(15) == 3, "sqrt(15) mismatch");
+        assertTrue(_mathSqrt(16) == 4, "sqrt(16) mismatch");
+    }
+
+    function testFixedPointHelpersMatchUQ112x112Expectations() public pure {
+        uint224 q112 = uint224(1) << 112;
+
+        assertTrue(_encodeUq112x112(5) == 5 * q112, "encode mismatch");
+        assertTrue(_uqdiv(10, 2) == 5 * q112, "uqdiv mismatch");
+    }
+}

--- a/test/helpers/AMMTestHarness.sol
+++ b/test/helpers/AMMTestHarness.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {AMMFixedPoint} from "../../src/amm/libraries/AMMFixedPoint.sol";
+import {AMMMath} from "../../src/amm/libraries/AMMMath.sol";
+import {AMMLpToken} from "../../src/amm/AMMLpToken.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+
+contract AMMLpTokenHarness is AMMLpToken {
+    function initializeAmmLpToken() external {
+        _initializeAmmLpToken();
+    }
+
+    function mint(address to, uint256 value) external {
+        _mintLp(to, value);
+    }
+
+    function burn(address from, uint256 value) external {
+        _burnLp(from, value);
+    }
+
+    function initialized() external view returns (bool) {
+        return _ammLpInitialized;
+    }
+}
+
+abstract contract AMMFoundationFixture is TestBase {
+    bytes32 internal constant EIP712_DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    bytes32 internal constant PERMIT_TYPEHASH =
+        keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+    bytes32 internal constant NAME_HASH = keccak256("Auralis V2 LP");
+    bytes32 internal constant VERSION_HASH = keccak256("1");
+    uint256 internal constant ALICE_PK = 0xA11CE;
+    uint256 internal constant BOB_PK = 0xB0B;
+    uint256 internal constant CAROL_PK = 0xCAFE;
+
+    AMMLpTokenHarness internal lpToken;
+    address internal alice;
+    address internal bob;
+    address internal carol;
+
+    function setUp() public virtual {
+        lpToken = new AMMLpTokenHarness();
+        alice = VM.addr(ALICE_PK);
+        bob = VM.addr(BOB_PK);
+        carol = VM.addr(CAROL_PK);
+    }
+
+    function _domainSeparator(address token) internal view returns (bytes32) {
+        return keccak256(abi.encode(EIP712_DOMAIN_TYPEHASH, NAME_HASH, VERSION_HASH, block.chainid, token));
+    }
+
+    function _permitDigest(address token, address owner, address spender, uint256 value, uint256 nonce_, uint256 deadline)
+        internal
+        view
+        returns (bytes32)
+    {
+        bytes32 structHash = keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, nonce_, deadline));
+        return keccak256(abi.encodePacked("\x19\x01", _domainSeparator(token), structHash));
+    }
+
+    function _signPermit(
+        uint256 signerKey,
+        address token,
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 nonce_,
+        uint256 deadline
+    ) internal returns (uint8 v, bytes32 r, bytes32 s) {
+        return VM.sign(signerKey, _permitDigest(token, owner, spender, value, nonce_, deadline));
+    }
+
+    function _recoverPermitSigner(
+        address token,
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 nonce_,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) internal view returns (address) {
+        return ecrecover(_permitDigest(token, owner, spender, value, nonce_, deadline), v, r, s);
+    }
+
+    function _invalidHighS(bytes32 s) internal pure returns (bytes32) {
+        return bytes32(
+            0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141 - uint256(s)
+        );
+    }
+
+    function _mathMin(uint256 x, uint256 y) internal pure returns (uint256) {
+        return AMMMath.min(x, y);
+    }
+
+    function _mathSqrt(uint256 value) internal pure returns (uint256) {
+        return AMMMath.sqrt(value);
+    }
+
+    function _encodeUq112x112(uint112 value) internal pure returns (uint224) {
+        return AMMFixedPoint.encode(value).value;
+    }
+
+    function _uqdiv(uint112 value, uint112 divisor) internal pure returns (uint224) {
+        return AMMFixedPoint.uqdiv(AMMFixedPoint.encode(value), divisor).value;
+    }
+}

--- a/test/helpers/AMMTestHarness.sol
+++ b/test/helpers/AMMTestHarness.sol
@@ -51,11 +51,14 @@ abstract contract AMMFoundationFixture is TestBase {
         return keccak256(abi.encode(EIP712_DOMAIN_TYPEHASH, NAME_HASH, VERSION_HASH, block.chainid, token));
     }
 
-    function _permitDigest(address token, address owner, address spender, uint256 value, uint256 nonce_, uint256 deadline)
-        internal
-        view
-        returns (bytes32)
-    {
+    function _permitDigest(
+        address token,
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 nonce_,
+        uint256 deadline
+    ) internal view returns (bytes32) {
         bytes32 structHash = keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, nonce_, deadline));
         return keccak256(abi.encodePacked("\x19\x01", _domainSeparator(token), structHash));
     }
@@ -87,9 +90,7 @@ abstract contract AMMFoundationFixture is TestBase {
     }
 
     function _invalidHighS(bytes32 s) internal pure returns (bytes32) {
-        return bytes32(
-            0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141 - uint256(s)
-        );
+        return bytes32(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141 - uint256(s));
     }
 
     function _mathMin(uint256 x, uint256 y) internal pure returns (uint256) {


### PR DESCRIPTION
## Summary
- add the AMM-local LP token base with ERC20 and permit support
- add the stable V2-shaped AMM interface surface for pair, factory, and router work
- add the shared math and fixed-point primitives for later pair and router issues
- add focused AMM foundation tests through a local harness

## Validation
- forge test --offline --match-path test/AMMFoundationCore.t.sol
- forge build --sizes --skip script

## Linked Issue
Closes #180
