### PR TITLE
feat: add AMM router periphery

### DIFF
--- a/src/amm/AMMRouter.sol
+++ b/src/amm/AMMRouter.sol
@@ -1,0 +1,574 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAMMFactory} from "../interfaces/IAMMFactory.sol";
+import {IAMMPair} from "../interfaces/IAMMPair.sol";
+import {IAMMRouter} from "../interfaces/IAMMRouter.sol";
+import {IERC20} from "../interfaces/IERC20.sol";
+import {IWrappedNative} from "../interfaces/IWrappedNative.sol";
+
+/// @title AMMRouter
+/// @notice User-facing router and quoting surface for the standalone AMM subsystem.
+contract AMMRouter is IAMMRouter {
+    uint256 internal constant FEE_DENOMINATOR = 1000;
+    uint256 internal constant FEE_NUMERATOR = 997;
+
+    error AMMRouterZeroAddress();
+    error AMMRouterExpired(uint256 deadline, uint256 currentTimestamp);
+    error AMMRouterInvalidPath();
+    error AMMRouterInvalidWrappedNativePath();
+    error AMMRouterInvalidWrappedNativeToken(address token);
+    error AMMRouterIdenticalTokens();
+    error AMMRouterZeroTokenAddress();
+    error AMMRouterInvalidNativeSender(address sender);
+    error AMMRouterPairUnavailable(address tokenA, address tokenB);
+    error AMMRouterInsufficientAmount();
+    error AMMRouterInsufficientLiquidity();
+    error AMMRouterInsufficientAAmount(uint256 amountA, uint256 minimumAmountA);
+    error AMMRouterInsufficientBAmount(uint256 amountB, uint256 minimumAmountB);
+    error AMMRouterInsufficientOutputAmount(uint256 amountOut, uint256 minimumAmountOut);
+    error AMMRouterExcessiveInputAmount(uint256 amountIn, uint256 maximumAmountIn);
+    error AMMRouterTransferFailed(address token, address to, uint256 value);
+    error AMMRouterTransferFromFailed(address token, address from, address to, uint256 value);
+    error AMMRouterWrapFailed(uint256 value);
+    error AMMRouterUnwrapFailed(uint256 value);
+    error AMMRouterNativeTransferFailed(address to, uint256 value);
+
+    address public immutable override factory;
+    address public immutable override wrappedNative;
+
+    modifier ensure(uint256 deadline) {
+        if (block.timestamp > deadline) {
+            revert AMMRouterExpired(deadline, block.timestamp);
+        }
+        _;
+    }
+
+    constructor(address factory_, address wrappedNative_) {
+        if (factory_ == address(0) || wrappedNative_ == address(0)) {
+            revert AMMRouterZeroAddress();
+        }
+
+        factory = factory_;
+        wrappedNative = wrappedNative_;
+    }
+
+    receive() external payable {
+        if (msg.sender != wrappedNative) {
+            revert AMMRouterInvalidNativeSender(msg.sender);
+        }
+    }
+
+    function quote(uint256 amountA, uint256 reserveA, uint256 reserveB) public pure override returns (uint256 amountB) {
+        if (amountA == 0) {
+            revert AMMRouterInsufficientAmount();
+        }
+        if (reserveA == 0 || reserveB == 0) {
+            revert AMMRouterInsufficientLiquidity();
+        }
+
+        amountB = (amountA * reserveB) / reserveA;
+    }
+
+    function getAmountOut(uint256 amountIn, uint256 reserveIn, uint256 reserveOut)
+        public
+        pure
+        override
+        returns (uint256 amountOut)
+    {
+        if (amountIn == 0) {
+            revert AMMRouterInsufficientAmount();
+        }
+        if (reserveIn == 0 || reserveOut == 0) {
+            revert AMMRouterInsufficientLiquidity();
+        }
+
+        uint256 amountInWithFee = amountIn * FEE_NUMERATOR;
+        amountOut = (amountInWithFee * reserveOut) / ((reserveIn * FEE_DENOMINATOR) + amountInWithFee);
+    }
+
+    function getAmountIn(uint256 amountOut, uint256 reserveIn, uint256 reserveOut)
+        public
+        pure
+        override
+        returns (uint256 amountIn)
+    {
+        if (amountOut == 0) {
+            revert AMMRouterInsufficientAmount();
+        }
+        if (reserveIn == 0 || reserveOut == 0 || amountOut >= reserveOut) {
+            revert AMMRouterInsufficientLiquidity();
+        }
+
+        uint256 numerator = reserveIn * amountOut * FEE_DENOMINATOR;
+        uint256 denominator = (reserveOut - amountOut) * FEE_NUMERATOR;
+        amountIn = (numerator / denominator) + 1;
+    }
+
+    function getAmountsOut(uint256 amountIn, address[] calldata path)
+        public
+        view
+        override
+        returns (uint256[] memory amounts)
+    {
+        _validatePath(path);
+
+        amounts = new uint256[](path.length);
+        amounts[0] = amountIn;
+
+        for (uint256 i = 0; i < path.length - 1; i++) {
+            (uint256 reserveIn, uint256 reserveOut) = _getReserves(path[i], path[i + 1]);
+            amounts[i + 1] = getAmountOut(amounts[i], reserveIn, reserveOut);
+        }
+    }
+
+    function getAmountsIn(uint256 amountOut, address[] calldata path)
+        public
+        view
+        override
+        returns (uint256[] memory amounts)
+    {
+        _validatePath(path);
+
+        amounts = new uint256[](path.length);
+        amounts[amounts.length - 1] = amountOut;
+
+        for (uint256 i = path.length - 1; i > 0; i--) {
+            (uint256 reserveIn, uint256 reserveOut) = _getReserves(path[i - 1], path[i]);
+            amounts[i - 1] = getAmountIn(amounts[i], reserveIn, reserveOut);
+        }
+    }
+
+    function addLiquidity(
+        address tokenA,
+        address tokenB,
+        uint256 amountADesired,
+        uint256 amountBDesired,
+        uint256 amountAMin,
+        uint256 amountBMin,
+        address to,
+        uint256 deadline
+    ) external override ensure(deadline) returns (uint256 amountA, uint256 amountB, uint256 liquidity) {
+        (address pair, uint256 addAmountA, uint256 addAmountB) =
+            _addLiquidity(tokenA, tokenB, amountADesired, amountBDesired, amountAMin, amountBMin);
+
+        _safeTransferFrom(tokenA, msg.sender, pair, addAmountA);
+        _safeTransferFrom(tokenB, msg.sender, pair, addAmountB);
+
+        liquidity = IAMMPair(pair).mint(to);
+        return (addAmountA, addAmountB, liquidity);
+    }
+
+    function addLiquidityNative(
+        address token,
+        uint256 amountTokenDesired,
+        uint256 amountTokenMin,
+        uint256 amountNativeMin,
+        address to,
+        uint256 deadline
+    )
+        external
+        payable
+        override
+        ensure(deadline)
+        returns (uint256 amountToken, uint256 amountNative, uint256 liquidity)
+    {
+        if (token == wrappedNative) {
+            revert AMMRouterInvalidWrappedNativeToken(token);
+        }
+
+        (address pair, uint256 addAmountToken, uint256 addAmountNative) =
+            _addLiquidity(token, wrappedNative, amountTokenDesired, msg.value, amountTokenMin, amountNativeMin);
+
+        _safeTransferFrom(token, msg.sender, pair, addAmountToken);
+        _wrapNative(addAmountNative);
+        _safeTransfer(wrappedNative, pair, addAmountNative);
+
+        liquidity = IAMMPair(pair).mint(to);
+
+        uint256 refund = msg.value - addAmountNative;
+        if (refund != 0) {
+            _safeTransferNative(msg.sender, refund);
+        }
+
+        return (addAmountToken, addAmountNative, liquidity);
+    }
+
+    function removeLiquidity(
+        address tokenA,
+        address tokenB,
+        uint256 liquidity,
+        uint256 amountAMin,
+        uint256 amountBMin,
+        address to,
+        uint256 deadline
+    ) public override ensure(deadline) returns (uint256 amountA, uint256 amountB) {
+        return _removeLiquidity(tokenA, tokenB, liquidity, amountAMin, amountBMin, to);
+    }
+
+    function removeLiquidityNative(
+        address token,
+        uint256 liquidity,
+        uint256 amountTokenMin,
+        uint256 amountNativeMin,
+        address to,
+        uint256 deadline
+    ) public override ensure(deadline) returns (uint256 amountToken, uint256 amountNative) {
+        if (token == wrappedNative) {
+            revert AMMRouterInvalidWrappedNativeToken(token);
+        }
+
+        (amountToken, amountNative) =
+            _removeLiquidity(token, wrappedNative, liquidity, amountTokenMin, amountNativeMin, address(this));
+
+        _safeTransfer(token, to, amountToken);
+        _unwrapNative(amountNative);
+        _safeTransferNative(to, amountNative);
+    }
+
+    function removeLiquidityWithPermit(
+        address tokenA,
+        address tokenB,
+        uint256 liquidity,
+        uint256 amountAMin,
+        uint256 amountBMin,
+        address to,
+        uint256 deadline,
+        bool approveMax,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external override ensure(deadline) returns (uint256 amountA, uint256 amountB) {
+        _permitLiquidity(tokenA, tokenB, liquidity, deadline, approveMax, v, r, s);
+        return removeLiquidity(tokenA, tokenB, liquidity, amountAMin, amountBMin, to, deadline);
+    }
+
+    function removeLiquidityNativeWithPermit(
+        address token,
+        uint256 liquidity,
+        uint256 amountTokenMin,
+        uint256 amountNativeMin,
+        address to,
+        uint256 deadline,
+        bool approveMax,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external override ensure(deadline) returns (uint256 amountToken, uint256 amountNative) {
+        _permitLiquidity(token, wrappedNative, liquidity, deadline, approveMax, v, r, s);
+        return removeLiquidityNative(token, liquidity, amountTokenMin, amountNativeMin, to, deadline);
+    }
+
+    function swapExactTokensForTokens(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external override ensure(deadline) returns (uint256[] memory amounts) {
+        amounts = getAmountsOut(amountIn, path);
+        uint256 finalAmountOut = amounts[amounts.length - 1];
+        if (finalAmountOut < amountOutMin) {
+            revert AMMRouterInsufficientOutputAmount(finalAmountOut, amountOutMin);
+        }
+
+        _safeTransferFrom(path[0], msg.sender, _pairFor(path[0], path[1]), amounts[0]);
+        _swap(amounts, path, to);
+    }
+
+    function swapTokensForExactTokens(
+        uint256 amountOut,
+        uint256 amountInMax,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external override ensure(deadline) returns (uint256[] memory amounts) {
+        amounts = getAmountsIn(amountOut, path);
+        uint256 requiredAmountIn = amounts[0];
+        if (requiredAmountIn > amountInMax) {
+            revert AMMRouterExcessiveInputAmount(requiredAmountIn, amountInMax);
+        }
+
+        _safeTransferFrom(path[0], msg.sender, _pairFor(path[0], path[1]), requiredAmountIn);
+        _swap(amounts, path, to);
+    }
+
+    function swapExactNativeForTokens(uint256 amountOutMin, address[] calldata path, address to, uint256 deadline)
+        external
+        payable
+        override
+        ensure(deadline)
+        returns (uint256[] memory amounts)
+    {
+        _validateNativeInPath(path);
+
+        amounts = getAmountsOut(msg.value, path);
+        uint256 finalAmountOut = amounts[amounts.length - 1];
+        if (finalAmountOut < amountOutMin) {
+            revert AMMRouterInsufficientOutputAmount(finalAmountOut, amountOutMin);
+        }
+
+        _wrapNative(amounts[0]);
+        _safeTransfer(wrappedNative, _pairFor(path[0], path[1]), amounts[0]);
+        _swap(amounts, path, to);
+    }
+
+    function swapTokensForExactNative(
+        uint256 amountOut,
+        uint256 amountInMax,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external override ensure(deadline) returns (uint256[] memory amounts) {
+        _validateNativeOutPath(path);
+
+        amounts = getAmountsIn(amountOut, path);
+        uint256 requiredAmountIn = amounts[0];
+        if (requiredAmountIn > amountInMax) {
+            revert AMMRouterExcessiveInputAmount(requiredAmountIn, amountInMax);
+        }
+
+        _safeTransferFrom(path[0], msg.sender, _pairFor(path[0], path[1]), requiredAmountIn);
+        _swap(amounts, path, address(this));
+
+        _unwrapNative(amounts[amounts.length - 1]);
+        _safeTransferNative(to, amounts[amounts.length - 1]);
+    }
+
+    function swapExactTokensForNative(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external override ensure(deadline) returns (uint256[] memory amounts) {
+        _validateNativeOutPath(path);
+
+        amounts = getAmountsOut(amountIn, path);
+        uint256 finalAmountOut = amounts[amounts.length - 1];
+        if (finalAmountOut < amountOutMin) {
+            revert AMMRouterInsufficientOutputAmount(finalAmountOut, amountOutMin);
+        }
+
+        _safeTransferFrom(path[0], msg.sender, _pairFor(path[0], path[1]), amounts[0]);
+        _swap(amounts, path, address(this));
+
+        _unwrapNative(finalAmountOut);
+        _safeTransferNative(to, finalAmountOut);
+    }
+
+    function swapNativeForExactTokens(uint256 amountOut, address[] calldata path, address to, uint256 deadline)
+        external
+        payable
+        override
+        ensure(deadline)
+        returns (uint256[] memory amounts)
+    {
+        _validateNativeInPath(path);
+
+        amounts = getAmountsIn(amountOut, path);
+        uint256 requiredNativeAmount = amounts[0];
+        if (requiredNativeAmount > msg.value) {
+            revert AMMRouterExcessiveInputAmount(requiredNativeAmount, msg.value);
+        }
+
+        _wrapNative(requiredNativeAmount);
+        _safeTransfer(wrappedNative, _pairFor(path[0], path[1]), requiredNativeAmount);
+        _swap(amounts, path, to);
+
+        uint256 refund = msg.value - requiredNativeAmount;
+        if (refund != 0) {
+            _safeTransferNative(msg.sender, refund);
+        }
+    }
+
+    function _validatePath(address[] calldata path) internal pure {
+        if (path.length < 2) {
+            revert AMMRouterInvalidPath();
+        }
+    }
+
+    function _validateNativeInPath(address[] calldata path) internal view {
+        _validatePath(path);
+        if (path[0] != wrappedNative) {
+            revert AMMRouterInvalidWrappedNativePath();
+        }
+    }
+
+    function _validateNativeOutPath(address[] calldata path) internal view {
+        _validatePath(path);
+        if (path[path.length - 1] != wrappedNative) {
+            revert AMMRouterInvalidWrappedNativePath();
+        }
+    }
+
+    function _addLiquidity(
+        address tokenA,
+        address tokenB,
+        uint256 amountADesired,
+        uint256 amountBDesired,
+        uint256 amountAMin,
+        uint256 amountBMin
+    ) internal returns (address pair, uint256 amountA, uint256 amountB) {
+        pair = IAMMFactory(factory).getPair(tokenA, tokenB);
+        if (pair == address(0)) {
+            pair = IAMMFactory(factory).createPair(tokenA, tokenB);
+        }
+
+        (uint256 reserveA, uint256 reserveB) = _getReserves(tokenA, tokenB);
+        if (reserveA == 0 && reserveB == 0) {
+            amountA = amountADesired;
+            amountB = amountBDesired;
+        } else {
+            uint256 amountBOptimal = quote(amountADesired, reserveA, reserveB);
+            if (amountBOptimal <= amountBDesired) {
+                amountA = amountADesired;
+                amountB = amountBOptimal;
+            } else {
+                amountA = quote(amountBDesired, reserveB, reserveA);
+                amountB = amountBDesired;
+            }
+        }
+
+        if (amountA < amountAMin) {
+            revert AMMRouterInsufficientAAmount(amountA, amountAMin);
+        }
+        if (amountB < amountBMin) {
+            revert AMMRouterInsufficientBAmount(amountB, amountBMin);
+        }
+    }
+
+    function _removeLiquidity(
+        address tokenA,
+        address tokenB,
+        uint256 liquidity,
+        uint256 amountAMin,
+        uint256 amountBMin,
+        address to
+    ) internal returns (uint256 amountA, uint256 amountB) {
+        address pair = _pairFor(tokenA, tokenB);
+        _safeTransferFrom(pair, msg.sender, pair, liquidity);
+
+        (uint256 amount0, uint256 amount1) = IAMMPair(pair).burn(to);
+        (address sortedToken0,) = _sortTokens(tokenA, tokenB);
+        (amountA, amountB) = tokenA == sortedToken0 ? (amount0, amount1) : (amount1, amount0);
+
+        if (amountA < amountAMin) {
+            revert AMMRouterInsufficientAAmount(amountA, amountAMin);
+        }
+        if (amountB < amountBMin) {
+            revert AMMRouterInsufficientBAmount(amountB, amountBMin);
+        }
+    }
+
+    function _swap(uint256[] memory amounts, address[] calldata path, address to) internal {
+        for (uint256 i = 0; i < path.length - 1; i++) {
+            address input = path[i];
+            address output = path[i + 1];
+            address pair = _pairFor(input, output);
+            (address token0,) = _sortTokens(input, output);
+            uint256 amountOut = amounts[i + 1];
+            (uint256 amount0Out, uint256 amount1Out) =
+                input == token0 ? (uint256(0), amountOut) : (amountOut, uint256(0));
+            address recipient = i < path.length - 2 ? _pairFor(output, path[i + 2]) : to;
+            IAMMPair(pair).swap(amount0Out, amount1Out, recipient, "");
+        }
+    }
+
+    function _getReserves(address tokenA, address tokenB) internal view returns (uint256 reserveA, uint256 reserveB) {
+        address pair = _pairFor(tokenA, tokenB);
+        (uint112 reserve0, uint112 reserve1,) = IAMMPair(pair).getReserves();
+        (address sortedToken0,) = _sortTokens(tokenA, tokenB);
+        return tokenA == sortedToken0 ? (reserve0, reserve1) : (reserve1, reserve0);
+    }
+
+    function _pairFor(address tokenA, address tokenB) internal view returns (address pair) {
+        _sortTokens(tokenA, tokenB);
+        pair = IAMMFactory(factory).getPair(tokenA, tokenB);
+        if (pair == address(0)) {
+            revert AMMRouterPairUnavailable(tokenA, tokenB);
+        }
+    }
+
+    function _sortTokens(address tokenA, address tokenB) internal pure returns (address token0, address token1) {
+        if (tokenA == tokenB) {
+            revert AMMRouterIdenticalTokens();
+        }
+        if (tokenA == address(0) || tokenB == address(0)) {
+            revert AMMRouterZeroTokenAddress();
+        }
+
+        (token0, token1) = tokenA < tokenB ? (tokenA, tokenB) : (tokenB, tokenA);
+    }
+
+    function _permitLiquidity(
+        address tokenA,
+        address tokenB,
+        uint256 liquidity,
+        uint256 deadline,
+        bool approveMax,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) internal {
+        uint256 allowanceValue = approveMax ? type(uint256).max : liquidity;
+        IAMMPair(_pairFor(tokenA, tokenB)).permit(msg.sender, address(this), allowanceValue, deadline, v, r, s);
+    }
+
+    function _wrapNative(uint256 value) internal {
+        if (value == 0) {
+            return;
+        }
+
+        (bool success,) = wrappedNative.call{value: value}(abi.encodeWithSelector(IWrappedNative.deposit.selector));
+        if (!success) {
+            revert AMMRouterWrapFailed(value);
+        }
+    }
+
+    function _unwrapNative(uint256 value) internal {
+        if (value == 0) {
+            return;
+        }
+
+        (bool success,) = wrappedNative.call(abi.encodeCall(IWrappedNative.withdraw, (value)));
+        if (!success) {
+            revert AMMRouterUnwrapFailed(value);
+        }
+    }
+
+    function _safeTransfer(address token, address to, uint256 value) internal {
+        if (value == 0) {
+            return;
+        }
+
+        (bool success, bytes memory data) = token.call(abi.encodeCall(IERC20.transfer, (to, value)));
+        bool validReturn = data.length == 0 || (data.length == 32 && abi.decode(data, (bool)));
+        if (!success || !validReturn) {
+            revert AMMRouterTransferFailed(token, to, value);
+        }
+    }
+
+    function _safeTransferFrom(address token, address from, address to, uint256 value) internal {
+        if (value == 0) {
+            return;
+        }
+
+        (bool success, bytes memory data) = token.call(abi.encodeCall(IERC20.transferFrom, (from, to, value)));
+        bool validReturn = data.length == 0 || (data.length == 32 && abi.decode(data, (bool)));
+        if (!success || !validReturn) {
+            revert AMMRouterTransferFromFailed(token, from, to, value);
+        }
+    }
+
+    function _safeTransferNative(address to, uint256 value) internal {
+        if (value == 0) {
+            return;
+        }
+
+        (bool success,) = payable(to).call{value: value}("");
+        if (!success) {
+            revert AMMRouterNativeTransferFailed(to, value);
+        }
+    }
+}

--- a/src/interfaces/IWrappedNative.sol
+++ b/src/interfaces/IWrappedNative.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC20} from "./IERC20.sol";
+
+/// @title IWrappedNative
+/// @notice Minimal wrapped-native token surface for AMM router integration.
+interface IWrappedNative is IERC20 {
+    function deposit() external payable;
+    function withdraw(uint256 value) external;
+}

--- a/test/AMMRouterCore.t.sol
+++ b/test/AMMRouterCore.t.sol
@@ -1,0 +1,441 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {AMMRouter} from "../src/amm/AMMRouter.sol";
+import {AMMPair} from "../src/amm/AMMPair.sol";
+import {AMMRouterFixture, MockWrappedNative, RejectingNativeReceiver} from "./helpers/AMMRouterTestHarness.sol";
+import {FalseReturningAMMToken, MockAMMToken} from "./helpers/AMMPairTestHarness.sol";
+
+contract AMMRouterCoreTest is AMMRouterFixture {
+    function testConstructorSetsFactoryAndWrappedNativeAndRejectsZeroAddresses() public view {
+        assertTrue(router.factory() == address(factory), "factory mismatch");
+        assertTrue(router.wrappedNative() == address(wrappedNativeToken), "wrapped native mismatch");
+    }
+
+    function testConstructorRevertsForZeroAddresses() public {
+        VM.expectRevert(AMMRouter.AMMRouterZeroAddress.selector);
+        new AMMRouter(address(0), address(wrappedNativeToken));
+
+        VM.expectRevert(AMMRouter.AMMRouterZeroAddress.selector);
+        new AMMRouter(address(factory), address(0));
+    }
+
+    function testQuoteMathAndPathTraversalHelpersMatchExpectedValues() public {
+        _provideRouterLiquidity(token0, token1, alice, 10_000, 20_000, alice);
+        _provideRouterLiquidity(token1, token2, alice, 20_000, 10_000, alice);
+
+        assertTrue(router.quote(500, 10_000, 20_000) == 1_000, "quote mismatch");
+
+        uint256 expectedHopOneOut = _getAmountOut(1_000, 10_000, 20_000);
+        uint256 expectedHopTwoOut = _getAmountOut(expectedHopOneOut, 20_000, 10_000);
+        uint256[] memory amountsOut =
+            router.getAmountsOut(1_000, _path(address(token0), address(token1), address(token2)));
+        assertTrue(amountsOut[0] == 1_000, "amountsOut input mismatch");
+        assertTrue(amountsOut[1] == expectedHopOneOut, "amountsOut first hop mismatch");
+        assertTrue(amountsOut[2] == expectedHopTwoOut, "amountsOut second hop mismatch");
+
+        uint256 expectedHopTwoIn = router.getAmountIn(700, 20_000, 10_000);
+        uint256 expectedHopOneIn = router.getAmountIn(expectedHopTwoIn, 10_000, 20_000);
+        uint256[] memory amountsIn = router.getAmountsIn(700, _path(address(token0), address(token1), address(token2)));
+        assertTrue(amountsIn[0] == expectedHopOneIn, "amountsIn first hop mismatch");
+        assertTrue(amountsIn[1] == expectedHopTwoIn, "amountsIn second hop mismatch");
+        assertTrue(amountsIn[2] == 700, "amountsIn output mismatch");
+    }
+
+    function testAddLiquidityCreatesPairAndMintsLpToRecipient() public {
+        MockAMMToken unsortedA = new MockAMMToken("Token A", "TKA", 18);
+        MockAMMToken unsortedB = new MockAMMToken("Token B", "TKB", 18);
+        unsortedA.mint(alice, 10_000);
+        unsortedB.mint(alice, 20_000);
+
+        VM.startPrank(alice);
+        assertTrue(unsortedA.approve(address(router), 10_000), "approve tokenA should succeed");
+        assertTrue(unsortedB.approve(address(router), 20_000), "approve tokenB should succeed");
+        (uint256 amountA, uint256 amountB, uint256 liquidity) =
+            router.addLiquidity(address(unsortedB), address(unsortedA), 20_000, 10_000, 20_000, 10_000, alice, DEADLINE);
+        VM.stopPrank();
+
+        address pairAddress = factory.getPair(address(unsortedA), address(unsortedB));
+        assertTrue(pairAddress != address(0), "pair should be created");
+        assertTrue(amountA == 20_000, "amountA mismatch");
+        assertTrue(amountB == 10_000, "amountB mismatch");
+        assertTrue(liquidity == 13_142, "liquidity mismatch");
+
+        AMMPair createdPair = AMMPair(pairAddress);
+        assertTrue(createdPair.balanceOf(alice) == liquidity, "lp balance mismatch");
+
+        (uint112 reserve0_, uint112 reserve1_,) = createdPair.getReserves();
+        (uint112 expectedReserve0, uint112 expectedReserve1) = address(unsortedA) < address(unsortedB)
+            ? (uint112(10_000), uint112(20_000))
+            : (uint112(20_000), uint112(10_000));
+        assertTrue(reserve0_ == expectedReserve0, "reserve0 mismatch");
+        assertTrue(reserve1_ == expectedReserve1, "reserve1 mismatch");
+    }
+
+    function testAddLiquidityUsesOptimalExistingRatioAndLeavesUnusedBalanceWithCaller() public {
+        _provideRouterLiquidity(token0, token1, alice, 10_000, 20_000, alice);
+
+        token0.mint(bob, 5_000);
+        token1.mint(bob, 20_000);
+
+        VM.startPrank(bob);
+        assertTrue(token0.approve(address(router), 5_000), "approve token0 should succeed");
+        assertTrue(token1.approve(address(router), 20_000), "approve token1 should succeed");
+        (uint256 amountA, uint256 amountB,) =
+            router.addLiquidity(address(token1), address(token0), 20_000, 5_000, 10_000, 5_000, bob, DEADLINE);
+        VM.stopPrank();
+
+        assertTrue(amountA == 10_000, "token1 amount mismatch");
+        assertTrue(amountB == 5_000, "token0 amount mismatch");
+        assertTrue(token1.balanceOf(bob) == 10_000, "unused token1 should remain with caller");
+
+        (uint112 reserve0_, uint112 reserve1_,) = pair.getReserves();
+        assertTrue(reserve0_ == 15_000, "reserve0 mismatch after add");
+        assertTrue(reserve1_ == 30_000, "reserve1 mismatch after add");
+    }
+
+    function testAddLiquidityRevertsWhenSlippageBoundsAreTooTight() public {
+        _provideRouterLiquidity(token0, token1, alice, 10_000, 20_000, alice);
+
+        token0.mint(bob, 5_000);
+        token1.mint(bob, 20_000);
+
+        VM.startPrank(bob);
+        assertTrue(token0.approve(address(router), 5_000), "approve token0 should succeed");
+        assertTrue(token1.approve(address(router), 20_000), "approve token1 should succeed");
+        VM.expectRevert(abi.encodeWithSelector(AMMRouter.AMMRouterInsufficientAAmount.selector, 10_000, 10_001));
+        router.addLiquidity(address(token1), address(token0), 20_000, 5_000, 10_001, 5_000, bob, DEADLINE);
+        VM.stopPrank();
+    }
+
+    function testAddLiquidityNativeWrapsOnlyUsedAmountAndRefundsExcessNative() public {
+        _provideRouterLiquidity(token0, wrappedNativeToken, alice, 10_000, 20_000, alice);
+
+        token0.mint(bob, 5_000);
+        VM.deal(bob, 50_000);
+
+        uint256 bobBalanceBefore = bob.balance;
+        VM.startPrank(bob);
+        assertTrue(token0.approve(address(router), 5_000), "approve token0 should succeed");
+        (uint256 amountToken, uint256 amountNative,) =
+            router.addLiquidityNative{value: 20_000}(address(token0), 5_000, 5_000, 10_000, bob, DEADLINE);
+        VM.stopPrank();
+
+        assertTrue(amountToken == 5_000, "token amount mismatch");
+        assertTrue(amountNative == 10_000, "native amount mismatch");
+        assertTrue(bob.balance == bobBalanceBefore - 10_000, "native refund mismatch");
+        assertTrue(address(router).balance == 0, "router should not retain native balance");
+        assertTrue(wrappedNativeToken.balanceOf(address(router)) == 0, "router should not retain wrapped native");
+
+        AMMPair nativePair = AMMPair(factory.getPair(address(token0), address(wrappedNativeToken)));
+        (uint112 reserve0_, uint112 reserve1_,) = nativePair.getReserves();
+        (uint112 expectedReserve0, uint112 expectedReserve1) = address(token0) < address(wrappedNativeToken)
+            ? (uint112(15_000), uint112(30_000))
+            : (uint112(30_000), uint112(15_000));
+        assertTrue(reserve0_ == expectedReserve0, "native reserve0 mismatch");
+        assertTrue(reserve1_ == expectedReserve1, "native reserve1 mismatch");
+    }
+
+    function testRemoveLiquidityReturnsAlignedAmountsForCallerTokenOrder() public {
+        _provideRouterLiquidity(token0, token1, alice, 10_000, 20_000, alice);
+
+        uint256 burnLiquidity = pair.balanceOf(alice) / 2;
+        uint256 totalSupplyBefore = pair.totalSupply();
+        (uint112 reserve0Before, uint112 reserve1Before,) = pair.getReserves();
+        uint256 expectedToken0 = (burnLiquidity * reserve0Before) / totalSupplyBefore;
+        uint256 expectedToken1 = (burnLiquidity * reserve1Before) / totalSupplyBefore;
+
+        VM.prank(alice);
+        assertTrue(pair.approve(address(router), burnLiquidity), "approve lp should succeed");
+
+        VM.prank(alice);
+        (uint256 amountToken1, uint256 amountToken0) =
+            router.removeLiquidity(address(token1), address(token0), burnLiquidity, 0, 0, bob, DEADLINE);
+
+        assertTrue(amountToken1 == expectedToken1, "token1 amount mismatch");
+        assertTrue(amountToken0 == expectedToken0, "token0 amount mismatch");
+        assertTrue(token1.balanceOf(bob) == expectedToken1, "bob token1 balance mismatch");
+        assertTrue(token0.balanceOf(bob) == expectedToken0, "bob token0 balance mismatch");
+    }
+
+    function testRemoveLiquidityWithPermitUsesLpPermitApproval() public {
+        _provideRouterLiquidity(token0, token1, alice, 10_000, 10_000, alice);
+
+        uint256 liquidity = pair.balanceOf(alice) / 2;
+        uint256 deadline = block.timestamp + 1 days;
+        (uint8 v, bytes32 r, bytes32 s) =
+            _signPermit(ALICE_PK, address(pair), alice, address(router), liquidity, 0, deadline);
+
+        uint256 aliceToken0Before = token0.balanceOf(alice);
+        uint256 aliceToken1Before = token1.balanceOf(alice);
+
+        VM.prank(alice);
+        (uint256 amount0, uint256 amount1) = _removeLiquidityWithPermit(liquidity, alice, deadline, v, r, s);
+
+        assertTrue(pair.nonces(alice) == 1, "permit nonce mismatch");
+        assertTrue(token0.balanceOf(alice) == aliceToken0Before + amount0, "alice token0 delta mismatch");
+        assertTrue(token1.balanceOf(alice) == aliceToken1Before + amount1, "alice token1 delta mismatch");
+    }
+
+    function testRemoveLiquidityNativeWithPermitUnwrapsAndTransfersNative() public {
+        AMMPair nativePair = AMMPair(factory.createPair(address(token0), address(wrappedNativeToken)));
+        _provideRouterLiquidity(token0, wrappedNativeToken, alice, 10_000, 10_000, alice);
+
+        uint256 liquidity = nativePair.balanceOf(alice) / 2;
+        uint256 deadline = block.timestamp + 1 days;
+        (uint8 v, bytes32 r, bytes32 s) =
+            _signPermit(ALICE_PK, address(nativePair), alice, address(router), liquidity, 0, deadline);
+
+        uint256 bobNativeBefore = bob.balance;
+        uint256 bobTokenBefore = token0.balanceOf(bob);
+
+        VM.prank(alice);
+        (uint256 amountToken, uint256 amountNative) =
+            _removeLiquidityNativeWithPermit(liquidity, bob, deadline, v, r, s);
+
+        assertTrue(nativePair.nonces(alice) == 1, "native permit nonce mismatch");
+        assertTrue(token0.balanceOf(bob) == bobTokenBefore + amountToken, "token payout mismatch");
+        assertTrue(bob.balance == bobNativeBefore + amountNative, "native payout mismatch");
+        assertTrue(address(router).balance == 0, "router should not retain native balance");
+    }
+
+    function testSwapExactTokensForTokensRoutesSingleHop() public {
+        _provideRouterLiquidity(token0, token1, alice, 10_000, 10_000, alice);
+
+        token0.mint(bob, 1_000);
+        uint256 expectedAmountOut = router.getAmountOut(1_000, 10_000, 10_000);
+
+        VM.startPrank(bob);
+        assertTrue(token0.approve(address(router), 1_000), "approve token0 should succeed");
+        uint256[] memory amounts = router.swapExactTokensForTokens(
+            1_000, expectedAmountOut, _path(address(token0), address(token1)), bob, DEADLINE
+        );
+        VM.stopPrank();
+
+        assertTrue(amounts[0] == 1_000, "amounts input mismatch");
+        assertTrue(amounts[1] == expectedAmountOut, "amounts output mismatch");
+        assertTrue(token1.balanceOf(bob) == expectedAmountOut, "bob token1 output mismatch");
+    }
+
+    function testSwapTokensForExactTokensRoutesMultiHop() public {
+        _provideRouterLiquidity(token0, token1, alice, 10_000, 20_000, alice);
+        _provideRouterLiquidity(token1, token2, alice, 20_000, 10_000, alice);
+
+        uint256 amountOut = 700;
+        uint256[] memory expectedAmounts =
+            router.getAmountsIn(amountOut, _path(address(token0), address(token1), address(token2)));
+        token0.mint(bob, expectedAmounts[0]);
+
+        VM.startPrank(bob);
+        assertTrue(token0.approve(address(router), expectedAmounts[0]), "approve token0 should succeed");
+        uint256[] memory amounts = router.swapTokensForExactTokens(
+            amountOut, expectedAmounts[0], _path(address(token0), address(token1), address(token2)), bob, DEADLINE
+        );
+        VM.stopPrank();
+
+        assertTrue(amounts[0] == expectedAmounts[0], "required input mismatch");
+        assertTrue(amounts[2] == amountOut, "exact output mismatch");
+        assertTrue(token2.balanceOf(bob) == amountOut, "bob token2 output mismatch");
+    }
+
+    function testSwapExactNativeForTokensWrapsInputAndRoutesOutput() public {
+        _provideRouterLiquidity(wrappedNativeToken, token0, alice, 10_000, 10_000, alice);
+
+        VM.deal(bob, 5_000);
+        uint256 expectedAmountOut = router.getAmountOut(1_000, 10_000, 10_000);
+
+        VM.prank(bob);
+        uint256[] memory amounts = router.swapExactNativeForTokens{value: 1_000}(
+            expectedAmountOut, _path(address(wrappedNativeToken), address(token0)), bob, DEADLINE
+        );
+
+        assertTrue(amounts[0] == 1_000, "native input mismatch");
+        assertTrue(amounts[1] == expectedAmountOut, "token output mismatch");
+        assertTrue(token0.balanceOf(bob) == expectedAmountOut, "bob token output mismatch");
+        assertTrue(address(router).balance == 0, "router should not retain native balance");
+    }
+
+    function testSwapNativeForExactTokensRefundsExcessValue() public {
+        _provideRouterLiquidity(wrappedNativeToken, token0, alice, 10_000, 10_000, alice);
+
+        uint256[] memory expectedAmounts = router.getAmountsIn(700, _path(address(wrappedNativeToken), address(token0)));
+        VM.deal(bob, expectedAmounts[0] + 500);
+        uint256 bobNativeBefore = bob.balance;
+
+        VM.prank(bob);
+        uint256[] memory amounts = router.swapNativeForExactTokens{value: expectedAmounts[0] + 500}(
+            700, _path(address(wrappedNativeToken), address(token0)), bob, DEADLINE
+        );
+
+        assertTrue(amounts[0] == expectedAmounts[0], "required native mismatch");
+        assertTrue(token0.balanceOf(bob) == 700, "bob token output mismatch");
+        assertTrue(bob.balance == bobNativeBefore - expectedAmounts[0], "native refund mismatch");
+    }
+
+    function testSwapExactTokensForNativeUnwrapsAndTransfersNative() public {
+        _provideRouterLiquidity(token0, wrappedNativeToken, alice, 10_000, 10_000, alice);
+
+        token0.mint(bob, 1_000);
+        uint256 expectedNativeOut = router.getAmountOut(1_000, 10_000, 10_000);
+        uint256 bobNativeBefore = bob.balance;
+
+        VM.startPrank(bob);
+        assertTrue(token0.approve(address(router), 1_000), "approve token0 should succeed");
+        uint256[] memory amounts = router.swapExactTokensForNative(
+            1_000, expectedNativeOut, _path(address(token0), address(wrappedNativeToken)), bob, DEADLINE
+        );
+        VM.stopPrank();
+
+        assertTrue(amounts[1] == expectedNativeOut, "native output mismatch");
+        assertTrue(bob.balance == bobNativeBefore + expectedNativeOut, "bob native payout mismatch");
+        assertTrue(address(router).balance == 0, "router should not retain native balance");
+    }
+
+    function testSwapTokensForExactNativeUsesExactInputAndTransfersNative() public {
+        _provideRouterLiquidity(token0, wrappedNativeToken, alice, 10_000, 10_000, alice);
+
+        uint256[] memory expectedAmounts = router.getAmountsIn(700, _path(address(token0), address(wrappedNativeToken)));
+        token0.mint(bob, expectedAmounts[0]);
+        uint256 bobNativeBefore = bob.balance;
+
+        VM.startPrank(bob);
+        assertTrue(token0.approve(address(router), expectedAmounts[0]), "approve token0 should succeed");
+        uint256[] memory amounts = router.swapTokensForExactNative(
+            700, expectedAmounts[0], _path(address(token0), address(wrappedNativeToken)), bob, DEADLINE
+        );
+        VM.stopPrank();
+
+        assertTrue(amounts[0] == expectedAmounts[0], "exact input mismatch");
+        assertTrue(amounts[1] == 700, "native amount mismatch");
+        assertTrue(bob.balance == bobNativeBefore + 700, "native payout mismatch");
+    }
+
+    function testGetAmountsOutRevertsForMissingPairAndInvalidPath() public {
+        address[] memory invalidPath = new address[](1);
+        invalidPath[0] = address(token0);
+        VM.expectRevert(AMMRouter.AMMRouterInvalidPath.selector);
+        router.getAmountsOut(1, invalidPath);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(AMMRouter.AMMRouterPairUnavailable.selector, address(token0), address(token2))
+        );
+        router.getAmountsOut(1, _path(address(token0), address(token2)));
+    }
+
+    function testNativeHelpersRevertForInvalidWrappedNativePath() public {
+        VM.deal(bob, 1_000);
+        VM.prank(bob);
+        VM.expectRevert(AMMRouter.AMMRouterInvalidWrappedNativePath.selector);
+        router.swapExactNativeForTokens{value: 1_000}(0, _path(address(token0), address(token1)), bob, DEADLINE);
+
+        token0.mint(bob, 1_000);
+        VM.startPrank(bob);
+        assertTrue(token0.approve(address(router), 1_000), "approve token0 should succeed");
+        VM.expectRevert(AMMRouter.AMMRouterInvalidWrappedNativePath.selector);
+        router.swapExactTokensForNative(1_000, 0, _path(address(token0), address(token1)), bob, DEADLINE);
+        VM.stopPrank();
+    }
+
+    function testSwapsRevertForSlippageAndMaxInputBounds() public {
+        _provideRouterLiquidity(token0, token1, alice, 10_000, 10_000, alice);
+
+        token0.mint(bob, 1_000);
+        uint256 expectedAmountOut = router.getAmountOut(1_000, 10_000, 10_000);
+        VM.startPrank(bob);
+        assertTrue(token0.approve(address(router), 1_000), "approve token0 should succeed");
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                AMMRouter.AMMRouterInsufficientOutputAmount.selector, expectedAmountOut, expectedAmountOut + 1
+            )
+        );
+        router.swapExactTokensForTokens(
+            1_000, expectedAmountOut + 1, _path(address(token0), address(token1)), bob, DEADLINE
+        );
+        VM.stopPrank();
+
+        uint256[] memory expectedAmounts = router.getAmountsIn(700, _path(address(token0), address(token1)));
+        token0.mint(bob, expectedAmounts[0]);
+        VM.startPrank(bob);
+        assertTrue(token0.approve(address(router), expectedAmounts[0]), "approve token0 should succeed");
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                AMMRouter.AMMRouterExcessiveInputAmount.selector, expectedAmounts[0], expectedAmounts[0] - 1
+            )
+        );
+        router.swapTokensForExactTokens(
+            700, expectedAmounts[0] - 1, _path(address(token0), address(token1)), bob, DEADLINE
+        );
+        VM.stopPrank();
+    }
+
+    function testAddLiquidityRevertsWhenTransferFromFails() public {
+        FalseReturningAMMToken falseToken = _deployFalseReturningToken();
+        address pairAddress = factory.createPair(address(falseToken), address(token1));
+        token1.mint(bob, 10_000);
+        falseToken.mint(bob, 10_000);
+
+        VM.startPrank(bob);
+        assertTrue(token1.approve(address(router), 10_000), "approve token1 should succeed");
+        assertTrue(falseToken.approve(address(router), 10_000), "approve false token should succeed");
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                AMMRouter.AMMRouterTransferFromFailed.selector, address(falseToken), bob, pairAddress, 10_000
+            )
+        );
+        router.addLiquidity(address(falseToken), address(token1), 10_000, 10_000, 0, 0, bob, DEADLINE);
+        VM.stopPrank();
+    }
+
+    function testRouterRejectsDirectNativeTransfersAndNativeRecipientsThatRevert() public {
+        VM.deal(address(this), 1);
+        (bool success, bytes memory returndata) = address(router).call{value: 1}("");
+        assertFalse(success, "direct native transfer should fail");
+
+        bytes4 revertSelector;
+        assembly {
+            revertSelector := mload(add(returndata, 0x20))
+        }
+        assertTrue(revertSelector == AMMRouter.AMMRouterInvalidNativeSender.selector, "unexpected direct native revert");
+
+        _provideRouterLiquidity(token0, wrappedNativeToken, alice, 10_000, 10_000, alice);
+        RejectingNativeReceiver rejectingReceiver = new RejectingNativeReceiver();
+
+        token0.mint(bob, 1_000);
+        VM.startPrank(bob);
+        assertTrue(token0.approve(address(router), 1_000), "approve token0 should succeed");
+        uint256 expectedNativeOut = router.getAmountOut(1_000, 10_000, 10_000);
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                AMMRouter.AMMRouterNativeTransferFailed.selector, address(rejectingReceiver), expectedNativeOut
+            )
+        );
+        router.swapExactTokensForNative(
+            1_000,
+            expectedNativeOut,
+            _path(address(token0), address(wrappedNativeToken)),
+            address(rejectingReceiver),
+            DEADLINE
+        );
+        VM.stopPrank();
+    }
+
+    function _removeLiquidityWithPermit(uint256 liquidity, address to, uint256 deadline, uint8 v, bytes32 r, bytes32 s)
+        internal
+        returns (uint256 amount0, uint256 amount1)
+    {
+        return router.removeLiquidityWithPermit(
+            address(token0), address(token1), liquidity, 0, 0, to, deadline, false, v, r, s
+        );
+    }
+
+    function _removeLiquidityNativeWithPermit(
+        uint256 liquidity,
+        address to,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) internal returns (uint256 amountToken, uint256 amountNative) {
+        return router.removeLiquidityNativeWithPermit(address(token0), liquidity, 0, 0, to, deadline, false, v, r, s);
+    }
+}

--- a/test/AMMRouterTime.t.sol
+++ b/test/AMMRouterTime.t.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {AMMRouter} from "../src/amm/AMMRouter.sol";
+import {AMMRouterFixture} from "./helpers/AMMRouterTestHarness.sol";
+
+contract AMMRouterTimeTest is AMMRouterFixture {
+    function testAddLiquidityRevertsAfterDeadline() public {
+        uint256 deadline = block.timestamp;
+        VM.warp(deadline + 1);
+
+        VM.expectRevert(abi.encodeWithSelector(AMMRouter.AMMRouterExpired.selector, deadline, block.timestamp));
+        router.addLiquidity(address(token0), address(token1), 1, 1, 0, 0, alice, deadline);
+    }
+
+    function testRemoveLiquidityWithPermitRevertsAfterDeadline() public {
+        uint256 deadline = block.timestamp;
+        VM.warp(deadline + 1);
+
+        VM.expectRevert(abi.encodeWithSelector(AMMRouter.AMMRouterExpired.selector, deadline, block.timestamp));
+        router.removeLiquidityWithPermit(
+            address(token0), address(token1), 1, 0, 0, alice, deadline, false, 0, bytes32(0), bytes32(0)
+        );
+    }
+
+    function testSwapExactTokensForTokensRevertsAfterDeadline() public {
+        uint256 deadline = block.timestamp;
+        VM.warp(deadline + 1);
+
+        VM.expectRevert(abi.encodeWithSelector(AMMRouter.AMMRouterExpired.selector, deadline, block.timestamp));
+        router.swapExactTokensForTokens(1, 0, _path(address(token0), address(token1)), alice, deadline);
+    }
+
+    function testSwapExactNativeForTokensRevertsAfterDeadline() public {
+        uint256 deadline = block.timestamp;
+        VM.warp(deadline + 1);
+
+        VM.expectRevert(abi.encodeWithSelector(AMMRouter.AMMRouterExpired.selector, deadline, block.timestamp));
+        router.swapExactNativeForTokens{value: 1}(
+            0, _path(address(wrappedNativeToken), address(token0)), alice, deadline
+        );
+    }
+}

--- a/test/helpers/AMMRouterTestHarness.sol
+++ b/test/helpers/AMMRouterTestHarness.sol
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {AMMRouter} from "../../src/amm/AMMRouter.sol";
+import {AMMFactory} from "../../src/amm/AMMFactory.sol";
+import {AMMPair} from "../../src/amm/AMMPair.sol";
+import {IWrappedNative} from "../../src/interfaces/IWrappedNative.sol";
+import {AMMPairCoreFixture, FalseReturningAMMToken, MockAMMToken} from "./AMMPairTestHarness.sol";
+
+contract MockWrappedNative is MockAMMToken, IWrappedNative {
+    constructor(string memory name_, string memory symbol_, uint8 decimals_) MockAMMToken(name_, symbol_, decimals_) {}
+
+    receive() external payable {
+        deposit();
+    }
+
+    function deposit() public payable {
+        _balances[msg.sender] += msg.value;
+        _totalSupply += msg.value;
+        emit Transfer(address(0), msg.sender, msg.value);
+    }
+
+    function withdraw(uint256 value) external {
+        uint256 balance = _balances[msg.sender];
+        require(balance >= value, "INSUFFICIENT_BALANCE");
+
+        unchecked {
+            _balances[msg.sender] = balance - value;
+            _totalSupply -= value;
+        }
+
+        emit Transfer(msg.sender, address(0), value);
+
+        (bool success,) = payable(msg.sender).call{value: value}("");
+        require(success, "NATIVE_TRANSFER_FAILED");
+    }
+}
+
+contract RejectingNativeReceiver {
+    receive() external payable {
+        revert("REJECT_NATIVE");
+    }
+}
+
+abstract contract AMMRouterFixture is AMMPairCoreFixture {
+    uint256 internal constant DEADLINE = type(uint256).max;
+
+    AMMRouter internal router;
+    MockWrappedNative internal wrappedNativeToken;
+    MockAMMToken internal token2;
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        wrappedNativeToken = new MockWrappedNative("Wrapped Native", "WNATIVE", 18);
+        token2 = new MockAMMToken("Token 2", "TK2", 18);
+        router = new AMMRouter(address(factory), address(wrappedNativeToken));
+    }
+
+    function _mintOrWrapTo(MockAMMToken token, address recipient, uint256 amount) internal {
+        if (address(token) == address(wrappedNativeToken)) {
+            VM.deal(recipient, recipient.balance + amount);
+            VM.prank(recipient);
+            wrappedNativeToken.deposit{value: amount}();
+            return;
+        }
+
+        token.mint(recipient, amount);
+    }
+
+    function _provideRouterLiquidity(
+        MockAMMToken tokenA_,
+        MockAMMToken tokenB_,
+        address provider,
+        uint256 amountA,
+        uint256 amountB,
+        address recipient
+    ) internal returns (AMMPair pair_, uint256 liquidity) {
+        address pairAddress = factory.getPair(address(tokenA_), address(tokenB_));
+        if (pairAddress == address(0)) {
+            pairAddress = factory.createPair(address(tokenA_), address(tokenB_));
+        }
+
+        pair_ = AMMPair(pairAddress);
+        (MockAMMToken pairToken0, MockAMMToken pairToken1, uint256 amount0, uint256 amount1) = address(tokenA_)
+                < address(tokenB_)
+            ? (tokenA_, tokenB_, amountA, amountB)
+            : (tokenB_, tokenA_, amountB, amountA);
+
+        _mintOrWrapTo(pairToken0, provider, amount0);
+        _mintOrWrapTo(pairToken1, provider, amount1);
+
+        VM.startPrank(provider);
+        assertTrue(pairToken0.transfer(address(pair_), amount0), "token0 transfer should succeed");
+        assertTrue(pairToken1.transfer(address(pair_), amount1), "token1 transfer should succeed");
+        VM.stopPrank();
+
+        liquidity = pair_.mint(recipient);
+    }
+
+    function _path(address tokenA_, address tokenB_) internal pure returns (address[] memory path_) {
+        path_ = new address[](2);
+        path_[0] = tokenA_;
+        path_[1] = tokenB_;
+    }
+
+    function _path(address tokenA_, address tokenB_, address tokenC_) internal pure returns (address[] memory path_) {
+        path_ = new address[](3);
+        path_[0] = tokenA_;
+        path_[1] = tokenB_;
+        path_[2] = tokenC_;
+    }
+
+    function _deployFalseReturningToken() internal returns (FalseReturningAMMToken token_) {
+        token_ = new FalseReturningAMMToken("False Token", "FTK", 18);
+    }
+}


### PR DESCRIPTION
## Summary
- add `AMMRouter` as the user-facing AMM periphery for quotes, liquidity, swaps, permits, and wrapped-native helpers
- introduce a minimal wrapped-native interface plus AMM router harness support with a local wrapped-native mock
- add focused AMM router Core and Time coverage for routing math, native refunds and unwraps, permit removals, slippage, deadlines, and bad paths

## Testing
- `forge fmt --check`
- `forge test --match-contract AMMRouterCoreTest`
- `forge test --match-contract AMMRouterTimeTest`
- `forge test --match-path 'test/AMM*.t.sol'`
- `forge test` (broad run progressed through AMM suites plus multiple long-running fuzz/invariant suites before I stopped waiting on the remaining tail)

## Linked Issue
Closes #183
