### PR TITLE
feat: add AMM factory registry

### DIFF
--- a/src/amm/AMMFactory.sol
+++ b/src/amm/AMMFactory.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {AMMPair} from "./AMMPair.sol";
+import {IAMMFactory} from "../interfaces/IAMMFactory.sol";
+
+/// @title AMMFactory
+/// @notice Deterministic CREATE2 registry for standalone V2-style AMM pairs.
+contract AMMFactory is IAMMFactory {
+    error AMMFactoryForbidden();
+    error AMMFactoryZeroAddress();
+    error AMMFactoryZeroFeeToSetter();
+    error AMMFactoryIdenticalTokens();
+    error AMMFactoryPairExists(address token0, address token1);
+
+    address public override feeTo;
+    address public override feeToSetter;
+    mapping(address tokenA => mapping(address tokenB => address pair)) public override getPair;
+    address[] public override allPairs;
+
+    constructor() {
+        feeToSetter = msg.sender;
+    }
+
+    function pairCodeHash() public pure override returns (bytes32) {
+        return keccak256(type(AMMPair).creationCode);
+    }
+
+    function allPairsLength() external view override returns (uint256) {
+        return allPairs.length;
+    }
+
+    function createPair(address tokenA, address tokenB) external override returns (address pair) {
+        (address token0, address token1) = _sortTokens(tokenA, tokenB);
+        if (getPair[token0][token1] != address(0)) {
+            revert AMMFactoryPairExists(token0, token1);
+        }
+
+        bytes32 salt = keccak256(abi.encodePacked(token0, token1));
+        pair = address(new AMMPair{salt: salt}());
+
+        getPair[token0][token1] = pair;
+        getPair[token1][token0] = pair;
+        allPairs.push(pair);
+        emit PairCreated(token0, token1, pair, allPairs.length);
+        AMMPair(pair).initialize(token0, token1);
+    }
+
+    function setFeeTo(address feeTo_) external override {
+        _requireFeeToSetter();
+        feeTo = feeTo_;
+    }
+
+    function setFeeToSetter(address feeToSetter_) external override {
+        _requireFeeToSetter();
+        if (feeToSetter_ == address(0)) {
+            revert AMMFactoryZeroFeeToSetter();
+        }
+        feeToSetter = feeToSetter_;
+    }
+
+    function _sortTokens(address tokenA, address tokenB) internal pure returns (address token0, address token1) {
+        if (tokenA == tokenB) {
+            revert AMMFactoryIdenticalTokens();
+        }
+        if (tokenA == address(0) || tokenB == address(0)) {
+            revert AMMFactoryZeroAddress();
+        }
+
+        (token0, token1) = tokenA < tokenB ? (tokenA, tokenB) : (tokenB, tokenA);
+    }
+
+    function _requireFeeToSetter() internal view {
+        if (msg.sender != feeToSetter) {
+            revert AMMFactoryForbidden();
+        }
+    }
+}

--- a/src/interfaces/IAMMFactory.sol
+++ b/src/interfaces/IAMMFactory.sol
@@ -8,6 +8,7 @@ interface IAMMFactory {
 
     function feeTo() external view returns (address);
     function feeToSetter() external view returns (address);
+    function pairCodeHash() external pure returns (bytes32);
     function getPair(address tokenA, address tokenB) external view returns (address);
     function allPairs(uint256 index) external view returns (address);
     function allPairsLength() external view returns (uint256);

--- a/test/AMMFactoryRegistry.t.sol
+++ b/test/AMMFactoryRegistry.t.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {AMMFactory} from "../src/amm/AMMFactory.sol";
+import {AMMPair} from "../src/amm/AMMPair.sol";
+import {AMMPairCoreFixture, MockAMMToken} from "./helpers/AMMPairTestHarness.sol";
+
+contract AMMFactoryRegistryTest is AMMPairCoreFixture {
+    function testConstructorSetsFeeToSetterAndPairCodeHash() public view {
+        assertTrue(factory.feeToSetter() == address(this), "feeToSetter mismatch");
+        assertTrue(factory.pairCodeHash() == keccak256(type(AMMPair).creationCode), "pair code hash mismatch");
+    }
+
+    function testCreatePairSortsTokensAndStoresBothLookupDirections() public {
+        MockAMMToken unsortedA = new MockAMMToken("Token A", "TKA", 18);
+        MockAMMToken unsortedB = new MockAMMToken("Token B", "TKB", 18);
+
+        address expectedToken0 = address(unsortedA) < address(unsortedB) ? address(unsortedA) : address(unsortedB);
+        address expectedToken1 = address(unsortedA) < address(unsortedB) ? address(unsortedB) : address(unsortedA);
+        address createdPair = factory.createPair(address(unsortedB), address(unsortedA));
+
+        assertTrue(factory.getPair(address(unsortedA), address(unsortedB)) == createdPair, "forward lookup mismatch");
+        assertTrue(factory.getPair(address(unsortedB), address(unsortedA)) == createdPair, "reverse lookup mismatch");
+        assertTrue(factory.allPairs(1) == createdPair, "allPairs entry mismatch");
+        assertTrue(factory.allPairsLength() == 2, "allPairs length mismatch");
+
+        AMMPair sortedPair = AMMPair(createdPair);
+        assertTrue(sortedPair.factory() == address(factory), "pair factory mismatch");
+        assertTrue(sortedPair.token0() == expectedToken0, "token0 sort mismatch");
+        assertTrue(sortedPair.token1() == expectedToken1, "token1 sort mismatch");
+    }
+
+    function testCreatePairRevertsForZeroIdenticalAndDuplicatePairs() public {
+        VM.expectRevert(AMMFactory.AMMFactoryZeroAddress.selector);
+        factory.createPair(address(0), address(token0));
+
+        VM.expectRevert(AMMFactory.AMMFactoryIdenticalTokens.selector);
+        factory.createPair(address(token0), address(token0));
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                AMMFactory.AMMFactoryPairExists.selector,
+                address(token0) < address(token1) ? address(token0) : address(token1),
+                address(token0) < address(token1) ? address(token1) : address(token0)
+            )
+        );
+        factory.createPair(address(token1), address(token0));
+    }
+
+    function testPredictedCreate2AddressMatchesDeployedPair() public {
+        MockAMMToken localToken0 = new MockAMMToken("Local Token 0", "LT0", 18);
+        MockAMMToken localToken1 = new MockAMMToken("Local Token 1", "LT1", 18);
+
+        address predictedPair = _predictPairAddress(address(factory), address(localToken0), address(localToken1));
+        address deployedPair = factory.createPair(address(localToken1), address(localToken0));
+
+        assertTrue(deployedPair == predictedPair, "predicted pair mismatch");
+    }
+
+    function testSetFeeToRequiresFeeToSetterAndPersists() public {
+        VM.prank(alice);
+        VM.expectRevert(AMMFactory.AMMFactoryForbidden.selector);
+        factory.setFeeTo(carol);
+
+        factory.setFeeTo(carol);
+        assertTrue(factory.feeTo() == carol, "feeTo mismatch");
+
+        factory.setFeeTo(address(0));
+        assertTrue(factory.feeTo() == address(0), "feeTo should clear");
+    }
+
+    function testSetFeeToSetterRequiresCurrentFeeToSetterAndPersists() public {
+        VM.prank(alice);
+        VM.expectRevert(AMMFactory.AMMFactoryForbidden.selector);
+        factory.setFeeToSetter(carol);
+
+        VM.expectRevert(AMMFactory.AMMFactoryZeroFeeToSetter.selector);
+        factory.setFeeToSetter(address(0));
+
+        factory.setFeeToSetter(carol);
+        assertTrue(factory.feeToSetter() == carol, "feeToSetter mismatch");
+
+        VM.expectRevert(AMMFactory.AMMFactoryForbidden.selector);
+        factory.setFeeTo(address(this));
+
+        VM.prank(carol);
+        factory.setFeeTo(alice);
+        assertTrue(factory.feeTo() == alice, "new feeToSetter should control feeTo");
+    }
+
+    function _predictPairAddress(address factory_, address tokenA, address tokenB) internal view returns (address) {
+        (address sortedToken0, address sortedToken1) = _sortTokens(tokenA, tokenB);
+        bytes32 salt = keccak256(abi.encodePacked(sortedToken0, sortedToken1));
+        bytes32 rawAddress = keccak256(abi.encodePacked(hex"ff", factory_, salt, factory.pairCodeHash()));
+        return address(uint160(uint256(rawAddress)));
+    }
+
+    function _sortTokens(address tokenA, address tokenB) internal pure returns (address token0_, address token1_) {
+        return tokenA < tokenB ? (tokenA, tokenB) : (tokenB, tokenA);
+    }
+}

--- a/test/AMMPairCore.t.sol
+++ b/test/AMMPairCore.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
+import {AMMFactory} from "../src/amm/AMMFactory.sol";
 import {AMMPair} from "../src/amm/AMMPair.sol";
 import {
-    AMMFactoryHarness,
     AMMPairCoreFixture,
     FalseReturningAMMToken,
     MalformedAMMToken,
@@ -251,53 +251,80 @@ contract AMMPairCoreTest is AMMPairCoreFixture {
     function testSwapRevertsWhenOutputTokenReturnsFalse() public {
         FalseReturningAMMToken falseToken = new FalseReturningAMMToken("False Token", "FTK", 18);
         MockAMMToken normalToken = new MockAMMToken("Normal Token", "NTK", 18);
-        AMMFactoryHarness localFactory = new AMMFactoryHarness(address(this));
+        AMMFactory localFactory = new AMMFactory();
         AMMPair falsePair = AMMPair(localFactory.createPair(address(falseToken), address(normalToken)));
 
         _seedLiquidityDirect(falsePair, falseToken, normalToken, 10_000, 10_000, alice);
         normalToken.mint(address(falsePair), 1_000);
 
-        VM.expectRevert(abi.encodeWithSelector(AMMPair.AMMPairTransferFailed.selector, address(falseToken), bob, 1));
-        falsePair.swap(1, 0, bob, "");
+        if (falsePair.token0() == address(falseToken)) {
+            VM.expectRevert(abi.encodeWithSelector(AMMPair.AMMPairTransferFailed.selector, address(falseToken), bob, 1));
+            falsePair.swap(1, 0, bob, "");
+        } else {
+            VM.expectRevert(abi.encodeWithSelector(AMMPair.AMMPairTransferFailed.selector, address(falseToken), bob, 1));
+            falsePair.swap(0, 1, bob, "");
+        }
     }
 
     function testSwapAcceptsSilentTransferToken() public {
         SilentAMMToken silentToken = new SilentAMMToken("Silent Token", "STK", 18);
         MockAMMToken normalToken = new MockAMMToken("Normal Token", "NTK", 18);
-        AMMFactoryHarness localFactory = new AMMFactoryHarness(address(this));
+        AMMFactory localFactory = new AMMFactory();
         AMMPair silentPair = AMMPair(localFactory.createPair(address(silentToken), address(normalToken)));
 
         _seedLiquidityDirect(silentPair, silentToken, normalToken, 10_000, 10_000, alice);
         normalToken.mint(address(silentPair), 1_000);
 
-        silentPair.swap(1, 0, bob, "");
+        if (silentPair.token0() == address(silentToken)) {
+            silentPair.swap(1, 0, bob, "");
+        } else {
+            silentPair.swap(0, 1, bob, "");
+        }
         assertTrue(silentToken.balanceOf(bob) == 1, "silent transfer output mismatch");
     }
 
     function testSwapRevertsWhenOutputTokenReturnsMalformedData() public {
         MalformedAMMToken malformedToken = new MalformedAMMToken("Malformed Token", "MTK", 18);
         MockAMMToken normalToken = new MockAMMToken("Normal Token", "NTK", 18);
-        AMMFactoryHarness localFactory = new AMMFactoryHarness(address(this));
+        AMMFactory localFactory = new AMMFactory();
         AMMPair malformedPair = AMMPair(localFactory.createPair(address(malformedToken), address(normalToken)));
 
         _seedLiquidityDirect(malformedPair, malformedToken, normalToken, 10_000, 10_000, alice);
         normalToken.mint(address(malformedPair), 1_000);
 
-        VM.expectRevert(abi.encodeWithSelector(AMMPair.AMMPairTransferFailed.selector, address(malformedToken), bob, 1));
-        malformedPair.swap(1, 0, bob, "");
+        if (malformedPair.token0() == address(malformedToken)) {
+            VM.expectRevert(
+                abi.encodeWithSelector(AMMPair.AMMPairTransferFailed.selector, address(malformedToken), bob, 1)
+            );
+            malformedPair.swap(1, 0, bob, "");
+        } else {
+            VM.expectRevert(
+                abi.encodeWithSelector(AMMPair.AMMPairTransferFailed.selector, address(malformedToken), bob, 1)
+            );
+            malformedPair.swap(0, 1, bob, "");
+        }
     }
 
     function testSwapRevertsWhenOutputTransferAttemptsReentrancy() public {
         ReentrantAMMToken reentrantToken = new ReentrantAMMToken("Reentrant Token", "RTK", 18);
         MockAMMToken normalToken = new MockAMMToken("Normal Token", "NTK", 18);
-        AMMFactoryHarness localFactory = new AMMFactoryHarness(address(this));
+        AMMFactory localFactory = new AMMFactory();
         AMMPair reentrantPair = AMMPair(localFactory.createPair(address(reentrantToken), address(normalToken)));
 
         _seedLiquidityDirect(reentrantPair, reentrantToken, normalToken, 10_000, 10_000, alice);
         normalToken.mint(address(reentrantPair), 1_000);
         reentrantToken.setReenterSync(address(reentrantPair), true);
 
-        VM.expectRevert(abi.encodeWithSelector(AMMPair.AMMPairTransferFailed.selector, address(reentrantToken), bob, 1));
-        reentrantPair.swap(1, 0, bob, "");
+        if (reentrantPair.token0() == address(reentrantToken)) {
+            VM.expectRevert(
+                abi.encodeWithSelector(AMMPair.AMMPairTransferFailed.selector, address(reentrantToken), bob, 1)
+            );
+            reentrantPair.swap(1, 0, bob, "");
+        } else {
+            VM.expectRevert(
+                abi.encodeWithSelector(AMMPair.AMMPairTransferFailed.selector, address(reentrantToken), bob, 1)
+            );
+            reentrantPair.swap(0, 1, bob, "");
+        }
     }
 }

--- a/test/helpers/AMMPairTestHarness.sol
+++ b/test/helpers/AMMPairTestHarness.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
+import {AMMFactory} from "../../src/amm/AMMFactory.sol";
 import {AMMPair} from "../../src/amm/AMMPair.sol";
-import {IAMMFactory} from "../../src/interfaces/IAMMFactory.sol";
 import {IERC20Metadata} from "../../src/interfaces/IERC20Metadata.sol";
 import {AMMFoundationFixture} from "./AMMTestHarness.sol";
 
@@ -183,116 +183,66 @@ contract ReentrantAMMToken is MockAMMToken {
     }
 }
 
-contract AMMFactoryHarness is IAMMFactory {
-    address public override feeTo;
-    address public override feeToSetter;
+abstract contract AMMPairCoreFixture is AMMFoundationFixture {
+    address internal constant BURN_SINK = 0x000000000000000000000000000000000000dEaD;
 
-    address[] internal _allPairs;
-    mapping(address => mapping(address => address)) internal _pairs;
+    AMMFactory internal factory;
+    AMMPair internal pair;
+    MockAMMToken internal token0;
+    MockAMMToken internal token1;
 
-    constructor(address feeToSetter_) {
-        feeToSetter = feeToSetter_;
+    function setUp() public virtual override {
+        super.setUp();
+
+        factory = new AMMFactory();
+        MockAMMToken firstToken = new MockAMMToken("Token 0", "TK0", 18);
+        MockAMMToken secondToken = new MockAMMToken("Token 1", "TK1", 18);
+
+        pair = AMMPair(factory.createPair(address(firstToken), address(secondToken)));
+        (token0, token1) =
+            address(firstToken) < address(secondToken) ? (firstToken, secondToken) : (secondToken, firstToken);
     }
 
-    function getPair(address tokenA, address tokenB) external view returns (address) {
-        return _pairs[tokenA][tokenB];
+    function _provideLiquidity(
+        AMMPair pair_,
+        MockAMMToken token0_,
+        MockAMMToken token1_,
+        address provider,
+        uint256 amount0,
+        uint256 amount1,
+        address recipient
+    ) internal returns (uint256 liquidity) {
+        token0_.mint(provider, amount0);
+        token1_.mint(provider, amount1);
+
+        VM.startPrank(provider);
+        assertTrue(token0_.transfer(address(pair_), amount0), "token0 transfer should succeed");
+        assertTrue(token1_.transfer(address(pair_), amount1), "token1 transfer should succeed");
+        VM.stopPrank();
+
+        liquidity = pair_.mint(recipient);
     }
 
-    function allPairs(uint256 index) external view returns (address) {
-        return _allPairs[index];
+    function _seedLiquidityDirect(
+        AMMPair pair_,
+        MockAMMToken token0_,
+        MockAMMToken token1_,
+        uint256 amount0,
+        uint256 amount1,
+        address recipient
+    ) internal returns (uint256 liquidity) {
+        token0_.mint(address(pair_), amount0);
+        token1_.mint(address(pair_), amount1);
+        liquidity = pair_.mint(recipient);
     }
 
-    function allPairsLength() external view returns (uint256) {
-        return _allPairs.length;
+    function _getAmountOut(uint256 amountIn, uint256 reserveIn, uint256 reserveOut) internal pure returns (uint256) {
+        uint256 amountInWithFee = amountIn * 997;
+        return (amountInWithFee * reserveOut) / ((reserveIn * 1000) + amountInWithFee);
     }
 
-    function createPair(address tokenA, address tokenB) external returns (address pair) {
-        require(tokenA != address(0) && tokenB != address(0), "ZERO_TOKEN");
-        require(tokenA != tokenB, "IDENTICAL_TOKEN");
-        require(_pairs[tokenA][tokenB] == address(0), "PAIR_EXISTS");
-
-        pair = address(new AMMPair());
-        AMMPair(pair).initialize(tokenA, tokenB);
-
-        _pairs[tokenA][tokenB] = pair;
-        _pairs[tokenB][tokenA] = pair;
-        _allPairs.push(pair);
-
-        emit PairCreated(tokenA, tokenB, pair, _allPairs.length);
-    }
-
-    function setFeeTo(address feeTo_) external {
-        require(msg.sender == feeToSetter, "FORBIDDEN");
-        feeTo = feeTo_;
-    }
-
-    function setFeeToSetter(address feeToSetter_) external {
-        require(msg.sender == feeToSetter, "FORBIDDEN");
-        feeToSetter = feeToSetter_;
+    function _deployPair(address token0_, address token1_) internal returns (AMMPair pair_) {
+        AMMFactory localFactory = new AMMFactory();
+        pair_ = AMMPair(localFactory.createPair(token0_, token1_));
     }
 }
-
-    abstract contract AMMPairCoreFixture is AMMFoundationFixture {
-        address internal constant BURN_SINK = 0x000000000000000000000000000000000000dEaD;
-
-        AMMFactoryHarness internal factory;
-        AMMPair internal pair;
-        MockAMMToken internal token0;
-        MockAMMToken internal token1;
-
-        function setUp() public virtual override {
-            super.setUp();
-
-            factory = new AMMFactoryHarness(address(this));
-            token0 = new MockAMMToken("Token 0", "TK0", 18);
-            token1 = new MockAMMToken("Token 1", "TK1", 18);
-            pair = AMMPair(factory.createPair(address(token0), address(token1)));
-        }
-
-        function _provideLiquidity(
-            AMMPair pair_,
-            MockAMMToken token0_,
-            MockAMMToken token1_,
-            address provider,
-            uint256 amount0,
-            uint256 amount1,
-            address recipient
-        ) internal returns (uint256 liquidity) {
-            token0_.mint(provider, amount0);
-            token1_.mint(provider, amount1);
-
-            VM.startPrank(provider);
-            assertTrue(token0_.transfer(address(pair_), amount0), "token0 transfer should succeed");
-            assertTrue(token1_.transfer(address(pair_), amount1), "token1 transfer should succeed");
-            VM.stopPrank();
-
-            liquidity = pair_.mint(recipient);
-        }
-
-        function _seedLiquidityDirect(
-            AMMPair pair_,
-            MockAMMToken token0_,
-            MockAMMToken token1_,
-            uint256 amount0,
-            uint256 amount1,
-            address recipient
-        ) internal returns (uint256 liquidity) {
-            token0_.mint(address(pair_), amount0);
-            token1_.mint(address(pair_), amount1);
-            liquidity = pair_.mint(recipient);
-        }
-
-        function _getAmountOut(uint256 amountIn, uint256 reserveIn, uint256 reserveOut)
-            internal
-            pure
-            returns (uint256)
-        {
-            uint256 amountInWithFee = amountIn * 997;
-            return (amountInWithFee * reserveOut) / ((reserveIn * 1000) + amountInWithFee);
-        }
-
-        function _deployPair(address token0_, address token1_) internal returns (AMMPair pair_) {
-            AMMFactoryHarness localFactory = new AMMFactoryHarness(address(this));
-            pair_ = AMMPair(localFactory.createPair(token0_, token1_));
-        }
-    }


### PR DESCRIPTION
## Summary
- add a deterministic `AMMFactory` with canonical token ordering, bidirectional pair lookup, pair enumeration, and fee control hooks
- replace the ad hoc pair-core factory harness usage with the real factory so pair tests execute against deterministic registry behavior
- add reviewer-facing registry coverage for duplicate and invalid pair rejection plus CREATE2 address derivation

## Testing
- `forge fmt --check`
- `forge test --match-contract AMMFactoryRegistryTest`
- `forge test --match-contract AMMPairCoreTest`
- `forge test`

## Linked Issue
Closes #182
