### PR TITLE
feat: implement AMM pair core

### DIFF
--- a/src/amm/AMMPair.sol
+++ b/src/amm/AMMPair.sol
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {AMMFixedPoint} from "./libraries/AMMFixedPoint.sol";
+import {AMMLpToken} from "./AMMLpToken.sol";
+import {AMMMath} from "./libraries/AMMMath.sol";
+import {IAMMFactory} from "../interfaces/IAMMFactory.sol";
+import {IAMMPair} from "../interfaces/IAMMPair.sol";
+import {IERC20} from "../interfaces/IERC20.sol";
+
+/// @title AMMPair
+/// @notice Constant-product pair core for the standalone V2-style AMM track.
+contract AMMPair is AMMLpToken, IAMMPair {
+    uint256 internal constant FEE_DENOMINATOR = 1000;
+    uint256 internal constant FEE_UNITS = 3;
+    address internal constant MINIMUM_LIQUIDITY_SINK = 0x000000000000000000000000000000000000dEaD;
+
+    error AMMPairForbidden();
+    error AMMPairAlreadyInitialized();
+    error AMMPairZeroTokenAddress();
+    error AMMPairIdenticalTokens();
+    error AMMPairLocked();
+    error AMMPairInvalidRecipient(address to);
+    error AMMPairInsufficientLiquidityMinted();
+    error AMMPairInsufficientLiquidityBurned();
+    error AMMPairInsufficientLiquidity();
+    error AMMPairInsufficientInputAmount();
+    error AMMPairInsufficientOutputAmount();
+    error AMMPairReserveOverflow();
+    error AMMPairUnsupportedSwapData();
+    error AMMPairTransferFailed(address token, address to, uint256 value);
+    error AMMPairKInvariant();
+
+    address public immutable override factory;
+
+    address public override token0;
+    address public override token1;
+    uint256 public override price0CumulativeLast;
+    uint256 public override price1CumulativeLast;
+    uint256 public override kLast;
+
+    uint112 internal _reserve0;
+    uint112 internal _reserve1;
+    uint32 internal _blockTimestampLast;
+    uint256 internal _unlocked = 1;
+
+    constructor() {
+        factory = msg.sender;
+    }
+
+    modifier lock() {
+        if (_unlocked != 1) {
+            revert AMMPairLocked();
+        }
+
+        _unlocked = 0;
+        _;
+        _unlocked = 1;
+    }
+
+    // forge-lint: disable-next-line(mixed-case-function)
+    function MINIMUM_LIQUIDITY() public pure override returns (uint256) {
+        return 1000;
+    }
+
+    function getReserves()
+        external
+        view
+        override
+        returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast)
+    {
+        return (_reserve0, _reserve1, _blockTimestampLast);
+    }
+
+    function initialize(address token0_, address token1_) external override {
+        if (msg.sender != factory) {
+            revert AMMPairForbidden();
+        }
+        if (_ammLpInitialized) {
+            revert AMMPairAlreadyInitialized();
+        }
+        if (token0_ == address(0) || token1_ == address(0)) {
+            revert AMMPairZeroTokenAddress();
+        }
+        if (token0_ == token1_) {
+            revert AMMPairIdenticalTokens();
+        }
+
+        _initializeAmmLpToken();
+        token0 = token0_;
+        token1 = token1_;
+    }
+
+    function mint(address to) external override lock returns (uint256 liquidity) {
+        uint112 reserve0_ = _reserve0;
+        uint112 reserve1_ = _reserve1;
+        (uint256 balance0, uint256 balance1) = _currentBalances();
+
+        uint256 amount0 = balance0 - reserve0_;
+        uint256 amount1 = balance1 - reserve1_;
+
+        bool feeOn = _mintFee(reserve0_, reserve1_);
+        uint256 totalSupply_ = totalSupply();
+
+        if (totalSupply_ == 0) {
+            uint256 rootK = AMMMath.sqrt(amount0 * amount1);
+            uint256 minimumLiquidity = MINIMUM_LIQUIDITY();
+            if (rootK <= minimumLiquidity) {
+                revert AMMPairInsufficientLiquidityMinted();
+            }
+
+            unchecked {
+                liquidity = rootK - minimumLiquidity;
+            }
+            _mintLp(MINIMUM_LIQUIDITY_SINK, minimumLiquidity);
+        } else {
+            liquidity = AMMMath.min((amount0 * totalSupply_) / reserve0_, (amount1 * totalSupply_) / reserve1_);
+        }
+
+        if (liquidity == 0) {
+            revert AMMPairInsufficientLiquidityMinted();
+        }
+
+        _mintLp(to, liquidity);
+        _update(balance0, balance1, reserve0_, reserve1_);
+        if (feeOn) {
+            kLast = uint256(_reserve0) * uint256(_reserve1);
+        }
+
+        emit Mint(msg.sender, amount0, amount1);
+    }
+
+    function burn(address to) external override lock returns (uint256 amount0, uint256 amount1) {
+        uint112 reserve0_ = _reserve0;
+        uint112 reserve1_ = _reserve1;
+        address token0_ = token0;
+        address token1_ = token1;
+        (uint256 balance0, uint256 balance1) = _currentBalances();
+        uint256 liquidity = balanceOf(address(this));
+
+        bool feeOn = _mintFee(reserve0_, reserve1_);
+        uint256 totalSupply_ = totalSupply();
+
+        amount0 = (liquidity * balance0) / totalSupply_;
+        amount1 = (liquidity * balance1) / totalSupply_;
+        if (amount0 == 0 || amount1 == 0) {
+            revert AMMPairInsufficientLiquidityBurned();
+        }
+
+        uint256 nextBalance0 = balance0 - amount0;
+        uint256 nextBalance1 = balance1 - amount1;
+
+        _burnLp(address(this), liquidity);
+        _update(nextBalance0, nextBalance1, reserve0_, reserve1_);
+        if (feeOn) {
+            kLast = uint256(_reserve0) * uint256(_reserve1);
+        }
+
+        _safeTransfer(token0_, to, amount0);
+        _safeTransfer(token1_, to, amount1);
+
+        emit Burn(msg.sender, amount0, amount1, to);
+    }
+
+    function swap(uint256 amount0Out, uint256 amount1Out, address to, bytes calldata data) external override lock {
+        if (amount0Out == 0 && amount1Out == 0) {
+            revert AMMPairInsufficientOutputAmount();
+        }
+        if (to == address(0) || to == token0 || to == token1) {
+            revert AMMPairInvalidRecipient(to);
+        }
+        if (data.length != 0) {
+            revert AMMPairUnsupportedSwapData();
+        }
+
+        uint256 amount0In;
+        uint256 amount1In;
+        {
+            uint112 reserve0_ = _reserve0;
+            uint112 reserve1_ = _reserve1;
+            if (amount0Out >= reserve0_ || amount1Out >= reserve1_) {
+                revert AMMPairInsufficientLiquidity();
+            }
+
+            (uint256 balance0Before, uint256 balance1Before) = _currentBalances();
+            uint256 balance0 = balance0Before - amount0Out;
+            uint256 balance1 = balance1Before - amount1Out;
+            amount0In = balance0Before > reserve0_ ? balance0Before - reserve0_ : 0;
+            amount1In = balance1Before > reserve1_ ? balance1Before - reserve1_ : 0;
+
+            if (amount0In == 0 && amount1In == 0) {
+                revert AMMPairInsufficientInputAmount();
+            }
+
+            uint256 balance0Adjusted = (balance0 * FEE_DENOMINATOR) - (amount0In * FEE_UNITS);
+            uint256 balance1Adjusted = (balance1 * FEE_DENOMINATOR) - (amount1In * FEE_UNITS);
+            uint256 reserveProduct = uint256(reserve0_) * uint256(reserve1_) * (FEE_DENOMINATOR ** 2);
+            if ((balance0Adjusted * balance1Adjusted) < reserveProduct) {
+                revert AMMPairKInvariant();
+            }
+
+            _update(balance0, balance1, reserve0_, reserve1_);
+        }
+
+        if (amount0Out != 0) {
+            _safeTransfer(token0, to, amount0Out);
+        }
+        if (amount1Out != 0) {
+            _safeTransfer(token1, to, amount1Out);
+        }
+        emit Swap(msg.sender, amount0In, amount1In, amount0Out, amount1Out, to);
+    }
+
+    function skim(address to) external override lock {
+        _safeTransfer(token0, to, IERC20(token0).balanceOf(address(this)) - _reserve0);
+        _safeTransfer(token1, to, IERC20(token1).balanceOf(address(this)) - _reserve1);
+    }
+
+    function sync() external override lock {
+        (uint256 balance0, uint256 balance1) = _currentBalances();
+        _update(balance0, balance1, _reserve0, _reserve1);
+    }
+
+    function _currentBalances() internal view returns (uint256 balance0, uint256 balance1) {
+        return (IERC20(token0).balanceOf(address(this)), IERC20(token1).balanceOf(address(this)));
+    }
+
+    function _mintFee(uint112 reserve0_, uint112 reserve1_) internal returns (bool feeOn) {
+        address feeTo = IAMMFactory(factory).feeTo();
+        feeOn = feeTo != address(0);
+
+        uint256 kLast_ = kLast;
+        if (feeOn) {
+            if (kLast_ != 0) {
+                uint256 rootK = AMMMath.sqrt(uint256(reserve0_) * uint256(reserve1_));
+                uint256 rootKLast = AMMMath.sqrt(kLast_);
+
+                if (rootK > rootKLast) {
+                    uint256 numerator = totalSupply() * (rootK - rootKLast);
+                    uint256 denominator = (rootK * 5) + rootKLast;
+                    uint256 liquidity = numerator / denominator;
+                    if (liquidity != 0) {
+                        _mintLp(feeTo, liquidity);
+                    }
+                }
+            }
+        } else if (kLast_ != 0) {
+            kLast = 0;
+        }
+    }
+
+    function _update(uint256 balance0, uint256 balance1, uint112 reserve0_, uint112 reserve1_) internal {
+        if (balance0 > type(uint112).max || balance1 > type(uint112).max) {
+            revert AMMPairReserveOverflow();
+        }
+
+        uint32 blockTimestamp = uint32(block.timestamp);
+        uint32 timeElapsed;
+        unchecked {
+            timeElapsed = blockTimestamp - _blockTimestampLast;
+        }
+
+        if (timeElapsed > 0 && reserve0_ != 0 && reserve1_ != 0) {
+            price0CumulativeLast += uint256(AMMFixedPoint.uqdiv(AMMFixedPoint.encode(reserve1_), reserve0_).value)
+            * timeElapsed;
+            price1CumulativeLast += uint256(AMMFixedPoint.uqdiv(AMMFixedPoint.encode(reserve0_), reserve1_).value)
+            * timeElapsed;
+        }
+
+        // forge-lint: disable-next-line(unsafe-typecast)
+        _reserve0 = uint112(balance0);
+        // forge-lint: disable-next-line(unsafe-typecast)
+        _reserve1 = uint112(balance1);
+        _blockTimestampLast = blockTimestamp;
+
+        emit Sync(_reserve0, _reserve1);
+    }
+
+    function _safeTransfer(address token, address to, uint256 value) internal {
+        if (value == 0) {
+            return;
+        }
+
+        (bool success, bytes memory returndata) =
+            token.call(abi.encodeWithSelector(IERC20.transfer.selector, to, value));
+
+        bool validReturn = returndata.length == 0 || (returndata.length == 32 && abi.decode(returndata, (bool)));
+        if (!success || !validReturn) {
+            revert AMMPairTransferFailed(token, to, value);
+        }
+    }
+}

--- a/test/AMMPairCore.t.sol
+++ b/test/AMMPairCore.t.sol
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {AMMPair} from "../src/amm/AMMPair.sol";
+import {
+    AMMFactoryHarness,
+    AMMPairCoreFixture,
+    FalseReturningAMMToken,
+    MalformedAMMToken,
+    MockAMMToken,
+    ReentrantAMMToken,
+    SilentAMMToken
+} from "./helpers/AMMPairTestHarness.sol";
+
+contract AMMPairCoreTest is AMMPairCoreFixture {
+    function testInitializeOnlyFactoryOnceAndRejectsInvalidTokens() public {
+        AMMPair unauthorized = new AMMPair();
+        assertTrue(unauthorized.factory() == address(this), "unexpected constructor factory");
+
+        VM.prank(alice);
+        VM.expectRevert(AMMPair.AMMPairForbidden.selector);
+        unauthorized.initialize(address(token0), address(token1));
+
+        AMMPair zeroToken = new AMMPair();
+        VM.expectRevert(AMMPair.AMMPairZeroTokenAddress.selector);
+        zeroToken.initialize(address(0), address(token1));
+
+        AMMPair identicalToken = new AMMPair();
+        VM.expectRevert(AMMPair.AMMPairIdenticalTokens.selector);
+        identicalToken.initialize(address(token0), address(token0));
+
+        AMMPair initialized = new AMMPair();
+        initialized.initialize(address(token0), address(token1));
+        assertTrue(initialized.token0() == address(token0), "token0 mismatch");
+        assertTrue(initialized.token1() == address(token1), "token1 mismatch");
+
+        (uint112 reserve0_, uint112 reserve1_, uint32 timestampLast) = initialized.getReserves();
+        assertTrue(reserve0_ == 0, "reserve0 should start at zero");
+        assertTrue(reserve1_ == 0, "reserve1 should start at zero");
+        assertTrue(timestampLast == 0, "timestamp should start at zero");
+
+        VM.expectRevert(AMMPair.AMMPairAlreadyInitialized.selector);
+        initialized.initialize(address(token0), address(token1));
+    }
+
+    function testFirstLiquidityMintLocksMinimumLiquidityAndUpdatesReserves() public {
+        uint256 liquidity = _provideLiquidity(pair, token0, token1, alice, 10_000, 40_000, alice);
+
+        assertTrue(liquidity == 19_000, "first-liquidity mint mismatch");
+        assertTrue(pair.balanceOf(alice) == 19_000, "provider lp balance mismatch");
+        assertTrue(pair.balanceOf(BURN_SINK) == pair.MINIMUM_LIQUIDITY(), "minimum liquidity not locked");
+        assertTrue(pair.totalSupply() == 20_000, "lp total supply mismatch");
+
+        (uint112 reserve0_, uint112 reserve1_,) = pair.getReserves();
+        assertTrue(reserve0_ == 10_000, "reserve0 mismatch");
+        assertTrue(reserve1_ == 40_000, "reserve1 mismatch");
+        assertTrue(pair.kLast() == 0, "kLast should remain zero when fee switch is off");
+    }
+
+    function testLaterLiquidityMintUsesCurrentReserveRatio() public {
+        _provideLiquidity(pair, token0, token1, alice, 10_000, 10_000, alice);
+        uint256 liquidity = _provideLiquidity(pair, token0, token1, bob, 5_000, 5_000, bob);
+
+        assertTrue(liquidity == 5_000, "second liquidity mint mismatch");
+        assertTrue(pair.balanceOf(bob) == 5_000, "bob lp balance mismatch");
+
+        (uint112 reserve0_, uint112 reserve1_,) = pair.getReserves();
+        assertTrue(reserve0_ == 15_000, "reserve0 mismatch after second mint");
+        assertTrue(reserve1_ == 15_000, "reserve1 mismatch after second mint");
+    }
+
+    function testBurnRedeemsUnderlyingProRata() public {
+        _provideLiquidity(pair, token0, token1, alice, 10_000, 10_000, alice);
+
+        VM.prank(alice);
+        assertTrue(pair.transfer(address(pair), 5_000), "lp transfer to pair should succeed");
+
+        (uint256 amount0, uint256 amount1) = pair.burn(alice);
+        assertTrue(amount0 == 5_000, "burn amount0 mismatch");
+        assertTrue(amount1 == 5_000, "burn amount1 mismatch");
+        assertTrue(token0.balanceOf(alice) == 5_000, "alice token0 post-burn mismatch");
+        assertTrue(token1.balanceOf(alice) == 5_000, "alice token1 post-burn mismatch");
+
+        (uint112 reserve0_, uint112 reserve1_,) = pair.getReserves();
+        assertTrue(reserve0_ == 5_000, "reserve0 mismatch after burn");
+        assertTrue(reserve1_ == 5_000, "reserve1 mismatch after burn");
+    }
+
+    function testSwapToken1Out() public {
+        _provideLiquidity(pair, token0, token1, alice, 10_000, 10_000, alice);
+
+        token0.mint(bob, 1_000);
+        VM.prank(bob);
+        assertTrue(token0.transfer(address(pair), 1_000), "token0 input transfer should succeed");
+
+        uint256 amount1Out = _getAmountOut(1_000, 10_000, 10_000);
+        VM.prank(bob);
+        pair.swap(0, amount1Out, bob, "");
+
+        assertTrue(token1.balanceOf(bob) == amount1Out, "token1 output mismatch");
+
+        (uint112 reserve0_, uint112 reserve1_,) = pair.getReserves();
+        assertTrue(reserve0_ == 11_000, "reserve0 mismatch after token1-out swap");
+        assertTrue(reserve1_ == 10_000 - amount1Out, "reserve1 mismatch after token1-out swap");
+    }
+
+    function testSwapToken0Out() public {
+        _provideLiquidity(pair, token0, token1, alice, 10_000, 10_000, alice);
+
+        token1.mint(bob, 1_000);
+        VM.prank(bob);
+        assertTrue(token1.transfer(address(pair), 1_000), "token1 input transfer should succeed");
+
+        uint256 amount0Out = _getAmountOut(1_000, 10_000, 10_000);
+        VM.prank(bob);
+        pair.swap(amount0Out, 0, bob, "");
+
+        assertTrue(token0.balanceOf(bob) == amount0Out, "token0 output mismatch");
+
+        (uint112 reserve0_, uint112 reserve1_,) = pair.getReserves();
+        assertTrue(reserve0_ == 10_000 - amount0Out, "reserve0 mismatch after token0-out swap");
+        assertTrue(reserve1_ == 11_000, "reserve1 mismatch after token0-out swap");
+    }
+
+    function testSwapRevertsOnInsufficientLiquidity() public {
+        _provideLiquidity(pair, token0, token1, alice, 10_000, 10_000, alice);
+
+        VM.expectRevert(AMMPair.AMMPairInsufficientLiquidity.selector);
+        pair.swap(10_000, 0, bob, "");
+    }
+
+    function testSwapRevertsOnUnsupportedData() public {
+        _provideLiquidity(pair, token0, token1, alice, 10_000, 10_000, alice);
+
+        VM.expectRevert(AMMPair.AMMPairUnsupportedSwapData.selector);
+        pair.swap(0, 1, bob, hex"01");
+    }
+
+    function testSwapRevertsOnInvalidRecipient() public {
+        _provideLiquidity(pair, token0, token1, alice, 10_000, 10_000, alice);
+
+        VM.expectRevert(abi.encodeWithSelector(AMMPair.AMMPairInvalidRecipient.selector, address(token0)));
+        pair.swap(0, 1, address(token0), "");
+    }
+
+    function testSwapRevertsWhenNoInputIsProvided() public {
+        _provideLiquidity(pair, token0, token1, alice, 10_000, 10_000, alice);
+
+        VM.expectRevert(AMMPair.AMMPairInsufficientInputAmount.selector);
+        pair.swap(0, 100, bob, "");
+    }
+
+    function testSwapRevertsOnConstantProductViolation() public {
+        _provideLiquidity(pair, token0, token1, alice, 10_000, 10_000, alice);
+
+        token0.mint(bob, 1_000);
+        VM.prank(bob);
+        assertTrue(token0.transfer(address(pair), 1_000), "token0 input transfer should succeed");
+
+        uint256 invalidAmount1Out = _getAmountOut(1_000, 10_000, 10_000) + 1;
+        VM.prank(bob);
+        VM.expectRevert(AMMPair.AMMPairKInvariant.selector);
+        pair.swap(0, invalidAmount1Out, bob, "");
+    }
+
+    function testSkimTransfersOnlyExcessBalances() public {
+        _provideLiquidity(pair, token0, token1, alice, 10_000, 10_000, alice);
+
+        token0.mint(address(pair), 500);
+        token1.mint(address(pair), 700);
+
+        pair.skim(carol);
+
+        assertTrue(token0.balanceOf(carol) == 500, "skim token0 mismatch");
+        assertTrue(token1.balanceOf(carol) == 700, "skim token1 mismatch");
+
+        (uint112 reserve0_, uint112 reserve1_,) = pair.getReserves();
+        assertTrue(reserve0_ == 10_000, "skim should not change reserve0");
+        assertTrue(reserve1_ == 10_000, "skim should not change reserve1");
+    }
+
+    function testSyncUpdatesReservesToActualBalances() public {
+        _provideLiquidity(pair, token0, token1, alice, 10_000, 10_000, alice);
+
+        token0.mint(address(pair), 500);
+        token1.mint(address(pair), 700);
+
+        pair.sync();
+
+        (uint112 reserve0_, uint112 reserve1_,) = pair.getReserves();
+        assertTrue(reserve0_ == 10_500, "reserve0 mismatch after sync");
+        assertTrue(reserve1_ == 10_700, "reserve1 mismatch after sync");
+    }
+
+    function testPriceAccumulatorsAdvanceAcrossElapsedTime() public {
+        _provideLiquidity(pair, token0, token1, alice, 10_000, 20_000, alice);
+
+        VM.warp(block.timestamp + 10);
+        pair.sync();
+
+        uint256 expectedPrice0 = uint256(_uqdiv(20_000, 10_000)) * 10;
+        uint256 expectedPrice1 = uint256(_uqdiv(10_000, 20_000)) * 10;
+
+        assertTrue(pair.price0CumulativeLast() == expectedPrice0, "price0 cumulative mismatch");
+        assertTrue(pair.price1CumulativeLast() == expectedPrice1, "price1 cumulative mismatch");
+    }
+
+    function testFeeOnMintsProtocolLiquidityAndUpdatesKLast() public {
+        factory.setFeeTo(carol);
+        _provideLiquidity(pair, token0, token1, alice, 1_000_000, 1_000_000, alice);
+
+        assertTrue(pair.kLast() == 1_000_000 * 1_000_000, "initial fee-on kLast mismatch");
+
+        token0.mint(bob, 100_000);
+        VM.prank(bob);
+        assertTrue(token0.transfer(address(pair), 100_000), "token0 input transfer should succeed");
+
+        uint256 amount1Out = _getAmountOut(100_000, 1_000_000, 1_000_000);
+        VM.prank(bob);
+        pair.swap(0, amount1Out, bob, "");
+
+        (uint112 reserve0_, uint112 reserve1_,) = pair.getReserves();
+        uint256 amount0 = 11_000;
+        uint256 amount1 = (amount0 * reserve1_) / reserve0_;
+
+        token0.mint(bob, amount0);
+        token1.mint(bob, amount1);
+        VM.startPrank(bob);
+        assertTrue(token0.transfer(address(pair), amount0), "token0 top-up transfer should succeed");
+        assertTrue(token1.transfer(address(pair), amount1), "token1 top-up transfer should succeed");
+        VM.stopPrank();
+
+        pair.mint(bob);
+
+        assertTrue(pair.balanceOf(carol) > 0, "protocol fee lp should mint");
+        (reserve0_, reserve1_,) = pair.getReserves();
+        assertTrue(pair.kLast() == uint256(reserve0_) * uint256(reserve1_), "fee-on kLast mismatch");
+    }
+
+    function testFeeOffClearsKLastOnNextLiquidityEvent() public {
+        factory.setFeeTo(carol);
+        _provideLiquidity(pair, token0, token1, alice, 100_000, 100_000, alice);
+        assertTrue(pair.kLast() != 0, "kLast should be set while fee switch is on");
+
+        factory.setFeeTo(address(0));
+        _provideLiquidity(pair, token0, token1, bob, 10_000, 10_000, bob);
+
+        assertTrue(pair.kLast() == 0, "kLast should clear when fee switch is off");
+    }
+
+    function testSwapRevertsWhenOutputTokenReturnsFalse() public {
+        FalseReturningAMMToken falseToken = new FalseReturningAMMToken("False Token", "FTK", 18);
+        MockAMMToken normalToken = new MockAMMToken("Normal Token", "NTK", 18);
+        AMMFactoryHarness localFactory = new AMMFactoryHarness(address(this));
+        AMMPair falsePair = AMMPair(localFactory.createPair(address(falseToken), address(normalToken)));
+
+        _seedLiquidityDirect(falsePair, falseToken, normalToken, 10_000, 10_000, alice);
+        normalToken.mint(address(falsePair), 1_000);
+
+        VM.expectRevert(abi.encodeWithSelector(AMMPair.AMMPairTransferFailed.selector, address(falseToken), bob, 1));
+        falsePair.swap(1, 0, bob, "");
+    }
+
+    function testSwapAcceptsSilentTransferToken() public {
+        SilentAMMToken silentToken = new SilentAMMToken("Silent Token", "STK", 18);
+        MockAMMToken normalToken = new MockAMMToken("Normal Token", "NTK", 18);
+        AMMFactoryHarness localFactory = new AMMFactoryHarness(address(this));
+        AMMPair silentPair = AMMPair(localFactory.createPair(address(silentToken), address(normalToken)));
+
+        _seedLiquidityDirect(silentPair, silentToken, normalToken, 10_000, 10_000, alice);
+        normalToken.mint(address(silentPair), 1_000);
+
+        silentPair.swap(1, 0, bob, "");
+        assertTrue(silentToken.balanceOf(bob) == 1, "silent transfer output mismatch");
+    }
+
+    function testSwapRevertsWhenOutputTokenReturnsMalformedData() public {
+        MalformedAMMToken malformedToken = new MalformedAMMToken("Malformed Token", "MTK", 18);
+        MockAMMToken normalToken = new MockAMMToken("Normal Token", "NTK", 18);
+        AMMFactoryHarness localFactory = new AMMFactoryHarness(address(this));
+        AMMPair malformedPair = AMMPair(localFactory.createPair(address(malformedToken), address(normalToken)));
+
+        _seedLiquidityDirect(malformedPair, malformedToken, normalToken, 10_000, 10_000, alice);
+        normalToken.mint(address(malformedPair), 1_000);
+
+        VM.expectRevert(abi.encodeWithSelector(AMMPair.AMMPairTransferFailed.selector, address(malformedToken), bob, 1));
+        malformedPair.swap(1, 0, bob, "");
+    }
+
+    function testSwapRevertsWhenOutputTransferAttemptsReentrancy() public {
+        ReentrantAMMToken reentrantToken = new ReentrantAMMToken("Reentrant Token", "RTK", 18);
+        MockAMMToken normalToken = new MockAMMToken("Normal Token", "NTK", 18);
+        AMMFactoryHarness localFactory = new AMMFactoryHarness(address(this));
+        AMMPair reentrantPair = AMMPair(localFactory.createPair(address(reentrantToken), address(normalToken)));
+
+        _seedLiquidityDirect(reentrantPair, reentrantToken, normalToken, 10_000, 10_000, alice);
+        normalToken.mint(address(reentrantPair), 1_000);
+        reentrantToken.setReenterSync(address(reentrantPair), true);
+
+        VM.expectRevert(abi.encodeWithSelector(AMMPair.AMMPairTransferFailed.selector, address(reentrantToken), bob, 1));
+        reentrantPair.swap(1, 0, bob, "");
+    }
+}

--- a/test/helpers/AMMPairTestHarness.sol
+++ b/test/helpers/AMMPairTestHarness.sol
@@ -1,0 +1,298 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {AMMPair} from "../../src/amm/AMMPair.sol";
+import {IAMMFactory} from "../../src/interfaces/IAMMFactory.sol";
+import {IERC20Metadata} from "../../src/interfaces/IERC20Metadata.sol";
+import {AMMFoundationFixture} from "./AMMTestHarness.sol";
+
+contract MockAMMToken is IERC20Metadata {
+    string internal _name;
+    string internal _symbol;
+    uint8 internal _decimals;
+    uint256 internal _totalSupply;
+
+    mapping(address => uint256) internal _balances;
+    mapping(address => mapping(address => uint256)) internal _allowances;
+
+    constructor(string memory name_, string memory symbol_, uint8 decimals_) {
+        _name = name_;
+        _symbol = symbol_;
+        _decimals = decimals_;
+    }
+
+    function name() external view returns (string memory) {
+        return _name;
+    }
+
+    function symbol() external view returns (string memory) {
+        return _symbol;
+    }
+
+    function decimals() external view returns (uint8) {
+        return _decimals;
+    }
+
+    function totalSupply() external view returns (uint256) {
+        return _totalSupply;
+    }
+
+    function balanceOf(address account) external view returns (uint256) {
+        return _balances[account];
+    }
+
+    function allowance(address owner, address spender) external view returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    function mint(address to, uint256 amount) external {
+        _balances[to] += amount;
+        _totalSupply += amount;
+        emit Transfer(address(0), to, amount);
+    }
+
+    function approve(address spender, uint256 value) external returns (bool) {
+        _allowances[msg.sender][spender] = value;
+        emit Approval(msg.sender, spender, value);
+        return true;
+    }
+
+    function transfer(address to, uint256 value) public virtual returns (bool) {
+        _transfer(msg.sender, to, value);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 value) public virtual returns (bool) {
+        uint256 currentAllowance = _allowances[from][msg.sender];
+        require(currentAllowance >= value, "INSUFFICIENT_ALLOWANCE");
+
+        if (currentAllowance != type(uint256).max) {
+            unchecked {
+                _allowances[from][msg.sender] = currentAllowance - value;
+            }
+            emit Approval(from, msg.sender, _allowances[from][msg.sender]);
+        }
+
+        _transfer(from, to, value);
+        return true;
+    }
+
+    function _transfer(address from, address to, uint256 value) internal {
+        require(to != address(0), "ZERO_TO");
+
+        uint256 fromBalance = _balances[from];
+        require(fromBalance >= value, "INSUFFICIENT_BALANCE");
+
+        unchecked {
+            _balances[from] = fromBalance - value;
+        }
+        _balances[to] += value;
+
+        emit Transfer(from, to, value);
+    }
+}
+
+contract FalseReturningAMMToken is MockAMMToken {
+    constructor(string memory name_, string memory symbol_, uint8 decimals_) MockAMMToken(name_, symbol_, decimals_) {}
+
+    function transfer(address, uint256) public pure override returns (bool) {
+        return false;
+    }
+
+    function transferFrom(address, address, uint256) public pure override returns (bool) {
+        return false;
+    }
+}
+
+contract SilentAMMToken is MockAMMToken {
+    constructor(string memory name_, string memory symbol_, uint8 decimals_) MockAMMToken(name_, symbol_, decimals_) {}
+
+    function transfer(address to, uint256 value) public override returns (bool) {
+        _transfer(msg.sender, to, value);
+        assembly {
+            return(0, 0)
+        }
+    }
+
+    function transferFrom(address from, address to, uint256 value) public override returns (bool) {
+        uint256 currentAllowance = _allowances[from][msg.sender];
+        require(currentAllowance >= value, "INSUFFICIENT_ALLOWANCE");
+
+        if (currentAllowance != type(uint256).max) {
+            unchecked {
+                _allowances[from][msg.sender] = currentAllowance - value;
+            }
+            emit Approval(from, msg.sender, _allowances[from][msg.sender]);
+        }
+
+        _transfer(from, to, value);
+        assembly {
+            return(0, 0)
+        }
+    }
+}
+
+contract MalformedAMMToken is MockAMMToken {
+    constructor(string memory name_, string memory symbol_, uint8 decimals_) MockAMMToken(name_, symbol_, decimals_) {}
+
+    function transfer(address to, uint256 value) public override returns (bool) {
+        _transfer(msg.sender, to, value);
+        assembly {
+            mstore(0x00, 1)
+            return(0x1f, 0x01)
+        }
+    }
+
+    function transferFrom(address from, address to, uint256 value) public override returns (bool) {
+        uint256 currentAllowance = _allowances[from][msg.sender];
+        require(currentAllowance >= value, "INSUFFICIENT_ALLOWANCE");
+
+        if (currentAllowance != type(uint256).max) {
+            unchecked {
+                _allowances[from][msg.sender] = currentAllowance - value;
+            }
+            emit Approval(from, msg.sender, _allowances[from][msg.sender]);
+        }
+
+        _transfer(from, to, value);
+        assembly {
+            mstore(0x00, 1)
+            return(0x1f, 0x01)
+        }
+    }
+}
+
+contract ReentrantAMMToken is MockAMMToken {
+    address internal _pairToReenter;
+    bool internal _reenterSyncEnabled;
+
+    constructor(string memory name_, string memory symbol_, uint8 decimals_) MockAMMToken(name_, symbol_, decimals_) {}
+
+    function setReenterSync(address pair_, bool enabled) external {
+        _pairToReenter = pair_;
+        _reenterSyncEnabled = enabled;
+    }
+
+    function transfer(address to, uint256 value) public override returns (bool) {
+        if (_reenterSyncEnabled && msg.sender == _pairToReenter) {
+            AMMPair(_pairToReenter).sync();
+        }
+
+        _transfer(msg.sender, to, value);
+        return true;
+    }
+}
+
+contract AMMFactoryHarness is IAMMFactory {
+    address public override feeTo;
+    address public override feeToSetter;
+
+    address[] internal _allPairs;
+    mapping(address => mapping(address => address)) internal _pairs;
+
+    constructor(address feeToSetter_) {
+        feeToSetter = feeToSetter_;
+    }
+
+    function getPair(address tokenA, address tokenB) external view returns (address) {
+        return _pairs[tokenA][tokenB];
+    }
+
+    function allPairs(uint256 index) external view returns (address) {
+        return _allPairs[index];
+    }
+
+    function allPairsLength() external view returns (uint256) {
+        return _allPairs.length;
+    }
+
+    function createPair(address tokenA, address tokenB) external returns (address pair) {
+        require(tokenA != address(0) && tokenB != address(0), "ZERO_TOKEN");
+        require(tokenA != tokenB, "IDENTICAL_TOKEN");
+        require(_pairs[tokenA][tokenB] == address(0), "PAIR_EXISTS");
+
+        pair = address(new AMMPair());
+        AMMPair(pair).initialize(tokenA, tokenB);
+
+        _pairs[tokenA][tokenB] = pair;
+        _pairs[tokenB][tokenA] = pair;
+        _allPairs.push(pair);
+
+        emit PairCreated(tokenA, tokenB, pair, _allPairs.length);
+    }
+
+    function setFeeTo(address feeTo_) external {
+        require(msg.sender == feeToSetter, "FORBIDDEN");
+        feeTo = feeTo_;
+    }
+
+    function setFeeToSetter(address feeToSetter_) external {
+        require(msg.sender == feeToSetter, "FORBIDDEN");
+        feeToSetter = feeToSetter_;
+    }
+}
+
+    abstract contract AMMPairCoreFixture is AMMFoundationFixture {
+        address internal constant BURN_SINK = 0x000000000000000000000000000000000000dEaD;
+
+        AMMFactoryHarness internal factory;
+        AMMPair internal pair;
+        MockAMMToken internal token0;
+        MockAMMToken internal token1;
+
+        function setUp() public virtual override {
+            super.setUp();
+
+            factory = new AMMFactoryHarness(address(this));
+            token0 = new MockAMMToken("Token 0", "TK0", 18);
+            token1 = new MockAMMToken("Token 1", "TK1", 18);
+            pair = AMMPair(factory.createPair(address(token0), address(token1)));
+        }
+
+        function _provideLiquidity(
+            AMMPair pair_,
+            MockAMMToken token0_,
+            MockAMMToken token1_,
+            address provider,
+            uint256 amount0,
+            uint256 amount1,
+            address recipient
+        ) internal returns (uint256 liquidity) {
+            token0_.mint(provider, amount0);
+            token1_.mint(provider, amount1);
+
+            VM.startPrank(provider);
+            assertTrue(token0_.transfer(address(pair_), amount0), "token0 transfer should succeed");
+            assertTrue(token1_.transfer(address(pair_), amount1), "token1 transfer should succeed");
+            VM.stopPrank();
+
+            liquidity = pair_.mint(recipient);
+        }
+
+        function _seedLiquidityDirect(
+            AMMPair pair_,
+            MockAMMToken token0_,
+            MockAMMToken token1_,
+            uint256 amount0,
+            uint256 amount1,
+            address recipient
+        ) internal returns (uint256 liquidity) {
+            token0_.mint(address(pair_), amount0);
+            token1_.mint(address(pair_), amount1);
+            liquidity = pair_.mint(recipient);
+        }
+
+        function _getAmountOut(uint256 amountIn, uint256 reserveIn, uint256 reserveOut)
+            internal
+            pure
+            returns (uint256)
+        {
+            uint256 amountInWithFee = amountIn * 997;
+            return (amountInWithFee * reserveOut) / ((reserveIn * 1000) + amountInWithFee);
+        }
+
+        function _deployPair(address token0_, address token1_) internal returns (AMMPair pair_) {
+            AMMFactoryHarness localFactory = new AMMFactoryHarness(address(this));
+            pair_ = AMMPair(localFactory.createPair(token0_, token1_));
+        }
+    }


### PR DESCRIPTION
## Summary
- add the concrete V2-style `AMMPair` fund-holding core
- implement reserve/oracle bookkeeping, mint/burn/swap flows, fee-switch accounting, `skim`, and `sync`
- add pair-core tests and token/factory harnesses for liquidity math, invariant enforcement, oracle accumulation, fee-on behavior, and transfer edge cases

Closes #181