### PR TITLE
docs: add AMM reviewer surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ reviewable engineering system.
 
 - Architecture decisions: `docs/adr/README.md`
 - Canonical docs map: `docs/README.md`
+- AMM architecture: `docs/amm.md`
 - Hosted vault architecture: `docs/vault-facets.md`
 - Smart-wallet architecture: `docs/multisig-wallet.md`
 - Security assumptions: `docs/threat-model.md`
@@ -36,15 +37,16 @@ reviewable engineering system.
 ## What This Repo Proves
 
 - Core architecture: diamond routing, selector ownership discipline, and
-  separate hosted token and vault deployment models plus a standalone
-  smart-wallet track.
+  separate hosted token and vault deployment models plus standalone AMM and
+  smart-wallet tracks.
 - Safety posture: RBAC, timed permissions, pause semantics, reentrancy
   protection, oracle validation, upgrade guardrails, and threshold-based wallet
   execution.
 - Protocol surfaces: ERC20 and ERC721 token hosts plus a hosted ERC-4626 vault
   platform with controls, strategy integration, and native-asset support, plus
-  a standalone multisig wallet with single-call, batch, and self-managed
-  configuration flows.
+  a standalone V2-style AMM with deterministic pair deployment, wrapped-native
+  routing, and protocol-fee controls, plus a standalone multisig wallet with
+  single-call, batch, and self-managed configuration flows.
 - Operational maturity: local bootstrap, smoke validation, activity flows,
   upgrade rehearsal, and matching CI/hardening gates.
 
@@ -58,6 +60,8 @@ reviewable engineering system.
   storage discipline.
 - `docs/vault-facets.md`: hosted vault facet split, lifecycle, and deployment
   model.
+- `docs/amm.md`: standalone AMM deployment model, pair/router behavior, math,
+  and reviewer path.
 - `docs/multisig-wallet.md`: wallet deployment model, signature semantics,
   replay protection, and self-managed configuration surface.
 - `docs/threat-model.md`: trust boundaries, threat assumptions, and residual
@@ -73,6 +77,14 @@ reviewable engineering system.
   across the hosted vault diamond path.
 - `test/DiamondTokenDeploymentIntegration.t.sol`: ERC20 and ERC721 host
   deployment and selector ownership.
+- `test/AMMFactoryRegistry.t.sol`: AMM factory registry behavior, sorted pair
+  lookups, and deterministic pair address coverage.
+- `test/AMMPairCore.t.sol`: pair mint/burn/swap accounting, fee switch, and
+  reserve update behavior.
+- `test/AMMRouterCore.t.sol`: router quoting, liquidity, wrapped-native, and
+  single-hop/multi-hop swap coverage.
+- `test/AMMHardening.t.sol`: malformed token, transfer-failure, protocol-fee,
+  and router balance hardening coverage.
 - `test/SystemOracleFailureScenarios.t.sol`: stale-data, breaker, fallback, and
   recovery behavior.
 - `test/SystemVaultStressInvariant.t.sol`: higher-signal system stress coverage
@@ -120,6 +132,16 @@ forge test --offline --match-path test/MultisigWalletManagement.t.sol
 forge test --offline --match-path test/MultisigWalletInvariant.t.sol
 ```
 
+For the AMM track:
+
+```shell
+forge test --offline --match-path test/AMMFoundationCore.t.sol
+forge test --offline --match-path test/AMMFactoryRegistry.t.sol
+forge test --offline --match-path test/AMMPairCore.t.sol
+forge test --offline --match-path test/AMMRouterCore.t.sol
+forge test --offline --match-path test/AMMRouterTime.t.sol
+```
+
 For the local Auralis workflow:
 
 ```shell
@@ -136,7 +158,8 @@ Recommended reviewer path:
 
 - Architecture decisions: `docs/adr/README.md`
 - Core architecture: `docs/diamond-core.md`, `docs/token-facets.md`,
-  `docs/vault-facets.md`, `docs/multisig-wallet.md`, `docs/oracle-adapter.md`
+  `docs/vault-facets.md`, `docs/amm.md`, `docs/multisig-wallet.md`,
+  `docs/oracle-adapter.md`
 - Security and validation: `docs/threat-model.md`, `docs/security-checks.md`
 - Operations and local workflow: `docs/ops/README.md`, `docs/auralis-local.md`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,10 +6,11 @@ Use this surface to understand the current architecture, the major design
 decisions behind it, how safety is validated, and where operator-facing
 runbooks live.
 
-The repo currently has three major protocol surfaces:
+The repo currently has four major protocol surfaces:
 
 - diamond-hosted token systems
 - diamond-hosted vault systems
+- a standalone AMM track
 - a standalone multisig wallet track
 
 ## Architecture Overview
@@ -20,6 +21,7 @@ flowchart TD
     Core["Diamond Core<br/>routing and upgrade base"]
     Token["Token Hosts<br/>ERC20 and ERC721 diamonds"]
     Vault["Vault Hosts<br/>hosted ERC-4626 platform"]
+    AMM["AMM Track<br/>standalone V2-style exchange"]
     Wallet["Wallet Track<br/>standalone multisig system"]
     Oracle["Oracle Adapter<br/>validation and breaker policy"]
     Security["Threat Model and Security Checks"]
@@ -28,11 +30,14 @@ flowchart TD
     ADR --> Core
     ADR --> Token
     ADR --> Vault
+    ADR --> AMM
+    ADR --> Wallet
     Wallet --> Security
     ADR --> Oracle
     Core --> Token
     Core --> Vault
     Oracle --> Vault
+    AMM --> Security
     Vault --> Security
     Token --> Security
     Core --> Security
@@ -45,6 +50,7 @@ flowchart TD
 - Diamond core architecture: `docs/diamond-core.md`
 - Hosted token architecture: `docs/token-facets.md`
 - Hosted vault architecture: `docs/vault-facets.md`
+- AMM architecture: `docs/amm.md`
 - Smart-wallet architecture: `docs/multisig-wallet.md`
 - Security assumptions: `docs/threat-model.md`
 - Validation and CI policy: `docs/security-checks.md`
@@ -60,6 +66,8 @@ visual model materially improves comprehension.
   role surface, and upgrade assumptions.
 - `docs/vault-facets.md`: hosted vault facet split, selector ownership, and
   deployment model.
+- `docs/amm.md`: standalone AMM deployment model, pair/router semantics, math,
+  and reviewer-facing validation path.
 - `docs/multisig-wallet.md`: standalone multisig wallet deployment,
   authorization, and configuration model.
 - `docs/erc4626-vault.md`: standalone ERC-4626 module semantics, math, fees,

--- a/docs/amm.md
+++ b/docs/amm.md
@@ -1,0 +1,199 @@
+# AMM Track
+
+This document is the canonical guide for the standalone V2-style AMM
+architecture in `Auralis`.
+
+The AMM track is intentionally separate from the repo's diamond-hosted token
+and vault systems and from the standalone multisig wallet track. It exists to
+show another protocol-style execution surface inside the repo: a
+deterministic-pair, constant-product exchange with explicit liquidity,
+wrapped-native routing, protocol-fee controls, and hardening coverage.
+
+## Supported Model
+
+The current AMM track supports:
+
+- one `AMMFactory` registry for deterministic pair creation
+- one `AMMRouter` user-facing quoting, liquidity, and swap surface
+- one `AMMPair` implementation deployed per sorted token pair with `CREATE2`
+- one ERC-20 + permit LP token base (`AMMLpToken`) for pair shares
+- one wrapped-native token dependency for native add/remove/swap routes
+- constant-product swaps with a fixed `0.3%` fee model
+- explicit `skim` and `sync` handling for balance/reserve drift
+
+It does not expose flash-swap callbacks or arbitrary swap hooks.
+
+```mermaid
+flowchart LR
+    Users["Liquidity Providers and Traders"]
+    Router["AMMRouter<br/>quote + add/remove + swap"]
+    Factory["AMMFactory<br/>CREATE2 pair registry"]
+    Pair["AMMPair<br/>reserves + LP shares"]
+    LP["AMMLpToken<br/>ERC-20 + permit"]
+    Tokens["ERC-20 Token Pair"]
+    WN["Wrapped Native"]
+
+    Users --> Router
+    Router --> Factory
+    Factory --> Pair
+    Router --> Pair
+    Pair --> LP
+    Pair --> Tokens
+    Router --> WN
+```
+
+## Deployment Model
+
+The AMM deployment flow is intentionally small:
+
+1. deploy the wrapped-native contract used for native routes
+2. deploy `AMMFactory`
+3. deploy `AMMRouter` with the factory and wrapped-native addresses
+4. create pairs either directly through `AMMFactory.createPair(...)` or lazily
+   on first `addLiquidity(...)` / `addLiquidityNative(...)`
+
+Important deployment properties:
+
+- `AMMFactory` constructor sets `feeToSetter = msg.sender`
+- pairs do not exist at factory/router deployment time
+- pair addresses are deterministic from the sorted token tuple and
+  `pairCodeHash()`
+- the router only auto-creates a pair on liquidity-add flows; swap and remove
+  flows require the pair to already exist
+
+For this issue, the deployment surface is reviewer-facing documentation rather
+than a new script package. The repo does not currently generate dedicated AMM
+deployment artifacts or a managed AMM local stack.
+
+## Pair Model
+
+Each `AMMPair` is a standalone constant-product market between `token0` and
+`token1`, where token ordering is address-sorted at creation.
+
+Key mechanics:
+
+- reserves are stored as `uint112` and updated explicitly through `_update(...)`
+- raw ERC-20 balances and tracked reserves are intentionally separate
+- the first liquidity event mints `MINIMUM_LIQUIDITY()` (`1000`) to the dead
+  sink to prevent total-supply edge cases
+- later liquidity mints are proportional to the current reserve ratio
+- burns redeem underlying pro rata from the pair's current balances
+- `skim(...)` transfers only surplus over tracked reserves
+- `sync()` forces tracked reserves to current balances
+
+The pair also maintains:
+
+- `price0CumulativeLast`
+- `price1CumulativeLast`
+- `kLast`
+
+Cumulative prices advance only when time has elapsed and both reserves are
+nonzero. They are raw V2-style fixed-point building blocks, not a full oracle
+policy by themselves.
+
+## Router Model
+
+`AMMRouter` is the user-facing surface for:
+
+- quoting via `quote`, `getAmountOut`, `getAmountIn`
+- multi-hop path traversal via `getAmountsOut`, `getAmountsIn`
+- token-token liquidity adds and removals
+- token-native liquidity adds and removals
+- exact-in and exact-out token swap routes
+- exact-in and exact-out native swap routes
+- LP permit-assisted removal flows
+
+Native-route rules are explicit:
+
+- wrapped-native must be the first path entry for native-in swaps
+- wrapped-native must be the last path entry for native-out swaps
+- the router only accepts raw native asset from the configured wrapped-native
+  contract
+- unused native value is refunded on `addLiquidityNative(...)` and
+  `swapNativeForExactTokens(...)`
+
+## Math Notes
+
+The AMM uses the standard constant-product shape with a fixed fee:
+
+- fee denominator: `1000`
+- fee numerator for swap input: `997`
+- effective swap fee: `0.3%`
+
+On swap, the pair enforces the adjusted-balance invariant:
+
+- `balance0Adjusted = balance0 * 1000 - amount0In * 3`
+- `balance1Adjusted = balance1 * 1000 - amount1In * 3`
+- `balance0Adjusted * balance1Adjusted >= reserve0 * reserve1 * 1000^2`
+
+Protocol-fee behavior is optional and factory-controlled:
+
+- fee minting is off when `feeTo == address(0)`
+- when `feeTo` is set, a later liquidity event may mint protocol LP based on
+  growth in `sqrt(k)`
+- `kLast` refreshes on fee-on liquidity events
+- disabling `feeTo` clears `kLast` on the next liquidity event
+
+## Security Notes
+
+The AMM track is opinionated about what it supports and what it rejects.
+
+Notable guard rails:
+
+- pair write paths use a lock to block reentrant execution
+- `swap(...)` rejects zero-output swaps, invalid recipients, and any nonempty
+  swap callback data
+- pair transfers use low-level ERC-20 calls and treat only empty return data or
+  decoded `true` as success
+- router transfer helpers apply the same success policy for token moves
+- router path validation rejects malformed or missing wrapped-native boundaries
+- zero-address and identical-token inputs are rejected at sort/lookup
+- pair reserve writes revert on `uint112` overflow
+
+Reviewer expectations:
+
+- malformed, false-returning, silent, and reentrant token behaviors are part of
+  the tested hardening surface
+- cumulative prices should be treated as low-level accounting outputs, not as a
+  complete production oracle or manipulation-resistant pricing policy
+
+## Reviewer Path
+
+Start with:
+
+- `README.md`
+- `docs/README.md`
+- `docs/threat-model.md`
+
+Architecture and behavior:
+
+- `docs/amm.md`
+- `src/amm/AMMFactory.sol`
+- `src/amm/AMMPair.sol`
+- `src/amm/AMMRouter.sol`
+
+Bounded reviewer-facing validation:
+
+- `test/AMMFoundationCore.t.sol`
+- `test/AMMFactoryRegistry.t.sol`
+- `test/AMMPairCore.t.sol`
+- `test/AMMRouterCore.t.sol`
+- `test/AMMRouterTime.t.sol`
+
+Hardening and adversarial validation:
+
+- `test/AMMPairFuzz.t.sol`
+- `test/AMMRouterFuzz.t.sol`
+- `test/AMMInvariant.t.sol`
+- `test/AMMHardening.t.sol`
+
+## Out Of Scope For V1
+
+The current AMM track does not include:
+
+- flash-swap callbacks
+- concentrated liquidity
+- custom routing hooks
+- onchain governance or timelock policy around `feeToSetter`
+- dedicated local deployment scripts or artifact files for AMM-only stacks
+- downstream oracle-consumer policy built on the cumulative price fields

--- a/docs/auralis-local.md
+++ b/docs/auralis-local.md
@@ -4,6 +4,9 @@
 ERC20 vault host, native vault host, and a small amount of simulated protocol
 activity on Anvil.
 
+The standalone AMM track is currently documented as a reviewer-facing,
+test-first local flow rather than a managed deployment script stack.
+
 ## Prerequisites
 
 - `anvil`
@@ -122,3 +125,45 @@ For the native hosted vault specifically, the local workflow assumes:
 - exits use standard `withdraw` and `redeem` and pay raw native asset
 - strategy profit injection is payable and uses raw ETH
 - force-sent ETH is not treated as managed assets by the vault accounting model
+
+## Standalone AMM Track
+
+The AMM subsystem is intentionally separate from `auralis-up.sh` and the
+diamond-hosted local stack.
+
+Today, the local AMM review path is:
+
+- read `docs/amm.md` for the deployment model, math, and security notes
+- use the AMM Foundry suites as the executable deployment and validation path
+- treat wrapped-native deployment, factory deployment, router deployment, and
+  first-pair creation as the canonical AMM bring-up order
+
+The deployment reasoning order is:
+
+1. deploy the wrapped-native dependency
+2. deploy `AMMFactory`
+3. deploy `AMMRouter`
+4. create pairs directly through the factory or lazily via the first liquidity
+   add flow
+
+The bounded local reviewer path is:
+
+```shell
+forge test --offline --match-path test/AMMFoundationCore.t.sol
+forge test --offline --match-path test/AMMFactoryRegistry.t.sol
+forge test --offline --match-path test/AMMPairCore.t.sol
+forge test --offline --match-path test/AMMRouterCore.t.sol
+forge test --offline --match-path test/AMMRouterTime.t.sol
+```
+
+For the fuller AMM hardening path:
+
+```shell
+forge test --offline --match-path test/AMMPairFuzz.t.sol
+forge test --offline --match-path test/AMMRouterFuzz.t.sol
+FOUNDRY_INVARIANT_RUNS=64 FOUNDRY_INVARIANT_DEPTH=32 forge test --offline --match-path test/AMMInvariant.t.sol
+forge test --offline --match-path test/AMMHardening.t.sol
+```
+
+The repo does not currently write a dedicated AMM deployment artifact file for
+this track.

--- a/docs/security-checks.md
+++ b/docs/security-checks.md
@@ -4,6 +4,21 @@ This repository runs security-focused CI checks in addition to baseline Foundry 
 
 ## CI Policy
 
+### Foundry CI (`.github/workflows/ci.yml`)
+
+- Trigger: pull requests, pushes to `main` and `milestone/**`, manual dispatch.
+- Tooling: GitHub Actions + Foundry.
+- Policy:
+  - `Foundry Fast PR Gate` runs formatting, `forge build --sizes --skip script`,
+    and the current fast diamond-host and system suites.
+  - `AMM Hardening` runs the standalone AMM fuzz, invariant, and hardening
+    suites.
+- AMM scope:
+  - `forge test --offline --match-path test/AMMPairFuzz.t.sol`
+  - `forge test --offline --match-path test/AMMRouterFuzz.t.sol`
+  - `FOUNDRY_INVARIANT_RUNS=64 FOUNDRY_INVARIANT_DEPTH=32 forge test --offline --match-path test/AMMInvariant.t.sol`
+  - `forge test --offline --match-path test/AMMHardening.t.sol`
+
 ### System Hardening (`.github/workflows/system-hardening.yml`)
 
 - Trigger: pull requests, pushes to `main` and `milestone/**`, manual dispatch.
@@ -83,6 +98,27 @@ Use these to reproduce hosted-vault deployment, strategy binding, live
 strategy-aware accounting, loss and emergency-exit behavior, selector
 ownership, facet replacement persistence, and diamond-routed vault invariants
 locally.
+
+### Standalone AMM
+
+The standalone AMM track has a bounded reviewer path plus a separate hardening
+gate in `Foundry CI`:
+
+```bash
+forge test --offline --match-path test/AMMFoundationCore.t.sol
+forge test --offline --match-path test/AMMFactoryRegistry.t.sol
+forge test --offline --match-path test/AMMPairCore.t.sol
+forge test --offline --match-path test/AMMRouterCore.t.sol
+forge test --offline --match-path test/AMMRouterTime.t.sol
+forge test --offline --match-path test/AMMPairFuzz.t.sol
+forge test --offline --match-path test/AMMRouterFuzz.t.sol
+FOUNDRY_INVARIANT_RUNS=64 FOUNDRY_INVARIANT_DEPTH=32 forge test --offline --match-path test/AMMInvariant.t.sol
+forge test --offline --match-path test/AMMHardening.t.sol
+```
+
+Use the first five suites when reviewing factory, pair, router, permit, and
+wrapped-native behavior, then run the fuzz, invariant, and hardening suites for
+the adversarial AMM surface.
 
 ### Multisig Wallet
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,7 +1,7 @@
 # Threat Model
 
 This summary covers security assumptions and guard rails for access, oracle,
-upgrade, vault, and wallet modules.
+upgrade, vault, AMM, and wallet modules.
 
 For the accepted architecture decisions that shape these assumptions, see
 `docs/adr/README.md`.
@@ -15,6 +15,10 @@ For the accepted architecture decisions that shape these assumptions, see
 - `Pausable`
 - `ReentrancyGuard`
 - `UpgradeGuardrails`
+- `AMMFactory`
+- `AMMPair`
+- `AMMRouter`
+- `AMMLpToken`
 - `MultisigWallet`
 - `MultisigWalletFactory`
 - `MultiSendCallOnly`
@@ -28,6 +32,8 @@ For the accepted architecture decisions that shape these assumptions, see
 - Reentrant state-changing entrypoints are blocked.
 - Upgrade execution follows explicit authorization and guardrail checks.
 - Vault share/accounting behavior remains explicit under rounding and low-liquidity edge conditions.
+- AMM liquidity, reserve updates, and fee-switch behavior remain explicit under
+  direct-transfer, malformed-token, and adversarial routing conditions.
 - Wallet execution requires the configured threshold of valid owner signatures.
 - Wallet replay protection prevents nonce reuse across signed transactions.
 - Wallet configuration changes require wallet-authorized self-calls.
@@ -37,6 +43,8 @@ For the accepted architecture decisions that shape these assumptions, see
 - Initial admin/upgrader/pauser assignments are correct at initialization.
 - Oracle feed sources are configured to trusted contracts with expected ABI behavior.
 - Governance/operator keys are managed securely off-chain.
+- The configured wrapped-native contract implements the expected deposit,
+  withdraw, and ERC-20 transfer semantics.
 - Wallet owners review and approve transaction payloads securely off-chain.
 - The configured `MultiSendCallOnly` helper is the intended fixed batch helper for deployed wallets.
 - Deployed contracts integrate `_applyUpgrade` correctly for their proxy/diamond mechanism.
@@ -86,6 +94,30 @@ For the accepted architecture decisions that shape these assumptions, see
 14. Batch execution widening into arbitrary delegatecall
 - Mitigation: batch execution delegatecalls only into the fixed `MultiSendCallOnly` helper, which performs plain external calls to the encoded targets.
 
+15. Unauthorized AMM fee-switch control
+- Mitigation: `feeTo` and `feeToSetter` changes are restricted to the current
+  `feeToSetter`, and pair fee minting is derived only from the factory state.
+
+16. Reentrant or malformed token behavior during AMM transfers
+- Mitigation: pair write paths are lock-guarded, router and pair transfers use
+  strict low-level success checks, and the hardening suites cover false,
+  silent, malformed, and reentrant token behaviors.
+
+17. Invalid wrapped-native routing or stuck native value
+- Mitigation: the router validates wrapped-native path boundaries, accepts raw
+  native value only from the configured wrapped-native contract, unwraps only
+  on native-out paths, and refunds surplus native input where applicable.
+
+18. Reserve drift after direct donations or token transfers
+- Mitigation: reserves are tracked separately from raw balances, `skim` and
+  `sync` remain explicit correction surfaces, and the invariant coverage checks
+  reserve and LP accounting consistency.
+
+19. Unstated assumptions around AMM price accumulation
+- Mitigation: cumulative prices advance only on elapsed-time reserve updates,
+  and the reviewer documentation treats them as low-level accounting outputs
+  rather than as a full oracle policy.
+
 ## Residual Risks / Out of Scope
 
 - Compromised privileged keys can still perform privileged actions.
@@ -94,6 +126,11 @@ For the accepted architecture decisions that shape these assumptions, see
 - Diamond `diamondCut` flows include core guardrails, but governance policy (timelocks/multisig approvals) remains an integration responsibility.
 - The current upgrade guardrails check nonzero implementation; deeper bytecode/interface validation is protocol-specific and should be added where needed.
 - Direct token donations to vault addresses can create untracked surplus unless explicitly reconciled by integration policy.
+- AMM cumulative prices are not, by themselves, a manipulation-resistant
+  oracle design.
+- Compromised `feeToSetter` control can redirect AMM protocol-fee minting.
+- Highly adversarial ERC-20 behavior beyond the documented supported semantics
+  remains an integration risk.
 - Compromised wallet owner keys can still authorize malicious transactions.
 - Off-chain signing and transaction review policy for multisig owners remains an operational responsibility.
 - The wallet does not yet include modules, guards, fallback handlers, contract owners, or ERC-4337 integration.


### PR DESCRIPTION
## Summary
- add a canonical AMM architecture and reviewer guide in `docs/amm.md`
- thread the AMM track through the root README, docs map, local workflow, security checks, and threat model
- document bounded and hardening AMM validation paths without adding new runtime behavior or deployment scripts

## Verification
- `FOUNDRY_INVARIANT_RUNS=64 FOUNDRY_INVARIANT_DEPTH=32 forge test --offline --match-path 'test/AMM*.t.sol'`

## Linked Issue
Closes #185
