### PR TITLE
test: add AMM hardening coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,39 @@ jobs:
 
       - name: Run System Oracle Failure Scenarios
         run: forge test --offline --match-path test/SystemOracleFailureScenarios.t.sol
+
+  amm-hardening:
+    name: AMM Hardening
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: 1.4.3
+
+      - name: Cache Foundry Artifacts
+        uses: actions/cache@v4
+        with:
+          path: ~/.foundry/cache
+          key: ${{ runner.os }}-foundry-cache-${{ hashFiles('foundry.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-foundry-cache-
+
+      - name: Build With Sizes
+        run: forge build --sizes --skip script
+
+      - name: Run AMM Pair Fuzz
+        run: forge test --offline --match-path test/AMMPairFuzz.t.sol
+
+      - name: Run AMM Router Fuzz
+        run: forge test --offline --match-path test/AMMRouterFuzz.t.sol
+
+      - name: Run AMM Invariants
+        run: FOUNDRY_INVARIANT_RUNS=64 FOUNDRY_INVARIANT_DEPTH=32 forge test --offline --match-path test/AMMInvariant.t.sol
+
+      - name: Run AMM Hardening
+        run: forge test --offline --match-path test/AMMHardening.t.sol

--- a/test/AMMHardening.t.sol
+++ b/test/AMMHardening.t.sol
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {AMMFactory} from "../src/amm/AMMFactory.sol";
+import {AMMPair} from "../src/amm/AMMPair.sol";
+import {AMMRouter} from "../src/amm/AMMRouter.sol";
+import {AMMHardeningFixture} from "./helpers/AMMHardeningTestHarness.sol";
+import {
+    FalseReturningAMMToken,
+    MalformedAMMToken,
+    MockAMMToken,
+    ReentrantAMMToken,
+    SilentAMMToken
+} from "./helpers/AMMPairTestHarness.sol";
+
+contract AMMHardeningTest is AMMHardeningFixture {
+    function testFeeOnMintsProtocolLpOnlyWhenLiquidityMoves() public {
+        AMMFactory localFactory = new AMMFactory();
+        localFactory.setFeeTo(carol);
+
+        MockAMMToken localToken0 = new MockAMMToken("Local Token 0", "LT0", 18);
+        MockAMMToken localToken1 = new MockAMMToken("Local Token 1", "LT1", 18);
+        AMMPair localPair = AMMPair(localFactory.createPair(address(localToken0), address(localToken1)));
+
+        _seedLiquidityDirect(localPair, localToken0, localToken1, 1_000_000, 1_000_000, alice);
+        assertTrue(localPair.kLast() == 1_000_000 * 1_000_000, "initial fee-on kLast mismatch");
+
+        localToken0.mint(address(localPair), 100_000);
+        uint256 amount1Out = _getAmountOut(100_000, 1_000_000, 1_000_000);
+        if (localPair.token0() == address(localToken0)) {
+            localPair.swap(0, amount1Out, bob, "");
+        } else {
+            localPair.swap(amount1Out, 0, bob, "");
+        }
+
+        (uint112 reserve0AfterSwap, uint112 reserve1AfterSwap,) = localPair.getReserves();
+        uint256 protocolLpBefore = localPair.balanceOf(carol);
+        (uint256 reserveLocal0, uint256 reserveLocal1) = localPair.token0() == address(localToken0)
+            ? (reserve0AfterSwap, reserve1AfterSwap)
+            : (reserve1AfterSwap, reserve0AfterSwap);
+        uint256 amount0Desired = 11_000;
+        uint256 amount1Desired = (amount0Desired * reserveLocal1) / reserveLocal0;
+
+        localToken0.mint(address(localPair), amount0Desired);
+        localToken1.mint(address(localPair), amount1Desired);
+        localPair.mint(bob);
+
+        assertTrue(localPair.balanceOf(carol) > protocolLpBefore, "protocol fee lp should mint on later liquidity");
+        (uint112 reserve0AfterMint, uint112 reserve1AfterMint,) = localPair.getReserves();
+        assertTrue(
+            localPair.kLast() == uint256(reserve0AfterMint) * uint256(reserve1AfterMint),
+            "fee-on kLast should refresh on liquidity event"
+        );
+    }
+
+    function testFeeOffClearsKLastOnlyOnNextLiquidityEvent() public {
+        factory.setFeeTo(carol);
+
+        VM.prank(bob);
+        router.addLiquidity(address(token0), address(token1), 20_000, 20_000, 0, 0, bob, DEADLINE);
+        _recordLiquidityEvent(address(pair01));
+
+        uint256 kLastBeforeDisable = pair01.kLast();
+        assertTrue(kLastBeforeDisable != 0, "kLast should be set while fee switch is on");
+
+        factory.setFeeTo(address(0));
+
+        address[] memory path_ = _path(address(token0), address(token1));
+        uint256 expectedAmountOut = router.getAmountsOut(10_000, path_)[1];
+        VM.prank(carol);
+        router.swapExactTokensForTokens(10_000, expectedAmountOut, path_, carol, DEADLINE);
+
+        assertTrue(pair01.kLast() == kLastBeforeDisable, "swap should not clear kLast after fee disable");
+
+        (uint256 reserve0Before, uint256 reserve1Before) = _getAlignedReserves(address(token0), address(token1));
+        uint256 amount1Desired = router.quote(15_000, reserve0Before, reserve1Before);
+        VM.prank(bob);
+        router.addLiquidity(address(token0), address(token1), 15_000, amount1Desired, 0, 0, bob, DEADLINE);
+
+        _recordLiquidityEvent(address(pair01));
+        assertTrue(pair01.kLast() == 0, "liquidity event should clear kLast after fee disable");
+        _assertTrackedAmmState();
+    }
+
+    function testDonationSkimAndSyncPreserveReserveSemantics() public {
+        (uint112 reserve0Before, uint112 reserve1Before,) = pair01.getReserves();
+
+        token0.mint(address(pair01), 5_000);
+        token1.mint(address(pair01), 7_000);
+        pair01.skim(dave);
+
+        (uint112 reserve0AfterSkim, uint112 reserve1AfterSkim,) = pair01.getReserves();
+        assertTrue(reserve0AfterSkim == reserve0Before, "skim should leave reserve0 unchanged");
+        assertTrue(reserve1AfterSkim == reserve1Before, "skim should leave reserve1 unchanged");
+
+        token0.mint(address(pair01), 3_000);
+        token1.mint(address(pair01), 4_000);
+        pair01.sync();
+
+        (uint112 reserve0AfterSync, uint112 reserve1AfterSync,) = pair01.getReserves();
+        assertTrue(reserve0AfterSync == reserve0Before + 3_000, "sync should advance reserve0 to balance");
+        assertTrue(reserve1AfterSync == reserve1Before + 4_000, "sync should advance reserve1 to balance");
+        _assertTrackedAmmState();
+    }
+
+    function testMultiActorTokenAndNativeSequenceKeepsTrackedStateCoherent() public {
+        VM.prank(bob);
+        router.addLiquidityNative{value: 20_000}(address(token0), 20_000, 0, 0, bob, DEADLINE);
+        _recordLiquidityEvent(address(pair0W));
+
+        VM.prank(carol);
+        router.swapExactTokensForTokens(
+            12_000, 0, _path(address(token2), address(token1), address(token0)), carol, DEADLINE
+        );
+
+        VM.prank(dave);
+        router.swapExactNativeForTokens{value: 15_000}(
+            0, _path(address(wrappedNativeToken), address(token1), address(token2)), dave, DEADLINE
+        );
+
+        uint256 liquidityToBurn = pair1W.balanceOf(alice) / 4;
+        VM.prank(alice);
+        router.removeLiquidityNative(address(token1), liquidityToBurn, 0, 0, alice, DEADLINE);
+        _recordLiquidityEvent(address(pair1W));
+
+        _assertTrackedAmmState();
+    }
+
+    function testRouterTransferFailureLeavesCreatedPairEmpty() public {
+        FalseReturningAMMToken falseToken = _deployFalseReturningToken();
+        MockAMMToken normalToken = new MockAMMToken("Normal Token", "NTK", 18);
+        falseToken.mint(bob, 10_000);
+        normalToken.mint(bob, 10_000);
+
+        VM.startPrank(bob);
+        falseToken.approve(address(router), type(uint256).max);
+        normalToken.approve(address(router), type(uint256).max);
+        try router.addLiquidity(address(falseToken), address(normalToken), 10_000, 10_000, 0, 0, bob, DEADLINE) {
+            revert("expected addLiquidity revert");
+        } catch (bytes memory revertData) {
+            bytes4 selector = bytes4(revertData);
+            assertTrue(selector == AMMRouter.AMMRouterTransferFromFailed.selector, "unexpected router revert");
+        }
+        VM.stopPrank();
+
+        address pairAddress = factory.getPair(address(falseToken), address(normalToken));
+        assertTrue(pairAddress == address(0), "failed transfer should revert pair creation too");
+    }
+
+    function testMalformedAndReentrantOutputFailuresDoNotCorruptPairs() public {
+        MalformedAMMToken malformedToken = new MalformedAMMToken("Malformed Token", "MTK", 18);
+        MockAMMToken normalToken = new MockAMMToken("Normal Token", "NTK", 18);
+        AMMPair malformedPair = _deployPair(address(malformedToken), address(normalToken));
+        _seedLiquidityDirect(malformedPair, malformedToken, normalToken, 20_000, 20_000, alice);
+
+        normalToken.mint(address(malformedPair), 1_000);
+        (uint112 malformedReserve0, uint112 malformedReserve1,) = malformedPair.getReserves();
+
+        if (malformedPair.token0() == address(malformedToken)) {
+            VM.expectRevert(
+                abi.encodeWithSelector(AMMPair.AMMPairTransferFailed.selector, address(malformedToken), bob, 949)
+            );
+            malformedPair.swap(949, 0, bob, "");
+        } else {
+            VM.expectRevert(
+                abi.encodeWithSelector(AMMPair.AMMPairTransferFailed.selector, address(malformedToken), bob, 949)
+            );
+            malformedPair.swap(0, 949, bob, "");
+        }
+
+        (uint112 malformedReserve0After, uint112 malformedReserve1After,) = malformedPair.getReserves();
+        assertTrue(malformedReserve0After == malformedReserve0, "malformed revert should preserve reserve0");
+        assertTrue(malformedReserve1After == malformedReserve1, "malformed revert should preserve reserve1");
+
+        ReentrantAMMToken reentrantToken = new ReentrantAMMToken("Reentrant Token", "RTK", 18);
+        MockAMMToken secondNormalToken = new MockAMMToken("Second Normal Token", "SNT", 18);
+        AMMPair reentrantPair = _deployPair(address(reentrantToken), address(secondNormalToken));
+        _seedLiquidityDirect(reentrantPair, reentrantToken, secondNormalToken, 20_000, 20_000, alice);
+        reentrantToken.setReenterSync(address(reentrantPair), true);
+
+        secondNormalToken.mint(address(reentrantPair), 1_000);
+        (uint112 reentrantReserve0, uint112 reentrantReserve1,) = reentrantPair.getReserves();
+
+        if (reentrantPair.token0() == address(reentrantToken)) {
+            VM.expectRevert(
+                abi.encodeWithSelector(AMMPair.AMMPairTransferFailed.selector, address(reentrantToken), bob, 949)
+            );
+            reentrantPair.swap(949, 0, bob, "");
+        } else {
+            VM.expectRevert(
+                abi.encodeWithSelector(AMMPair.AMMPairTransferFailed.selector, address(reentrantToken), bob, 949)
+            );
+            reentrantPair.swap(0, 949, bob, "");
+        }
+
+        (uint112 reentrantReserve0After, uint112 reentrantReserve1After,) = reentrantPair.getReserves();
+        assertTrue(reentrantReserve0After == reentrantReserve0, "reentrant revert should preserve reserve0");
+        assertTrue(reentrantReserve1After == reentrantReserve1, "reentrant revert should preserve reserve1");
+
+        reentrantToken.setReenterSync(address(reentrantPair), false);
+        reentrantPair.sync();
+    }
+
+    function testSilentOutputTokenCanSustainRepeatedSwaps() public {
+        SilentAMMToken silentToken = new SilentAMMToken("Silent Token", "STK", 18);
+        MockAMMToken normalToken = new MockAMMToken("Normal Token", "NTK", 18);
+        AMMPair silentPair = _deployPair(address(silentToken), address(normalToken));
+        _seedLiquidityDirect(silentPair, silentToken, normalToken, 30_000, 30_000, alice);
+
+        normalToken.mint(address(silentPair), 1_000);
+        if (silentPair.token0() == address(silentToken)) {
+            silentPair.swap(964, 0, bob, "");
+        } else {
+            silentPair.swap(0, 964, bob, "");
+        }
+
+        normalToken.mint(address(silentPair), 500);
+        if (silentPair.token0() == address(silentToken)) {
+            silentPair.swap(447, 0, carol, "");
+        } else {
+            silentPair.swap(0, 447, carol, "");
+        }
+
+        (uint112 reserve0_, uint112 reserve1_,) = silentPair.getReserves();
+        assertTrue(
+            reserve0_ <= MockAMMToken(silentPair.token0()).balanceOf(address(silentPair)),
+            "silent reserve0 should not exceed balance"
+        );
+        assertTrue(
+            reserve1_ <= MockAMMToken(silentPair.token1()).balanceOf(address(silentPair)),
+            "silent reserve1 should not exceed balance"
+        );
+    }
+}

--- a/test/AMMInvariant.t.sol
+++ b/test/AMMInvariant.t.sol
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {AMMPair} from "../src/amm/AMMPair.sol";
+import {MockAMMToken} from "./helpers/AMMPairTestHarness.sol";
+import {AMMHardeningFixture} from "./helpers/AMMHardeningTestHarness.sol";
+
+contract AMMInvariantTest is AMMHardeningFixture {
+    function targetContracts() external view returns (address[] memory contracts) {
+        contracts = new address[](1);
+        contracts[0] = address(this);
+    }
+
+    function actionAddLiquidity(uint8 actorSeed, uint8 pairSeed, uint96 amountRaw) external {
+        (AMMPair trackedPair, MockAMMToken tokenA_, MockAMMToken tokenB_) = _tokenPairFixture(pairSeed);
+        address actor = _actor(actorSeed);
+        (uint256 reserveA, uint256 reserveB) = _getAlignedReserves(address(tokenA_), address(tokenB_));
+        uint256 maxAmountA = tokenA_.balanceOf(actor) / 16;
+        uint256 amountA = _boundAmount(amountRaw, maxAmountA);
+        if (amountA == 0) {
+            return;
+        }
+
+        uint256 amountB = reserveA == 0 || reserveB == 0 ? amountA : router.quote(amountA, reserveA, reserveB);
+        if (amountB == 0 || amountB > tokenB_.balanceOf(actor)) {
+            return;
+        }
+
+        VM.prank(actor);
+        router.addLiquidity(address(tokenA_), address(tokenB_), amountA, amountB, 0, 0, actor, DEADLINE);
+        _recordLiquidityEvent(address(trackedPair));
+    }
+
+    function actionAddLiquidityNative(uint8 actorSeed, uint8 pairSeed, uint96 amountRaw) external {
+        (AMMPair trackedPair, MockAMMToken token_) = _nativePairFixture(pairSeed);
+        address actor = _actor(actorSeed);
+        (uint256 reserveToken, uint256 reserveNative) =
+            _getAlignedReserves(address(token_), address(wrappedNativeToken));
+        uint256 maxAmountToken = token_.balanceOf(actor) / 16;
+        uint256 amountToken = _boundAmount(amountRaw, maxAmountToken);
+        if (amountToken == 0) {
+            return;
+        }
+
+        uint256 amountNative = reserveToken == 0 || reserveNative == 0
+            ? amountToken
+            : router.quote(amountToken, reserveToken, reserveNative);
+        if (amountNative == 0 || amountNative > actor.balance) {
+            return;
+        }
+
+        VM.prank(actor);
+        router.addLiquidityNative{value: amountNative}(address(token_), amountToken, 0, 0, actor, DEADLINE);
+        _recordLiquidityEvent(address(trackedPair));
+    }
+
+    function actionRemoveLiquidity(uint8 actorSeed, uint8 pairSeed, uint96 liquidityRaw) external {
+        (AMMPair trackedPair, MockAMMToken tokenA_, MockAMMToken tokenB_) = _tokenPairFixture(pairSeed);
+        address actor = _actor(actorSeed);
+        uint256 liquidity = _boundAmount(liquidityRaw, trackedPair.balanceOf(actor));
+        if (liquidity == 0) {
+            return;
+        }
+
+        VM.prank(actor);
+        router.removeLiquidity(address(tokenA_), address(tokenB_), liquidity, 0, 0, actor, DEADLINE);
+        _recordLiquidityEvent(address(trackedPair));
+    }
+
+    function actionRemoveLiquidityNative(uint8 actorSeed, uint8 pairSeed, uint96 liquidityRaw) external {
+        (AMMPair trackedPair, MockAMMToken token_) = _nativePairFixture(pairSeed);
+        address actor = _actor(actorSeed);
+        uint256 liquidity = _boundAmount(liquidityRaw, trackedPair.balanceOf(actor));
+        if (liquidity == 0) {
+            return;
+        }
+
+        VM.prank(actor);
+        router.removeLiquidityNative(address(token_), liquidity, 0, 0, actor, DEADLINE);
+        _recordLiquidityEvent(address(trackedPair));
+    }
+
+    function actionSwapExactTokens(uint8 actorSeed, uint8 pathSeed, uint96 amountRaw) external {
+        address actor = _actor(actorSeed);
+        address[] memory path_ = _tokenSwapPath(pathSeed);
+        uint256 amountIn = _boundAmount(amountRaw, MockAMMToken(path_[0]).balanceOf(actor) / 16);
+        if (amountIn == 0) {
+            return;
+        }
+
+        uint256[] memory amountsOut = router.getAmountsOut(amountIn, path_);
+        if (amountsOut[amountsOut.length - 1] == 0) {
+            return;
+        }
+
+        VM.prank(actor);
+        router.swapExactTokensForTokens(amountIn, 0, path_, actor, DEADLINE);
+    }
+
+    function actionSwapTokensForExactTokens(uint8 actorSeed, uint8 pathSeed, uint96 amountRaw) external {
+        address actor = _actor(actorSeed);
+        address[] memory path_ = _tokenSwapPath(pathSeed);
+        (, uint256 reserveOut) = _getAlignedReserves(path_[path_.length - 2], path_[path_.length - 1]);
+        uint256 amountOut = _boundAmount(amountRaw, reserveOut / 16);
+        if (amountOut == 0) {
+            return;
+        }
+
+        uint256[] memory amountsIn = router.getAmountsIn(amountOut, path_);
+        if (amountsIn[0] > MockAMMToken(path_[0]).balanceOf(actor)) {
+            return;
+        }
+
+        VM.prank(actor);
+        router.swapTokensForExactTokens(amountOut, amountsIn[0], path_, actor, DEADLINE);
+    }
+
+    function actionSwapExactNative(uint8 actorSeed, uint8 pathSeed, uint96 amountRaw) external {
+        address actor = _actor(actorSeed);
+        address[] memory path_ = _nativeInPath(pathSeed);
+        uint256 amountIn = _boundAmount(amountRaw, actor.balance / 16);
+        if (amountIn == 0) {
+            return;
+        }
+
+        uint256[] memory amountsOut = router.getAmountsOut(amountIn, path_);
+        if (amountsOut[amountsOut.length - 1] == 0) {
+            return;
+        }
+
+        VM.prank(actor);
+        router.swapExactNativeForTokens{value: amountIn}(0, path_, actor, DEADLINE);
+    }
+
+    function actionSwapTokensForExactNative(uint8 actorSeed, uint8 pathSeed, uint96 amountRaw) external {
+        address actor = _actor(actorSeed);
+        address[] memory path_ = _nativeOutPath(pathSeed);
+        (, uint256 reserveOut) = _getAlignedReserves(path_[path_.length - 2], path_[path_.length - 1]);
+        uint256 amountOut = _boundAmount(amountRaw, reserveOut / 16);
+        if (amountOut == 0) {
+            return;
+        }
+
+        uint256[] memory amountsIn = router.getAmountsIn(amountOut, path_);
+        if (amountsIn[0] > MockAMMToken(path_[0]).balanceOf(actor)) {
+            return;
+        }
+
+        VM.prank(actor);
+        router.swapTokensForExactNative(amountOut, amountsIn[0], path_, actor, DEADLINE);
+    }
+
+    function actionDonateToPair(uint8 actorSeed, uint8 pairSeed, uint8 tokenSeed, uint96 amountRaw) external {
+        address actor = _actor(actorSeed);
+        AMMPair trackedPair = _trackedPair(pairSeed);
+        MockAMMToken pairToken =
+            tokenSeed % 2 == 0 ? MockAMMToken(trackedPair.token0()) : MockAMMToken(trackedPair.token1());
+        uint256 amount = _boundAmount(amountRaw, _donationCapacity(actor, pairToken) / 16);
+        if (amount == 0) {
+            return;
+        }
+
+        if (address(pairToken) == address(wrappedNativeToken) && pairToken.balanceOf(actor) < amount) {
+            if (actor.balance < amount) {
+                return;
+            }
+            _seedWrappedToken(actor, amount);
+        }
+
+        VM.prank(actor);
+        pairToken.transfer(address(trackedPair), amount);
+    }
+
+    function actionSkim(uint8 pairSeed, uint8 recipientSeed) external {
+        AMMPair trackedPair = _trackedPair(pairSeed);
+        trackedPair.skim(_actor(recipientSeed));
+    }
+
+    function actionSync(uint8 pairSeed) external {
+        _trackedPair(pairSeed).sync();
+    }
+
+    function actionToggleFeeTo() external {
+        if (factory.feeTo() == address(0)) {
+            factory.setFeeTo(carol);
+            return;
+        }
+
+        factory.setFeeTo(address(0));
+    }
+
+    function invariantTrackedAmmStateHolds() public view {
+        _assertTrackedAmmState();
+    }
+
+    function invariantRouterNeverRetainsFunds() public view {
+        _assertRouterZeroBalances();
+    }
+
+    function _tokenPairFixture(uint256 seed)
+        internal
+        view
+        returns (AMMPair trackedPair, MockAMMToken tokenA_, MockAMMToken tokenB_)
+    {
+        uint256 selector = seed % 3;
+        if (selector == 0) {
+            return (pair01, token0, token1);
+        }
+        if (selector == 1) {
+            return (pair12, token1, token2);
+        }
+        return (pair02, token0, token2);
+    }
+
+    function _nativePairFixture(uint256 seed) internal view returns (AMMPair trackedPair, MockAMMToken token_) {
+        if (seed % 2 == 0) {
+            return (pair0W, token0);
+        }
+        return (pair1W, token1);
+    }
+
+    function _donationCapacity(address actor, MockAMMToken token_) internal view returns (uint256 amount) {
+        if (address(token_) == address(wrappedNativeToken)) {
+            amount = token_.balanceOf(actor) + actor.balance;
+        } else {
+            amount = token_.balanceOf(actor);
+        }
+    }
+}

--- a/test/AMMPairFuzz.t.sol
+++ b/test/AMMPairFuzz.t.sol
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {AMMPair} from "../src/amm/AMMPair.sol";
+import {MockAMMToken} from "./helpers/AMMPairTestHarness.sol";
+import {AMMPairCoreFixture} from "./helpers/AMMPairTestHarness.sol";
+
+contract AMMPairFuzzTest is AMMPairCoreFixture {
+    function testFuzzFirstMintLocksMinimumLiquidity(uint96 amount0Raw, uint96 amount1Raw) public {
+        AMMPair localPair = _deployPair(address(token0), address(token1));
+        uint256 amount0 = _boundAmount(amount0Raw, 1_000_000);
+        uint256 amount1 = _boundAmount(amount1Raw, 1_000_000);
+        uint256 rootK = _mathSqrt(amount0 * amount1);
+        if (rootK <= localPair.MINIMUM_LIQUIDITY()) {
+            return;
+        }
+
+        uint256 liquidity = _provideLiquidity(localPair, token0, token1, alice, amount0, amount1, alice);
+
+        assertTrue(liquidity == rootK - localPair.MINIMUM_LIQUIDITY(), "first mint liquidity mismatch");
+        assertTrue(localPair.balanceOf(BURN_SINK) == localPair.MINIMUM_LIQUIDITY(), "minimum liquidity sink mismatch");
+        assertTrue(localPair.balanceOf(alice) == liquidity, "provider lp balance mismatch");
+    }
+
+    function testFuzzLaterMintFollowsReserveRatio(uint96 firstAmount0Raw, uint96 secondAmount0Raw) public {
+        AMMPair localPair = _deployPair(address(token0), address(token1));
+        uint256 firstAmount0 = _boundAmount(firstAmount0Raw, 1_000_000);
+        uint256 firstAmount1 = firstAmount0 * 2;
+        uint256 rootK = _mathSqrt(firstAmount0 * firstAmount1);
+        if (rootK <= localPair.MINIMUM_LIQUIDITY()) {
+            return;
+        }
+
+        _provideLiquidity(localPair, token0, token1, alice, firstAmount0, firstAmount1, alice);
+
+        uint256 secondAmount0 = _boundAmount(secondAmount0Raw, 500_000);
+        uint256 secondAmount1 = secondAmount0 * 2;
+        uint256 totalSupplyBefore = localPair.totalSupply();
+        (uint112 reserve0Before, uint112 reserve1Before,) = localPair.getReserves();
+
+        uint256 liquidity = _provideLiquidity(localPair, token0, token1, bob, secondAmount0, secondAmount1, bob);
+        uint256 expectedLiquidity = _mathMin(
+            (secondAmount0 * totalSupplyBefore) / reserve0Before, (secondAmount1 * totalSupplyBefore) / reserve1Before
+        );
+
+        assertTrue(liquidity == expectedLiquidity, "later mint liquidity mismatch");
+    }
+
+    function testFuzzBurnRedeemsProRata(uint96 amount0Raw, uint96 burnRaw) public {
+        AMMPair localPair = _deployPair(address(token0), address(token1));
+        uint256 amount0 = _boundAmount(amount0Raw, 1_000_000);
+        uint256 amount1 = amount0;
+        uint256 rootK = _mathSqrt(amount0 * amount1);
+        if (rootK <= localPair.MINIMUM_LIQUIDITY()) {
+            return;
+        }
+
+        _provideLiquidity(localPair, token0, token1, alice, amount0, amount1, alice);
+
+        uint256 burnLiquidity = _boundAmount(burnRaw, localPair.balanceOf(alice));
+        uint256 totalSupplyBefore = localPair.totalSupply();
+        (uint112 reserve0Before, uint112 reserve1Before,) = localPair.getReserves();
+        uint256 expectedAmount0 = (burnLiquidity * reserve0Before) / totalSupplyBefore;
+        uint256 expectedAmount1 = (burnLiquidity * reserve1Before) / totalSupplyBefore;
+
+        VM.prank(alice);
+        localPair.transfer(address(localPair), burnLiquidity);
+
+        (uint256 amount0Out, uint256 amount1Out) = localPair.burn(alice);
+
+        assertTrue(amount0Out == expectedAmount0, "burn amount0 mismatch");
+        assertTrue(amount1Out == expectedAmount1, "burn amount1 mismatch");
+    }
+
+    function testFuzzSwapRespectsQuotedOutput(uint96 amountInRaw) public {
+        _provideLiquidity(pair, token0, token1, alice, 500_000, 500_000, alice);
+
+        uint256 amountIn = _boundAmount(amountInRaw, 100_000);
+        uint256 expectedAmountOut = _getAmountOut(amountIn, 500_000, 500_000);
+        if (expectedAmountOut == 0) {
+            return;
+        }
+
+        token0.mint(bob, amountIn);
+        VM.prank(bob);
+        token0.transfer(address(pair), amountIn);
+
+        VM.prank(bob);
+        pair.swap(0, expectedAmountOut, bob, "");
+
+        (uint112 reserve0After, uint112 reserve1After,) = pair.getReserves();
+        assertTrue(reserve0After == 500_000 + amountIn, "reserve0 mismatch after swap");
+        assertTrue(reserve1After == 500_000 - expectedAmountOut, "reserve1 mismatch after swap");
+        assertTrue(token1.balanceOf(bob) == expectedAmountOut, "quoted output mismatch");
+    }
+
+    function testFuzzSkimAndSyncHandleExcessBalances(uint96 excess0Raw, uint96 excess1Raw) public {
+        _provideLiquidity(pair, token0, token1, alice, 250_000, 250_000, alice);
+
+        uint256 excess0 = _boundAmount(excess0Raw, 100_000);
+        uint256 excess1 = _boundAmount(excess1Raw, 100_000);
+        token0.mint(address(pair), excess0);
+        token1.mint(address(pair), excess1);
+
+        pair.skim(carol);
+        assertTrue(token0.balanceOf(carol) == excess0, "skimmed token0 mismatch");
+        assertTrue(token1.balanceOf(carol) == excess1, "skimmed token1 mismatch");
+
+        token0.mint(address(pair), excess0);
+        token1.mint(address(pair), excess1);
+        pair.sync();
+
+        (uint112 reserve0After, uint112 reserve1After,) = pair.getReserves();
+        assertTrue(reserve0After == 250_000 + excess0, "synced reserve0 mismatch");
+        assertTrue(reserve1After == 250_000 + excess1, "synced reserve1 mismatch");
+    }
+
+    function _boundAmount(uint256 raw, uint256 max) internal pure returns (uint256 amount) {
+        if (max == 0) {
+            return 0;
+        }
+
+        amount = (raw % max) + 1;
+    }
+}

--- a/test/AMMRouterFuzz.t.sol
+++ b/test/AMMRouterFuzz.t.sol
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {AMMPair} from "../src/amm/AMMPair.sol";
+import {AMMHardeningFixture} from "./helpers/AMMHardeningTestHarness.sol";
+import {MockAMMToken} from "./helpers/AMMPairTestHarness.sol";
+
+contract AMMRouterFuzzTest is AMMHardeningFixture {
+    function testFuzzQuoteHelpersRemainInternallyConsistent(uint8 pathSeed, uint96 amountInRaw) public view {
+        address[] memory path_ = _tokenSwapPath(pathSeed);
+        (uint256 reserveIn,) = _getAlignedReserves(path_[0], path_[1]);
+        uint256 maxAmountIn = reserveIn / 8;
+        uint256 amountIn = _boundAmount(amountInRaw, maxAmountIn);
+        if (amountIn == 0) {
+            return;
+        }
+
+        uint256[] memory amountsOut;
+        try router.getAmountsOut(amountIn, path_) returns (uint256[] memory quotedAmounts) {
+            amountsOut = quotedAmounts;
+        } catch {
+            return;
+        }
+
+        uint256[] memory amountsIn;
+        try router.getAmountsIn(amountsOut[amountsOut.length - 1], path_) returns (uint256[] memory requiredAmounts) {
+            amountsIn = requiredAmounts;
+        } catch {
+            return;
+        }
+
+        assertTrue(amountsOut[0] == amountIn, "amountsOut input mismatch");
+        assertTrue(amountsIn[amountsIn.length - 1] == amountsOut[amountsOut.length - 1], "terminal amount mismatch");
+        assertTrue(amountsIn[0] <= amountIn, "reverse quote should not exceed original input");
+    }
+
+    function testFuzzAddAndRemoveLiquidityPreserveTokenOrderAlignment(uint96 desiredRaw) public {
+        address provider = bob;
+        uint256 desiredAmount = _boundAmount(desiredRaw, 100_000);
+        uint256 bobToken0Before = token0.balanceOf(provider);
+        uint256 bobToken1Before = token1.balanceOf(provider);
+
+        VM.prank(provider);
+        (,, uint256 liquidity) = router.addLiquidity(
+            address(token1), address(token0), desiredAmount, desiredAmount, 0, 0, provider, DEADLINE
+        );
+
+        uint256 removeLiquidityAmount = liquidity / 2;
+        if (removeLiquidityAmount == 0) {
+            return;
+        }
+
+        VM.prank(provider);
+        (uint256 amountToken1, uint256 amountToken0) =
+            router.removeLiquidity(address(token1), address(token0), removeLiquidityAmount, 0, 0, provider, DEADLINE);
+
+        _recordLiquidityEvent(address(pair01));
+        assertTrue(amountToken1 != 0, "token1 removal amount should be nonzero");
+        assertTrue(amountToken0 != 0, "token0 removal amount should be nonzero");
+        assertTrue(token0.balanceOf(provider) >= bobToken0Before - desiredAmount, "token0 balance regression");
+        assertTrue(token1.balanceOf(provider) >= bobToken1Before - desiredAmount, "token1 balance regression");
+        _assertRouterZeroBalances();
+    }
+
+    function testFuzzExactInSwapRoutesAcrossTrackedPaths(uint8 actorSeed, uint8 pathSeed, uint96 amountInRaw) public {
+        address trader = _actor(actorSeed);
+        address[] memory path_ = _tokenSwapPath(pathSeed);
+        uint256 maxAmountIn = MockAMMToken(path_[0]).balanceOf(trader) / 8;
+        uint256 amountIn = _boundAmount(amountInRaw, maxAmountIn);
+        if (amountIn == 0) {
+            return;
+        }
+
+        uint256[] memory quotedAmounts;
+        try router.getAmountsOut(amountIn, path_) returns (uint256[] memory pathAmounts) {
+            quotedAmounts = pathAmounts;
+        } catch {
+            return;
+        }
+
+        uint256 expectedAmountOut = quotedAmounts[path_.length - 1];
+        if (expectedAmountOut == 0) {
+            return;
+        }
+        uint256 recipientBalanceBefore = MockAMMToken(path_[path_.length - 1]).balanceOf(trader);
+
+        VM.prank(trader);
+        uint256[] memory amounts = router.swapExactTokensForTokens(amountIn, expectedAmountOut, path_, trader, DEADLINE);
+
+        assertTrue(amounts[0] == amountIn, "swap input mismatch");
+        assertTrue(amounts[amounts.length - 1] == expectedAmountOut, "swap output mismatch");
+        assertTrue(
+            MockAMMToken(path_[path_.length - 1]).balanceOf(trader) == recipientBalanceBefore + expectedAmountOut,
+            "recipient output delta mismatch"
+        );
+        _assertRouterZeroBalances();
+    }
+
+    function testFuzzExactOutSwapHonorsMaximumInput(uint8 actorSeed, uint8 pathSeed, uint96 amountOutRaw) public {
+        address trader = _actor(actorSeed);
+        address[] memory path_ = _tokenSwapPath(pathSeed);
+        (, uint256 reserveOut) = _getAlignedReserves(path_[path_.length - 2], path_[path_.length - 1]);
+        uint256 amountOut = _boundAmount(amountOutRaw, reserveOut / 8);
+        if (amountOut == 0) {
+            return;
+        }
+
+        uint256[] memory expectedAmounts = router.getAmountsIn(amountOut, path_);
+        if (expectedAmounts[0] > MockAMMToken(path_[0]).balanceOf(trader)) {
+            return;
+        }
+
+        uint256 recipientBalanceBefore = MockAMMToken(path_[path_.length - 1]).balanceOf(trader);
+        VM.prank(trader);
+        uint256[] memory amounts =
+            router.swapTokensForExactTokens(amountOut, expectedAmounts[0], path_, trader, DEADLINE);
+
+        assertTrue(amounts[0] == expectedAmounts[0], "required input mismatch");
+        assertTrue(amounts[amounts.length - 1] == amountOut, "exact output mismatch");
+        assertTrue(
+            MockAMMToken(path_[path_.length - 1]).balanceOf(trader) == recipientBalanceBefore + amountOut,
+            "recipient exact output delta mismatch"
+        );
+        _assertRouterZeroBalances();
+    }
+
+    function testFuzzAddLiquidityNativeRefundsUnusedValue(uint96 tokenAmountRaw) public {
+        address provider = carol;
+        uint256 tokenAmount = _boundAmount(tokenAmountRaw, 100_000);
+        uint256 nativeAmount = tokenAmount * 2;
+        uint256 nativeBalanceBefore = provider.balance;
+
+        VM.prank(provider);
+        (uint256 amountToken, uint256 amountNative,) =
+            router.addLiquidityNative{value: nativeAmount}(address(token0), tokenAmount, 0, 0, provider, DEADLINE);
+
+        _recordLiquidityEvent(address(pair0W));
+        assertTrue(amountToken == tokenAmount, "native add token amount mismatch");
+        assertTrue(amountNative == tokenAmount, "native add used amount mismatch");
+        assertTrue(provider.balance == nativeBalanceBefore - amountNative, "unused native refund mismatch");
+        _assertRouterZeroBalances();
+    }
+
+    function testFuzzSwapNativeForExactTokensRefundsExcessValue(uint8 actorSeed, uint8 pathSeed, uint96 amountOutRaw)
+        public
+    {
+        address trader = _actor(actorSeed);
+        address[] memory nativeInPath = _nativeInPath(pathSeed);
+        (, uint256 reserveOut) =
+            _getAlignedReserves(nativeInPath[nativeInPath.length - 2], nativeInPath[nativeInPath.length - 1]);
+        uint256 amountOut = _boundAmount(amountOutRaw, reserveOut / 8);
+        if (amountOut == 0) {
+            return;
+        }
+
+        uint256[] memory amountsIn = router.getAmountsIn(amountOut, nativeInPath);
+        uint256 refundPadding = amountOut + 1;
+        uint256 nativeBalanceBefore = trader.balance;
+
+        VM.prank(trader);
+        uint256[] memory nativeInAmounts = router.swapNativeForExactTokens{value: amountsIn[0] + refundPadding}(
+            amountOut, nativeInPath, trader, DEADLINE
+        );
+
+        assertTrue(nativeInAmounts[0] == amountsIn[0], "native exact input mismatch");
+        assertTrue(trader.balance == nativeBalanceBefore - amountsIn[0], "native refund accounting mismatch");
+        _assertRouterZeroBalances();
+    }
+
+    function testFuzzSwapTokensForExactNativeUnwrapsOutput(uint8 actorSeed, uint8 pathSeed, uint96 amountOutRaw)
+        public
+    {
+        address trader = _actor(actorSeed);
+        address[] memory nativeOutPath = _nativeOutPath(pathSeed);
+        (, uint256 reserveOut) =
+            _getAlignedReserves(nativeOutPath[nativeOutPath.length - 2], nativeOutPath[nativeOutPath.length - 1]);
+        uint256 nativeOut = _boundAmount(amountOutRaw, reserveOut / 8);
+        uint256[] memory expectedNativeIn = router.getAmountsIn(nativeOut, nativeOutPath);
+        if (expectedNativeIn[0] > MockAMMToken(nativeOutPath[0]).balanceOf(trader)) {
+            _assertRouterZeroBalances();
+            return;
+        }
+
+        uint256 nativeBalanceBeforeOut = trader.balance;
+        VM.prank(trader);
+        uint256[] memory nativeOutAmounts =
+            router.swapTokensForExactNative(nativeOut, expectedNativeIn[0], nativeOutPath, trader, DEADLINE);
+
+        assertTrue(nativeOutAmounts[nativeOutAmounts.length - 1] == nativeOut, "native exact output mismatch");
+        assertTrue(trader.balance == nativeBalanceBeforeOut + nativeOut, "native unwrap delta mismatch");
+        _assertRouterZeroBalances();
+    }
+}

--- a/test/helpers/AMMHardeningTestHarness.sol
+++ b/test/helpers/AMMHardeningTestHarness.sol
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {AMMPair} from "../../src/amm/AMMPair.sol";
+import {MockAMMToken} from "./AMMPairTestHarness.sol";
+import {AMMRouterFixture} from "./AMMRouterTestHarness.sol";
+
+abstract contract AMMHardeningFixture is AMMRouterFixture {
+    uint256 internal constant ACTOR_COUNT = 4;
+    uint256 internal constant PAIR_COUNT = 5;
+    uint256 internal constant TRACKED_TOKEN_COUNT = 4;
+    uint256 internal constant INITIAL_TOKEN_BALANCE = 5_000_000;
+    uint256 internal constant INITIAL_NATIVE_BALANCE = 5_000_000;
+    address internal dave = address(0xD0D);
+    address[ACTOR_COUNT] internal actors;
+    address[PAIR_COUNT] internal trackedPairs;
+    address[TRACKED_TOKEN_COUNT] internal trackedTokens;
+    uint256[PAIR_COUNT] internal expectedKLasts;
+
+    AMMPair internal pair01;
+    AMMPair internal pair12;
+    AMMPair internal pair02;
+    AMMPair internal pair0W;
+    AMMPair internal pair1W;
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        actors[0] = alice;
+        actors[1] = bob;
+        actors[2] = carol;
+        actors[3] = dave;
+
+        trackedTokens[0] = address(token0);
+        trackedTokens[1] = address(token1);
+        trackedTokens[2] = address(token2);
+        trackedTokens[3] = address(wrappedNativeToken);
+
+        _fundActors();
+        _approveTrackedAssets();
+        _seedTrackedPairs();
+        _approveTrackedPairs();
+    }
+
+    function _actor(uint256 seed) internal view returns (address actor) {
+        actor = actors[seed % ACTOR_COUNT];
+    }
+
+    function _boundAmount(uint256 raw, uint256 max) internal pure returns (uint256 amount) {
+        if (max == 0) {
+            return 0;
+        }
+
+        amount = (raw % max) + 1;
+    }
+
+    function _trackedPair(uint256 seed) internal view returns (AMMPair pair_) {
+        pair_ = AMMPair(trackedPairs[seed % PAIR_COUNT]);
+    }
+
+    function _pairIndex(address pairAddress) internal view returns (uint256 index) {
+        for (uint256 i = 0; i < PAIR_COUNT; i++) {
+            if (trackedPairs[i] == pairAddress) {
+                return i;
+            }
+        }
+
+        revert("UNKNOWN_PAIR");
+    }
+
+    function _trackedToken(uint256 seed) internal view returns (MockAMMToken token_) {
+        token_ = MockAMMToken(trackedTokens[seed % TRACKED_TOKEN_COUNT]);
+    }
+
+    function _tokenSwapPath(uint256 seed) internal view returns (address[] memory path_) {
+        uint256 selector = seed % 6;
+        if (selector == 0) {
+            return _path(address(token0), address(token1));
+        }
+        if (selector == 1) {
+            return _path(address(token1), address(token2));
+        }
+        if (selector == 2) {
+            return _path(address(token0), address(token2));
+        }
+        if (selector == 3) {
+            return _path(address(token0), address(token1), address(token2));
+        }
+        if (selector == 4) {
+            return _path(address(token2), address(token1), address(token0));
+        }
+        return _path(address(token2), address(token0), address(token1));
+    }
+
+    function _nativeInPath(uint256 seed) internal view returns (address[] memory path_) {
+        uint256 selector = seed % 4;
+        if (selector == 0) {
+            return _path(address(wrappedNativeToken), address(token0));
+        }
+        if (selector == 1) {
+            return _path(address(wrappedNativeToken), address(token1));
+        }
+        if (selector == 2) {
+            return _path(address(wrappedNativeToken), address(token1), address(token2));
+        }
+        return _path(address(wrappedNativeToken), address(token0), address(token2));
+    }
+
+    function _nativeOutPath(uint256 seed) internal view returns (address[] memory path_) {
+        uint256 selector = seed % 4;
+        if (selector == 0) {
+            return _path(address(token0), address(wrappedNativeToken));
+        }
+        if (selector == 1) {
+            return _path(address(token1), address(wrappedNativeToken));
+        }
+        if (selector == 2) {
+            return _path(address(token2), address(token1), address(wrappedNativeToken));
+        }
+        return _path(address(token2), address(token0), address(wrappedNativeToken));
+    }
+
+    function _getAlignedReserves(address tokenA_, address tokenB_)
+        internal
+        view
+        returns (uint256 reserveA, uint256 reserveB)
+    {
+        address pairAddress = factory.getPair(tokenA_, tokenB_);
+        if (pairAddress == address(0)) {
+            return (0, 0);
+        }
+
+        AMMPair pair_ = AMMPair(pairAddress);
+        (uint112 reserve0_, uint112 reserve1_,) = pair_.getReserves();
+        if (pair_.token0() == tokenA_) {
+            return (reserve0_, reserve1_);
+        }
+        return (reserve1_, reserve0_);
+    }
+
+    function _recordLiquidityEvent(address pairAddress) internal {
+        uint256 pairIdx = _pairIndex(pairAddress);
+        if (factory.feeTo() == address(0)) {
+            expectedKLasts[pairIdx] = 0;
+            return;
+        }
+
+        (uint112 reserve0_, uint112 reserve1_,) = AMMPair(pairAddress).getReserves();
+        expectedKLasts[pairIdx] = uint256(reserve0_) * uint256(reserve1_);
+    }
+
+    function _sumTrackedLpBalances(AMMPair pair_) internal view returns (uint256 sum) {
+        sum += pair_.balanceOf(BURN_SINK);
+        sum += pair_.balanceOf(address(pair_));
+        sum += pair_.balanceOf(address(router));
+        sum += pair_.balanceOf(address(this));
+
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            sum += pair_.balanceOf(actors[i]);
+        }
+    }
+
+    function _assertRouterZeroBalances() internal view {
+        assertTrue(address(router).balance == 0, "router native balance should be zero");
+
+        for (uint256 i = 0; i < TRACKED_TOKEN_COUNT; i++) {
+            assertTrue(
+                MockAMMToken(trackedTokens[i]).balanceOf(address(router)) == 0, "router token balance should be zero"
+            );
+        }
+    }
+
+    function _assertPairRegistered(AMMPair pair_) internal view {
+        address tokenA_ = pair_.token0();
+        address tokenB_ = pair_.token1();
+
+        assertTrue(factory.getPair(tokenA_, tokenB_) == address(pair_), "forward pair lookup mismatch");
+        assertTrue(factory.getPair(tokenB_, tokenA_) == address(pair_), "reverse pair lookup mismatch");
+    }
+
+    function _assertPairReservesDoNotExceedBalances(AMMPair pair_) internal view {
+        (uint112 reserve0_, uint112 reserve1_,) = pair_.getReserves();
+        assertTrue(
+            reserve0_ <= MockAMMToken(pair_.token0()).balanceOf(address(pair_)),
+            "reserve0 should not exceed token0 balance"
+        );
+        assertTrue(
+            reserve1_ <= MockAMMToken(pair_.token1()).balanceOf(address(pair_)),
+            "reserve1 should not exceed token1 balance"
+        );
+    }
+
+    function _assertTrackedAmmState() internal view {
+        _assertRouterZeroBalances();
+
+        for (uint256 i = 0; i < PAIR_COUNT; i++) {
+            AMMPair trackedPair = AMMPair(trackedPairs[i]);
+            _assertPairRegistered(trackedPair);
+            _assertPairReservesDoNotExceedBalances(trackedPair);
+            assertTrue(trackedPair.totalSupply() == _sumTrackedLpBalances(trackedPair), "tracked lp supply mismatch");
+            assertTrue(trackedPair.kLast() == expectedKLasts[i], "tracked kLast mismatch");
+
+            if (trackedPair.totalSupply() != 0) {
+                assertTrue(
+                    trackedPair.balanceOf(BURN_SINK) == trackedPair.MINIMUM_LIQUIDITY(),
+                    "minimum liquidity sink mismatch"
+                );
+            }
+        }
+    }
+
+    function _seedWrappedToken(address actor, uint256 amount) internal {
+        if (amount == 0) {
+            return;
+        }
+
+        VM.prank(actor);
+        wrappedNativeToken.deposit{value: amount}();
+    }
+
+    function _fundActors() internal {
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            address actor = actors[i];
+            token0.mint(actor, INITIAL_TOKEN_BALANCE);
+            token1.mint(actor, INITIAL_TOKEN_BALANCE);
+            token2.mint(actor, INITIAL_TOKEN_BALANCE);
+            VM.deal(actor, INITIAL_NATIVE_BALANCE);
+        }
+    }
+
+    function _approveTrackedAssets() internal {
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            address actor = actors[i];
+            VM.startPrank(actor);
+            token0.approve(address(router), type(uint256).max);
+            token1.approve(address(router), type(uint256).max);
+            token2.approve(address(router), type(uint256).max);
+            wrappedNativeToken.approve(address(router), type(uint256).max);
+            VM.stopPrank();
+        }
+    }
+
+    function _approveTrackedPairs() internal {
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            address actor = actors[i];
+            VM.startPrank(actor);
+            for (uint256 j = 0; j < PAIR_COUNT; j++) {
+                AMMPair(trackedPairs[j]).approve(address(router), type(uint256).max);
+            }
+            VM.stopPrank();
+        }
+    }
+
+    function _seedTrackedPairs() internal {
+        pair01 = _seedTokenPair(alice, token0, token1, 500_000, 500_000);
+        pair12 = _seedTokenPair(alice, token1, token2, 500_000, 250_000);
+        pair02 = _seedTokenPair(alice, token0, token2, 400_000, 300_000);
+        pair0W = _seedNativePair(alice, token0, 350_000, 350_000);
+        pair1W = _seedNativePair(alice, token1, 300_000, 450_000);
+
+        trackedPairs[0] = address(pair01);
+        trackedPairs[1] = address(pair12);
+        trackedPairs[2] = address(pair02);
+        trackedPairs[3] = address(pair0W);
+        trackedPairs[4] = address(pair1W);
+    }
+
+    function _seedTokenPair(
+        address provider,
+        MockAMMToken tokenA_,
+        MockAMMToken tokenB_,
+        uint256 amountA,
+        uint256 amountB
+    ) internal returns (AMMPair pair_) {
+        VM.prank(provider);
+        router.addLiquidity(address(tokenA_), address(tokenB_), amountA, amountB, 0, 0, provider, DEADLINE);
+
+        pair_ = AMMPair(factory.getPair(address(tokenA_), address(tokenB_)));
+    }
+
+    function _seedNativePair(address provider, MockAMMToken token_, uint256 amountToken, uint256 amountNative)
+        internal
+        returns (AMMPair pair_)
+    {
+        VM.prank(provider);
+        router.addLiquidityNative{value: amountNative}(address(token_), amountToken, 0, 0, provider, DEADLINE);
+
+        pair_ = AMMPair(factory.getPair(address(token_), address(wrappedNativeToken)));
+    }
+}


### PR DESCRIPTION
## Summary
- add shared AMM hardening harnesses for tracked actors, pairs, and accounting assertions
- add pair and router fuzz suites plus AMM invariant coverage
- add reviewer-facing AMM hardening scenarios and a dedicated CI job for the AMM hardening lane

## Linked Issue
Closes #184
