### PR TITLE
milestone: ship Uniswap V2-style AMM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,39 @@ jobs:
 
       - name: Run System Oracle Failure Scenarios
         run: forge test --offline --match-path test/SystemOracleFailureScenarios.t.sol
+
+  amm-hardening:
+    name: AMM Hardening
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: 1.4.3
+
+      - name: Cache Foundry Artifacts
+        uses: actions/cache@v4
+        with:
+          path: ~/.foundry/cache
+          key: ${{ runner.os }}-foundry-cache-${{ hashFiles('foundry.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-foundry-cache-
+
+      - name: Build With Sizes
+        run: forge build --sizes --skip script
+
+      - name: Run AMM Pair Fuzz
+        run: forge test --offline --match-path test/AMMPairFuzz.t.sol
+
+      - name: Run AMM Router Fuzz
+        run: forge test --offline --match-path test/AMMRouterFuzz.t.sol
+
+      - name: Run AMM Invariants
+        run: FOUNDRY_INVARIANT_RUNS=64 FOUNDRY_INVARIANT_DEPTH=32 forge test --offline --match-path test/AMMInvariant.t.sol
+
+      - name: Run AMM Hardening
+        run: forge test --offline --match-path test/AMMHardening.t.sol

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ reviewable engineering system.
 
 - Architecture decisions: `docs/adr/README.md`
 - Canonical docs map: `docs/README.md`
+- AMM architecture: `docs/amm.md`
 - Hosted vault architecture: `docs/vault-facets.md`
 - Smart-wallet architecture: `docs/multisig-wallet.md`
 - Security assumptions: `docs/threat-model.md`
@@ -36,15 +37,16 @@ reviewable engineering system.
 ## What This Repo Proves
 
 - Core architecture: diamond routing, selector ownership discipline, and
-  separate hosted token and vault deployment models plus a standalone
-  smart-wallet track.
+  separate hosted token and vault deployment models plus standalone AMM and
+  smart-wallet tracks.
 - Safety posture: RBAC, timed permissions, pause semantics, reentrancy
   protection, oracle validation, upgrade guardrails, and threshold-based wallet
   execution.
 - Protocol surfaces: ERC20 and ERC721 token hosts plus a hosted ERC-4626 vault
   platform with controls, strategy integration, and native-asset support, plus
-  a standalone multisig wallet with single-call, batch, and self-managed
-  configuration flows.
+  a standalone V2-style AMM with deterministic pair deployment, wrapped-native
+  routing, and protocol-fee controls, plus a standalone multisig wallet with
+  single-call, batch, and self-managed configuration flows.
 - Operational maturity: local bootstrap, smoke validation, activity flows,
   upgrade rehearsal, and matching CI/hardening gates.
 
@@ -58,6 +60,8 @@ reviewable engineering system.
   storage discipline.
 - `docs/vault-facets.md`: hosted vault facet split, lifecycle, and deployment
   model.
+- `docs/amm.md`: standalone AMM deployment model, pair/router behavior, math,
+  and reviewer path.
 - `docs/multisig-wallet.md`: wallet deployment model, signature semantics,
   replay protection, and self-managed configuration surface.
 - `docs/threat-model.md`: trust boundaries, threat assumptions, and residual
@@ -73,6 +77,14 @@ reviewable engineering system.
   across the hosted vault diamond path.
 - `test/DiamondTokenDeploymentIntegration.t.sol`: ERC20 and ERC721 host
   deployment and selector ownership.
+- `test/AMMFactoryRegistry.t.sol`: AMM factory registry behavior, sorted pair
+  lookups, and deterministic pair address coverage.
+- `test/AMMPairCore.t.sol`: pair mint/burn/swap accounting, fee switch, and
+  reserve update behavior.
+- `test/AMMRouterCore.t.sol`: router quoting, liquidity, wrapped-native, and
+  single-hop/multi-hop swap coverage.
+- `test/AMMHardening.t.sol`: malformed token, transfer-failure, protocol-fee,
+  and router balance hardening coverage.
 - `test/SystemOracleFailureScenarios.t.sol`: stale-data, breaker, fallback, and
   recovery behavior.
 - `test/SystemVaultStressInvariant.t.sol`: higher-signal system stress coverage
@@ -120,6 +132,16 @@ forge test --offline --match-path test/MultisigWalletManagement.t.sol
 forge test --offline --match-path test/MultisigWalletInvariant.t.sol
 ```
 
+For the AMM track:
+
+```shell
+forge test --offline --match-path test/AMMFoundationCore.t.sol
+forge test --offline --match-path test/AMMFactoryRegistry.t.sol
+forge test --offline --match-path test/AMMPairCore.t.sol
+forge test --offline --match-path test/AMMRouterCore.t.sol
+forge test --offline --match-path test/AMMRouterTime.t.sol
+```
+
 For the local Auralis workflow:
 
 ```shell
@@ -136,7 +158,8 @@ Recommended reviewer path:
 
 - Architecture decisions: `docs/adr/README.md`
 - Core architecture: `docs/diamond-core.md`, `docs/token-facets.md`,
-  `docs/vault-facets.md`, `docs/multisig-wallet.md`, `docs/oracle-adapter.md`
+  `docs/vault-facets.md`, `docs/amm.md`, `docs/multisig-wallet.md`,
+  `docs/oracle-adapter.md`
 - Security and validation: `docs/threat-model.md`, `docs/security-checks.md`
 - Operations and local workflow: `docs/ops/README.md`, `docs/auralis-local.md`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,10 +6,11 @@ Use this surface to understand the current architecture, the major design
 decisions behind it, how safety is validated, and where operator-facing
 runbooks live.
 
-The repo currently has three major protocol surfaces:
+The repo currently has four major protocol surfaces:
 
 - diamond-hosted token systems
 - diamond-hosted vault systems
+- a standalone AMM track
 - a standalone multisig wallet track
 
 ## Architecture Overview
@@ -20,6 +21,7 @@ flowchart TD
     Core["Diamond Core<br/>routing and upgrade base"]
     Token["Token Hosts<br/>ERC20 and ERC721 diamonds"]
     Vault["Vault Hosts<br/>hosted ERC-4626 platform"]
+    AMM["AMM Track<br/>standalone V2-style exchange"]
     Wallet["Wallet Track<br/>standalone multisig system"]
     Oracle["Oracle Adapter<br/>validation and breaker policy"]
     Security["Threat Model and Security Checks"]
@@ -28,11 +30,14 @@ flowchart TD
     ADR --> Core
     ADR --> Token
     ADR --> Vault
+    ADR --> AMM
+    ADR --> Wallet
     Wallet --> Security
     ADR --> Oracle
     Core --> Token
     Core --> Vault
     Oracle --> Vault
+    AMM --> Security
     Vault --> Security
     Token --> Security
     Core --> Security
@@ -45,6 +50,7 @@ flowchart TD
 - Diamond core architecture: `docs/diamond-core.md`
 - Hosted token architecture: `docs/token-facets.md`
 - Hosted vault architecture: `docs/vault-facets.md`
+- AMM architecture: `docs/amm.md`
 - Smart-wallet architecture: `docs/multisig-wallet.md`
 - Security assumptions: `docs/threat-model.md`
 - Validation and CI policy: `docs/security-checks.md`
@@ -60,6 +66,8 @@ visual model materially improves comprehension.
   role surface, and upgrade assumptions.
 - `docs/vault-facets.md`: hosted vault facet split, selector ownership, and
   deployment model.
+- `docs/amm.md`: standalone AMM deployment model, pair/router semantics, math,
+  and reviewer-facing validation path.
 - `docs/multisig-wallet.md`: standalone multisig wallet deployment,
   authorization, and configuration model.
 - `docs/erc4626-vault.md`: standalone ERC-4626 module semantics, math, fees,

--- a/docs/amm.md
+++ b/docs/amm.md
@@ -1,0 +1,199 @@
+# AMM Track
+
+This document is the canonical guide for the standalone V2-style AMM
+architecture in `Auralis`.
+
+The AMM track is intentionally separate from the repo's diamond-hosted token
+and vault systems and from the standalone multisig wallet track. It exists to
+show another protocol-style execution surface inside the repo: a
+deterministic-pair, constant-product exchange with explicit liquidity,
+wrapped-native routing, protocol-fee controls, and hardening coverage.
+
+## Supported Model
+
+The current AMM track supports:
+
+- one `AMMFactory` registry for deterministic pair creation
+- one `AMMRouter` user-facing quoting, liquidity, and swap surface
+- one `AMMPair` implementation deployed per sorted token pair with `CREATE2`
+- one ERC-20 + permit LP token base (`AMMLpToken`) for pair shares
+- one wrapped-native token dependency for native add/remove/swap routes
+- constant-product swaps with a fixed `0.3%` fee model
+- explicit `skim` and `sync` handling for balance/reserve drift
+
+It does not expose flash-swap callbacks or arbitrary swap hooks.
+
+```mermaid
+flowchart LR
+    Users["Liquidity Providers and Traders"]
+    Router["AMMRouter<br/>quote + add/remove + swap"]
+    Factory["AMMFactory<br/>CREATE2 pair registry"]
+    Pair["AMMPair<br/>reserves + LP shares"]
+    LP["AMMLpToken<br/>ERC-20 + permit"]
+    Tokens["ERC-20 Token Pair"]
+    WN["Wrapped Native"]
+
+    Users --> Router
+    Router --> Factory
+    Factory --> Pair
+    Router --> Pair
+    Pair --> LP
+    Pair --> Tokens
+    Router --> WN
+```
+
+## Deployment Model
+
+The AMM deployment flow is intentionally small:
+
+1. deploy the wrapped-native contract used for native routes
+2. deploy `AMMFactory`
+3. deploy `AMMRouter` with the factory and wrapped-native addresses
+4. create pairs either directly through `AMMFactory.createPair(...)` or lazily
+   on first `addLiquidity(...)` / `addLiquidityNative(...)`
+
+Important deployment properties:
+
+- `AMMFactory` constructor sets `feeToSetter = msg.sender`
+- pairs do not exist at factory/router deployment time
+- pair addresses are deterministic from the sorted token tuple and
+  `pairCodeHash()`
+- the router only auto-creates a pair on liquidity-add flows; swap and remove
+  flows require the pair to already exist
+
+For this issue, the deployment surface is reviewer-facing documentation rather
+than a new script package. The repo does not currently generate dedicated AMM
+deployment artifacts or a managed AMM local stack.
+
+## Pair Model
+
+Each `AMMPair` is a standalone constant-product market between `token0` and
+`token1`, where token ordering is address-sorted at creation.
+
+Key mechanics:
+
+- reserves are stored as `uint112` and updated explicitly through `_update(...)`
+- raw ERC-20 balances and tracked reserves are intentionally separate
+- the first liquidity event mints `MINIMUM_LIQUIDITY()` (`1000`) to the dead
+  sink to prevent total-supply edge cases
+- later liquidity mints are proportional to the current reserve ratio
+- burns redeem underlying pro rata from the pair's current balances
+- `skim(...)` transfers only surplus over tracked reserves
+- `sync()` forces tracked reserves to current balances
+
+The pair also maintains:
+
+- `price0CumulativeLast`
+- `price1CumulativeLast`
+- `kLast`
+
+Cumulative prices advance only when time has elapsed and both reserves are
+nonzero. They are raw V2-style fixed-point building blocks, not a full oracle
+policy by themselves.
+
+## Router Model
+
+`AMMRouter` is the user-facing surface for:
+
+- quoting via `quote`, `getAmountOut`, `getAmountIn`
+- multi-hop path traversal via `getAmountsOut`, `getAmountsIn`
+- token-token liquidity adds and removals
+- token-native liquidity adds and removals
+- exact-in and exact-out token swap routes
+- exact-in and exact-out native swap routes
+- LP permit-assisted removal flows
+
+Native-route rules are explicit:
+
+- wrapped-native must be the first path entry for native-in swaps
+- wrapped-native must be the last path entry for native-out swaps
+- the router only accepts raw native asset from the configured wrapped-native
+  contract
+- unused native value is refunded on `addLiquidityNative(...)` and
+  `swapNativeForExactTokens(...)`
+
+## Math Notes
+
+The AMM uses the standard constant-product shape with a fixed fee:
+
+- fee denominator: `1000`
+- fee numerator for swap input: `997`
+- effective swap fee: `0.3%`
+
+On swap, the pair enforces the adjusted-balance invariant:
+
+- `balance0Adjusted = balance0 * 1000 - amount0In * 3`
+- `balance1Adjusted = balance1 * 1000 - amount1In * 3`
+- `balance0Adjusted * balance1Adjusted >= reserve0 * reserve1 * 1000^2`
+
+Protocol-fee behavior is optional and factory-controlled:
+
+- fee minting is off when `feeTo == address(0)`
+- when `feeTo` is set, a later liquidity event may mint protocol LP based on
+  growth in `sqrt(k)`
+- `kLast` refreshes on fee-on liquidity events
+- disabling `feeTo` clears `kLast` on the next liquidity event
+
+## Security Notes
+
+The AMM track is opinionated about what it supports and what it rejects.
+
+Notable guard rails:
+
+- pair write paths use a lock to block reentrant execution
+- `swap(...)` rejects zero-output swaps, invalid recipients, and any nonempty
+  swap callback data
+- pair transfers use low-level ERC-20 calls and treat only empty return data or
+  decoded `true` as success
+- router transfer helpers apply the same success policy for token moves
+- router path validation rejects malformed or missing wrapped-native boundaries
+- zero-address and identical-token inputs are rejected at sort/lookup
+- pair reserve writes revert on `uint112` overflow
+
+Reviewer expectations:
+
+- malformed, false-returning, silent, and reentrant token behaviors are part of
+  the tested hardening surface
+- cumulative prices should be treated as low-level accounting outputs, not as a
+  complete production oracle or manipulation-resistant pricing policy
+
+## Reviewer Path
+
+Start with:
+
+- `README.md`
+- `docs/README.md`
+- `docs/threat-model.md`
+
+Architecture and behavior:
+
+- `docs/amm.md`
+- `src/amm/AMMFactory.sol`
+- `src/amm/AMMPair.sol`
+- `src/amm/AMMRouter.sol`
+
+Bounded reviewer-facing validation:
+
+- `test/AMMFoundationCore.t.sol`
+- `test/AMMFactoryRegistry.t.sol`
+- `test/AMMPairCore.t.sol`
+- `test/AMMRouterCore.t.sol`
+- `test/AMMRouterTime.t.sol`
+
+Hardening and adversarial validation:
+
+- `test/AMMPairFuzz.t.sol`
+- `test/AMMRouterFuzz.t.sol`
+- `test/AMMInvariant.t.sol`
+- `test/AMMHardening.t.sol`
+
+## Out Of Scope For V1
+
+The current AMM track does not include:
+
+- flash-swap callbacks
+- concentrated liquidity
+- custom routing hooks
+- onchain governance or timelock policy around `feeToSetter`
+- dedicated local deployment scripts or artifact files for AMM-only stacks
+- downstream oracle-consumer policy built on the cumulative price fields

--- a/docs/auralis-local.md
+++ b/docs/auralis-local.md
@@ -4,6 +4,9 @@
 ERC20 vault host, native vault host, and a small amount of simulated protocol
 activity on Anvil.
 
+The standalone AMM track is currently documented as a reviewer-facing,
+test-first local flow rather than a managed deployment script stack.
+
 ## Prerequisites
 
 - `anvil`
@@ -122,3 +125,45 @@ For the native hosted vault specifically, the local workflow assumes:
 - exits use standard `withdraw` and `redeem` and pay raw native asset
 - strategy profit injection is payable and uses raw ETH
 - force-sent ETH is not treated as managed assets by the vault accounting model
+
+## Standalone AMM Track
+
+The AMM subsystem is intentionally separate from `auralis-up.sh` and the
+diamond-hosted local stack.
+
+Today, the local AMM review path is:
+
+- read `docs/amm.md` for the deployment model, math, and security notes
+- use the AMM Foundry suites as the executable deployment and validation path
+- treat wrapped-native deployment, factory deployment, router deployment, and
+  first-pair creation as the canonical AMM bring-up order
+
+The deployment reasoning order is:
+
+1. deploy the wrapped-native dependency
+2. deploy `AMMFactory`
+3. deploy `AMMRouter`
+4. create pairs directly through the factory or lazily via the first liquidity
+   add flow
+
+The bounded local reviewer path is:
+
+```shell
+forge test --offline --match-path test/AMMFoundationCore.t.sol
+forge test --offline --match-path test/AMMFactoryRegistry.t.sol
+forge test --offline --match-path test/AMMPairCore.t.sol
+forge test --offline --match-path test/AMMRouterCore.t.sol
+forge test --offline --match-path test/AMMRouterTime.t.sol
+```
+
+For the fuller AMM hardening path:
+
+```shell
+forge test --offline --match-path test/AMMPairFuzz.t.sol
+forge test --offline --match-path test/AMMRouterFuzz.t.sol
+FOUNDRY_INVARIANT_RUNS=64 FOUNDRY_INVARIANT_DEPTH=32 forge test --offline --match-path test/AMMInvariant.t.sol
+forge test --offline --match-path test/AMMHardening.t.sol
+```
+
+The repo does not currently write a dedicated AMM deployment artifact file for
+this track.

--- a/docs/security-checks.md
+++ b/docs/security-checks.md
@@ -4,6 +4,21 @@ This repository runs security-focused CI checks in addition to baseline Foundry 
 
 ## CI Policy
 
+### Foundry CI (`.github/workflows/ci.yml`)
+
+- Trigger: pull requests, pushes to `main` and `milestone/**`, manual dispatch.
+- Tooling: GitHub Actions + Foundry.
+- Policy:
+  - `Foundry Fast PR Gate` runs formatting, `forge build --sizes --skip script`,
+    and the current fast diamond-host and system suites.
+  - `AMM Hardening` runs the standalone AMM fuzz, invariant, and hardening
+    suites.
+- AMM scope:
+  - `forge test --offline --match-path test/AMMPairFuzz.t.sol`
+  - `forge test --offline --match-path test/AMMRouterFuzz.t.sol`
+  - `FOUNDRY_INVARIANT_RUNS=64 FOUNDRY_INVARIANT_DEPTH=32 forge test --offline --match-path test/AMMInvariant.t.sol`
+  - `forge test --offline --match-path test/AMMHardening.t.sol`
+
 ### System Hardening (`.github/workflows/system-hardening.yml`)
 
 - Trigger: pull requests, pushes to `main` and `milestone/**`, manual dispatch.
@@ -83,6 +98,27 @@ Use these to reproduce hosted-vault deployment, strategy binding, live
 strategy-aware accounting, loss and emergency-exit behavior, selector
 ownership, facet replacement persistence, and diamond-routed vault invariants
 locally.
+
+### Standalone AMM
+
+The standalone AMM track has a bounded reviewer path plus a separate hardening
+gate in `Foundry CI`:
+
+```bash
+forge test --offline --match-path test/AMMFoundationCore.t.sol
+forge test --offline --match-path test/AMMFactoryRegistry.t.sol
+forge test --offline --match-path test/AMMPairCore.t.sol
+forge test --offline --match-path test/AMMRouterCore.t.sol
+forge test --offline --match-path test/AMMRouterTime.t.sol
+forge test --offline --match-path test/AMMPairFuzz.t.sol
+forge test --offline --match-path test/AMMRouterFuzz.t.sol
+FOUNDRY_INVARIANT_RUNS=64 FOUNDRY_INVARIANT_DEPTH=32 forge test --offline --match-path test/AMMInvariant.t.sol
+forge test --offline --match-path test/AMMHardening.t.sol
+```
+
+Use the first five suites when reviewing factory, pair, router, permit, and
+wrapped-native behavior, then run the fuzz, invariant, and hardening suites for
+the adversarial AMM surface.
 
 ### Multisig Wallet
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,7 +1,7 @@
 # Threat Model
 
 This summary covers security assumptions and guard rails for access, oracle,
-upgrade, vault, and wallet modules.
+upgrade, vault, AMM, and wallet modules.
 
 For the accepted architecture decisions that shape these assumptions, see
 `docs/adr/README.md`.
@@ -15,6 +15,10 @@ For the accepted architecture decisions that shape these assumptions, see
 - `Pausable`
 - `ReentrancyGuard`
 - `UpgradeGuardrails`
+- `AMMFactory`
+- `AMMPair`
+- `AMMRouter`
+- `AMMLpToken`
 - `MultisigWallet`
 - `MultisigWalletFactory`
 - `MultiSendCallOnly`
@@ -28,6 +32,8 @@ For the accepted architecture decisions that shape these assumptions, see
 - Reentrant state-changing entrypoints are blocked.
 - Upgrade execution follows explicit authorization and guardrail checks.
 - Vault share/accounting behavior remains explicit under rounding and low-liquidity edge conditions.
+- AMM liquidity, reserve updates, and fee-switch behavior remain explicit under
+  direct-transfer, malformed-token, and adversarial routing conditions.
 - Wallet execution requires the configured threshold of valid owner signatures.
 - Wallet replay protection prevents nonce reuse across signed transactions.
 - Wallet configuration changes require wallet-authorized self-calls.
@@ -37,6 +43,8 @@ For the accepted architecture decisions that shape these assumptions, see
 - Initial admin/upgrader/pauser assignments are correct at initialization.
 - Oracle feed sources are configured to trusted contracts with expected ABI behavior.
 - Governance/operator keys are managed securely off-chain.
+- The configured wrapped-native contract implements the expected deposit,
+  withdraw, and ERC-20 transfer semantics.
 - Wallet owners review and approve transaction payloads securely off-chain.
 - The configured `MultiSendCallOnly` helper is the intended fixed batch helper for deployed wallets.
 - Deployed contracts integrate `_applyUpgrade` correctly for their proxy/diamond mechanism.
@@ -86,6 +94,30 @@ For the accepted architecture decisions that shape these assumptions, see
 14. Batch execution widening into arbitrary delegatecall
 - Mitigation: batch execution delegatecalls only into the fixed `MultiSendCallOnly` helper, which performs plain external calls to the encoded targets.
 
+15. Unauthorized AMM fee-switch control
+- Mitigation: `feeTo` and `feeToSetter` changes are restricted to the current
+  `feeToSetter`, and pair fee minting is derived only from the factory state.
+
+16. Reentrant or malformed token behavior during AMM transfers
+- Mitigation: pair write paths are lock-guarded, router and pair transfers use
+  strict low-level success checks, and the hardening suites cover false,
+  silent, malformed, and reentrant token behaviors.
+
+17. Invalid wrapped-native routing or stuck native value
+- Mitigation: the router validates wrapped-native path boundaries, accepts raw
+  native value only from the configured wrapped-native contract, unwraps only
+  on native-out paths, and refunds surplus native input where applicable.
+
+18. Reserve drift after direct donations or token transfers
+- Mitigation: reserves are tracked separately from raw balances, `skim` and
+  `sync` remain explicit correction surfaces, and the invariant coverage checks
+  reserve and LP accounting consistency.
+
+19. Unstated assumptions around AMM price accumulation
+- Mitigation: cumulative prices advance only on elapsed-time reserve updates,
+  and the reviewer documentation treats them as low-level accounting outputs
+  rather than as a full oracle policy.
+
 ## Residual Risks / Out of Scope
 
 - Compromised privileged keys can still perform privileged actions.
@@ -94,6 +126,11 @@ For the accepted architecture decisions that shape these assumptions, see
 - Diamond `diamondCut` flows include core guardrails, but governance policy (timelocks/multisig approvals) remains an integration responsibility.
 - The current upgrade guardrails check nonzero implementation; deeper bytecode/interface validation is protocol-specific and should be added where needed.
 - Direct token donations to vault addresses can create untracked surplus unless explicitly reconciled by integration policy.
+- AMM cumulative prices are not, by themselves, a manipulation-resistant
+  oracle design.
+- Compromised `feeToSetter` control can redirect AMM protocol-fee minting.
+- Highly adversarial ERC-20 behavior beyond the documented supported semantics
+  remains an integration risk.
 - Compromised wallet owner keys can still authorize malicious transactions.
 - Off-chain signing and transaction review policy for multisig owners remains an operational responsibility.
 - The wallet does not yet include modules, guards, fallback handlers, contract owners, or ERC-4337 integration.

--- a/src/amm/AMMFactory.sol
+++ b/src/amm/AMMFactory.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {AMMPair} from "./AMMPair.sol";
+import {IAMMFactory} from "../interfaces/IAMMFactory.sol";
+
+/// @title AMMFactory
+/// @notice Deterministic CREATE2 registry for standalone V2-style AMM pairs.
+contract AMMFactory is IAMMFactory {
+    error AMMFactoryForbidden();
+    error AMMFactoryZeroAddress();
+    error AMMFactoryZeroFeeToSetter();
+    error AMMFactoryIdenticalTokens();
+    error AMMFactoryPairExists(address token0, address token1);
+
+    address public override feeTo;
+    address public override feeToSetter;
+    mapping(address tokenA => mapping(address tokenB => address pair)) public override getPair;
+    address[] public override allPairs;
+
+    constructor() {
+        feeToSetter = msg.sender;
+    }
+
+    function pairCodeHash() public pure override returns (bytes32) {
+        return keccak256(type(AMMPair).creationCode);
+    }
+
+    function allPairsLength() external view override returns (uint256) {
+        return allPairs.length;
+    }
+
+    function createPair(address tokenA, address tokenB) external override returns (address pair) {
+        (address token0, address token1) = _sortTokens(tokenA, tokenB);
+        if (getPair[token0][token1] != address(0)) {
+            revert AMMFactoryPairExists(token0, token1);
+        }
+
+        bytes32 salt = keccak256(abi.encodePacked(token0, token1));
+        pair = address(new AMMPair{salt: salt}());
+
+        getPair[token0][token1] = pair;
+        getPair[token1][token0] = pair;
+        allPairs.push(pair);
+        emit PairCreated(token0, token1, pair, allPairs.length);
+        AMMPair(pair).initialize(token0, token1);
+    }
+
+    function setFeeTo(address feeTo_) external override {
+        _requireFeeToSetter();
+        feeTo = feeTo_;
+    }
+
+    function setFeeToSetter(address feeToSetter_) external override {
+        _requireFeeToSetter();
+        if (feeToSetter_ == address(0)) {
+            revert AMMFactoryZeroFeeToSetter();
+        }
+        feeToSetter = feeToSetter_;
+    }
+
+    function _sortTokens(address tokenA, address tokenB) internal pure returns (address token0, address token1) {
+        if (tokenA == tokenB) {
+            revert AMMFactoryIdenticalTokens();
+        }
+        if (tokenA == address(0) || tokenB == address(0)) {
+            revert AMMFactoryZeroAddress();
+        }
+
+        (token0, token1) = tokenA < tokenB ? (tokenA, tokenB) : (tokenB, tokenA);
+    }
+
+    function _requireFeeToSetter() internal view {
+        if (msg.sender != feeToSetter) {
+            revert AMMFactoryForbidden();
+        }
+    }
+}

--- a/src/amm/AMMLpToken.sol
+++ b/src/amm/AMMLpToken.sol
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAMMLpToken} from "../interfaces/IAMMLpToken.sol";
+
+/// @title AMMLpToken
+/// @notice Abstract ERC-20 + permit base for AMM LP shares.
+abstract contract AMMLpToken is IAMMLpToken {
+    bytes32 internal constant EIP712_DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    bytes32 internal constant PERMIT_TYPEHASH =
+        keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+    bytes32 internal constant NAME_HASH = keccak256("Auralis V2 LP");
+    bytes32 internal constant VERSION_HASH = keccak256("1");
+    uint256 internal constant SECP256K1N_DIV_2 = 0x7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0;
+
+    bool internal _ammLpInitialized;
+    uint256 internal _ammLpTotalSupply;
+    mapping(address account => uint256 balance) internal _ammLpBalances;
+    mapping(address owner => mapping(address spender => uint256 allowance_)) internal _ammLpAllowances;
+    mapping(address owner => uint256 nonce_) internal _permitNonces;
+    bytes32 internal _hashedName;
+    uint256 internal _cachedChainId;
+    bytes32 internal _cachedDomainSeparator;
+
+    function name() public pure virtual returns (string memory) {
+        return "Auralis V2 LP";
+    }
+
+    function symbol() public pure virtual returns (string memory) {
+        return "AUR-V2-LP";
+    }
+
+    function decimals() public pure virtual returns (uint8) {
+        return 18;
+    }
+
+    function totalSupply() public view virtual returns (uint256) {
+        return _ammLpTotalSupply;
+    }
+
+    function balanceOf(address account) public view virtual returns (uint256) {
+        return _ammLpBalances[account];
+    }
+
+    function allowance(address owner, address spender) public view virtual returns (uint256) {
+        return _ammLpAllowances[owner][spender];
+    }
+
+    function approve(address spender, uint256 value) external virtual returns (bool) {
+        _requireInitialized();
+        _approveLp(msg.sender, spender, value);
+        return true;
+    }
+
+    function transfer(address to, uint256 value) external virtual returns (bool) {
+        _transferLp(msg.sender, to, value);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 value) external virtual returns (bool) {
+        _spendAllowance(from, msg.sender, value);
+        _transferLp(from, to, value);
+        return true;
+    }
+
+    function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s)
+        external
+        virtual
+    {
+        _requireInitialized();
+
+        if (block.timestamp > deadline) {
+            revert AMMLpPermitExpired(deadline, block.timestamp);
+        }
+
+        uint256 nonce_ = _permitNonces[owner];
+        // forge-lint: disable-next-line(asm-keccak256)
+        bytes32 structHash = keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, nonce_, deadline));
+        // forge-lint: disable-next-line(asm-keccak256)
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR(), structHash));
+        address signer = _recoverSigner(digest, v, r, s);
+        if (signer != owner) {
+            revert AMMLpPermitInvalidSigner(signer, owner);
+        }
+
+        _permitNonces[owner] = nonce_ + 1;
+        _approveLp(owner, spender, value);
+    }
+
+    function nonces(address owner) external view virtual returns (uint256) {
+        return _permitNonces[owner];
+    }
+
+    // forge-lint: disable-next-line(mixed-case-function)
+    function DOMAIN_SEPARATOR() public view virtual returns (bytes32) {
+        bytes32 hashedName = _hashedName == bytes32(0) ? NAME_HASH : _hashedName;
+        if (_cachedChainId == block.chainid && _cachedDomainSeparator != bytes32(0)) {
+            return _cachedDomainSeparator;
+        }
+        return _buildDomainSeparator(hashedName, block.chainid);
+    }
+
+    function _initializeAmmLpToken() internal {
+        if (_ammLpInitialized) {
+            revert AMMLpAlreadyInitialized();
+        }
+
+        _ammLpInitialized = true;
+        _hashedName = NAME_HASH;
+        _cachedChainId = block.chainid;
+        _cachedDomainSeparator = _buildDomainSeparator(NAME_HASH, block.chainid);
+    }
+
+    function _mintLp(address to, uint256 value) internal {
+        _requireInitialized();
+        _requireNonZeroAddress(to);
+
+        _ammLpTotalSupply += value;
+        _ammLpBalances[to] += value;
+
+        emit Transfer(address(0), to, value);
+    }
+
+    function _burnLp(address from, uint256 value) internal {
+        _requireInitialized();
+        _requireNonZeroAddress(from);
+
+        uint256 fromBalance = _ammLpBalances[from];
+        if (fromBalance < value) {
+            revert AMMLpInsufficientBalance(from, fromBalance, value);
+        }
+
+        unchecked {
+            _ammLpBalances[from] = fromBalance - value;
+            _ammLpTotalSupply -= value;
+        }
+
+        emit Transfer(from, address(0), value);
+    }
+
+    function _transferLp(address from, address to, uint256 value) internal {
+        _requireInitialized();
+        _requireNonZeroAddress(from);
+        _requireNonZeroAddress(to);
+
+        uint256 fromBalance = _ammLpBalances[from];
+        if (fromBalance < value) {
+            revert AMMLpInsufficientBalance(from, fromBalance, value);
+        }
+
+        unchecked {
+            _ammLpBalances[from] = fromBalance - value;
+        }
+        _ammLpBalances[to] += value;
+
+        emit Transfer(from, to, value);
+    }
+
+    function _approveLp(address owner, address spender, uint256 value) internal {
+        _requireInitialized();
+        _requireNonZeroAddress(owner);
+
+        _ammLpAllowances[owner][spender] = value;
+        emit Approval(owner, spender, value);
+    }
+
+    function _spendAllowance(address owner, address spender, uint256 value) internal {
+        _requireInitialized();
+        _requireNonZeroAddress(owner);
+
+        uint256 currentAllowance = allowance(owner, spender);
+        if (currentAllowance == type(uint256).max) {
+            return;
+        }
+        if (currentAllowance < value) {
+            revert AMMLpInsufficientAllowance(owner, spender, currentAllowance, value);
+        }
+
+        unchecked {
+            _approveLp(owner, spender, currentAllowance - value);
+        }
+    }
+
+    function _buildDomainSeparator(bytes32 hashedName, uint256 chainId) internal view returns (bytes32) {
+        // forge-lint: disable-next-line(asm-keccak256)
+        return keccak256(abi.encode(EIP712_DOMAIN_TYPEHASH, hashedName, VERSION_HASH, chainId, address(this)));
+    }
+
+    function _recoverSigner(bytes32 digest, uint8 v, bytes32 r, bytes32 s) internal pure returns (address) {
+        if (v != 27 && v != 28) {
+            return address(0);
+        }
+        if (uint256(s) > SECP256K1N_DIV_2) {
+            return address(0);
+        }
+
+        return ecrecover(digest, v, r, s);
+    }
+
+    function _requireInitialized() internal view {
+        if (!_ammLpInitialized) {
+            revert AMMLpNotInitialized();
+        }
+    }
+
+    function _requireNonZeroAddress(address account) internal pure {
+        if (account == address(0)) {
+            revert AMMLpZeroAddress();
+        }
+    }
+}

--- a/src/amm/AMMPair.sol
+++ b/src/amm/AMMPair.sol
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {AMMFixedPoint} from "./libraries/AMMFixedPoint.sol";
+import {AMMLpToken} from "./AMMLpToken.sol";
+import {AMMMath} from "./libraries/AMMMath.sol";
+import {IAMMFactory} from "../interfaces/IAMMFactory.sol";
+import {IAMMPair} from "../interfaces/IAMMPair.sol";
+import {IERC20} from "../interfaces/IERC20.sol";
+
+/// @title AMMPair
+/// @notice Constant-product pair core for the standalone V2-style AMM track.
+contract AMMPair is AMMLpToken, IAMMPair {
+    uint256 internal constant FEE_DENOMINATOR = 1000;
+    uint256 internal constant FEE_UNITS = 3;
+    address internal constant MINIMUM_LIQUIDITY_SINK = 0x000000000000000000000000000000000000dEaD;
+
+    error AMMPairForbidden();
+    error AMMPairAlreadyInitialized();
+    error AMMPairZeroTokenAddress();
+    error AMMPairIdenticalTokens();
+    error AMMPairLocked();
+    error AMMPairInvalidRecipient(address to);
+    error AMMPairInsufficientLiquidityMinted();
+    error AMMPairInsufficientLiquidityBurned();
+    error AMMPairInsufficientLiquidity();
+    error AMMPairInsufficientInputAmount();
+    error AMMPairInsufficientOutputAmount();
+    error AMMPairReserveOverflow();
+    error AMMPairUnsupportedSwapData();
+    error AMMPairTransferFailed(address token, address to, uint256 value);
+    error AMMPairKInvariant();
+
+    address public immutable override factory;
+
+    address public override token0;
+    address public override token1;
+    uint256 public override price0CumulativeLast;
+    uint256 public override price1CumulativeLast;
+    uint256 public override kLast;
+
+    uint112 internal _reserve0;
+    uint112 internal _reserve1;
+    uint32 internal _blockTimestampLast;
+    uint256 internal _unlocked = 1;
+
+    constructor() {
+        factory = msg.sender;
+    }
+
+    modifier lock() {
+        if (_unlocked != 1) {
+            revert AMMPairLocked();
+        }
+
+        _unlocked = 0;
+        _;
+        _unlocked = 1;
+    }
+
+    // forge-lint: disable-next-line(mixed-case-function)
+    function MINIMUM_LIQUIDITY() public pure override returns (uint256) {
+        return 1000;
+    }
+
+    function getReserves()
+        external
+        view
+        override
+        returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast)
+    {
+        return (_reserve0, _reserve1, _blockTimestampLast);
+    }
+
+    function initialize(address token0_, address token1_) external override {
+        if (msg.sender != factory) {
+            revert AMMPairForbidden();
+        }
+        if (_ammLpInitialized) {
+            revert AMMPairAlreadyInitialized();
+        }
+        if (token0_ == address(0) || token1_ == address(0)) {
+            revert AMMPairZeroTokenAddress();
+        }
+        if (token0_ == token1_) {
+            revert AMMPairIdenticalTokens();
+        }
+
+        _initializeAmmLpToken();
+        token0 = token0_;
+        token1 = token1_;
+    }
+
+    function mint(address to) external override lock returns (uint256 liquidity) {
+        uint112 reserve0_ = _reserve0;
+        uint112 reserve1_ = _reserve1;
+        (uint256 balance0, uint256 balance1) = _currentBalances();
+
+        uint256 amount0 = balance0 - reserve0_;
+        uint256 amount1 = balance1 - reserve1_;
+
+        bool feeOn = _mintFee(reserve0_, reserve1_);
+        uint256 totalSupply_ = totalSupply();
+
+        if (totalSupply_ == 0) {
+            uint256 rootK = AMMMath.sqrt(amount0 * amount1);
+            uint256 minimumLiquidity = MINIMUM_LIQUIDITY();
+            if (rootK <= minimumLiquidity) {
+                revert AMMPairInsufficientLiquidityMinted();
+            }
+
+            unchecked {
+                liquidity = rootK - minimumLiquidity;
+            }
+            _mintLp(MINIMUM_LIQUIDITY_SINK, minimumLiquidity);
+        } else {
+            liquidity = AMMMath.min((amount0 * totalSupply_) / reserve0_, (amount1 * totalSupply_) / reserve1_);
+        }
+
+        if (liquidity == 0) {
+            revert AMMPairInsufficientLiquidityMinted();
+        }
+
+        _mintLp(to, liquidity);
+        _update(balance0, balance1, reserve0_, reserve1_);
+        if (feeOn) {
+            kLast = uint256(_reserve0) * uint256(_reserve1);
+        }
+
+        emit Mint(msg.sender, amount0, amount1);
+    }
+
+    function burn(address to) external override lock returns (uint256 amount0, uint256 amount1) {
+        uint112 reserve0_ = _reserve0;
+        uint112 reserve1_ = _reserve1;
+        address token0_ = token0;
+        address token1_ = token1;
+        (uint256 balance0, uint256 balance1) = _currentBalances();
+        uint256 liquidity = balanceOf(address(this));
+
+        bool feeOn = _mintFee(reserve0_, reserve1_);
+        uint256 totalSupply_ = totalSupply();
+
+        amount0 = (liquidity * balance0) / totalSupply_;
+        amount1 = (liquidity * balance1) / totalSupply_;
+        if (amount0 == 0 || amount1 == 0) {
+            revert AMMPairInsufficientLiquidityBurned();
+        }
+
+        uint256 nextBalance0 = balance0 - amount0;
+        uint256 nextBalance1 = balance1 - amount1;
+
+        _burnLp(address(this), liquidity);
+        _update(nextBalance0, nextBalance1, reserve0_, reserve1_);
+        if (feeOn) {
+            kLast = uint256(_reserve0) * uint256(_reserve1);
+        }
+
+        _safeTransfer(token0_, to, amount0);
+        _safeTransfer(token1_, to, amount1);
+
+        emit Burn(msg.sender, amount0, amount1, to);
+    }
+
+    function swap(uint256 amount0Out, uint256 amount1Out, address to, bytes calldata data) external override lock {
+        if (amount0Out == 0 && amount1Out == 0) {
+            revert AMMPairInsufficientOutputAmount();
+        }
+        if (to == address(0) || to == token0 || to == token1) {
+            revert AMMPairInvalidRecipient(to);
+        }
+        if (data.length != 0) {
+            revert AMMPairUnsupportedSwapData();
+        }
+
+        uint256 amount0In;
+        uint256 amount1In;
+        {
+            uint112 reserve0_ = _reserve0;
+            uint112 reserve1_ = _reserve1;
+            if (amount0Out >= reserve0_ || amount1Out >= reserve1_) {
+                revert AMMPairInsufficientLiquidity();
+            }
+
+            (uint256 balance0Before, uint256 balance1Before) = _currentBalances();
+            uint256 balance0 = balance0Before - amount0Out;
+            uint256 balance1 = balance1Before - amount1Out;
+            amount0In = balance0Before > reserve0_ ? balance0Before - reserve0_ : 0;
+            amount1In = balance1Before > reserve1_ ? balance1Before - reserve1_ : 0;
+
+            if (amount0In == 0 && amount1In == 0) {
+                revert AMMPairInsufficientInputAmount();
+            }
+
+            uint256 balance0Adjusted = (balance0 * FEE_DENOMINATOR) - (amount0In * FEE_UNITS);
+            uint256 balance1Adjusted = (balance1 * FEE_DENOMINATOR) - (amount1In * FEE_UNITS);
+            uint256 reserveProduct = uint256(reserve0_) * uint256(reserve1_) * (FEE_DENOMINATOR ** 2);
+            if ((balance0Adjusted * balance1Adjusted) < reserveProduct) {
+                revert AMMPairKInvariant();
+            }
+
+            _update(balance0, balance1, reserve0_, reserve1_);
+        }
+
+        if (amount0Out != 0) {
+            _safeTransfer(token0, to, amount0Out);
+        }
+        if (amount1Out != 0) {
+            _safeTransfer(token1, to, amount1Out);
+        }
+        emit Swap(msg.sender, amount0In, amount1In, amount0Out, amount1Out, to);
+    }
+
+    function skim(address to) external override lock {
+        _safeTransfer(token0, to, IERC20(token0).balanceOf(address(this)) - _reserve0);
+        _safeTransfer(token1, to, IERC20(token1).balanceOf(address(this)) - _reserve1);
+    }
+
+    function sync() external override lock {
+        (uint256 balance0, uint256 balance1) = _currentBalances();
+        _update(balance0, balance1, _reserve0, _reserve1);
+    }
+
+    function _currentBalances() internal view returns (uint256 balance0, uint256 balance1) {
+        return (IERC20(token0).balanceOf(address(this)), IERC20(token1).balanceOf(address(this)));
+    }
+
+    function _mintFee(uint112 reserve0_, uint112 reserve1_) internal returns (bool feeOn) {
+        address feeTo = IAMMFactory(factory).feeTo();
+        feeOn = feeTo != address(0);
+
+        uint256 kLast_ = kLast;
+        if (feeOn) {
+            if (kLast_ != 0) {
+                uint256 rootK = AMMMath.sqrt(uint256(reserve0_) * uint256(reserve1_));
+                uint256 rootKLast = AMMMath.sqrt(kLast_);
+
+                if (rootK > rootKLast) {
+                    uint256 numerator = totalSupply() * (rootK - rootKLast);
+                    uint256 denominator = (rootK * 5) + rootKLast;
+                    uint256 liquidity = numerator / denominator;
+                    if (liquidity != 0) {
+                        _mintLp(feeTo, liquidity);
+                    }
+                }
+            }
+        } else if (kLast_ != 0) {
+            kLast = 0;
+        }
+    }
+
+    function _update(uint256 balance0, uint256 balance1, uint112 reserve0_, uint112 reserve1_) internal {
+        if (balance0 > type(uint112).max || balance1 > type(uint112).max) {
+            revert AMMPairReserveOverflow();
+        }
+
+        uint32 blockTimestamp = uint32(block.timestamp);
+        uint32 timeElapsed;
+        unchecked {
+            timeElapsed = blockTimestamp - _blockTimestampLast;
+        }
+
+        if (timeElapsed > 0 && reserve0_ != 0 && reserve1_ != 0) {
+            price0CumulativeLast += uint256(AMMFixedPoint.uqdiv(AMMFixedPoint.encode(reserve1_), reserve0_).value)
+            * timeElapsed;
+            price1CumulativeLast += uint256(AMMFixedPoint.uqdiv(AMMFixedPoint.encode(reserve0_), reserve1_).value)
+            * timeElapsed;
+        }
+
+        // forge-lint: disable-next-line(unsafe-typecast)
+        _reserve0 = uint112(balance0);
+        // forge-lint: disable-next-line(unsafe-typecast)
+        _reserve1 = uint112(balance1);
+        _blockTimestampLast = blockTimestamp;
+
+        emit Sync(_reserve0, _reserve1);
+    }
+
+    function _safeTransfer(address token, address to, uint256 value) internal {
+        if (value == 0) {
+            return;
+        }
+
+        (bool success, bytes memory returndata) =
+            token.call(abi.encodeWithSelector(IERC20.transfer.selector, to, value));
+
+        bool validReturn = returndata.length == 0 || (returndata.length == 32 && abi.decode(returndata, (bool)));
+        if (!success || !validReturn) {
+            revert AMMPairTransferFailed(token, to, value);
+        }
+    }
+}

--- a/src/amm/AMMRouter.sol
+++ b/src/amm/AMMRouter.sol
@@ -1,0 +1,574 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAMMFactory} from "../interfaces/IAMMFactory.sol";
+import {IAMMPair} from "../interfaces/IAMMPair.sol";
+import {IAMMRouter} from "../interfaces/IAMMRouter.sol";
+import {IERC20} from "../interfaces/IERC20.sol";
+import {IWrappedNative} from "../interfaces/IWrappedNative.sol";
+
+/// @title AMMRouter
+/// @notice User-facing router and quoting surface for the standalone AMM subsystem.
+contract AMMRouter is IAMMRouter {
+    uint256 internal constant FEE_DENOMINATOR = 1000;
+    uint256 internal constant FEE_NUMERATOR = 997;
+
+    error AMMRouterZeroAddress();
+    error AMMRouterExpired(uint256 deadline, uint256 currentTimestamp);
+    error AMMRouterInvalidPath();
+    error AMMRouterInvalidWrappedNativePath();
+    error AMMRouterInvalidWrappedNativeToken(address token);
+    error AMMRouterIdenticalTokens();
+    error AMMRouterZeroTokenAddress();
+    error AMMRouterInvalidNativeSender(address sender);
+    error AMMRouterPairUnavailable(address tokenA, address tokenB);
+    error AMMRouterInsufficientAmount();
+    error AMMRouterInsufficientLiquidity();
+    error AMMRouterInsufficientAAmount(uint256 amountA, uint256 minimumAmountA);
+    error AMMRouterInsufficientBAmount(uint256 amountB, uint256 minimumAmountB);
+    error AMMRouterInsufficientOutputAmount(uint256 amountOut, uint256 minimumAmountOut);
+    error AMMRouterExcessiveInputAmount(uint256 amountIn, uint256 maximumAmountIn);
+    error AMMRouterTransferFailed(address token, address to, uint256 value);
+    error AMMRouterTransferFromFailed(address token, address from, address to, uint256 value);
+    error AMMRouterWrapFailed(uint256 value);
+    error AMMRouterUnwrapFailed(uint256 value);
+    error AMMRouterNativeTransferFailed(address to, uint256 value);
+
+    address public immutable override factory;
+    address public immutable override wrappedNative;
+
+    modifier ensure(uint256 deadline) {
+        if (block.timestamp > deadline) {
+            revert AMMRouterExpired(deadline, block.timestamp);
+        }
+        _;
+    }
+
+    constructor(address factory_, address wrappedNative_) {
+        if (factory_ == address(0) || wrappedNative_ == address(0)) {
+            revert AMMRouterZeroAddress();
+        }
+
+        factory = factory_;
+        wrappedNative = wrappedNative_;
+    }
+
+    receive() external payable {
+        if (msg.sender != wrappedNative) {
+            revert AMMRouterInvalidNativeSender(msg.sender);
+        }
+    }
+
+    function quote(uint256 amountA, uint256 reserveA, uint256 reserveB) public pure override returns (uint256 amountB) {
+        if (amountA == 0) {
+            revert AMMRouterInsufficientAmount();
+        }
+        if (reserveA == 0 || reserveB == 0) {
+            revert AMMRouterInsufficientLiquidity();
+        }
+
+        amountB = (amountA * reserveB) / reserveA;
+    }
+
+    function getAmountOut(uint256 amountIn, uint256 reserveIn, uint256 reserveOut)
+        public
+        pure
+        override
+        returns (uint256 amountOut)
+    {
+        if (amountIn == 0) {
+            revert AMMRouterInsufficientAmount();
+        }
+        if (reserveIn == 0 || reserveOut == 0) {
+            revert AMMRouterInsufficientLiquidity();
+        }
+
+        uint256 amountInWithFee = amountIn * FEE_NUMERATOR;
+        amountOut = (amountInWithFee * reserveOut) / ((reserveIn * FEE_DENOMINATOR) + amountInWithFee);
+    }
+
+    function getAmountIn(uint256 amountOut, uint256 reserveIn, uint256 reserveOut)
+        public
+        pure
+        override
+        returns (uint256 amountIn)
+    {
+        if (amountOut == 0) {
+            revert AMMRouterInsufficientAmount();
+        }
+        if (reserveIn == 0 || reserveOut == 0 || amountOut >= reserveOut) {
+            revert AMMRouterInsufficientLiquidity();
+        }
+
+        uint256 numerator = reserveIn * amountOut * FEE_DENOMINATOR;
+        uint256 denominator = (reserveOut - amountOut) * FEE_NUMERATOR;
+        amountIn = (numerator / denominator) + 1;
+    }
+
+    function getAmountsOut(uint256 amountIn, address[] calldata path)
+        public
+        view
+        override
+        returns (uint256[] memory amounts)
+    {
+        _validatePath(path);
+
+        amounts = new uint256[](path.length);
+        amounts[0] = amountIn;
+
+        for (uint256 i = 0; i < path.length - 1; i++) {
+            (uint256 reserveIn, uint256 reserveOut) = _getReserves(path[i], path[i + 1]);
+            amounts[i + 1] = getAmountOut(amounts[i], reserveIn, reserveOut);
+        }
+    }
+
+    function getAmountsIn(uint256 amountOut, address[] calldata path)
+        public
+        view
+        override
+        returns (uint256[] memory amounts)
+    {
+        _validatePath(path);
+
+        amounts = new uint256[](path.length);
+        amounts[amounts.length - 1] = amountOut;
+
+        for (uint256 i = path.length - 1; i > 0; i--) {
+            (uint256 reserveIn, uint256 reserveOut) = _getReserves(path[i - 1], path[i]);
+            amounts[i - 1] = getAmountIn(amounts[i], reserveIn, reserveOut);
+        }
+    }
+
+    function addLiquidity(
+        address tokenA,
+        address tokenB,
+        uint256 amountADesired,
+        uint256 amountBDesired,
+        uint256 amountAMin,
+        uint256 amountBMin,
+        address to,
+        uint256 deadline
+    ) external override ensure(deadline) returns (uint256 amountA, uint256 amountB, uint256 liquidity) {
+        (address pair, uint256 addAmountA, uint256 addAmountB) =
+            _addLiquidity(tokenA, tokenB, amountADesired, amountBDesired, amountAMin, amountBMin);
+
+        _safeTransferFrom(tokenA, msg.sender, pair, addAmountA);
+        _safeTransferFrom(tokenB, msg.sender, pair, addAmountB);
+
+        liquidity = IAMMPair(pair).mint(to);
+        return (addAmountA, addAmountB, liquidity);
+    }
+
+    function addLiquidityNative(
+        address token,
+        uint256 amountTokenDesired,
+        uint256 amountTokenMin,
+        uint256 amountNativeMin,
+        address to,
+        uint256 deadline
+    )
+        external
+        payable
+        override
+        ensure(deadline)
+        returns (uint256 amountToken, uint256 amountNative, uint256 liquidity)
+    {
+        if (token == wrappedNative) {
+            revert AMMRouterInvalidWrappedNativeToken(token);
+        }
+
+        (address pair, uint256 addAmountToken, uint256 addAmountNative) =
+            _addLiquidity(token, wrappedNative, amountTokenDesired, msg.value, amountTokenMin, amountNativeMin);
+
+        _safeTransferFrom(token, msg.sender, pair, addAmountToken);
+        _wrapNative(addAmountNative);
+        _safeTransfer(wrappedNative, pair, addAmountNative);
+
+        liquidity = IAMMPair(pair).mint(to);
+
+        uint256 refund = msg.value - addAmountNative;
+        if (refund != 0) {
+            _safeTransferNative(msg.sender, refund);
+        }
+
+        return (addAmountToken, addAmountNative, liquidity);
+    }
+
+    function removeLiquidity(
+        address tokenA,
+        address tokenB,
+        uint256 liquidity,
+        uint256 amountAMin,
+        uint256 amountBMin,
+        address to,
+        uint256 deadline
+    ) public override ensure(deadline) returns (uint256 amountA, uint256 amountB) {
+        return _removeLiquidity(tokenA, tokenB, liquidity, amountAMin, amountBMin, to);
+    }
+
+    function removeLiquidityNative(
+        address token,
+        uint256 liquidity,
+        uint256 amountTokenMin,
+        uint256 amountNativeMin,
+        address to,
+        uint256 deadline
+    ) public override ensure(deadline) returns (uint256 amountToken, uint256 amountNative) {
+        if (token == wrappedNative) {
+            revert AMMRouterInvalidWrappedNativeToken(token);
+        }
+
+        (amountToken, amountNative) =
+            _removeLiquidity(token, wrappedNative, liquidity, amountTokenMin, amountNativeMin, address(this));
+
+        _safeTransfer(token, to, amountToken);
+        _unwrapNative(amountNative);
+        _safeTransferNative(to, amountNative);
+    }
+
+    function removeLiquidityWithPermit(
+        address tokenA,
+        address tokenB,
+        uint256 liquidity,
+        uint256 amountAMin,
+        uint256 amountBMin,
+        address to,
+        uint256 deadline,
+        bool approveMax,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external override ensure(deadline) returns (uint256 amountA, uint256 amountB) {
+        _permitLiquidity(tokenA, tokenB, liquidity, deadline, approveMax, v, r, s);
+        return removeLiquidity(tokenA, tokenB, liquidity, amountAMin, amountBMin, to, deadline);
+    }
+
+    function removeLiquidityNativeWithPermit(
+        address token,
+        uint256 liquidity,
+        uint256 amountTokenMin,
+        uint256 amountNativeMin,
+        address to,
+        uint256 deadline,
+        bool approveMax,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external override ensure(deadline) returns (uint256 amountToken, uint256 amountNative) {
+        _permitLiquidity(token, wrappedNative, liquidity, deadline, approveMax, v, r, s);
+        return removeLiquidityNative(token, liquidity, amountTokenMin, amountNativeMin, to, deadline);
+    }
+
+    function swapExactTokensForTokens(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external override ensure(deadline) returns (uint256[] memory amounts) {
+        amounts = getAmountsOut(amountIn, path);
+        uint256 finalAmountOut = amounts[amounts.length - 1];
+        if (finalAmountOut < amountOutMin) {
+            revert AMMRouterInsufficientOutputAmount(finalAmountOut, amountOutMin);
+        }
+
+        _safeTransferFrom(path[0], msg.sender, _pairFor(path[0], path[1]), amounts[0]);
+        _swap(amounts, path, to);
+    }
+
+    function swapTokensForExactTokens(
+        uint256 amountOut,
+        uint256 amountInMax,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external override ensure(deadline) returns (uint256[] memory amounts) {
+        amounts = getAmountsIn(amountOut, path);
+        uint256 requiredAmountIn = amounts[0];
+        if (requiredAmountIn > amountInMax) {
+            revert AMMRouterExcessiveInputAmount(requiredAmountIn, amountInMax);
+        }
+
+        _safeTransferFrom(path[0], msg.sender, _pairFor(path[0], path[1]), requiredAmountIn);
+        _swap(amounts, path, to);
+    }
+
+    function swapExactNativeForTokens(uint256 amountOutMin, address[] calldata path, address to, uint256 deadline)
+        external
+        payable
+        override
+        ensure(deadline)
+        returns (uint256[] memory amounts)
+    {
+        _validateNativeInPath(path);
+
+        amounts = getAmountsOut(msg.value, path);
+        uint256 finalAmountOut = amounts[amounts.length - 1];
+        if (finalAmountOut < amountOutMin) {
+            revert AMMRouterInsufficientOutputAmount(finalAmountOut, amountOutMin);
+        }
+
+        _wrapNative(amounts[0]);
+        _safeTransfer(wrappedNative, _pairFor(path[0], path[1]), amounts[0]);
+        _swap(amounts, path, to);
+    }
+
+    function swapTokensForExactNative(
+        uint256 amountOut,
+        uint256 amountInMax,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external override ensure(deadline) returns (uint256[] memory amounts) {
+        _validateNativeOutPath(path);
+
+        amounts = getAmountsIn(amountOut, path);
+        uint256 requiredAmountIn = amounts[0];
+        if (requiredAmountIn > amountInMax) {
+            revert AMMRouterExcessiveInputAmount(requiredAmountIn, amountInMax);
+        }
+
+        _safeTransferFrom(path[0], msg.sender, _pairFor(path[0], path[1]), requiredAmountIn);
+        _swap(amounts, path, address(this));
+
+        _unwrapNative(amounts[amounts.length - 1]);
+        _safeTransferNative(to, amounts[amounts.length - 1]);
+    }
+
+    function swapExactTokensForNative(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external override ensure(deadline) returns (uint256[] memory amounts) {
+        _validateNativeOutPath(path);
+
+        amounts = getAmountsOut(amountIn, path);
+        uint256 finalAmountOut = amounts[amounts.length - 1];
+        if (finalAmountOut < amountOutMin) {
+            revert AMMRouterInsufficientOutputAmount(finalAmountOut, amountOutMin);
+        }
+
+        _safeTransferFrom(path[0], msg.sender, _pairFor(path[0], path[1]), amounts[0]);
+        _swap(amounts, path, address(this));
+
+        _unwrapNative(finalAmountOut);
+        _safeTransferNative(to, finalAmountOut);
+    }
+
+    function swapNativeForExactTokens(uint256 amountOut, address[] calldata path, address to, uint256 deadline)
+        external
+        payable
+        override
+        ensure(deadline)
+        returns (uint256[] memory amounts)
+    {
+        _validateNativeInPath(path);
+
+        amounts = getAmountsIn(amountOut, path);
+        uint256 requiredNativeAmount = amounts[0];
+        if (requiredNativeAmount > msg.value) {
+            revert AMMRouterExcessiveInputAmount(requiredNativeAmount, msg.value);
+        }
+
+        _wrapNative(requiredNativeAmount);
+        _safeTransfer(wrappedNative, _pairFor(path[0], path[1]), requiredNativeAmount);
+        _swap(amounts, path, to);
+
+        uint256 refund = msg.value - requiredNativeAmount;
+        if (refund != 0) {
+            _safeTransferNative(msg.sender, refund);
+        }
+    }
+
+    function _validatePath(address[] calldata path) internal pure {
+        if (path.length < 2) {
+            revert AMMRouterInvalidPath();
+        }
+    }
+
+    function _validateNativeInPath(address[] calldata path) internal view {
+        _validatePath(path);
+        if (path[0] != wrappedNative) {
+            revert AMMRouterInvalidWrappedNativePath();
+        }
+    }
+
+    function _validateNativeOutPath(address[] calldata path) internal view {
+        _validatePath(path);
+        if (path[path.length - 1] != wrappedNative) {
+            revert AMMRouterInvalidWrappedNativePath();
+        }
+    }
+
+    function _addLiquidity(
+        address tokenA,
+        address tokenB,
+        uint256 amountADesired,
+        uint256 amountBDesired,
+        uint256 amountAMin,
+        uint256 amountBMin
+    ) internal returns (address pair, uint256 amountA, uint256 amountB) {
+        pair = IAMMFactory(factory).getPair(tokenA, tokenB);
+        if (pair == address(0)) {
+            pair = IAMMFactory(factory).createPair(tokenA, tokenB);
+        }
+
+        (uint256 reserveA, uint256 reserveB) = _getReserves(tokenA, tokenB);
+        if (reserveA == 0 && reserveB == 0) {
+            amountA = amountADesired;
+            amountB = amountBDesired;
+        } else {
+            uint256 amountBOptimal = quote(amountADesired, reserveA, reserveB);
+            if (amountBOptimal <= amountBDesired) {
+                amountA = amountADesired;
+                amountB = amountBOptimal;
+            } else {
+                amountA = quote(amountBDesired, reserveB, reserveA);
+                amountB = amountBDesired;
+            }
+        }
+
+        if (amountA < amountAMin) {
+            revert AMMRouterInsufficientAAmount(amountA, amountAMin);
+        }
+        if (amountB < amountBMin) {
+            revert AMMRouterInsufficientBAmount(amountB, amountBMin);
+        }
+    }
+
+    function _removeLiquidity(
+        address tokenA,
+        address tokenB,
+        uint256 liquidity,
+        uint256 amountAMin,
+        uint256 amountBMin,
+        address to
+    ) internal returns (uint256 amountA, uint256 amountB) {
+        address pair = _pairFor(tokenA, tokenB);
+        _safeTransferFrom(pair, msg.sender, pair, liquidity);
+
+        (uint256 amount0, uint256 amount1) = IAMMPair(pair).burn(to);
+        (address sortedToken0,) = _sortTokens(tokenA, tokenB);
+        (amountA, amountB) = tokenA == sortedToken0 ? (amount0, amount1) : (amount1, amount0);
+
+        if (amountA < amountAMin) {
+            revert AMMRouterInsufficientAAmount(amountA, amountAMin);
+        }
+        if (amountB < amountBMin) {
+            revert AMMRouterInsufficientBAmount(amountB, amountBMin);
+        }
+    }
+
+    function _swap(uint256[] memory amounts, address[] calldata path, address to) internal {
+        for (uint256 i = 0; i < path.length - 1; i++) {
+            address input = path[i];
+            address output = path[i + 1];
+            address pair = _pairFor(input, output);
+            (address token0,) = _sortTokens(input, output);
+            uint256 amountOut = amounts[i + 1];
+            (uint256 amount0Out, uint256 amount1Out) =
+                input == token0 ? (uint256(0), amountOut) : (amountOut, uint256(0));
+            address recipient = i < path.length - 2 ? _pairFor(output, path[i + 2]) : to;
+            IAMMPair(pair).swap(amount0Out, amount1Out, recipient, "");
+        }
+    }
+
+    function _getReserves(address tokenA, address tokenB) internal view returns (uint256 reserveA, uint256 reserveB) {
+        address pair = _pairFor(tokenA, tokenB);
+        (uint112 reserve0, uint112 reserve1,) = IAMMPair(pair).getReserves();
+        (address sortedToken0,) = _sortTokens(tokenA, tokenB);
+        return tokenA == sortedToken0 ? (reserve0, reserve1) : (reserve1, reserve0);
+    }
+
+    function _pairFor(address tokenA, address tokenB) internal view returns (address pair) {
+        _sortTokens(tokenA, tokenB);
+        pair = IAMMFactory(factory).getPair(tokenA, tokenB);
+        if (pair == address(0)) {
+            revert AMMRouterPairUnavailable(tokenA, tokenB);
+        }
+    }
+
+    function _sortTokens(address tokenA, address tokenB) internal pure returns (address token0, address token1) {
+        if (tokenA == tokenB) {
+            revert AMMRouterIdenticalTokens();
+        }
+        if (tokenA == address(0) || tokenB == address(0)) {
+            revert AMMRouterZeroTokenAddress();
+        }
+
+        (token0, token1) = tokenA < tokenB ? (tokenA, tokenB) : (tokenB, tokenA);
+    }
+
+    function _permitLiquidity(
+        address tokenA,
+        address tokenB,
+        uint256 liquidity,
+        uint256 deadline,
+        bool approveMax,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) internal {
+        uint256 allowanceValue = approveMax ? type(uint256).max : liquidity;
+        IAMMPair(_pairFor(tokenA, tokenB)).permit(msg.sender, address(this), allowanceValue, deadline, v, r, s);
+    }
+
+    function _wrapNative(uint256 value) internal {
+        if (value == 0) {
+            return;
+        }
+
+        (bool success,) = wrappedNative.call{value: value}(abi.encodeWithSelector(IWrappedNative.deposit.selector));
+        if (!success) {
+            revert AMMRouterWrapFailed(value);
+        }
+    }
+
+    function _unwrapNative(uint256 value) internal {
+        if (value == 0) {
+            return;
+        }
+
+        (bool success,) = wrappedNative.call(abi.encodeCall(IWrappedNative.withdraw, (value)));
+        if (!success) {
+            revert AMMRouterUnwrapFailed(value);
+        }
+    }
+
+    function _safeTransfer(address token, address to, uint256 value) internal {
+        if (value == 0) {
+            return;
+        }
+
+        (bool success, bytes memory data) = token.call(abi.encodeCall(IERC20.transfer, (to, value)));
+        bool validReturn = data.length == 0 || (data.length == 32 && abi.decode(data, (bool)));
+        if (!success || !validReturn) {
+            revert AMMRouterTransferFailed(token, to, value);
+        }
+    }
+
+    function _safeTransferFrom(address token, address from, address to, uint256 value) internal {
+        if (value == 0) {
+            return;
+        }
+
+        (bool success, bytes memory data) = token.call(abi.encodeCall(IERC20.transferFrom, (from, to, value)));
+        bool validReturn = data.length == 0 || (data.length == 32 && abi.decode(data, (bool)));
+        if (!success || !validReturn) {
+            revert AMMRouterTransferFromFailed(token, from, to, value);
+        }
+    }
+
+    function _safeTransferNative(address to, uint256 value) internal {
+        if (value == 0) {
+            return;
+        }
+
+        (bool success,) = payable(to).call{value: value}("");
+        if (!success) {
+            revert AMMRouterNativeTransferFailed(to, value);
+        }
+    }
+}

--- a/src/amm/libraries/AMMFixedPoint.sol
+++ b/src/amm/libraries/AMMFixedPoint.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title AMMFixedPoint
+/// @notice Minimal UQ112x112 fixed-point helpers for V2-style price accumulation.
+library AMMFixedPoint {
+    uint224 internal constant Q112 = uint224(1) << 112;
+
+    struct UQ112x112 {
+        uint224 value;
+    }
+
+    function encode(uint112 value) internal pure returns (UQ112x112 memory) {
+        return UQ112x112(uint224(value) * Q112);
+    }
+
+    function uqdiv(UQ112x112 memory self, uint112 value) internal pure returns (UQ112x112 memory) {
+        return UQ112x112(self.value / uint224(value));
+    }
+}

--- a/src/amm/libraries/AMMMath.sol
+++ b/src/amm/libraries/AMMMath.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title AMMMath
+/// @notice Shared math helpers for the standalone AMM subsystem.
+library AMMMath {
+    function min(uint256 x, uint256 y) internal pure returns (uint256) {
+        return x < y ? x : y;
+    }
+
+    function sqrt(uint256 y) internal pure returns (uint256 z) {
+        if (y == 0) {
+            return 0;
+        }
+        if (y <= 3) {
+            return 1;
+        }
+
+        z = y;
+        uint256 x = (y / 2) + 1;
+        while (x < z) {
+            z = x;
+            x = ((y / x) + x) / 2;
+        }
+    }
+}

--- a/src/interfaces/IAMMFactory.sol
+++ b/src/interfaces/IAMMFactory.sol
@@ -8,6 +8,7 @@ interface IAMMFactory {
 
     function feeTo() external view returns (address);
     function feeToSetter() external view returns (address);
+    function pairCodeHash() external pure returns (bytes32);
     function getPair(address tokenA, address tokenB) external view returns (address);
     function allPairs(uint256 index) external view returns (address);
     function allPairsLength() external view returns (uint256);

--- a/src/interfaces/IAMMFactory.sol
+++ b/src/interfaces/IAMMFactory.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title IAMMFactory
+/// @notice Factory and registry surface for deterministic AMM pair deployment.
+interface IAMMFactory {
+    event PairCreated(address indexed token0, address indexed token1, address pair, uint256 pairIndex);
+
+    function feeTo() external view returns (address);
+    function feeToSetter() external view returns (address);
+    function getPair(address tokenA, address tokenB) external view returns (address);
+    function allPairs(uint256 index) external view returns (address);
+    function allPairsLength() external view returns (uint256);
+
+    function createPair(address tokenA, address tokenB) external returns (address pair);
+    function setFeeTo(address feeTo_) external;
+    function setFeeToSetter(address feeToSetter_) external;
+}

--- a/src/interfaces/IAMMLpToken.sol
+++ b/src/interfaces/IAMMLpToken.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC20Metadata} from "./IERC20Metadata.sol";
+import {IERC20Permit} from "./IERC20Permit.sol";
+
+/// @title IAMMLpToken
+/// @notice ERC-20 + permit surface for the standalone AMM LP token.
+interface IAMMLpToken is IERC20Metadata, IERC20Permit {
+    error AMMLpAlreadyInitialized();
+    error AMMLpNotInitialized();
+    error AMMLpZeroAddress();
+    error AMMLpInsufficientBalance(address account, uint256 available, uint256 required);
+    error AMMLpInsufficientAllowance(address owner, address spender, uint256 available, uint256 required);
+    error AMMLpPermitExpired(uint256 deadline, uint256 currentTimestamp);
+    error AMMLpPermitInvalidSigner(address signer, address owner);
+}

--- a/src/interfaces/IAMMPair.sol
+++ b/src/interfaces/IAMMPair.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAMMLpToken} from "./IAMMLpToken.sol";
+
+/// @title IAMMPair
+/// @notice Constant-product AMM pair surface, including LP token behavior.
+interface IAMMPair is IAMMLpToken {
+    event Mint(address indexed sender, uint256 amount0, uint256 amount1);
+    event Burn(address indexed sender, uint256 amount0, uint256 amount1, address indexed to);
+    event Swap(
+        address indexed sender,
+        uint256 amount0In,
+        uint256 amount1In,
+        uint256 amount0Out,
+        uint256 amount1Out,
+        address indexed to
+    );
+    event Sync(uint112 reserve0, uint112 reserve1);
+
+    function factory() external view returns (address);
+    function token0() external view returns (address);
+    function token1() external view returns (address);
+    function MINIMUM_LIQUIDITY() external pure returns (uint256);
+    function getReserves() external view returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast);
+    function price0CumulativeLast() external view returns (uint256);
+    function price1CumulativeLast() external view returns (uint256);
+    function kLast() external view returns (uint256);
+
+    function initialize(address token0_, address token1_) external;
+    function mint(address to) external returns (uint256 liquidity);
+    function burn(address to) external returns (uint256 amount0, uint256 amount1);
+    function swap(uint256 amount0Out, uint256 amount1Out, address to, bytes calldata data) external;
+    function skim(address to) external;
+    function sync() external;
+}

--- a/src/interfaces/IAMMRouter.sol
+++ b/src/interfaces/IAMMRouter.sol
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title IAMMRouter
+/// @notice User-facing router and quoting surface for the standalone AMM subsystem.
+interface IAMMRouter {
+    function factory() external view returns (address);
+    function wrappedNative() external view returns (address);
+
+    function quote(uint256 amountA, uint256 reserveA, uint256 reserveB) external pure returns (uint256 amountB);
+    function getAmountOut(uint256 amountIn, uint256 reserveIn, uint256 reserveOut) external pure returns (uint256);
+    function getAmountIn(uint256 amountOut, uint256 reserveIn, uint256 reserveOut) external pure returns (uint256);
+    function getAmountsOut(uint256 amountIn, address[] calldata path) external view returns (uint256[] memory amounts);
+    function getAmountsIn(uint256 amountOut, address[] calldata path) external view returns (uint256[] memory amounts);
+
+    function addLiquidity(
+        address tokenA,
+        address tokenB,
+        uint256 amountADesired,
+        uint256 amountBDesired,
+        uint256 amountAMin,
+        uint256 amountBMin,
+        address to,
+        uint256 deadline
+    ) external returns (uint256 amountA, uint256 amountB, uint256 liquidity);
+
+    function addLiquidityNative(
+        address token,
+        uint256 amountTokenDesired,
+        uint256 amountTokenMin,
+        uint256 amountNativeMin,
+        address to,
+        uint256 deadline
+    ) external payable returns (uint256 amountToken, uint256 amountNative, uint256 liquidity);
+
+    function removeLiquidity(
+        address tokenA,
+        address tokenB,
+        uint256 liquidity,
+        uint256 amountAMin,
+        uint256 amountBMin,
+        address to,
+        uint256 deadline
+    ) external returns (uint256 amountA, uint256 amountB);
+
+    function removeLiquidityNative(
+        address token,
+        uint256 liquidity,
+        uint256 amountTokenMin,
+        uint256 amountNativeMin,
+        address to,
+        uint256 deadline
+    ) external returns (uint256 amountToken, uint256 amountNative);
+
+    function removeLiquidityWithPermit(
+        address tokenA,
+        address tokenB,
+        uint256 liquidity,
+        uint256 amountAMin,
+        uint256 amountBMin,
+        address to,
+        uint256 deadline,
+        bool approveMax,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external returns (uint256 amountA, uint256 amountB);
+
+    function removeLiquidityNativeWithPermit(
+        address token,
+        uint256 liquidity,
+        uint256 amountTokenMin,
+        uint256 amountNativeMin,
+        address to,
+        uint256 deadline,
+        bool approveMax,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external returns (uint256 amountToken, uint256 amountNative);
+
+    function swapExactTokensForTokens(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external returns (uint256[] memory amounts);
+
+    function swapTokensForExactTokens(
+        uint256 amountOut,
+        uint256 amountInMax,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external returns (uint256[] memory amounts);
+
+    function swapExactNativeForTokens(uint256 amountOutMin, address[] calldata path, address to, uint256 deadline)
+        external
+        payable
+        returns (uint256[] memory amounts);
+
+    function swapTokensForExactNative(
+        uint256 amountOut,
+        uint256 amountInMax,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external returns (uint256[] memory amounts);
+
+    function swapExactTokensForNative(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+    ) external returns (uint256[] memory amounts);
+
+    function swapNativeForExactTokens(uint256 amountOut, address[] calldata path, address to, uint256 deadline)
+        external
+        payable
+        returns (uint256[] memory amounts);
+}

--- a/src/interfaces/IWrappedNative.sol
+++ b/src/interfaces/IWrappedNative.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC20} from "./IERC20.sol";
+
+/// @title IWrappedNative
+/// @notice Minimal wrapped-native token surface for AMM router integration.
+interface IWrappedNative is IERC20 {
+    function deposit() external payable;
+    function withdraw(uint256 value) external;
+}

--- a/test/AMMFactoryRegistry.t.sol
+++ b/test/AMMFactoryRegistry.t.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {AMMFactory} from "../src/amm/AMMFactory.sol";
+import {AMMPair} from "../src/amm/AMMPair.sol";
+import {AMMPairCoreFixture, MockAMMToken} from "./helpers/AMMPairTestHarness.sol";
+
+contract AMMFactoryRegistryTest is AMMPairCoreFixture {
+    function testConstructorSetsFeeToSetterAndPairCodeHash() public view {
+        assertTrue(factory.feeToSetter() == address(this), "feeToSetter mismatch");
+        assertTrue(factory.pairCodeHash() == keccak256(type(AMMPair).creationCode), "pair code hash mismatch");
+    }
+
+    function testCreatePairSortsTokensAndStoresBothLookupDirections() public {
+        MockAMMToken unsortedA = new MockAMMToken("Token A", "TKA", 18);
+        MockAMMToken unsortedB = new MockAMMToken("Token B", "TKB", 18);
+
+        address expectedToken0 = address(unsortedA) < address(unsortedB) ? address(unsortedA) : address(unsortedB);
+        address expectedToken1 = address(unsortedA) < address(unsortedB) ? address(unsortedB) : address(unsortedA);
+        address createdPair = factory.createPair(address(unsortedB), address(unsortedA));
+
+        assertTrue(factory.getPair(address(unsortedA), address(unsortedB)) == createdPair, "forward lookup mismatch");
+        assertTrue(factory.getPair(address(unsortedB), address(unsortedA)) == createdPair, "reverse lookup mismatch");
+        assertTrue(factory.allPairs(1) == createdPair, "allPairs entry mismatch");
+        assertTrue(factory.allPairsLength() == 2, "allPairs length mismatch");
+
+        AMMPair sortedPair = AMMPair(createdPair);
+        assertTrue(sortedPair.factory() == address(factory), "pair factory mismatch");
+        assertTrue(sortedPair.token0() == expectedToken0, "token0 sort mismatch");
+        assertTrue(sortedPair.token1() == expectedToken1, "token1 sort mismatch");
+    }
+
+    function testCreatePairRevertsForZeroIdenticalAndDuplicatePairs() public {
+        VM.expectRevert(AMMFactory.AMMFactoryZeroAddress.selector);
+        factory.createPair(address(0), address(token0));
+
+        VM.expectRevert(AMMFactory.AMMFactoryIdenticalTokens.selector);
+        factory.createPair(address(token0), address(token0));
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                AMMFactory.AMMFactoryPairExists.selector,
+                address(token0) < address(token1) ? address(token0) : address(token1),
+                address(token0) < address(token1) ? address(token1) : address(token0)
+            )
+        );
+        factory.createPair(address(token1), address(token0));
+    }
+
+    function testPredictedCreate2AddressMatchesDeployedPair() public {
+        MockAMMToken localToken0 = new MockAMMToken("Local Token 0", "LT0", 18);
+        MockAMMToken localToken1 = new MockAMMToken("Local Token 1", "LT1", 18);
+
+        address predictedPair = _predictPairAddress(address(factory), address(localToken0), address(localToken1));
+        address deployedPair = factory.createPair(address(localToken1), address(localToken0));
+
+        assertTrue(deployedPair == predictedPair, "predicted pair mismatch");
+    }
+
+    function testSetFeeToRequiresFeeToSetterAndPersists() public {
+        VM.prank(alice);
+        VM.expectRevert(AMMFactory.AMMFactoryForbidden.selector);
+        factory.setFeeTo(carol);
+
+        factory.setFeeTo(carol);
+        assertTrue(factory.feeTo() == carol, "feeTo mismatch");
+
+        factory.setFeeTo(address(0));
+        assertTrue(factory.feeTo() == address(0), "feeTo should clear");
+    }
+
+    function testSetFeeToSetterRequiresCurrentFeeToSetterAndPersists() public {
+        VM.prank(alice);
+        VM.expectRevert(AMMFactory.AMMFactoryForbidden.selector);
+        factory.setFeeToSetter(carol);
+
+        VM.expectRevert(AMMFactory.AMMFactoryZeroFeeToSetter.selector);
+        factory.setFeeToSetter(address(0));
+
+        factory.setFeeToSetter(carol);
+        assertTrue(factory.feeToSetter() == carol, "feeToSetter mismatch");
+
+        VM.expectRevert(AMMFactory.AMMFactoryForbidden.selector);
+        factory.setFeeTo(address(this));
+
+        VM.prank(carol);
+        factory.setFeeTo(alice);
+        assertTrue(factory.feeTo() == alice, "new feeToSetter should control feeTo");
+    }
+
+    function _predictPairAddress(address factory_, address tokenA, address tokenB) internal view returns (address) {
+        (address sortedToken0, address sortedToken1) = _sortTokens(tokenA, tokenB);
+        bytes32 salt = keccak256(abi.encodePacked(sortedToken0, sortedToken1));
+        bytes32 rawAddress = keccak256(abi.encodePacked(hex"ff", factory_, salt, factory.pairCodeHash()));
+        return address(uint160(uint256(rawAddress)));
+    }
+
+    function _sortTokens(address tokenA, address tokenB) internal pure returns (address token0_, address token1_) {
+        return tokenA < tokenB ? (tokenA, tokenB) : (tokenB, tokenA);
+    }
+}

--- a/test/AMMFoundationCore.t.sol
+++ b/test/AMMFoundationCore.t.sol
@@ -111,7 +111,8 @@ contract AMMFoundationCoreTest is AMMFoundationFixture {
         lpToken.mint(alice, 10);
 
         VM.prank(alice);
-        (bool success, bytes memory returndata) = address(lpToken).call(abi.encodeCall(lpToken.transfer, (address(0), 1)));
+        (bool success, bytes memory returndata) =
+            address(lpToken).call(abi.encodeCall(lpToken.transfer, (address(0), 1)));
         assertFalse(success, "zero-address transfer should revert");
 
         bytes4 revertSelector;

--- a/test/AMMFoundationCore.t.sol
+++ b/test/AMMFoundationCore.t.sol
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IAMMLpToken} from "../src/interfaces/IAMMLpToken.sol";
+import {AMMFoundationFixture} from "./helpers/AMMTestHarness.sol";
+
+contract AMMFoundationCoreTest is AMMFoundationFixture {
+    function testInitializationSucceedsOnceAndCachesDomainSeparator() public {
+        lpToken.initializeAmmLpToken();
+
+        assertTrue(lpToken.initialized(), "lp token should initialize");
+        assertTrue(keccak256(bytes(lpToken.name())) == keccak256(bytes("Auralis V2 LP")), "name mismatch");
+        assertTrue(keccak256(bytes(lpToken.symbol())) == keccak256(bytes("AUR-V2-LP")), "symbol mismatch");
+        assertTrue(lpToken.decimals() == 18, "decimals mismatch");
+        assertTrue(lpToken.DOMAIN_SEPARATOR() == _domainSeparator(address(lpToken)), "domain separator mismatch");
+
+        VM.expectRevert(IAMMLpToken.AMMLpAlreadyInitialized.selector);
+        lpToken.initializeAmmLpToken();
+    }
+
+    function testMintTransferApproveTransferFromAndBurn() public {
+        lpToken.initializeAmmLpToken();
+
+        lpToken.mint(alice, 100);
+        assertTrue(lpToken.totalSupply() == 100, "total supply mismatch");
+        assertTrue(lpToken.balanceOf(alice) == 100, "alice balance mismatch");
+
+        VM.prank(alice);
+        assertTrue(lpToken.transfer(bob, 40), "transfer should succeed");
+        assertTrue(lpToken.balanceOf(alice) == 60, "alice post-transfer mismatch");
+        assertTrue(lpToken.balanceOf(bob) == 40, "bob post-transfer mismatch");
+
+        VM.prank(alice);
+        assertTrue(lpToken.approve(bob, 25), "approve should succeed");
+        assertTrue(lpToken.allowance(alice, bob) == 25, "allowance mismatch");
+
+        VM.prank(bob);
+        assertTrue(lpToken.transferFrom(alice, carol, 20), "transferFrom should succeed");
+        assertTrue(lpToken.balanceOf(carol) == 20, "carol balance mismatch");
+        assertTrue(lpToken.allowance(alice, bob) == 5, "allowance post-transferFrom mismatch");
+
+        lpToken.burn(carol, 10);
+        assertTrue(lpToken.balanceOf(carol) == 10, "carol post-burn mismatch");
+        assertTrue(lpToken.totalSupply() == 90, "total supply post-burn mismatch");
+    }
+
+    function testPermitSetsAllowanceAndIncrementsNonce() public {
+        lpToken.initializeAmmLpToken();
+
+        uint256 deadline = block.timestamp + 1 days;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(ALICE_PK, address(lpToken), alice, bob, 55, 0, deadline);
+
+        lpToken.permit(alice, bob, 55, deadline, v, r, s);
+
+        assertTrue(lpToken.allowance(alice, bob) == 55, "permit allowance mismatch");
+        assertTrue(lpToken.nonces(alice) == 1, "permit nonce mismatch");
+    }
+
+    function testPermitReplayReverts() public {
+        lpToken.initializeAmmLpToken();
+
+        uint256 deadline = block.timestamp + 1 days;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(ALICE_PK, address(lpToken), alice, bob, 55, 0, deadline);
+
+        lpToken.permit(alice, bob, 55, deadline, v, r, s);
+
+        address replaySigner = _recoverPermitSigner(address(lpToken), alice, bob, 55, 1, deadline, v, r, s);
+        VM.expectRevert(abi.encodeWithSelector(IAMMLpToken.AMMLpPermitInvalidSigner.selector, replaySigner, alice));
+        lpToken.permit(alice, bob, 55, deadline, v, r, s);
+    }
+
+    function testPermitRevertsOnExpiredDeadline() public {
+        lpToken.initializeAmmLpToken();
+
+        uint256 deadline = block.timestamp;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(ALICE_PK, address(lpToken), alice, bob, 33, 0, deadline);
+
+        VM.warp(deadline + 1);
+        VM.expectRevert(abi.encodeWithSelector(IAMMLpToken.AMMLpPermitExpired.selector, deadline, block.timestamp));
+        lpToken.permit(alice, bob, 33, deadline, v, r, s);
+    }
+
+    function testPermitRevertsOnWrongPayload() public {
+        lpToken.initializeAmmLpToken();
+
+        uint256 deadline = block.timestamp + 1 days;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(ALICE_PK, address(lpToken), alice, bob, 55, 0, deadline);
+
+        address wrongSpenderSigner = _recoverPermitSigner(address(lpToken), alice, carol, 55, 0, deadline, v, r, s);
+        VM.expectRevert(
+            abi.encodeWithSelector(IAMMLpToken.AMMLpPermitInvalidSigner.selector, wrongSpenderSigner, alice)
+        );
+        lpToken.permit(alice, carol, 55, deadline, v, r, s);
+    }
+
+    function testPermitRejectsInvalidVAndHighS() public {
+        lpToken.initializeAmmLpToken();
+
+        uint256 deadline = block.timestamp + 1 days;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(ALICE_PK, address(lpToken), alice, bob, 77, 0, deadline);
+
+        VM.expectRevert(abi.encodeWithSelector(IAMMLpToken.AMMLpPermitInvalidSigner.selector, address(0), alice));
+        lpToken.permit(alice, bob, 77, deadline, v + 2, r, s);
+
+        VM.expectRevert(abi.encodeWithSelector(IAMMLpToken.AMMLpPermitInvalidSigner.selector, address(0), alice));
+        lpToken.permit(alice, bob, 77, deadline, v, r, _invalidHighS(s));
+    }
+
+    function testZeroAddressTransferRevertsAndZeroSpenderApproveIsAllowed() public {
+        lpToken.initializeAmmLpToken();
+        lpToken.mint(alice, 10);
+
+        VM.prank(alice);
+        (bool success, bytes memory returndata) = address(lpToken).call(abi.encodeCall(lpToken.transfer, (address(0), 1)));
+        assertFalse(success, "zero-address transfer should revert");
+
+        bytes4 revertSelector;
+        assembly {
+            revertSelector := mload(add(returndata, 0x20))
+        }
+        assertTrue(revertSelector == IAMMLpToken.AMMLpZeroAddress.selector, "unexpected revert selector");
+
+        VM.prank(alice);
+        assertTrue(lpToken.approve(address(0), 7), "approve zero spender should succeed");
+        assertTrue(lpToken.allowance(alice, address(0)) == 7, "zero spender allowance mismatch");
+    }
+
+    function testMutatingActionsRevertBeforeInitialization() public {
+        VM.expectRevert(IAMMLpToken.AMMLpNotInitialized.selector);
+        lpToken.mint(alice, 1);
+
+        VM.prank(alice);
+        VM.expectRevert(IAMMLpToken.AMMLpNotInitialized.selector);
+        lpToken.approve(bob, 1);
+    }
+
+    function testMathHelpersMatchExpectedValues() public pure {
+        assertTrue(_mathMin(4, 9) == 4, "min mismatch");
+        assertTrue(_mathSqrt(0) == 0, "sqrt(0) mismatch");
+        assertTrue(_mathSqrt(1) == 1, "sqrt(1) mismatch");
+        assertTrue(_mathSqrt(2) == 1, "sqrt(2) mismatch");
+        assertTrue(_mathSqrt(15) == 3, "sqrt(15) mismatch");
+        assertTrue(_mathSqrt(16) == 4, "sqrt(16) mismatch");
+    }
+
+    function testFixedPointHelpersMatchUQ112x112Expectations() public pure {
+        uint224 q112 = uint224(1) << 112;
+
+        assertTrue(_encodeUq112x112(5) == 5 * q112, "encode mismatch");
+        assertTrue(_uqdiv(10, 2) == 5 * q112, "uqdiv mismatch");
+    }
+}

--- a/test/AMMHardening.t.sol
+++ b/test/AMMHardening.t.sol
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {AMMFactory} from "../src/amm/AMMFactory.sol";
+import {AMMPair} from "../src/amm/AMMPair.sol";
+import {AMMRouter} from "../src/amm/AMMRouter.sol";
+import {AMMHardeningFixture} from "./helpers/AMMHardeningTestHarness.sol";
+import {
+    FalseReturningAMMToken,
+    MalformedAMMToken,
+    MockAMMToken,
+    ReentrantAMMToken,
+    SilentAMMToken
+} from "./helpers/AMMPairTestHarness.sol";
+
+contract AMMHardeningTest is AMMHardeningFixture {
+    function testFeeOnMintsProtocolLpOnlyWhenLiquidityMoves() public {
+        AMMFactory localFactory = new AMMFactory();
+        localFactory.setFeeTo(carol);
+
+        MockAMMToken localToken0 = new MockAMMToken("Local Token 0", "LT0", 18);
+        MockAMMToken localToken1 = new MockAMMToken("Local Token 1", "LT1", 18);
+        AMMPair localPair = AMMPair(localFactory.createPair(address(localToken0), address(localToken1)));
+
+        _seedLiquidityDirect(localPair, localToken0, localToken1, 1_000_000, 1_000_000, alice);
+        assertTrue(localPair.kLast() == 1_000_000 * 1_000_000, "initial fee-on kLast mismatch");
+
+        localToken0.mint(address(localPair), 100_000);
+        uint256 amount1Out = _getAmountOut(100_000, 1_000_000, 1_000_000);
+        if (localPair.token0() == address(localToken0)) {
+            localPair.swap(0, amount1Out, bob, "");
+        } else {
+            localPair.swap(amount1Out, 0, bob, "");
+        }
+
+        (uint112 reserve0AfterSwap, uint112 reserve1AfterSwap,) = localPair.getReserves();
+        uint256 protocolLpBefore = localPair.balanceOf(carol);
+        (uint256 reserveLocal0, uint256 reserveLocal1) = localPair.token0() == address(localToken0)
+            ? (reserve0AfterSwap, reserve1AfterSwap)
+            : (reserve1AfterSwap, reserve0AfterSwap);
+        uint256 amount0Desired = 11_000;
+        uint256 amount1Desired = (amount0Desired * reserveLocal1) / reserveLocal0;
+
+        localToken0.mint(address(localPair), amount0Desired);
+        localToken1.mint(address(localPair), amount1Desired);
+        localPair.mint(bob);
+
+        assertTrue(localPair.balanceOf(carol) > protocolLpBefore, "protocol fee lp should mint on later liquidity");
+        (uint112 reserve0AfterMint, uint112 reserve1AfterMint,) = localPair.getReserves();
+        assertTrue(
+            localPair.kLast() == uint256(reserve0AfterMint) * uint256(reserve1AfterMint),
+            "fee-on kLast should refresh on liquidity event"
+        );
+    }
+
+    function testFeeOffClearsKLastOnlyOnNextLiquidityEvent() public {
+        factory.setFeeTo(carol);
+
+        VM.prank(bob);
+        router.addLiquidity(address(token0), address(token1), 20_000, 20_000, 0, 0, bob, DEADLINE);
+        _recordLiquidityEvent(address(pair01));
+
+        uint256 kLastBeforeDisable = pair01.kLast();
+        assertTrue(kLastBeforeDisable != 0, "kLast should be set while fee switch is on");
+
+        factory.setFeeTo(address(0));
+
+        address[] memory path_ = _path(address(token0), address(token1));
+        uint256 expectedAmountOut = router.getAmountsOut(10_000, path_)[1];
+        VM.prank(carol);
+        router.swapExactTokensForTokens(10_000, expectedAmountOut, path_, carol, DEADLINE);
+
+        assertTrue(pair01.kLast() == kLastBeforeDisable, "swap should not clear kLast after fee disable");
+
+        (uint256 reserve0Before, uint256 reserve1Before) = _getAlignedReserves(address(token0), address(token1));
+        uint256 amount1Desired = router.quote(15_000, reserve0Before, reserve1Before);
+        VM.prank(bob);
+        router.addLiquidity(address(token0), address(token1), 15_000, amount1Desired, 0, 0, bob, DEADLINE);
+
+        _recordLiquidityEvent(address(pair01));
+        assertTrue(pair01.kLast() == 0, "liquidity event should clear kLast after fee disable");
+        _assertTrackedAmmState();
+    }
+
+    function testDonationSkimAndSyncPreserveReserveSemantics() public {
+        (uint112 reserve0Before, uint112 reserve1Before,) = pair01.getReserves();
+
+        token0.mint(address(pair01), 5_000);
+        token1.mint(address(pair01), 7_000);
+        pair01.skim(dave);
+
+        (uint112 reserve0AfterSkim, uint112 reserve1AfterSkim,) = pair01.getReserves();
+        assertTrue(reserve0AfterSkim == reserve0Before, "skim should leave reserve0 unchanged");
+        assertTrue(reserve1AfterSkim == reserve1Before, "skim should leave reserve1 unchanged");
+
+        token0.mint(address(pair01), 3_000);
+        token1.mint(address(pair01), 4_000);
+        pair01.sync();
+
+        (uint112 reserve0AfterSync, uint112 reserve1AfterSync,) = pair01.getReserves();
+        assertTrue(reserve0AfterSync == reserve0Before + 3_000, "sync should advance reserve0 to balance");
+        assertTrue(reserve1AfterSync == reserve1Before + 4_000, "sync should advance reserve1 to balance");
+        _assertTrackedAmmState();
+    }
+
+    function testMultiActorTokenAndNativeSequenceKeepsTrackedStateCoherent() public {
+        VM.prank(bob);
+        router.addLiquidityNative{value: 20_000}(address(token0), 20_000, 0, 0, bob, DEADLINE);
+        _recordLiquidityEvent(address(pair0W));
+
+        VM.prank(carol);
+        router.swapExactTokensForTokens(
+            12_000, 0, _path(address(token2), address(token1), address(token0)), carol, DEADLINE
+        );
+
+        VM.prank(dave);
+        router.swapExactNativeForTokens{value: 15_000}(
+            0, _path(address(wrappedNativeToken), address(token1), address(token2)), dave, DEADLINE
+        );
+
+        uint256 liquidityToBurn = pair1W.balanceOf(alice) / 4;
+        VM.prank(alice);
+        router.removeLiquidityNative(address(token1), liquidityToBurn, 0, 0, alice, DEADLINE);
+        _recordLiquidityEvent(address(pair1W));
+
+        _assertTrackedAmmState();
+    }
+
+    function testRouterTransferFailureLeavesCreatedPairEmpty() public {
+        FalseReturningAMMToken falseToken = _deployFalseReturningToken();
+        MockAMMToken normalToken = new MockAMMToken("Normal Token", "NTK", 18);
+        falseToken.mint(bob, 10_000);
+        normalToken.mint(bob, 10_000);
+
+        VM.startPrank(bob);
+        falseToken.approve(address(router), type(uint256).max);
+        normalToken.approve(address(router), type(uint256).max);
+        try router.addLiquidity(address(falseToken), address(normalToken), 10_000, 10_000, 0, 0, bob, DEADLINE) {
+            revert("expected addLiquidity revert");
+        } catch (bytes memory revertData) {
+            bytes4 selector = bytes4(revertData);
+            assertTrue(selector == AMMRouter.AMMRouterTransferFromFailed.selector, "unexpected router revert");
+        }
+        VM.stopPrank();
+
+        address pairAddress = factory.getPair(address(falseToken), address(normalToken));
+        assertTrue(pairAddress == address(0), "failed transfer should revert pair creation too");
+    }
+
+    function testMalformedAndReentrantOutputFailuresDoNotCorruptPairs() public {
+        MalformedAMMToken malformedToken = new MalformedAMMToken("Malformed Token", "MTK", 18);
+        MockAMMToken normalToken = new MockAMMToken("Normal Token", "NTK", 18);
+        AMMPair malformedPair = _deployPair(address(malformedToken), address(normalToken));
+        _seedLiquidityDirect(malformedPair, malformedToken, normalToken, 20_000, 20_000, alice);
+
+        normalToken.mint(address(malformedPair), 1_000);
+        (uint112 malformedReserve0, uint112 malformedReserve1,) = malformedPair.getReserves();
+
+        if (malformedPair.token0() == address(malformedToken)) {
+            VM.expectRevert(
+                abi.encodeWithSelector(AMMPair.AMMPairTransferFailed.selector, address(malformedToken), bob, 949)
+            );
+            malformedPair.swap(949, 0, bob, "");
+        } else {
+            VM.expectRevert(
+                abi.encodeWithSelector(AMMPair.AMMPairTransferFailed.selector, address(malformedToken), bob, 949)
+            );
+            malformedPair.swap(0, 949, bob, "");
+        }
+
+        (uint112 malformedReserve0After, uint112 malformedReserve1After,) = malformedPair.getReserves();
+        assertTrue(malformedReserve0After == malformedReserve0, "malformed revert should preserve reserve0");
+        assertTrue(malformedReserve1After == malformedReserve1, "malformed revert should preserve reserve1");
+
+        ReentrantAMMToken reentrantToken = new ReentrantAMMToken("Reentrant Token", "RTK", 18);
+        MockAMMToken secondNormalToken = new MockAMMToken("Second Normal Token", "SNT", 18);
+        AMMPair reentrantPair = _deployPair(address(reentrantToken), address(secondNormalToken));
+        _seedLiquidityDirect(reentrantPair, reentrantToken, secondNormalToken, 20_000, 20_000, alice);
+        reentrantToken.setReenterSync(address(reentrantPair), true);
+
+        secondNormalToken.mint(address(reentrantPair), 1_000);
+        (uint112 reentrantReserve0, uint112 reentrantReserve1,) = reentrantPair.getReserves();
+
+        if (reentrantPair.token0() == address(reentrantToken)) {
+            VM.expectRevert(
+                abi.encodeWithSelector(AMMPair.AMMPairTransferFailed.selector, address(reentrantToken), bob, 949)
+            );
+            reentrantPair.swap(949, 0, bob, "");
+        } else {
+            VM.expectRevert(
+                abi.encodeWithSelector(AMMPair.AMMPairTransferFailed.selector, address(reentrantToken), bob, 949)
+            );
+            reentrantPair.swap(0, 949, bob, "");
+        }
+
+        (uint112 reentrantReserve0After, uint112 reentrantReserve1After,) = reentrantPair.getReserves();
+        assertTrue(reentrantReserve0After == reentrantReserve0, "reentrant revert should preserve reserve0");
+        assertTrue(reentrantReserve1After == reentrantReserve1, "reentrant revert should preserve reserve1");
+
+        reentrantToken.setReenterSync(address(reentrantPair), false);
+        reentrantPair.sync();
+    }
+
+    function testSilentOutputTokenCanSustainRepeatedSwaps() public {
+        SilentAMMToken silentToken = new SilentAMMToken("Silent Token", "STK", 18);
+        MockAMMToken normalToken = new MockAMMToken("Normal Token", "NTK", 18);
+        AMMPair silentPair = _deployPair(address(silentToken), address(normalToken));
+        _seedLiquidityDirect(silentPair, silentToken, normalToken, 30_000, 30_000, alice);
+
+        normalToken.mint(address(silentPair), 1_000);
+        if (silentPair.token0() == address(silentToken)) {
+            silentPair.swap(964, 0, bob, "");
+        } else {
+            silentPair.swap(0, 964, bob, "");
+        }
+
+        normalToken.mint(address(silentPair), 500);
+        if (silentPair.token0() == address(silentToken)) {
+            silentPair.swap(447, 0, carol, "");
+        } else {
+            silentPair.swap(0, 447, carol, "");
+        }
+
+        (uint112 reserve0_, uint112 reserve1_,) = silentPair.getReserves();
+        assertTrue(
+            reserve0_ <= MockAMMToken(silentPair.token0()).balanceOf(address(silentPair)),
+            "silent reserve0 should not exceed balance"
+        );
+        assertTrue(
+            reserve1_ <= MockAMMToken(silentPair.token1()).balanceOf(address(silentPair)),
+            "silent reserve1 should not exceed balance"
+        );
+    }
+}

--- a/test/AMMInvariant.t.sol
+++ b/test/AMMInvariant.t.sol
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {AMMPair} from "../src/amm/AMMPair.sol";
+import {MockAMMToken} from "./helpers/AMMPairTestHarness.sol";
+import {AMMHardeningFixture} from "./helpers/AMMHardeningTestHarness.sol";
+
+contract AMMInvariantTest is AMMHardeningFixture {
+    function targetContracts() external view returns (address[] memory contracts) {
+        contracts = new address[](1);
+        contracts[0] = address(this);
+    }
+
+    function actionAddLiquidity(uint8 actorSeed, uint8 pairSeed, uint96 amountRaw) external {
+        (AMMPair trackedPair, MockAMMToken tokenA_, MockAMMToken tokenB_) = _tokenPairFixture(pairSeed);
+        address actor = _actor(actorSeed);
+        (uint256 reserveA, uint256 reserveB) = _getAlignedReserves(address(tokenA_), address(tokenB_));
+        uint256 maxAmountA = tokenA_.balanceOf(actor) / 16;
+        uint256 amountA = _boundAmount(amountRaw, maxAmountA);
+        if (amountA == 0) {
+            return;
+        }
+
+        uint256 amountB = reserveA == 0 || reserveB == 0 ? amountA : router.quote(amountA, reserveA, reserveB);
+        if (amountB == 0 || amountB > tokenB_.balanceOf(actor)) {
+            return;
+        }
+
+        VM.prank(actor);
+        router.addLiquidity(address(tokenA_), address(tokenB_), amountA, amountB, 0, 0, actor, DEADLINE);
+        _recordLiquidityEvent(address(trackedPair));
+    }
+
+    function actionAddLiquidityNative(uint8 actorSeed, uint8 pairSeed, uint96 amountRaw) external {
+        (AMMPair trackedPair, MockAMMToken token_) = _nativePairFixture(pairSeed);
+        address actor = _actor(actorSeed);
+        (uint256 reserveToken, uint256 reserveNative) =
+            _getAlignedReserves(address(token_), address(wrappedNativeToken));
+        uint256 maxAmountToken = token_.balanceOf(actor) / 16;
+        uint256 amountToken = _boundAmount(amountRaw, maxAmountToken);
+        if (amountToken == 0) {
+            return;
+        }
+
+        uint256 amountNative = reserveToken == 0 || reserveNative == 0
+            ? amountToken
+            : router.quote(amountToken, reserveToken, reserveNative);
+        if (amountNative == 0 || amountNative > actor.balance) {
+            return;
+        }
+
+        VM.prank(actor);
+        router.addLiquidityNative{value: amountNative}(address(token_), amountToken, 0, 0, actor, DEADLINE);
+        _recordLiquidityEvent(address(trackedPair));
+    }
+
+    function actionRemoveLiquidity(uint8 actorSeed, uint8 pairSeed, uint96 liquidityRaw) external {
+        (AMMPair trackedPair, MockAMMToken tokenA_, MockAMMToken tokenB_) = _tokenPairFixture(pairSeed);
+        address actor = _actor(actorSeed);
+        uint256 liquidity = _boundAmount(liquidityRaw, trackedPair.balanceOf(actor));
+        if (liquidity == 0) {
+            return;
+        }
+
+        VM.prank(actor);
+        router.removeLiquidity(address(tokenA_), address(tokenB_), liquidity, 0, 0, actor, DEADLINE);
+        _recordLiquidityEvent(address(trackedPair));
+    }
+
+    function actionRemoveLiquidityNative(uint8 actorSeed, uint8 pairSeed, uint96 liquidityRaw) external {
+        (AMMPair trackedPair, MockAMMToken token_) = _nativePairFixture(pairSeed);
+        address actor = _actor(actorSeed);
+        uint256 liquidity = _boundAmount(liquidityRaw, trackedPair.balanceOf(actor));
+        if (liquidity == 0) {
+            return;
+        }
+
+        VM.prank(actor);
+        router.removeLiquidityNative(address(token_), liquidity, 0, 0, actor, DEADLINE);
+        _recordLiquidityEvent(address(trackedPair));
+    }
+
+    function actionSwapExactTokens(uint8 actorSeed, uint8 pathSeed, uint96 amountRaw) external {
+        address actor = _actor(actorSeed);
+        address[] memory path_ = _tokenSwapPath(pathSeed);
+        uint256 amountIn = _boundAmount(amountRaw, MockAMMToken(path_[0]).balanceOf(actor) / 16);
+        if (amountIn == 0) {
+            return;
+        }
+
+        uint256[] memory amountsOut = router.getAmountsOut(amountIn, path_);
+        if (amountsOut[amountsOut.length - 1] == 0) {
+            return;
+        }
+
+        VM.prank(actor);
+        router.swapExactTokensForTokens(amountIn, 0, path_, actor, DEADLINE);
+    }
+
+    function actionSwapTokensForExactTokens(uint8 actorSeed, uint8 pathSeed, uint96 amountRaw) external {
+        address actor = _actor(actorSeed);
+        address[] memory path_ = _tokenSwapPath(pathSeed);
+        (, uint256 reserveOut) = _getAlignedReserves(path_[path_.length - 2], path_[path_.length - 1]);
+        uint256 amountOut = _boundAmount(amountRaw, reserveOut / 16);
+        if (amountOut == 0) {
+            return;
+        }
+
+        uint256[] memory amountsIn = router.getAmountsIn(amountOut, path_);
+        if (amountsIn[0] > MockAMMToken(path_[0]).balanceOf(actor)) {
+            return;
+        }
+
+        VM.prank(actor);
+        router.swapTokensForExactTokens(amountOut, amountsIn[0], path_, actor, DEADLINE);
+    }
+
+    function actionSwapExactNative(uint8 actorSeed, uint8 pathSeed, uint96 amountRaw) external {
+        address actor = _actor(actorSeed);
+        address[] memory path_ = _nativeInPath(pathSeed);
+        uint256 amountIn = _boundAmount(amountRaw, actor.balance / 16);
+        if (amountIn == 0) {
+            return;
+        }
+
+        uint256[] memory amountsOut = router.getAmountsOut(amountIn, path_);
+        if (amountsOut[amountsOut.length - 1] == 0) {
+            return;
+        }
+
+        VM.prank(actor);
+        router.swapExactNativeForTokens{value: amountIn}(0, path_, actor, DEADLINE);
+    }
+
+    function actionSwapTokensForExactNative(uint8 actorSeed, uint8 pathSeed, uint96 amountRaw) external {
+        address actor = _actor(actorSeed);
+        address[] memory path_ = _nativeOutPath(pathSeed);
+        (, uint256 reserveOut) = _getAlignedReserves(path_[path_.length - 2], path_[path_.length - 1]);
+        uint256 amountOut = _boundAmount(amountRaw, reserveOut / 16);
+        if (amountOut == 0) {
+            return;
+        }
+
+        uint256[] memory amountsIn = router.getAmountsIn(amountOut, path_);
+        if (amountsIn[0] > MockAMMToken(path_[0]).balanceOf(actor)) {
+            return;
+        }
+
+        VM.prank(actor);
+        router.swapTokensForExactNative(amountOut, amountsIn[0], path_, actor, DEADLINE);
+    }
+
+    function actionDonateToPair(uint8 actorSeed, uint8 pairSeed, uint8 tokenSeed, uint96 amountRaw) external {
+        address actor = _actor(actorSeed);
+        AMMPair trackedPair = _trackedPair(pairSeed);
+        MockAMMToken pairToken =
+            tokenSeed % 2 == 0 ? MockAMMToken(trackedPair.token0()) : MockAMMToken(trackedPair.token1());
+        uint256 amount = _boundAmount(amountRaw, _donationCapacity(actor, pairToken) / 16);
+        if (amount == 0) {
+            return;
+        }
+
+        if (address(pairToken) == address(wrappedNativeToken) && pairToken.balanceOf(actor) < amount) {
+            if (actor.balance < amount) {
+                return;
+            }
+            _seedWrappedToken(actor, amount);
+        }
+
+        VM.prank(actor);
+        pairToken.transfer(address(trackedPair), amount);
+    }
+
+    function actionSkim(uint8 pairSeed, uint8 recipientSeed) external {
+        AMMPair trackedPair = _trackedPair(pairSeed);
+        trackedPair.skim(_actor(recipientSeed));
+    }
+
+    function actionSync(uint8 pairSeed) external {
+        _trackedPair(pairSeed).sync();
+    }
+
+    function actionToggleFeeTo() external {
+        if (factory.feeTo() == address(0)) {
+            factory.setFeeTo(carol);
+            return;
+        }
+
+        factory.setFeeTo(address(0));
+    }
+
+    function invariantTrackedAmmStateHolds() public view {
+        _assertTrackedAmmState();
+    }
+
+    function invariantRouterNeverRetainsFunds() public view {
+        _assertRouterZeroBalances();
+    }
+
+    function _tokenPairFixture(uint256 seed)
+        internal
+        view
+        returns (AMMPair trackedPair, MockAMMToken tokenA_, MockAMMToken tokenB_)
+    {
+        uint256 selector = seed % 3;
+        if (selector == 0) {
+            return (pair01, token0, token1);
+        }
+        if (selector == 1) {
+            return (pair12, token1, token2);
+        }
+        return (pair02, token0, token2);
+    }
+
+    function _nativePairFixture(uint256 seed) internal view returns (AMMPair trackedPair, MockAMMToken token_) {
+        if (seed % 2 == 0) {
+            return (pair0W, token0);
+        }
+        return (pair1W, token1);
+    }
+
+    function _donationCapacity(address actor, MockAMMToken token_) internal view returns (uint256 amount) {
+        if (address(token_) == address(wrappedNativeToken)) {
+            amount = token_.balanceOf(actor) + actor.balance;
+        } else {
+            amount = token_.balanceOf(actor);
+        }
+    }
+}

--- a/test/AMMPairCore.t.sol
+++ b/test/AMMPairCore.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
+import {AMMFactory} from "../src/amm/AMMFactory.sol";
 import {AMMPair} from "../src/amm/AMMPair.sol";
 import {
-    AMMFactoryHarness,
     AMMPairCoreFixture,
     FalseReturningAMMToken,
     MalformedAMMToken,
@@ -251,53 +251,80 @@ contract AMMPairCoreTest is AMMPairCoreFixture {
     function testSwapRevertsWhenOutputTokenReturnsFalse() public {
         FalseReturningAMMToken falseToken = new FalseReturningAMMToken("False Token", "FTK", 18);
         MockAMMToken normalToken = new MockAMMToken("Normal Token", "NTK", 18);
-        AMMFactoryHarness localFactory = new AMMFactoryHarness(address(this));
+        AMMFactory localFactory = new AMMFactory();
         AMMPair falsePair = AMMPair(localFactory.createPair(address(falseToken), address(normalToken)));
 
         _seedLiquidityDirect(falsePair, falseToken, normalToken, 10_000, 10_000, alice);
         normalToken.mint(address(falsePair), 1_000);
 
-        VM.expectRevert(abi.encodeWithSelector(AMMPair.AMMPairTransferFailed.selector, address(falseToken), bob, 1));
-        falsePair.swap(1, 0, bob, "");
+        if (falsePair.token0() == address(falseToken)) {
+            VM.expectRevert(abi.encodeWithSelector(AMMPair.AMMPairTransferFailed.selector, address(falseToken), bob, 1));
+            falsePair.swap(1, 0, bob, "");
+        } else {
+            VM.expectRevert(abi.encodeWithSelector(AMMPair.AMMPairTransferFailed.selector, address(falseToken), bob, 1));
+            falsePair.swap(0, 1, bob, "");
+        }
     }
 
     function testSwapAcceptsSilentTransferToken() public {
         SilentAMMToken silentToken = new SilentAMMToken("Silent Token", "STK", 18);
         MockAMMToken normalToken = new MockAMMToken("Normal Token", "NTK", 18);
-        AMMFactoryHarness localFactory = new AMMFactoryHarness(address(this));
+        AMMFactory localFactory = new AMMFactory();
         AMMPair silentPair = AMMPair(localFactory.createPair(address(silentToken), address(normalToken)));
 
         _seedLiquidityDirect(silentPair, silentToken, normalToken, 10_000, 10_000, alice);
         normalToken.mint(address(silentPair), 1_000);
 
-        silentPair.swap(1, 0, bob, "");
+        if (silentPair.token0() == address(silentToken)) {
+            silentPair.swap(1, 0, bob, "");
+        } else {
+            silentPair.swap(0, 1, bob, "");
+        }
         assertTrue(silentToken.balanceOf(bob) == 1, "silent transfer output mismatch");
     }
 
     function testSwapRevertsWhenOutputTokenReturnsMalformedData() public {
         MalformedAMMToken malformedToken = new MalformedAMMToken("Malformed Token", "MTK", 18);
         MockAMMToken normalToken = new MockAMMToken("Normal Token", "NTK", 18);
-        AMMFactoryHarness localFactory = new AMMFactoryHarness(address(this));
+        AMMFactory localFactory = new AMMFactory();
         AMMPair malformedPair = AMMPair(localFactory.createPair(address(malformedToken), address(normalToken)));
 
         _seedLiquidityDirect(malformedPair, malformedToken, normalToken, 10_000, 10_000, alice);
         normalToken.mint(address(malformedPair), 1_000);
 
-        VM.expectRevert(abi.encodeWithSelector(AMMPair.AMMPairTransferFailed.selector, address(malformedToken), bob, 1));
-        malformedPair.swap(1, 0, bob, "");
+        if (malformedPair.token0() == address(malformedToken)) {
+            VM.expectRevert(
+                abi.encodeWithSelector(AMMPair.AMMPairTransferFailed.selector, address(malformedToken), bob, 1)
+            );
+            malformedPair.swap(1, 0, bob, "");
+        } else {
+            VM.expectRevert(
+                abi.encodeWithSelector(AMMPair.AMMPairTransferFailed.selector, address(malformedToken), bob, 1)
+            );
+            malformedPair.swap(0, 1, bob, "");
+        }
     }
 
     function testSwapRevertsWhenOutputTransferAttemptsReentrancy() public {
         ReentrantAMMToken reentrantToken = new ReentrantAMMToken("Reentrant Token", "RTK", 18);
         MockAMMToken normalToken = new MockAMMToken("Normal Token", "NTK", 18);
-        AMMFactoryHarness localFactory = new AMMFactoryHarness(address(this));
+        AMMFactory localFactory = new AMMFactory();
         AMMPair reentrantPair = AMMPair(localFactory.createPair(address(reentrantToken), address(normalToken)));
 
         _seedLiquidityDirect(reentrantPair, reentrantToken, normalToken, 10_000, 10_000, alice);
         normalToken.mint(address(reentrantPair), 1_000);
         reentrantToken.setReenterSync(address(reentrantPair), true);
 
-        VM.expectRevert(abi.encodeWithSelector(AMMPair.AMMPairTransferFailed.selector, address(reentrantToken), bob, 1));
-        reentrantPair.swap(1, 0, bob, "");
+        if (reentrantPair.token0() == address(reentrantToken)) {
+            VM.expectRevert(
+                abi.encodeWithSelector(AMMPair.AMMPairTransferFailed.selector, address(reentrantToken), bob, 1)
+            );
+            reentrantPair.swap(1, 0, bob, "");
+        } else {
+            VM.expectRevert(
+                abi.encodeWithSelector(AMMPair.AMMPairTransferFailed.selector, address(reentrantToken), bob, 1)
+            );
+            reentrantPair.swap(0, 1, bob, "");
+        }
     }
 }

--- a/test/AMMPairCore.t.sol
+++ b/test/AMMPairCore.t.sol
@@ -1,0 +1,303 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {AMMPair} from "../src/amm/AMMPair.sol";
+import {
+    AMMFactoryHarness,
+    AMMPairCoreFixture,
+    FalseReturningAMMToken,
+    MalformedAMMToken,
+    MockAMMToken,
+    ReentrantAMMToken,
+    SilentAMMToken
+} from "./helpers/AMMPairTestHarness.sol";
+
+contract AMMPairCoreTest is AMMPairCoreFixture {
+    function testInitializeOnlyFactoryOnceAndRejectsInvalidTokens() public {
+        AMMPair unauthorized = new AMMPair();
+        assertTrue(unauthorized.factory() == address(this), "unexpected constructor factory");
+
+        VM.prank(alice);
+        VM.expectRevert(AMMPair.AMMPairForbidden.selector);
+        unauthorized.initialize(address(token0), address(token1));
+
+        AMMPair zeroToken = new AMMPair();
+        VM.expectRevert(AMMPair.AMMPairZeroTokenAddress.selector);
+        zeroToken.initialize(address(0), address(token1));
+
+        AMMPair identicalToken = new AMMPair();
+        VM.expectRevert(AMMPair.AMMPairIdenticalTokens.selector);
+        identicalToken.initialize(address(token0), address(token0));
+
+        AMMPair initialized = new AMMPair();
+        initialized.initialize(address(token0), address(token1));
+        assertTrue(initialized.token0() == address(token0), "token0 mismatch");
+        assertTrue(initialized.token1() == address(token1), "token1 mismatch");
+
+        (uint112 reserve0_, uint112 reserve1_, uint32 timestampLast) = initialized.getReserves();
+        assertTrue(reserve0_ == 0, "reserve0 should start at zero");
+        assertTrue(reserve1_ == 0, "reserve1 should start at zero");
+        assertTrue(timestampLast == 0, "timestamp should start at zero");
+
+        VM.expectRevert(AMMPair.AMMPairAlreadyInitialized.selector);
+        initialized.initialize(address(token0), address(token1));
+    }
+
+    function testFirstLiquidityMintLocksMinimumLiquidityAndUpdatesReserves() public {
+        uint256 liquidity = _provideLiquidity(pair, token0, token1, alice, 10_000, 40_000, alice);
+
+        assertTrue(liquidity == 19_000, "first-liquidity mint mismatch");
+        assertTrue(pair.balanceOf(alice) == 19_000, "provider lp balance mismatch");
+        assertTrue(pair.balanceOf(BURN_SINK) == pair.MINIMUM_LIQUIDITY(), "minimum liquidity not locked");
+        assertTrue(pair.totalSupply() == 20_000, "lp total supply mismatch");
+
+        (uint112 reserve0_, uint112 reserve1_,) = pair.getReserves();
+        assertTrue(reserve0_ == 10_000, "reserve0 mismatch");
+        assertTrue(reserve1_ == 40_000, "reserve1 mismatch");
+        assertTrue(pair.kLast() == 0, "kLast should remain zero when fee switch is off");
+    }
+
+    function testLaterLiquidityMintUsesCurrentReserveRatio() public {
+        _provideLiquidity(pair, token0, token1, alice, 10_000, 10_000, alice);
+        uint256 liquidity = _provideLiquidity(pair, token0, token1, bob, 5_000, 5_000, bob);
+
+        assertTrue(liquidity == 5_000, "second liquidity mint mismatch");
+        assertTrue(pair.balanceOf(bob) == 5_000, "bob lp balance mismatch");
+
+        (uint112 reserve0_, uint112 reserve1_,) = pair.getReserves();
+        assertTrue(reserve0_ == 15_000, "reserve0 mismatch after second mint");
+        assertTrue(reserve1_ == 15_000, "reserve1 mismatch after second mint");
+    }
+
+    function testBurnRedeemsUnderlyingProRata() public {
+        _provideLiquidity(pair, token0, token1, alice, 10_000, 10_000, alice);
+
+        VM.prank(alice);
+        assertTrue(pair.transfer(address(pair), 5_000), "lp transfer to pair should succeed");
+
+        (uint256 amount0, uint256 amount1) = pair.burn(alice);
+        assertTrue(amount0 == 5_000, "burn amount0 mismatch");
+        assertTrue(amount1 == 5_000, "burn amount1 mismatch");
+        assertTrue(token0.balanceOf(alice) == 5_000, "alice token0 post-burn mismatch");
+        assertTrue(token1.balanceOf(alice) == 5_000, "alice token1 post-burn mismatch");
+
+        (uint112 reserve0_, uint112 reserve1_,) = pair.getReserves();
+        assertTrue(reserve0_ == 5_000, "reserve0 mismatch after burn");
+        assertTrue(reserve1_ == 5_000, "reserve1 mismatch after burn");
+    }
+
+    function testSwapToken1Out() public {
+        _provideLiquidity(pair, token0, token1, alice, 10_000, 10_000, alice);
+
+        token0.mint(bob, 1_000);
+        VM.prank(bob);
+        assertTrue(token0.transfer(address(pair), 1_000), "token0 input transfer should succeed");
+
+        uint256 amount1Out = _getAmountOut(1_000, 10_000, 10_000);
+        VM.prank(bob);
+        pair.swap(0, amount1Out, bob, "");
+
+        assertTrue(token1.balanceOf(bob) == amount1Out, "token1 output mismatch");
+
+        (uint112 reserve0_, uint112 reserve1_,) = pair.getReserves();
+        assertTrue(reserve0_ == 11_000, "reserve0 mismatch after token1-out swap");
+        assertTrue(reserve1_ == 10_000 - amount1Out, "reserve1 mismatch after token1-out swap");
+    }
+
+    function testSwapToken0Out() public {
+        _provideLiquidity(pair, token0, token1, alice, 10_000, 10_000, alice);
+
+        token1.mint(bob, 1_000);
+        VM.prank(bob);
+        assertTrue(token1.transfer(address(pair), 1_000), "token1 input transfer should succeed");
+
+        uint256 amount0Out = _getAmountOut(1_000, 10_000, 10_000);
+        VM.prank(bob);
+        pair.swap(amount0Out, 0, bob, "");
+
+        assertTrue(token0.balanceOf(bob) == amount0Out, "token0 output mismatch");
+
+        (uint112 reserve0_, uint112 reserve1_,) = pair.getReserves();
+        assertTrue(reserve0_ == 10_000 - amount0Out, "reserve0 mismatch after token0-out swap");
+        assertTrue(reserve1_ == 11_000, "reserve1 mismatch after token0-out swap");
+    }
+
+    function testSwapRevertsOnInsufficientLiquidity() public {
+        _provideLiquidity(pair, token0, token1, alice, 10_000, 10_000, alice);
+
+        VM.expectRevert(AMMPair.AMMPairInsufficientLiquidity.selector);
+        pair.swap(10_000, 0, bob, "");
+    }
+
+    function testSwapRevertsOnUnsupportedData() public {
+        _provideLiquidity(pair, token0, token1, alice, 10_000, 10_000, alice);
+
+        VM.expectRevert(AMMPair.AMMPairUnsupportedSwapData.selector);
+        pair.swap(0, 1, bob, hex"01");
+    }
+
+    function testSwapRevertsOnInvalidRecipient() public {
+        _provideLiquidity(pair, token0, token1, alice, 10_000, 10_000, alice);
+
+        VM.expectRevert(abi.encodeWithSelector(AMMPair.AMMPairInvalidRecipient.selector, address(token0)));
+        pair.swap(0, 1, address(token0), "");
+    }
+
+    function testSwapRevertsWhenNoInputIsProvided() public {
+        _provideLiquidity(pair, token0, token1, alice, 10_000, 10_000, alice);
+
+        VM.expectRevert(AMMPair.AMMPairInsufficientInputAmount.selector);
+        pair.swap(0, 100, bob, "");
+    }
+
+    function testSwapRevertsOnConstantProductViolation() public {
+        _provideLiquidity(pair, token0, token1, alice, 10_000, 10_000, alice);
+
+        token0.mint(bob, 1_000);
+        VM.prank(bob);
+        assertTrue(token0.transfer(address(pair), 1_000), "token0 input transfer should succeed");
+
+        uint256 invalidAmount1Out = _getAmountOut(1_000, 10_000, 10_000) + 1;
+        VM.prank(bob);
+        VM.expectRevert(AMMPair.AMMPairKInvariant.selector);
+        pair.swap(0, invalidAmount1Out, bob, "");
+    }
+
+    function testSkimTransfersOnlyExcessBalances() public {
+        _provideLiquidity(pair, token0, token1, alice, 10_000, 10_000, alice);
+
+        token0.mint(address(pair), 500);
+        token1.mint(address(pair), 700);
+
+        pair.skim(carol);
+
+        assertTrue(token0.balanceOf(carol) == 500, "skim token0 mismatch");
+        assertTrue(token1.balanceOf(carol) == 700, "skim token1 mismatch");
+
+        (uint112 reserve0_, uint112 reserve1_,) = pair.getReserves();
+        assertTrue(reserve0_ == 10_000, "skim should not change reserve0");
+        assertTrue(reserve1_ == 10_000, "skim should not change reserve1");
+    }
+
+    function testSyncUpdatesReservesToActualBalances() public {
+        _provideLiquidity(pair, token0, token1, alice, 10_000, 10_000, alice);
+
+        token0.mint(address(pair), 500);
+        token1.mint(address(pair), 700);
+
+        pair.sync();
+
+        (uint112 reserve0_, uint112 reserve1_,) = pair.getReserves();
+        assertTrue(reserve0_ == 10_500, "reserve0 mismatch after sync");
+        assertTrue(reserve1_ == 10_700, "reserve1 mismatch after sync");
+    }
+
+    function testPriceAccumulatorsAdvanceAcrossElapsedTime() public {
+        _provideLiquidity(pair, token0, token1, alice, 10_000, 20_000, alice);
+
+        VM.warp(block.timestamp + 10);
+        pair.sync();
+
+        uint256 expectedPrice0 = uint256(_uqdiv(20_000, 10_000)) * 10;
+        uint256 expectedPrice1 = uint256(_uqdiv(10_000, 20_000)) * 10;
+
+        assertTrue(pair.price0CumulativeLast() == expectedPrice0, "price0 cumulative mismatch");
+        assertTrue(pair.price1CumulativeLast() == expectedPrice1, "price1 cumulative mismatch");
+    }
+
+    function testFeeOnMintsProtocolLiquidityAndUpdatesKLast() public {
+        factory.setFeeTo(carol);
+        _provideLiquidity(pair, token0, token1, alice, 1_000_000, 1_000_000, alice);
+
+        assertTrue(pair.kLast() == 1_000_000 * 1_000_000, "initial fee-on kLast mismatch");
+
+        token0.mint(bob, 100_000);
+        VM.prank(bob);
+        assertTrue(token0.transfer(address(pair), 100_000), "token0 input transfer should succeed");
+
+        uint256 amount1Out = _getAmountOut(100_000, 1_000_000, 1_000_000);
+        VM.prank(bob);
+        pair.swap(0, amount1Out, bob, "");
+
+        (uint112 reserve0_, uint112 reserve1_,) = pair.getReserves();
+        uint256 amount0 = 11_000;
+        uint256 amount1 = (amount0 * reserve1_) / reserve0_;
+
+        token0.mint(bob, amount0);
+        token1.mint(bob, amount1);
+        VM.startPrank(bob);
+        assertTrue(token0.transfer(address(pair), amount0), "token0 top-up transfer should succeed");
+        assertTrue(token1.transfer(address(pair), amount1), "token1 top-up transfer should succeed");
+        VM.stopPrank();
+
+        pair.mint(bob);
+
+        assertTrue(pair.balanceOf(carol) > 0, "protocol fee lp should mint");
+        (reserve0_, reserve1_,) = pair.getReserves();
+        assertTrue(pair.kLast() == uint256(reserve0_) * uint256(reserve1_), "fee-on kLast mismatch");
+    }
+
+    function testFeeOffClearsKLastOnNextLiquidityEvent() public {
+        factory.setFeeTo(carol);
+        _provideLiquidity(pair, token0, token1, alice, 100_000, 100_000, alice);
+        assertTrue(pair.kLast() != 0, "kLast should be set while fee switch is on");
+
+        factory.setFeeTo(address(0));
+        _provideLiquidity(pair, token0, token1, bob, 10_000, 10_000, bob);
+
+        assertTrue(pair.kLast() == 0, "kLast should clear when fee switch is off");
+    }
+
+    function testSwapRevertsWhenOutputTokenReturnsFalse() public {
+        FalseReturningAMMToken falseToken = new FalseReturningAMMToken("False Token", "FTK", 18);
+        MockAMMToken normalToken = new MockAMMToken("Normal Token", "NTK", 18);
+        AMMFactoryHarness localFactory = new AMMFactoryHarness(address(this));
+        AMMPair falsePair = AMMPair(localFactory.createPair(address(falseToken), address(normalToken)));
+
+        _seedLiquidityDirect(falsePair, falseToken, normalToken, 10_000, 10_000, alice);
+        normalToken.mint(address(falsePair), 1_000);
+
+        VM.expectRevert(abi.encodeWithSelector(AMMPair.AMMPairTransferFailed.selector, address(falseToken), bob, 1));
+        falsePair.swap(1, 0, bob, "");
+    }
+
+    function testSwapAcceptsSilentTransferToken() public {
+        SilentAMMToken silentToken = new SilentAMMToken("Silent Token", "STK", 18);
+        MockAMMToken normalToken = new MockAMMToken("Normal Token", "NTK", 18);
+        AMMFactoryHarness localFactory = new AMMFactoryHarness(address(this));
+        AMMPair silentPair = AMMPair(localFactory.createPair(address(silentToken), address(normalToken)));
+
+        _seedLiquidityDirect(silentPair, silentToken, normalToken, 10_000, 10_000, alice);
+        normalToken.mint(address(silentPair), 1_000);
+
+        silentPair.swap(1, 0, bob, "");
+        assertTrue(silentToken.balanceOf(bob) == 1, "silent transfer output mismatch");
+    }
+
+    function testSwapRevertsWhenOutputTokenReturnsMalformedData() public {
+        MalformedAMMToken malformedToken = new MalformedAMMToken("Malformed Token", "MTK", 18);
+        MockAMMToken normalToken = new MockAMMToken("Normal Token", "NTK", 18);
+        AMMFactoryHarness localFactory = new AMMFactoryHarness(address(this));
+        AMMPair malformedPair = AMMPair(localFactory.createPair(address(malformedToken), address(normalToken)));
+
+        _seedLiquidityDirect(malformedPair, malformedToken, normalToken, 10_000, 10_000, alice);
+        normalToken.mint(address(malformedPair), 1_000);
+
+        VM.expectRevert(abi.encodeWithSelector(AMMPair.AMMPairTransferFailed.selector, address(malformedToken), bob, 1));
+        malformedPair.swap(1, 0, bob, "");
+    }
+
+    function testSwapRevertsWhenOutputTransferAttemptsReentrancy() public {
+        ReentrantAMMToken reentrantToken = new ReentrantAMMToken("Reentrant Token", "RTK", 18);
+        MockAMMToken normalToken = new MockAMMToken("Normal Token", "NTK", 18);
+        AMMFactoryHarness localFactory = new AMMFactoryHarness(address(this));
+        AMMPair reentrantPair = AMMPair(localFactory.createPair(address(reentrantToken), address(normalToken)));
+
+        _seedLiquidityDirect(reentrantPair, reentrantToken, normalToken, 10_000, 10_000, alice);
+        normalToken.mint(address(reentrantPair), 1_000);
+        reentrantToken.setReenterSync(address(reentrantPair), true);
+
+        VM.expectRevert(abi.encodeWithSelector(AMMPair.AMMPairTransferFailed.selector, address(reentrantToken), bob, 1));
+        reentrantPair.swap(1, 0, bob, "");
+    }
+}

--- a/test/AMMPairFuzz.t.sol
+++ b/test/AMMPairFuzz.t.sol
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {AMMPair} from "../src/amm/AMMPair.sol";
+import {MockAMMToken} from "./helpers/AMMPairTestHarness.sol";
+import {AMMPairCoreFixture} from "./helpers/AMMPairTestHarness.sol";
+
+contract AMMPairFuzzTest is AMMPairCoreFixture {
+    function testFuzzFirstMintLocksMinimumLiquidity(uint96 amount0Raw, uint96 amount1Raw) public {
+        AMMPair localPair = _deployPair(address(token0), address(token1));
+        uint256 amount0 = _boundAmount(amount0Raw, 1_000_000);
+        uint256 amount1 = _boundAmount(amount1Raw, 1_000_000);
+        uint256 rootK = _mathSqrt(amount0 * amount1);
+        if (rootK <= localPair.MINIMUM_LIQUIDITY()) {
+            return;
+        }
+
+        uint256 liquidity = _provideLiquidity(localPair, token0, token1, alice, amount0, amount1, alice);
+
+        assertTrue(liquidity == rootK - localPair.MINIMUM_LIQUIDITY(), "first mint liquidity mismatch");
+        assertTrue(localPair.balanceOf(BURN_SINK) == localPair.MINIMUM_LIQUIDITY(), "minimum liquidity sink mismatch");
+        assertTrue(localPair.balanceOf(alice) == liquidity, "provider lp balance mismatch");
+    }
+
+    function testFuzzLaterMintFollowsReserveRatio(uint96 firstAmount0Raw, uint96 secondAmount0Raw) public {
+        AMMPair localPair = _deployPair(address(token0), address(token1));
+        uint256 firstAmount0 = _boundAmount(firstAmount0Raw, 1_000_000);
+        uint256 firstAmount1 = firstAmount0 * 2;
+        uint256 rootK = _mathSqrt(firstAmount0 * firstAmount1);
+        if (rootK <= localPair.MINIMUM_LIQUIDITY()) {
+            return;
+        }
+
+        _provideLiquidity(localPair, token0, token1, alice, firstAmount0, firstAmount1, alice);
+
+        uint256 secondAmount0 = _boundAmount(secondAmount0Raw, 500_000);
+        uint256 secondAmount1 = secondAmount0 * 2;
+        uint256 totalSupplyBefore = localPair.totalSupply();
+        (uint112 reserve0Before, uint112 reserve1Before,) = localPair.getReserves();
+
+        uint256 liquidity = _provideLiquidity(localPair, token0, token1, bob, secondAmount0, secondAmount1, bob);
+        uint256 expectedLiquidity = _mathMin(
+            (secondAmount0 * totalSupplyBefore) / reserve0Before, (secondAmount1 * totalSupplyBefore) / reserve1Before
+        );
+
+        assertTrue(liquidity == expectedLiquidity, "later mint liquidity mismatch");
+    }
+
+    function testFuzzBurnRedeemsProRata(uint96 amount0Raw, uint96 burnRaw) public {
+        AMMPair localPair = _deployPair(address(token0), address(token1));
+        uint256 amount0 = _boundAmount(amount0Raw, 1_000_000);
+        uint256 amount1 = amount0;
+        uint256 rootK = _mathSqrt(amount0 * amount1);
+        if (rootK <= localPair.MINIMUM_LIQUIDITY()) {
+            return;
+        }
+
+        _provideLiquidity(localPair, token0, token1, alice, amount0, amount1, alice);
+
+        uint256 burnLiquidity = _boundAmount(burnRaw, localPair.balanceOf(alice));
+        uint256 totalSupplyBefore = localPair.totalSupply();
+        (uint112 reserve0Before, uint112 reserve1Before,) = localPair.getReserves();
+        uint256 expectedAmount0 = (burnLiquidity * reserve0Before) / totalSupplyBefore;
+        uint256 expectedAmount1 = (burnLiquidity * reserve1Before) / totalSupplyBefore;
+
+        VM.prank(alice);
+        localPair.transfer(address(localPair), burnLiquidity);
+
+        (uint256 amount0Out, uint256 amount1Out) = localPair.burn(alice);
+
+        assertTrue(amount0Out == expectedAmount0, "burn amount0 mismatch");
+        assertTrue(amount1Out == expectedAmount1, "burn amount1 mismatch");
+    }
+
+    function testFuzzSwapRespectsQuotedOutput(uint96 amountInRaw) public {
+        _provideLiquidity(pair, token0, token1, alice, 500_000, 500_000, alice);
+
+        uint256 amountIn = _boundAmount(amountInRaw, 100_000);
+        uint256 expectedAmountOut = _getAmountOut(amountIn, 500_000, 500_000);
+        if (expectedAmountOut == 0) {
+            return;
+        }
+
+        token0.mint(bob, amountIn);
+        VM.prank(bob);
+        token0.transfer(address(pair), amountIn);
+
+        VM.prank(bob);
+        pair.swap(0, expectedAmountOut, bob, "");
+
+        (uint112 reserve0After, uint112 reserve1After,) = pair.getReserves();
+        assertTrue(reserve0After == 500_000 + amountIn, "reserve0 mismatch after swap");
+        assertTrue(reserve1After == 500_000 - expectedAmountOut, "reserve1 mismatch after swap");
+        assertTrue(token1.balanceOf(bob) == expectedAmountOut, "quoted output mismatch");
+    }
+
+    function testFuzzSkimAndSyncHandleExcessBalances(uint96 excess0Raw, uint96 excess1Raw) public {
+        _provideLiquidity(pair, token0, token1, alice, 250_000, 250_000, alice);
+
+        uint256 excess0 = _boundAmount(excess0Raw, 100_000);
+        uint256 excess1 = _boundAmount(excess1Raw, 100_000);
+        token0.mint(address(pair), excess0);
+        token1.mint(address(pair), excess1);
+
+        pair.skim(carol);
+        assertTrue(token0.balanceOf(carol) == excess0, "skimmed token0 mismatch");
+        assertTrue(token1.balanceOf(carol) == excess1, "skimmed token1 mismatch");
+
+        token0.mint(address(pair), excess0);
+        token1.mint(address(pair), excess1);
+        pair.sync();
+
+        (uint112 reserve0After, uint112 reserve1After,) = pair.getReserves();
+        assertTrue(reserve0After == 250_000 + excess0, "synced reserve0 mismatch");
+        assertTrue(reserve1After == 250_000 + excess1, "synced reserve1 mismatch");
+    }
+
+    function _boundAmount(uint256 raw, uint256 max) internal pure returns (uint256 amount) {
+        if (max == 0) {
+            return 0;
+        }
+
+        amount = (raw % max) + 1;
+    }
+}

--- a/test/AMMRouterCore.t.sol
+++ b/test/AMMRouterCore.t.sol
@@ -1,0 +1,441 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {AMMRouter} from "../src/amm/AMMRouter.sol";
+import {AMMPair} from "../src/amm/AMMPair.sol";
+import {AMMRouterFixture, MockWrappedNative, RejectingNativeReceiver} from "./helpers/AMMRouterTestHarness.sol";
+import {FalseReturningAMMToken, MockAMMToken} from "./helpers/AMMPairTestHarness.sol";
+
+contract AMMRouterCoreTest is AMMRouterFixture {
+    function testConstructorSetsFactoryAndWrappedNativeAndRejectsZeroAddresses() public view {
+        assertTrue(router.factory() == address(factory), "factory mismatch");
+        assertTrue(router.wrappedNative() == address(wrappedNativeToken), "wrapped native mismatch");
+    }
+
+    function testConstructorRevertsForZeroAddresses() public {
+        VM.expectRevert(AMMRouter.AMMRouterZeroAddress.selector);
+        new AMMRouter(address(0), address(wrappedNativeToken));
+
+        VM.expectRevert(AMMRouter.AMMRouterZeroAddress.selector);
+        new AMMRouter(address(factory), address(0));
+    }
+
+    function testQuoteMathAndPathTraversalHelpersMatchExpectedValues() public {
+        _provideRouterLiquidity(token0, token1, alice, 10_000, 20_000, alice);
+        _provideRouterLiquidity(token1, token2, alice, 20_000, 10_000, alice);
+
+        assertTrue(router.quote(500, 10_000, 20_000) == 1_000, "quote mismatch");
+
+        uint256 expectedHopOneOut = _getAmountOut(1_000, 10_000, 20_000);
+        uint256 expectedHopTwoOut = _getAmountOut(expectedHopOneOut, 20_000, 10_000);
+        uint256[] memory amountsOut =
+            router.getAmountsOut(1_000, _path(address(token0), address(token1), address(token2)));
+        assertTrue(amountsOut[0] == 1_000, "amountsOut input mismatch");
+        assertTrue(amountsOut[1] == expectedHopOneOut, "amountsOut first hop mismatch");
+        assertTrue(amountsOut[2] == expectedHopTwoOut, "amountsOut second hop mismatch");
+
+        uint256 expectedHopTwoIn = router.getAmountIn(700, 20_000, 10_000);
+        uint256 expectedHopOneIn = router.getAmountIn(expectedHopTwoIn, 10_000, 20_000);
+        uint256[] memory amountsIn = router.getAmountsIn(700, _path(address(token0), address(token1), address(token2)));
+        assertTrue(amountsIn[0] == expectedHopOneIn, "amountsIn first hop mismatch");
+        assertTrue(amountsIn[1] == expectedHopTwoIn, "amountsIn second hop mismatch");
+        assertTrue(amountsIn[2] == 700, "amountsIn output mismatch");
+    }
+
+    function testAddLiquidityCreatesPairAndMintsLpToRecipient() public {
+        MockAMMToken unsortedA = new MockAMMToken("Token A", "TKA", 18);
+        MockAMMToken unsortedB = new MockAMMToken("Token B", "TKB", 18);
+        unsortedA.mint(alice, 10_000);
+        unsortedB.mint(alice, 20_000);
+
+        VM.startPrank(alice);
+        assertTrue(unsortedA.approve(address(router), 10_000), "approve tokenA should succeed");
+        assertTrue(unsortedB.approve(address(router), 20_000), "approve tokenB should succeed");
+        (uint256 amountA, uint256 amountB, uint256 liquidity) =
+            router.addLiquidity(address(unsortedB), address(unsortedA), 20_000, 10_000, 20_000, 10_000, alice, DEADLINE);
+        VM.stopPrank();
+
+        address pairAddress = factory.getPair(address(unsortedA), address(unsortedB));
+        assertTrue(pairAddress != address(0), "pair should be created");
+        assertTrue(amountA == 20_000, "amountA mismatch");
+        assertTrue(amountB == 10_000, "amountB mismatch");
+        assertTrue(liquidity == 13_142, "liquidity mismatch");
+
+        AMMPair createdPair = AMMPair(pairAddress);
+        assertTrue(createdPair.balanceOf(alice) == liquidity, "lp balance mismatch");
+
+        (uint112 reserve0_, uint112 reserve1_,) = createdPair.getReserves();
+        (uint112 expectedReserve0, uint112 expectedReserve1) = address(unsortedA) < address(unsortedB)
+            ? (uint112(10_000), uint112(20_000))
+            : (uint112(20_000), uint112(10_000));
+        assertTrue(reserve0_ == expectedReserve0, "reserve0 mismatch");
+        assertTrue(reserve1_ == expectedReserve1, "reserve1 mismatch");
+    }
+
+    function testAddLiquidityUsesOptimalExistingRatioAndLeavesUnusedBalanceWithCaller() public {
+        _provideRouterLiquidity(token0, token1, alice, 10_000, 20_000, alice);
+
+        token0.mint(bob, 5_000);
+        token1.mint(bob, 20_000);
+
+        VM.startPrank(bob);
+        assertTrue(token0.approve(address(router), 5_000), "approve token0 should succeed");
+        assertTrue(token1.approve(address(router), 20_000), "approve token1 should succeed");
+        (uint256 amountA, uint256 amountB,) =
+            router.addLiquidity(address(token1), address(token0), 20_000, 5_000, 10_000, 5_000, bob, DEADLINE);
+        VM.stopPrank();
+
+        assertTrue(amountA == 10_000, "token1 amount mismatch");
+        assertTrue(amountB == 5_000, "token0 amount mismatch");
+        assertTrue(token1.balanceOf(bob) == 10_000, "unused token1 should remain with caller");
+
+        (uint112 reserve0_, uint112 reserve1_,) = pair.getReserves();
+        assertTrue(reserve0_ == 15_000, "reserve0 mismatch after add");
+        assertTrue(reserve1_ == 30_000, "reserve1 mismatch after add");
+    }
+
+    function testAddLiquidityRevertsWhenSlippageBoundsAreTooTight() public {
+        _provideRouterLiquidity(token0, token1, alice, 10_000, 20_000, alice);
+
+        token0.mint(bob, 5_000);
+        token1.mint(bob, 20_000);
+
+        VM.startPrank(bob);
+        assertTrue(token0.approve(address(router), 5_000), "approve token0 should succeed");
+        assertTrue(token1.approve(address(router), 20_000), "approve token1 should succeed");
+        VM.expectRevert(abi.encodeWithSelector(AMMRouter.AMMRouterInsufficientAAmount.selector, 10_000, 10_001));
+        router.addLiquidity(address(token1), address(token0), 20_000, 5_000, 10_001, 5_000, bob, DEADLINE);
+        VM.stopPrank();
+    }
+
+    function testAddLiquidityNativeWrapsOnlyUsedAmountAndRefundsExcessNative() public {
+        _provideRouterLiquidity(token0, wrappedNativeToken, alice, 10_000, 20_000, alice);
+
+        token0.mint(bob, 5_000);
+        VM.deal(bob, 50_000);
+
+        uint256 bobBalanceBefore = bob.balance;
+        VM.startPrank(bob);
+        assertTrue(token0.approve(address(router), 5_000), "approve token0 should succeed");
+        (uint256 amountToken, uint256 amountNative,) =
+            router.addLiquidityNative{value: 20_000}(address(token0), 5_000, 5_000, 10_000, bob, DEADLINE);
+        VM.stopPrank();
+
+        assertTrue(amountToken == 5_000, "token amount mismatch");
+        assertTrue(amountNative == 10_000, "native amount mismatch");
+        assertTrue(bob.balance == bobBalanceBefore - 10_000, "native refund mismatch");
+        assertTrue(address(router).balance == 0, "router should not retain native balance");
+        assertTrue(wrappedNativeToken.balanceOf(address(router)) == 0, "router should not retain wrapped native");
+
+        AMMPair nativePair = AMMPair(factory.getPair(address(token0), address(wrappedNativeToken)));
+        (uint112 reserve0_, uint112 reserve1_,) = nativePair.getReserves();
+        (uint112 expectedReserve0, uint112 expectedReserve1) = address(token0) < address(wrappedNativeToken)
+            ? (uint112(15_000), uint112(30_000))
+            : (uint112(30_000), uint112(15_000));
+        assertTrue(reserve0_ == expectedReserve0, "native reserve0 mismatch");
+        assertTrue(reserve1_ == expectedReserve1, "native reserve1 mismatch");
+    }
+
+    function testRemoveLiquidityReturnsAlignedAmountsForCallerTokenOrder() public {
+        _provideRouterLiquidity(token0, token1, alice, 10_000, 20_000, alice);
+
+        uint256 burnLiquidity = pair.balanceOf(alice) / 2;
+        uint256 totalSupplyBefore = pair.totalSupply();
+        (uint112 reserve0Before, uint112 reserve1Before,) = pair.getReserves();
+        uint256 expectedToken0 = (burnLiquidity * reserve0Before) / totalSupplyBefore;
+        uint256 expectedToken1 = (burnLiquidity * reserve1Before) / totalSupplyBefore;
+
+        VM.prank(alice);
+        assertTrue(pair.approve(address(router), burnLiquidity), "approve lp should succeed");
+
+        VM.prank(alice);
+        (uint256 amountToken1, uint256 amountToken0) =
+            router.removeLiquidity(address(token1), address(token0), burnLiquidity, 0, 0, bob, DEADLINE);
+
+        assertTrue(amountToken1 == expectedToken1, "token1 amount mismatch");
+        assertTrue(amountToken0 == expectedToken0, "token0 amount mismatch");
+        assertTrue(token1.balanceOf(bob) == expectedToken1, "bob token1 balance mismatch");
+        assertTrue(token0.balanceOf(bob) == expectedToken0, "bob token0 balance mismatch");
+    }
+
+    function testRemoveLiquidityWithPermitUsesLpPermitApproval() public {
+        _provideRouterLiquidity(token0, token1, alice, 10_000, 10_000, alice);
+
+        uint256 liquidity = pair.balanceOf(alice) / 2;
+        uint256 deadline = block.timestamp + 1 days;
+        (uint8 v, bytes32 r, bytes32 s) =
+            _signPermit(ALICE_PK, address(pair), alice, address(router), liquidity, 0, deadline);
+
+        uint256 aliceToken0Before = token0.balanceOf(alice);
+        uint256 aliceToken1Before = token1.balanceOf(alice);
+
+        VM.prank(alice);
+        (uint256 amount0, uint256 amount1) = _removeLiquidityWithPermit(liquidity, alice, deadline, v, r, s);
+
+        assertTrue(pair.nonces(alice) == 1, "permit nonce mismatch");
+        assertTrue(token0.balanceOf(alice) == aliceToken0Before + amount0, "alice token0 delta mismatch");
+        assertTrue(token1.balanceOf(alice) == aliceToken1Before + amount1, "alice token1 delta mismatch");
+    }
+
+    function testRemoveLiquidityNativeWithPermitUnwrapsAndTransfersNative() public {
+        AMMPair nativePair = AMMPair(factory.createPair(address(token0), address(wrappedNativeToken)));
+        _provideRouterLiquidity(token0, wrappedNativeToken, alice, 10_000, 10_000, alice);
+
+        uint256 liquidity = nativePair.balanceOf(alice) / 2;
+        uint256 deadline = block.timestamp + 1 days;
+        (uint8 v, bytes32 r, bytes32 s) =
+            _signPermit(ALICE_PK, address(nativePair), alice, address(router), liquidity, 0, deadline);
+
+        uint256 bobNativeBefore = bob.balance;
+        uint256 bobTokenBefore = token0.balanceOf(bob);
+
+        VM.prank(alice);
+        (uint256 amountToken, uint256 amountNative) =
+            _removeLiquidityNativeWithPermit(liquidity, bob, deadline, v, r, s);
+
+        assertTrue(nativePair.nonces(alice) == 1, "native permit nonce mismatch");
+        assertTrue(token0.balanceOf(bob) == bobTokenBefore + amountToken, "token payout mismatch");
+        assertTrue(bob.balance == bobNativeBefore + amountNative, "native payout mismatch");
+        assertTrue(address(router).balance == 0, "router should not retain native balance");
+    }
+
+    function testSwapExactTokensForTokensRoutesSingleHop() public {
+        _provideRouterLiquidity(token0, token1, alice, 10_000, 10_000, alice);
+
+        token0.mint(bob, 1_000);
+        uint256 expectedAmountOut = router.getAmountOut(1_000, 10_000, 10_000);
+
+        VM.startPrank(bob);
+        assertTrue(token0.approve(address(router), 1_000), "approve token0 should succeed");
+        uint256[] memory amounts = router.swapExactTokensForTokens(
+            1_000, expectedAmountOut, _path(address(token0), address(token1)), bob, DEADLINE
+        );
+        VM.stopPrank();
+
+        assertTrue(amounts[0] == 1_000, "amounts input mismatch");
+        assertTrue(amounts[1] == expectedAmountOut, "amounts output mismatch");
+        assertTrue(token1.balanceOf(bob) == expectedAmountOut, "bob token1 output mismatch");
+    }
+
+    function testSwapTokensForExactTokensRoutesMultiHop() public {
+        _provideRouterLiquidity(token0, token1, alice, 10_000, 20_000, alice);
+        _provideRouterLiquidity(token1, token2, alice, 20_000, 10_000, alice);
+
+        uint256 amountOut = 700;
+        uint256[] memory expectedAmounts =
+            router.getAmountsIn(amountOut, _path(address(token0), address(token1), address(token2)));
+        token0.mint(bob, expectedAmounts[0]);
+
+        VM.startPrank(bob);
+        assertTrue(token0.approve(address(router), expectedAmounts[0]), "approve token0 should succeed");
+        uint256[] memory amounts = router.swapTokensForExactTokens(
+            amountOut, expectedAmounts[0], _path(address(token0), address(token1), address(token2)), bob, DEADLINE
+        );
+        VM.stopPrank();
+
+        assertTrue(amounts[0] == expectedAmounts[0], "required input mismatch");
+        assertTrue(amounts[2] == amountOut, "exact output mismatch");
+        assertTrue(token2.balanceOf(bob) == amountOut, "bob token2 output mismatch");
+    }
+
+    function testSwapExactNativeForTokensWrapsInputAndRoutesOutput() public {
+        _provideRouterLiquidity(wrappedNativeToken, token0, alice, 10_000, 10_000, alice);
+
+        VM.deal(bob, 5_000);
+        uint256 expectedAmountOut = router.getAmountOut(1_000, 10_000, 10_000);
+
+        VM.prank(bob);
+        uint256[] memory amounts = router.swapExactNativeForTokens{value: 1_000}(
+            expectedAmountOut, _path(address(wrappedNativeToken), address(token0)), bob, DEADLINE
+        );
+
+        assertTrue(amounts[0] == 1_000, "native input mismatch");
+        assertTrue(amounts[1] == expectedAmountOut, "token output mismatch");
+        assertTrue(token0.balanceOf(bob) == expectedAmountOut, "bob token output mismatch");
+        assertTrue(address(router).balance == 0, "router should not retain native balance");
+    }
+
+    function testSwapNativeForExactTokensRefundsExcessValue() public {
+        _provideRouterLiquidity(wrappedNativeToken, token0, alice, 10_000, 10_000, alice);
+
+        uint256[] memory expectedAmounts = router.getAmountsIn(700, _path(address(wrappedNativeToken), address(token0)));
+        VM.deal(bob, expectedAmounts[0] + 500);
+        uint256 bobNativeBefore = bob.balance;
+
+        VM.prank(bob);
+        uint256[] memory amounts = router.swapNativeForExactTokens{value: expectedAmounts[0] + 500}(
+            700, _path(address(wrappedNativeToken), address(token0)), bob, DEADLINE
+        );
+
+        assertTrue(amounts[0] == expectedAmounts[0], "required native mismatch");
+        assertTrue(token0.balanceOf(bob) == 700, "bob token output mismatch");
+        assertTrue(bob.balance == bobNativeBefore - expectedAmounts[0], "native refund mismatch");
+    }
+
+    function testSwapExactTokensForNativeUnwrapsAndTransfersNative() public {
+        _provideRouterLiquidity(token0, wrappedNativeToken, alice, 10_000, 10_000, alice);
+
+        token0.mint(bob, 1_000);
+        uint256 expectedNativeOut = router.getAmountOut(1_000, 10_000, 10_000);
+        uint256 bobNativeBefore = bob.balance;
+
+        VM.startPrank(bob);
+        assertTrue(token0.approve(address(router), 1_000), "approve token0 should succeed");
+        uint256[] memory amounts = router.swapExactTokensForNative(
+            1_000, expectedNativeOut, _path(address(token0), address(wrappedNativeToken)), bob, DEADLINE
+        );
+        VM.stopPrank();
+
+        assertTrue(amounts[1] == expectedNativeOut, "native output mismatch");
+        assertTrue(bob.balance == bobNativeBefore + expectedNativeOut, "bob native payout mismatch");
+        assertTrue(address(router).balance == 0, "router should not retain native balance");
+    }
+
+    function testSwapTokensForExactNativeUsesExactInputAndTransfersNative() public {
+        _provideRouterLiquidity(token0, wrappedNativeToken, alice, 10_000, 10_000, alice);
+
+        uint256[] memory expectedAmounts = router.getAmountsIn(700, _path(address(token0), address(wrappedNativeToken)));
+        token0.mint(bob, expectedAmounts[0]);
+        uint256 bobNativeBefore = bob.balance;
+
+        VM.startPrank(bob);
+        assertTrue(token0.approve(address(router), expectedAmounts[0]), "approve token0 should succeed");
+        uint256[] memory amounts = router.swapTokensForExactNative(
+            700, expectedAmounts[0], _path(address(token0), address(wrappedNativeToken)), bob, DEADLINE
+        );
+        VM.stopPrank();
+
+        assertTrue(amounts[0] == expectedAmounts[0], "exact input mismatch");
+        assertTrue(amounts[1] == 700, "native amount mismatch");
+        assertTrue(bob.balance == bobNativeBefore + 700, "native payout mismatch");
+    }
+
+    function testGetAmountsOutRevertsForMissingPairAndInvalidPath() public {
+        address[] memory invalidPath = new address[](1);
+        invalidPath[0] = address(token0);
+        VM.expectRevert(AMMRouter.AMMRouterInvalidPath.selector);
+        router.getAmountsOut(1, invalidPath);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(AMMRouter.AMMRouterPairUnavailable.selector, address(token0), address(token2))
+        );
+        router.getAmountsOut(1, _path(address(token0), address(token2)));
+    }
+
+    function testNativeHelpersRevertForInvalidWrappedNativePath() public {
+        VM.deal(bob, 1_000);
+        VM.prank(bob);
+        VM.expectRevert(AMMRouter.AMMRouterInvalidWrappedNativePath.selector);
+        router.swapExactNativeForTokens{value: 1_000}(0, _path(address(token0), address(token1)), bob, DEADLINE);
+
+        token0.mint(bob, 1_000);
+        VM.startPrank(bob);
+        assertTrue(token0.approve(address(router), 1_000), "approve token0 should succeed");
+        VM.expectRevert(AMMRouter.AMMRouterInvalidWrappedNativePath.selector);
+        router.swapExactTokensForNative(1_000, 0, _path(address(token0), address(token1)), bob, DEADLINE);
+        VM.stopPrank();
+    }
+
+    function testSwapsRevertForSlippageAndMaxInputBounds() public {
+        _provideRouterLiquidity(token0, token1, alice, 10_000, 10_000, alice);
+
+        token0.mint(bob, 1_000);
+        uint256 expectedAmountOut = router.getAmountOut(1_000, 10_000, 10_000);
+        VM.startPrank(bob);
+        assertTrue(token0.approve(address(router), 1_000), "approve token0 should succeed");
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                AMMRouter.AMMRouterInsufficientOutputAmount.selector, expectedAmountOut, expectedAmountOut + 1
+            )
+        );
+        router.swapExactTokensForTokens(
+            1_000, expectedAmountOut + 1, _path(address(token0), address(token1)), bob, DEADLINE
+        );
+        VM.stopPrank();
+
+        uint256[] memory expectedAmounts = router.getAmountsIn(700, _path(address(token0), address(token1)));
+        token0.mint(bob, expectedAmounts[0]);
+        VM.startPrank(bob);
+        assertTrue(token0.approve(address(router), expectedAmounts[0]), "approve token0 should succeed");
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                AMMRouter.AMMRouterExcessiveInputAmount.selector, expectedAmounts[0], expectedAmounts[0] - 1
+            )
+        );
+        router.swapTokensForExactTokens(
+            700, expectedAmounts[0] - 1, _path(address(token0), address(token1)), bob, DEADLINE
+        );
+        VM.stopPrank();
+    }
+
+    function testAddLiquidityRevertsWhenTransferFromFails() public {
+        FalseReturningAMMToken falseToken = _deployFalseReturningToken();
+        address pairAddress = factory.createPair(address(falseToken), address(token1));
+        token1.mint(bob, 10_000);
+        falseToken.mint(bob, 10_000);
+
+        VM.startPrank(bob);
+        assertTrue(token1.approve(address(router), 10_000), "approve token1 should succeed");
+        assertTrue(falseToken.approve(address(router), 10_000), "approve false token should succeed");
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                AMMRouter.AMMRouterTransferFromFailed.selector, address(falseToken), bob, pairAddress, 10_000
+            )
+        );
+        router.addLiquidity(address(falseToken), address(token1), 10_000, 10_000, 0, 0, bob, DEADLINE);
+        VM.stopPrank();
+    }
+
+    function testRouterRejectsDirectNativeTransfersAndNativeRecipientsThatRevert() public {
+        VM.deal(address(this), 1);
+        (bool success, bytes memory returndata) = address(router).call{value: 1}("");
+        assertFalse(success, "direct native transfer should fail");
+
+        bytes4 revertSelector;
+        assembly {
+            revertSelector := mload(add(returndata, 0x20))
+        }
+        assertTrue(revertSelector == AMMRouter.AMMRouterInvalidNativeSender.selector, "unexpected direct native revert");
+
+        _provideRouterLiquidity(token0, wrappedNativeToken, alice, 10_000, 10_000, alice);
+        RejectingNativeReceiver rejectingReceiver = new RejectingNativeReceiver();
+
+        token0.mint(bob, 1_000);
+        VM.startPrank(bob);
+        assertTrue(token0.approve(address(router), 1_000), "approve token0 should succeed");
+        uint256 expectedNativeOut = router.getAmountOut(1_000, 10_000, 10_000);
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                AMMRouter.AMMRouterNativeTransferFailed.selector, address(rejectingReceiver), expectedNativeOut
+            )
+        );
+        router.swapExactTokensForNative(
+            1_000,
+            expectedNativeOut,
+            _path(address(token0), address(wrappedNativeToken)),
+            address(rejectingReceiver),
+            DEADLINE
+        );
+        VM.stopPrank();
+    }
+
+    function _removeLiquidityWithPermit(uint256 liquidity, address to, uint256 deadline, uint8 v, bytes32 r, bytes32 s)
+        internal
+        returns (uint256 amount0, uint256 amount1)
+    {
+        return router.removeLiquidityWithPermit(
+            address(token0), address(token1), liquidity, 0, 0, to, deadline, false, v, r, s
+        );
+    }
+
+    function _removeLiquidityNativeWithPermit(
+        uint256 liquidity,
+        address to,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) internal returns (uint256 amountToken, uint256 amountNative) {
+        return router.removeLiquidityNativeWithPermit(address(token0), liquidity, 0, 0, to, deadline, false, v, r, s);
+    }
+}

--- a/test/AMMRouterFuzz.t.sol
+++ b/test/AMMRouterFuzz.t.sol
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {AMMPair} from "../src/amm/AMMPair.sol";
+import {AMMHardeningFixture} from "./helpers/AMMHardeningTestHarness.sol";
+import {MockAMMToken} from "./helpers/AMMPairTestHarness.sol";
+
+contract AMMRouterFuzzTest is AMMHardeningFixture {
+    function testFuzzQuoteHelpersRemainInternallyConsistent(uint8 pathSeed, uint96 amountInRaw) public view {
+        address[] memory path_ = _tokenSwapPath(pathSeed);
+        (uint256 reserveIn,) = _getAlignedReserves(path_[0], path_[1]);
+        uint256 maxAmountIn = reserveIn / 8;
+        uint256 amountIn = _boundAmount(amountInRaw, maxAmountIn);
+        if (amountIn == 0) {
+            return;
+        }
+
+        uint256[] memory amountsOut;
+        try router.getAmountsOut(amountIn, path_) returns (uint256[] memory quotedAmounts) {
+            amountsOut = quotedAmounts;
+        } catch {
+            return;
+        }
+
+        uint256[] memory amountsIn;
+        try router.getAmountsIn(amountsOut[amountsOut.length - 1], path_) returns (uint256[] memory requiredAmounts) {
+            amountsIn = requiredAmounts;
+        } catch {
+            return;
+        }
+
+        assertTrue(amountsOut[0] == amountIn, "amountsOut input mismatch");
+        assertTrue(amountsIn[amountsIn.length - 1] == amountsOut[amountsOut.length - 1], "terminal amount mismatch");
+        assertTrue(amountsIn[0] <= amountIn, "reverse quote should not exceed original input");
+    }
+
+    function testFuzzAddAndRemoveLiquidityPreserveTokenOrderAlignment(uint96 desiredRaw) public {
+        address provider = bob;
+        uint256 desiredAmount = _boundAmount(desiredRaw, 100_000);
+        uint256 bobToken0Before = token0.balanceOf(provider);
+        uint256 bobToken1Before = token1.balanceOf(provider);
+
+        VM.prank(provider);
+        (,, uint256 liquidity) = router.addLiquidity(
+            address(token1), address(token0), desiredAmount, desiredAmount, 0, 0, provider, DEADLINE
+        );
+
+        uint256 removeLiquidityAmount = liquidity / 2;
+        if (removeLiquidityAmount == 0) {
+            return;
+        }
+
+        VM.prank(provider);
+        (uint256 amountToken1, uint256 amountToken0) =
+            router.removeLiquidity(address(token1), address(token0), removeLiquidityAmount, 0, 0, provider, DEADLINE);
+
+        _recordLiquidityEvent(address(pair01));
+        assertTrue(amountToken1 != 0, "token1 removal amount should be nonzero");
+        assertTrue(amountToken0 != 0, "token0 removal amount should be nonzero");
+        assertTrue(token0.balanceOf(provider) >= bobToken0Before - desiredAmount, "token0 balance regression");
+        assertTrue(token1.balanceOf(provider) >= bobToken1Before - desiredAmount, "token1 balance regression");
+        _assertRouterZeroBalances();
+    }
+
+    function testFuzzExactInSwapRoutesAcrossTrackedPaths(uint8 actorSeed, uint8 pathSeed, uint96 amountInRaw) public {
+        address trader = _actor(actorSeed);
+        address[] memory path_ = _tokenSwapPath(pathSeed);
+        uint256 maxAmountIn = MockAMMToken(path_[0]).balanceOf(trader) / 8;
+        uint256 amountIn = _boundAmount(amountInRaw, maxAmountIn);
+        if (amountIn == 0) {
+            return;
+        }
+
+        uint256[] memory quotedAmounts;
+        try router.getAmountsOut(amountIn, path_) returns (uint256[] memory pathAmounts) {
+            quotedAmounts = pathAmounts;
+        } catch {
+            return;
+        }
+
+        uint256 expectedAmountOut = quotedAmounts[path_.length - 1];
+        if (expectedAmountOut == 0) {
+            return;
+        }
+        uint256 recipientBalanceBefore = MockAMMToken(path_[path_.length - 1]).balanceOf(trader);
+
+        VM.prank(trader);
+        uint256[] memory amounts = router.swapExactTokensForTokens(amountIn, expectedAmountOut, path_, trader, DEADLINE);
+
+        assertTrue(amounts[0] == amountIn, "swap input mismatch");
+        assertTrue(amounts[amounts.length - 1] == expectedAmountOut, "swap output mismatch");
+        assertTrue(
+            MockAMMToken(path_[path_.length - 1]).balanceOf(trader) == recipientBalanceBefore + expectedAmountOut,
+            "recipient output delta mismatch"
+        );
+        _assertRouterZeroBalances();
+    }
+
+    function testFuzzExactOutSwapHonorsMaximumInput(uint8 actorSeed, uint8 pathSeed, uint96 amountOutRaw) public {
+        address trader = _actor(actorSeed);
+        address[] memory path_ = _tokenSwapPath(pathSeed);
+        (, uint256 reserveOut) = _getAlignedReserves(path_[path_.length - 2], path_[path_.length - 1]);
+        uint256 amountOut = _boundAmount(amountOutRaw, reserveOut / 8);
+        if (amountOut == 0) {
+            return;
+        }
+
+        uint256[] memory expectedAmounts = router.getAmountsIn(amountOut, path_);
+        if (expectedAmounts[0] > MockAMMToken(path_[0]).balanceOf(trader)) {
+            return;
+        }
+
+        uint256 recipientBalanceBefore = MockAMMToken(path_[path_.length - 1]).balanceOf(trader);
+        VM.prank(trader);
+        uint256[] memory amounts =
+            router.swapTokensForExactTokens(amountOut, expectedAmounts[0], path_, trader, DEADLINE);
+
+        assertTrue(amounts[0] == expectedAmounts[0], "required input mismatch");
+        assertTrue(amounts[amounts.length - 1] == amountOut, "exact output mismatch");
+        assertTrue(
+            MockAMMToken(path_[path_.length - 1]).balanceOf(trader) == recipientBalanceBefore + amountOut,
+            "recipient exact output delta mismatch"
+        );
+        _assertRouterZeroBalances();
+    }
+
+    function testFuzzAddLiquidityNativeRefundsUnusedValue(uint96 tokenAmountRaw) public {
+        address provider = carol;
+        uint256 tokenAmount = _boundAmount(tokenAmountRaw, 100_000);
+        uint256 nativeAmount = tokenAmount * 2;
+        uint256 nativeBalanceBefore = provider.balance;
+
+        VM.prank(provider);
+        (uint256 amountToken, uint256 amountNative,) =
+            router.addLiquidityNative{value: nativeAmount}(address(token0), tokenAmount, 0, 0, provider, DEADLINE);
+
+        _recordLiquidityEvent(address(pair0W));
+        assertTrue(amountToken == tokenAmount, "native add token amount mismatch");
+        assertTrue(amountNative == tokenAmount, "native add used amount mismatch");
+        assertTrue(provider.balance == nativeBalanceBefore - amountNative, "unused native refund mismatch");
+        _assertRouterZeroBalances();
+    }
+
+    function testFuzzSwapNativeForExactTokensRefundsExcessValue(uint8 actorSeed, uint8 pathSeed, uint96 amountOutRaw)
+        public
+    {
+        address trader = _actor(actorSeed);
+        address[] memory nativeInPath = _nativeInPath(pathSeed);
+        (, uint256 reserveOut) =
+            _getAlignedReserves(nativeInPath[nativeInPath.length - 2], nativeInPath[nativeInPath.length - 1]);
+        uint256 amountOut = _boundAmount(amountOutRaw, reserveOut / 8);
+        if (amountOut == 0) {
+            return;
+        }
+
+        uint256[] memory amountsIn = router.getAmountsIn(amountOut, nativeInPath);
+        uint256 refundPadding = amountOut + 1;
+        uint256 nativeBalanceBefore = trader.balance;
+
+        VM.prank(trader);
+        uint256[] memory nativeInAmounts = router.swapNativeForExactTokens{value: amountsIn[0] + refundPadding}(
+            amountOut, nativeInPath, trader, DEADLINE
+        );
+
+        assertTrue(nativeInAmounts[0] == amountsIn[0], "native exact input mismatch");
+        assertTrue(trader.balance == nativeBalanceBefore - amountsIn[0], "native refund accounting mismatch");
+        _assertRouterZeroBalances();
+    }
+
+    function testFuzzSwapTokensForExactNativeUnwrapsOutput(uint8 actorSeed, uint8 pathSeed, uint96 amountOutRaw)
+        public
+    {
+        address trader = _actor(actorSeed);
+        address[] memory nativeOutPath = _nativeOutPath(pathSeed);
+        (, uint256 reserveOut) =
+            _getAlignedReserves(nativeOutPath[nativeOutPath.length - 2], nativeOutPath[nativeOutPath.length - 1]);
+        uint256 nativeOut = _boundAmount(amountOutRaw, reserveOut / 8);
+        uint256[] memory expectedNativeIn = router.getAmountsIn(nativeOut, nativeOutPath);
+        if (expectedNativeIn[0] > MockAMMToken(nativeOutPath[0]).balanceOf(trader)) {
+            _assertRouterZeroBalances();
+            return;
+        }
+
+        uint256 nativeBalanceBeforeOut = trader.balance;
+        VM.prank(trader);
+        uint256[] memory nativeOutAmounts =
+            router.swapTokensForExactNative(nativeOut, expectedNativeIn[0], nativeOutPath, trader, DEADLINE);
+
+        assertTrue(nativeOutAmounts[nativeOutAmounts.length - 1] == nativeOut, "native exact output mismatch");
+        assertTrue(trader.balance == nativeBalanceBeforeOut + nativeOut, "native unwrap delta mismatch");
+        _assertRouterZeroBalances();
+    }
+}

--- a/test/AMMRouterTime.t.sol
+++ b/test/AMMRouterTime.t.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {AMMRouter} from "../src/amm/AMMRouter.sol";
+import {AMMRouterFixture} from "./helpers/AMMRouterTestHarness.sol";
+
+contract AMMRouterTimeTest is AMMRouterFixture {
+    function testAddLiquidityRevertsAfterDeadline() public {
+        uint256 deadline = block.timestamp;
+        VM.warp(deadline + 1);
+
+        VM.expectRevert(abi.encodeWithSelector(AMMRouter.AMMRouterExpired.selector, deadline, block.timestamp));
+        router.addLiquidity(address(token0), address(token1), 1, 1, 0, 0, alice, deadline);
+    }
+
+    function testRemoveLiquidityWithPermitRevertsAfterDeadline() public {
+        uint256 deadline = block.timestamp;
+        VM.warp(deadline + 1);
+
+        VM.expectRevert(abi.encodeWithSelector(AMMRouter.AMMRouterExpired.selector, deadline, block.timestamp));
+        router.removeLiquidityWithPermit(
+            address(token0), address(token1), 1, 0, 0, alice, deadline, false, 0, bytes32(0), bytes32(0)
+        );
+    }
+
+    function testSwapExactTokensForTokensRevertsAfterDeadline() public {
+        uint256 deadline = block.timestamp;
+        VM.warp(deadline + 1);
+
+        VM.expectRevert(abi.encodeWithSelector(AMMRouter.AMMRouterExpired.selector, deadline, block.timestamp));
+        router.swapExactTokensForTokens(1, 0, _path(address(token0), address(token1)), alice, deadline);
+    }
+
+    function testSwapExactNativeForTokensRevertsAfterDeadline() public {
+        uint256 deadline = block.timestamp;
+        VM.warp(deadline + 1);
+
+        VM.expectRevert(abi.encodeWithSelector(AMMRouter.AMMRouterExpired.selector, deadline, block.timestamp));
+        router.swapExactNativeForTokens{value: 1}(
+            0, _path(address(wrappedNativeToken), address(token0)), alice, deadline
+        );
+    }
+}

--- a/test/helpers/AMMHardeningTestHarness.sol
+++ b/test/helpers/AMMHardeningTestHarness.sol
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {AMMPair} from "../../src/amm/AMMPair.sol";
+import {MockAMMToken} from "./AMMPairTestHarness.sol";
+import {AMMRouterFixture} from "./AMMRouterTestHarness.sol";
+
+abstract contract AMMHardeningFixture is AMMRouterFixture {
+    uint256 internal constant ACTOR_COUNT = 4;
+    uint256 internal constant PAIR_COUNT = 5;
+    uint256 internal constant TRACKED_TOKEN_COUNT = 4;
+    uint256 internal constant INITIAL_TOKEN_BALANCE = 5_000_000;
+    uint256 internal constant INITIAL_NATIVE_BALANCE = 5_000_000;
+    address internal dave = address(0xD0D);
+    address[ACTOR_COUNT] internal actors;
+    address[PAIR_COUNT] internal trackedPairs;
+    address[TRACKED_TOKEN_COUNT] internal trackedTokens;
+    uint256[PAIR_COUNT] internal expectedKLasts;
+
+    AMMPair internal pair01;
+    AMMPair internal pair12;
+    AMMPair internal pair02;
+    AMMPair internal pair0W;
+    AMMPair internal pair1W;
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        actors[0] = alice;
+        actors[1] = bob;
+        actors[2] = carol;
+        actors[3] = dave;
+
+        trackedTokens[0] = address(token0);
+        trackedTokens[1] = address(token1);
+        trackedTokens[2] = address(token2);
+        trackedTokens[3] = address(wrappedNativeToken);
+
+        _fundActors();
+        _approveTrackedAssets();
+        _seedTrackedPairs();
+        _approveTrackedPairs();
+    }
+
+    function _actor(uint256 seed) internal view returns (address actor) {
+        actor = actors[seed % ACTOR_COUNT];
+    }
+
+    function _boundAmount(uint256 raw, uint256 max) internal pure returns (uint256 amount) {
+        if (max == 0) {
+            return 0;
+        }
+
+        amount = (raw % max) + 1;
+    }
+
+    function _trackedPair(uint256 seed) internal view returns (AMMPair pair_) {
+        pair_ = AMMPair(trackedPairs[seed % PAIR_COUNT]);
+    }
+
+    function _pairIndex(address pairAddress) internal view returns (uint256 index) {
+        for (uint256 i = 0; i < PAIR_COUNT; i++) {
+            if (trackedPairs[i] == pairAddress) {
+                return i;
+            }
+        }
+
+        revert("UNKNOWN_PAIR");
+    }
+
+    function _trackedToken(uint256 seed) internal view returns (MockAMMToken token_) {
+        token_ = MockAMMToken(trackedTokens[seed % TRACKED_TOKEN_COUNT]);
+    }
+
+    function _tokenSwapPath(uint256 seed) internal view returns (address[] memory path_) {
+        uint256 selector = seed % 6;
+        if (selector == 0) {
+            return _path(address(token0), address(token1));
+        }
+        if (selector == 1) {
+            return _path(address(token1), address(token2));
+        }
+        if (selector == 2) {
+            return _path(address(token0), address(token2));
+        }
+        if (selector == 3) {
+            return _path(address(token0), address(token1), address(token2));
+        }
+        if (selector == 4) {
+            return _path(address(token2), address(token1), address(token0));
+        }
+        return _path(address(token2), address(token0), address(token1));
+    }
+
+    function _nativeInPath(uint256 seed) internal view returns (address[] memory path_) {
+        uint256 selector = seed % 4;
+        if (selector == 0) {
+            return _path(address(wrappedNativeToken), address(token0));
+        }
+        if (selector == 1) {
+            return _path(address(wrappedNativeToken), address(token1));
+        }
+        if (selector == 2) {
+            return _path(address(wrappedNativeToken), address(token1), address(token2));
+        }
+        return _path(address(wrappedNativeToken), address(token0), address(token2));
+    }
+
+    function _nativeOutPath(uint256 seed) internal view returns (address[] memory path_) {
+        uint256 selector = seed % 4;
+        if (selector == 0) {
+            return _path(address(token0), address(wrappedNativeToken));
+        }
+        if (selector == 1) {
+            return _path(address(token1), address(wrappedNativeToken));
+        }
+        if (selector == 2) {
+            return _path(address(token2), address(token1), address(wrappedNativeToken));
+        }
+        return _path(address(token2), address(token0), address(wrappedNativeToken));
+    }
+
+    function _getAlignedReserves(address tokenA_, address tokenB_)
+        internal
+        view
+        returns (uint256 reserveA, uint256 reserveB)
+    {
+        address pairAddress = factory.getPair(tokenA_, tokenB_);
+        if (pairAddress == address(0)) {
+            return (0, 0);
+        }
+
+        AMMPair pair_ = AMMPair(pairAddress);
+        (uint112 reserve0_, uint112 reserve1_,) = pair_.getReserves();
+        if (pair_.token0() == tokenA_) {
+            return (reserve0_, reserve1_);
+        }
+        return (reserve1_, reserve0_);
+    }
+
+    function _recordLiquidityEvent(address pairAddress) internal {
+        uint256 pairIdx = _pairIndex(pairAddress);
+        if (factory.feeTo() == address(0)) {
+            expectedKLasts[pairIdx] = 0;
+            return;
+        }
+
+        (uint112 reserve0_, uint112 reserve1_,) = AMMPair(pairAddress).getReserves();
+        expectedKLasts[pairIdx] = uint256(reserve0_) * uint256(reserve1_);
+    }
+
+    function _sumTrackedLpBalances(AMMPair pair_) internal view returns (uint256 sum) {
+        sum += pair_.balanceOf(BURN_SINK);
+        sum += pair_.balanceOf(address(pair_));
+        sum += pair_.balanceOf(address(router));
+        sum += pair_.balanceOf(address(this));
+
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            sum += pair_.balanceOf(actors[i]);
+        }
+    }
+
+    function _assertRouterZeroBalances() internal view {
+        assertTrue(address(router).balance == 0, "router native balance should be zero");
+
+        for (uint256 i = 0; i < TRACKED_TOKEN_COUNT; i++) {
+            assertTrue(
+                MockAMMToken(trackedTokens[i]).balanceOf(address(router)) == 0, "router token balance should be zero"
+            );
+        }
+    }
+
+    function _assertPairRegistered(AMMPair pair_) internal view {
+        address tokenA_ = pair_.token0();
+        address tokenB_ = pair_.token1();
+
+        assertTrue(factory.getPair(tokenA_, tokenB_) == address(pair_), "forward pair lookup mismatch");
+        assertTrue(factory.getPair(tokenB_, tokenA_) == address(pair_), "reverse pair lookup mismatch");
+    }
+
+    function _assertPairReservesDoNotExceedBalances(AMMPair pair_) internal view {
+        (uint112 reserve0_, uint112 reserve1_,) = pair_.getReserves();
+        assertTrue(
+            reserve0_ <= MockAMMToken(pair_.token0()).balanceOf(address(pair_)),
+            "reserve0 should not exceed token0 balance"
+        );
+        assertTrue(
+            reserve1_ <= MockAMMToken(pair_.token1()).balanceOf(address(pair_)),
+            "reserve1 should not exceed token1 balance"
+        );
+    }
+
+    function _assertTrackedAmmState() internal view {
+        _assertRouterZeroBalances();
+
+        for (uint256 i = 0; i < PAIR_COUNT; i++) {
+            AMMPair trackedPair = AMMPair(trackedPairs[i]);
+            _assertPairRegistered(trackedPair);
+            _assertPairReservesDoNotExceedBalances(trackedPair);
+            assertTrue(trackedPair.totalSupply() == _sumTrackedLpBalances(trackedPair), "tracked lp supply mismatch");
+            assertTrue(trackedPair.kLast() == expectedKLasts[i], "tracked kLast mismatch");
+
+            if (trackedPair.totalSupply() != 0) {
+                assertTrue(
+                    trackedPair.balanceOf(BURN_SINK) == trackedPair.MINIMUM_LIQUIDITY(),
+                    "minimum liquidity sink mismatch"
+                );
+            }
+        }
+    }
+
+    function _seedWrappedToken(address actor, uint256 amount) internal {
+        if (amount == 0) {
+            return;
+        }
+
+        VM.prank(actor);
+        wrappedNativeToken.deposit{value: amount}();
+    }
+
+    function _fundActors() internal {
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            address actor = actors[i];
+            token0.mint(actor, INITIAL_TOKEN_BALANCE);
+            token1.mint(actor, INITIAL_TOKEN_BALANCE);
+            token2.mint(actor, INITIAL_TOKEN_BALANCE);
+            VM.deal(actor, INITIAL_NATIVE_BALANCE);
+        }
+    }
+
+    function _approveTrackedAssets() internal {
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            address actor = actors[i];
+            VM.startPrank(actor);
+            token0.approve(address(router), type(uint256).max);
+            token1.approve(address(router), type(uint256).max);
+            token2.approve(address(router), type(uint256).max);
+            wrappedNativeToken.approve(address(router), type(uint256).max);
+            VM.stopPrank();
+        }
+    }
+
+    function _approveTrackedPairs() internal {
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            address actor = actors[i];
+            VM.startPrank(actor);
+            for (uint256 j = 0; j < PAIR_COUNT; j++) {
+                AMMPair(trackedPairs[j]).approve(address(router), type(uint256).max);
+            }
+            VM.stopPrank();
+        }
+    }
+
+    function _seedTrackedPairs() internal {
+        pair01 = _seedTokenPair(alice, token0, token1, 500_000, 500_000);
+        pair12 = _seedTokenPair(alice, token1, token2, 500_000, 250_000);
+        pair02 = _seedTokenPair(alice, token0, token2, 400_000, 300_000);
+        pair0W = _seedNativePair(alice, token0, 350_000, 350_000);
+        pair1W = _seedNativePair(alice, token1, 300_000, 450_000);
+
+        trackedPairs[0] = address(pair01);
+        trackedPairs[1] = address(pair12);
+        trackedPairs[2] = address(pair02);
+        trackedPairs[3] = address(pair0W);
+        trackedPairs[4] = address(pair1W);
+    }
+
+    function _seedTokenPair(
+        address provider,
+        MockAMMToken tokenA_,
+        MockAMMToken tokenB_,
+        uint256 amountA,
+        uint256 amountB
+    ) internal returns (AMMPair pair_) {
+        VM.prank(provider);
+        router.addLiquidity(address(tokenA_), address(tokenB_), amountA, amountB, 0, 0, provider, DEADLINE);
+
+        pair_ = AMMPair(factory.getPair(address(tokenA_), address(tokenB_)));
+    }
+
+    function _seedNativePair(address provider, MockAMMToken token_, uint256 amountToken, uint256 amountNative)
+        internal
+        returns (AMMPair pair_)
+    {
+        VM.prank(provider);
+        router.addLiquidityNative{value: amountNative}(address(token_), amountToken, 0, 0, provider, DEADLINE);
+
+        pair_ = AMMPair(factory.getPair(address(token_), address(wrappedNativeToken)));
+    }
+}

--- a/test/helpers/AMMPairTestHarness.sol
+++ b/test/helpers/AMMPairTestHarness.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
+import {AMMFactory} from "../../src/amm/AMMFactory.sol";
 import {AMMPair} from "../../src/amm/AMMPair.sol";
-import {IAMMFactory} from "../../src/interfaces/IAMMFactory.sol";
 import {IERC20Metadata} from "../../src/interfaces/IERC20Metadata.sol";
 import {AMMFoundationFixture} from "./AMMTestHarness.sol";
 
@@ -183,116 +183,66 @@ contract ReentrantAMMToken is MockAMMToken {
     }
 }
 
-contract AMMFactoryHarness is IAMMFactory {
-    address public override feeTo;
-    address public override feeToSetter;
+abstract contract AMMPairCoreFixture is AMMFoundationFixture {
+    address internal constant BURN_SINK = 0x000000000000000000000000000000000000dEaD;
 
-    address[] internal _allPairs;
-    mapping(address => mapping(address => address)) internal _pairs;
+    AMMFactory internal factory;
+    AMMPair internal pair;
+    MockAMMToken internal token0;
+    MockAMMToken internal token1;
 
-    constructor(address feeToSetter_) {
-        feeToSetter = feeToSetter_;
+    function setUp() public virtual override {
+        super.setUp();
+
+        factory = new AMMFactory();
+        MockAMMToken firstToken = new MockAMMToken("Token 0", "TK0", 18);
+        MockAMMToken secondToken = new MockAMMToken("Token 1", "TK1", 18);
+
+        pair = AMMPair(factory.createPair(address(firstToken), address(secondToken)));
+        (token0, token1) =
+            address(firstToken) < address(secondToken) ? (firstToken, secondToken) : (secondToken, firstToken);
     }
 
-    function getPair(address tokenA, address tokenB) external view returns (address) {
-        return _pairs[tokenA][tokenB];
+    function _provideLiquidity(
+        AMMPair pair_,
+        MockAMMToken token0_,
+        MockAMMToken token1_,
+        address provider,
+        uint256 amount0,
+        uint256 amount1,
+        address recipient
+    ) internal returns (uint256 liquidity) {
+        token0_.mint(provider, amount0);
+        token1_.mint(provider, amount1);
+
+        VM.startPrank(provider);
+        assertTrue(token0_.transfer(address(pair_), amount0), "token0 transfer should succeed");
+        assertTrue(token1_.transfer(address(pair_), amount1), "token1 transfer should succeed");
+        VM.stopPrank();
+
+        liquidity = pair_.mint(recipient);
     }
 
-    function allPairs(uint256 index) external view returns (address) {
-        return _allPairs[index];
+    function _seedLiquidityDirect(
+        AMMPair pair_,
+        MockAMMToken token0_,
+        MockAMMToken token1_,
+        uint256 amount0,
+        uint256 amount1,
+        address recipient
+    ) internal returns (uint256 liquidity) {
+        token0_.mint(address(pair_), amount0);
+        token1_.mint(address(pair_), amount1);
+        liquidity = pair_.mint(recipient);
     }
 
-    function allPairsLength() external view returns (uint256) {
-        return _allPairs.length;
+    function _getAmountOut(uint256 amountIn, uint256 reserveIn, uint256 reserveOut) internal pure returns (uint256) {
+        uint256 amountInWithFee = amountIn * 997;
+        return (amountInWithFee * reserveOut) / ((reserveIn * 1000) + amountInWithFee);
     }
 
-    function createPair(address tokenA, address tokenB) external returns (address pair) {
-        require(tokenA != address(0) && tokenB != address(0), "ZERO_TOKEN");
-        require(tokenA != tokenB, "IDENTICAL_TOKEN");
-        require(_pairs[tokenA][tokenB] == address(0), "PAIR_EXISTS");
-
-        pair = address(new AMMPair());
-        AMMPair(pair).initialize(tokenA, tokenB);
-
-        _pairs[tokenA][tokenB] = pair;
-        _pairs[tokenB][tokenA] = pair;
-        _allPairs.push(pair);
-
-        emit PairCreated(tokenA, tokenB, pair, _allPairs.length);
-    }
-
-    function setFeeTo(address feeTo_) external {
-        require(msg.sender == feeToSetter, "FORBIDDEN");
-        feeTo = feeTo_;
-    }
-
-    function setFeeToSetter(address feeToSetter_) external {
-        require(msg.sender == feeToSetter, "FORBIDDEN");
-        feeToSetter = feeToSetter_;
+    function _deployPair(address token0_, address token1_) internal returns (AMMPair pair_) {
+        AMMFactory localFactory = new AMMFactory();
+        pair_ = AMMPair(localFactory.createPair(token0_, token1_));
     }
 }
-
-    abstract contract AMMPairCoreFixture is AMMFoundationFixture {
-        address internal constant BURN_SINK = 0x000000000000000000000000000000000000dEaD;
-
-        AMMFactoryHarness internal factory;
-        AMMPair internal pair;
-        MockAMMToken internal token0;
-        MockAMMToken internal token1;
-
-        function setUp() public virtual override {
-            super.setUp();
-
-            factory = new AMMFactoryHarness(address(this));
-            token0 = new MockAMMToken("Token 0", "TK0", 18);
-            token1 = new MockAMMToken("Token 1", "TK1", 18);
-            pair = AMMPair(factory.createPair(address(token0), address(token1)));
-        }
-
-        function _provideLiquidity(
-            AMMPair pair_,
-            MockAMMToken token0_,
-            MockAMMToken token1_,
-            address provider,
-            uint256 amount0,
-            uint256 amount1,
-            address recipient
-        ) internal returns (uint256 liquidity) {
-            token0_.mint(provider, amount0);
-            token1_.mint(provider, amount1);
-
-            VM.startPrank(provider);
-            assertTrue(token0_.transfer(address(pair_), amount0), "token0 transfer should succeed");
-            assertTrue(token1_.transfer(address(pair_), amount1), "token1 transfer should succeed");
-            VM.stopPrank();
-
-            liquidity = pair_.mint(recipient);
-        }
-
-        function _seedLiquidityDirect(
-            AMMPair pair_,
-            MockAMMToken token0_,
-            MockAMMToken token1_,
-            uint256 amount0,
-            uint256 amount1,
-            address recipient
-        ) internal returns (uint256 liquidity) {
-            token0_.mint(address(pair_), amount0);
-            token1_.mint(address(pair_), amount1);
-            liquidity = pair_.mint(recipient);
-        }
-
-        function _getAmountOut(uint256 amountIn, uint256 reserveIn, uint256 reserveOut)
-            internal
-            pure
-            returns (uint256)
-        {
-            uint256 amountInWithFee = amountIn * 997;
-            return (amountInWithFee * reserveOut) / ((reserveIn * 1000) + amountInWithFee);
-        }
-
-        function _deployPair(address token0_, address token1_) internal returns (AMMPair pair_) {
-            AMMFactoryHarness localFactory = new AMMFactoryHarness(address(this));
-            pair_ = AMMPair(localFactory.createPair(token0_, token1_));
-        }
-    }

--- a/test/helpers/AMMPairTestHarness.sol
+++ b/test/helpers/AMMPairTestHarness.sol
@@ -1,0 +1,298 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {AMMPair} from "../../src/amm/AMMPair.sol";
+import {IAMMFactory} from "../../src/interfaces/IAMMFactory.sol";
+import {IERC20Metadata} from "../../src/interfaces/IERC20Metadata.sol";
+import {AMMFoundationFixture} from "./AMMTestHarness.sol";
+
+contract MockAMMToken is IERC20Metadata {
+    string internal _name;
+    string internal _symbol;
+    uint8 internal _decimals;
+    uint256 internal _totalSupply;
+
+    mapping(address => uint256) internal _balances;
+    mapping(address => mapping(address => uint256)) internal _allowances;
+
+    constructor(string memory name_, string memory symbol_, uint8 decimals_) {
+        _name = name_;
+        _symbol = symbol_;
+        _decimals = decimals_;
+    }
+
+    function name() external view returns (string memory) {
+        return _name;
+    }
+
+    function symbol() external view returns (string memory) {
+        return _symbol;
+    }
+
+    function decimals() external view returns (uint8) {
+        return _decimals;
+    }
+
+    function totalSupply() external view returns (uint256) {
+        return _totalSupply;
+    }
+
+    function balanceOf(address account) external view returns (uint256) {
+        return _balances[account];
+    }
+
+    function allowance(address owner, address spender) external view returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    function mint(address to, uint256 amount) external {
+        _balances[to] += amount;
+        _totalSupply += amount;
+        emit Transfer(address(0), to, amount);
+    }
+
+    function approve(address spender, uint256 value) external returns (bool) {
+        _allowances[msg.sender][spender] = value;
+        emit Approval(msg.sender, spender, value);
+        return true;
+    }
+
+    function transfer(address to, uint256 value) public virtual returns (bool) {
+        _transfer(msg.sender, to, value);
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 value) public virtual returns (bool) {
+        uint256 currentAllowance = _allowances[from][msg.sender];
+        require(currentAllowance >= value, "INSUFFICIENT_ALLOWANCE");
+
+        if (currentAllowance != type(uint256).max) {
+            unchecked {
+                _allowances[from][msg.sender] = currentAllowance - value;
+            }
+            emit Approval(from, msg.sender, _allowances[from][msg.sender]);
+        }
+
+        _transfer(from, to, value);
+        return true;
+    }
+
+    function _transfer(address from, address to, uint256 value) internal {
+        require(to != address(0), "ZERO_TO");
+
+        uint256 fromBalance = _balances[from];
+        require(fromBalance >= value, "INSUFFICIENT_BALANCE");
+
+        unchecked {
+            _balances[from] = fromBalance - value;
+        }
+        _balances[to] += value;
+
+        emit Transfer(from, to, value);
+    }
+}
+
+contract FalseReturningAMMToken is MockAMMToken {
+    constructor(string memory name_, string memory symbol_, uint8 decimals_) MockAMMToken(name_, symbol_, decimals_) {}
+
+    function transfer(address, uint256) public pure override returns (bool) {
+        return false;
+    }
+
+    function transferFrom(address, address, uint256) public pure override returns (bool) {
+        return false;
+    }
+}
+
+contract SilentAMMToken is MockAMMToken {
+    constructor(string memory name_, string memory symbol_, uint8 decimals_) MockAMMToken(name_, symbol_, decimals_) {}
+
+    function transfer(address to, uint256 value) public override returns (bool) {
+        _transfer(msg.sender, to, value);
+        assembly {
+            return(0, 0)
+        }
+    }
+
+    function transferFrom(address from, address to, uint256 value) public override returns (bool) {
+        uint256 currentAllowance = _allowances[from][msg.sender];
+        require(currentAllowance >= value, "INSUFFICIENT_ALLOWANCE");
+
+        if (currentAllowance != type(uint256).max) {
+            unchecked {
+                _allowances[from][msg.sender] = currentAllowance - value;
+            }
+            emit Approval(from, msg.sender, _allowances[from][msg.sender]);
+        }
+
+        _transfer(from, to, value);
+        assembly {
+            return(0, 0)
+        }
+    }
+}
+
+contract MalformedAMMToken is MockAMMToken {
+    constructor(string memory name_, string memory symbol_, uint8 decimals_) MockAMMToken(name_, symbol_, decimals_) {}
+
+    function transfer(address to, uint256 value) public override returns (bool) {
+        _transfer(msg.sender, to, value);
+        assembly {
+            mstore(0x00, 1)
+            return(0x1f, 0x01)
+        }
+    }
+
+    function transferFrom(address from, address to, uint256 value) public override returns (bool) {
+        uint256 currentAllowance = _allowances[from][msg.sender];
+        require(currentAllowance >= value, "INSUFFICIENT_ALLOWANCE");
+
+        if (currentAllowance != type(uint256).max) {
+            unchecked {
+                _allowances[from][msg.sender] = currentAllowance - value;
+            }
+            emit Approval(from, msg.sender, _allowances[from][msg.sender]);
+        }
+
+        _transfer(from, to, value);
+        assembly {
+            mstore(0x00, 1)
+            return(0x1f, 0x01)
+        }
+    }
+}
+
+contract ReentrantAMMToken is MockAMMToken {
+    address internal _pairToReenter;
+    bool internal _reenterSyncEnabled;
+
+    constructor(string memory name_, string memory symbol_, uint8 decimals_) MockAMMToken(name_, symbol_, decimals_) {}
+
+    function setReenterSync(address pair_, bool enabled) external {
+        _pairToReenter = pair_;
+        _reenterSyncEnabled = enabled;
+    }
+
+    function transfer(address to, uint256 value) public override returns (bool) {
+        if (_reenterSyncEnabled && msg.sender == _pairToReenter) {
+            AMMPair(_pairToReenter).sync();
+        }
+
+        _transfer(msg.sender, to, value);
+        return true;
+    }
+}
+
+contract AMMFactoryHarness is IAMMFactory {
+    address public override feeTo;
+    address public override feeToSetter;
+
+    address[] internal _allPairs;
+    mapping(address => mapping(address => address)) internal _pairs;
+
+    constructor(address feeToSetter_) {
+        feeToSetter = feeToSetter_;
+    }
+
+    function getPair(address tokenA, address tokenB) external view returns (address) {
+        return _pairs[tokenA][tokenB];
+    }
+
+    function allPairs(uint256 index) external view returns (address) {
+        return _allPairs[index];
+    }
+
+    function allPairsLength() external view returns (uint256) {
+        return _allPairs.length;
+    }
+
+    function createPair(address tokenA, address tokenB) external returns (address pair) {
+        require(tokenA != address(0) && tokenB != address(0), "ZERO_TOKEN");
+        require(tokenA != tokenB, "IDENTICAL_TOKEN");
+        require(_pairs[tokenA][tokenB] == address(0), "PAIR_EXISTS");
+
+        pair = address(new AMMPair());
+        AMMPair(pair).initialize(tokenA, tokenB);
+
+        _pairs[tokenA][tokenB] = pair;
+        _pairs[tokenB][tokenA] = pair;
+        _allPairs.push(pair);
+
+        emit PairCreated(tokenA, tokenB, pair, _allPairs.length);
+    }
+
+    function setFeeTo(address feeTo_) external {
+        require(msg.sender == feeToSetter, "FORBIDDEN");
+        feeTo = feeTo_;
+    }
+
+    function setFeeToSetter(address feeToSetter_) external {
+        require(msg.sender == feeToSetter, "FORBIDDEN");
+        feeToSetter = feeToSetter_;
+    }
+}
+
+    abstract contract AMMPairCoreFixture is AMMFoundationFixture {
+        address internal constant BURN_SINK = 0x000000000000000000000000000000000000dEaD;
+
+        AMMFactoryHarness internal factory;
+        AMMPair internal pair;
+        MockAMMToken internal token0;
+        MockAMMToken internal token1;
+
+        function setUp() public virtual override {
+            super.setUp();
+
+            factory = new AMMFactoryHarness(address(this));
+            token0 = new MockAMMToken("Token 0", "TK0", 18);
+            token1 = new MockAMMToken("Token 1", "TK1", 18);
+            pair = AMMPair(factory.createPair(address(token0), address(token1)));
+        }
+
+        function _provideLiquidity(
+            AMMPair pair_,
+            MockAMMToken token0_,
+            MockAMMToken token1_,
+            address provider,
+            uint256 amount0,
+            uint256 amount1,
+            address recipient
+        ) internal returns (uint256 liquidity) {
+            token0_.mint(provider, amount0);
+            token1_.mint(provider, amount1);
+
+            VM.startPrank(provider);
+            assertTrue(token0_.transfer(address(pair_), amount0), "token0 transfer should succeed");
+            assertTrue(token1_.transfer(address(pair_), amount1), "token1 transfer should succeed");
+            VM.stopPrank();
+
+            liquidity = pair_.mint(recipient);
+        }
+
+        function _seedLiquidityDirect(
+            AMMPair pair_,
+            MockAMMToken token0_,
+            MockAMMToken token1_,
+            uint256 amount0,
+            uint256 amount1,
+            address recipient
+        ) internal returns (uint256 liquidity) {
+            token0_.mint(address(pair_), amount0);
+            token1_.mint(address(pair_), amount1);
+            liquidity = pair_.mint(recipient);
+        }
+
+        function _getAmountOut(uint256 amountIn, uint256 reserveIn, uint256 reserveOut)
+            internal
+            pure
+            returns (uint256)
+        {
+            uint256 amountInWithFee = amountIn * 997;
+            return (amountInWithFee * reserveOut) / ((reserveIn * 1000) + amountInWithFee);
+        }
+
+        function _deployPair(address token0_, address token1_) internal returns (AMMPair pair_) {
+            AMMFactoryHarness localFactory = new AMMFactoryHarness(address(this));
+            pair_ = AMMPair(localFactory.createPair(token0_, token1_));
+        }
+    }

--- a/test/helpers/AMMRouterTestHarness.sol
+++ b/test/helpers/AMMRouterTestHarness.sol
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {AMMRouter} from "../../src/amm/AMMRouter.sol";
+import {AMMFactory} from "../../src/amm/AMMFactory.sol";
+import {AMMPair} from "../../src/amm/AMMPair.sol";
+import {IWrappedNative} from "../../src/interfaces/IWrappedNative.sol";
+import {AMMPairCoreFixture, FalseReturningAMMToken, MockAMMToken} from "./AMMPairTestHarness.sol";
+
+contract MockWrappedNative is MockAMMToken, IWrappedNative {
+    constructor(string memory name_, string memory symbol_, uint8 decimals_) MockAMMToken(name_, symbol_, decimals_) {}
+
+    receive() external payable {
+        deposit();
+    }
+
+    function deposit() public payable {
+        _balances[msg.sender] += msg.value;
+        _totalSupply += msg.value;
+        emit Transfer(address(0), msg.sender, msg.value);
+    }
+
+    function withdraw(uint256 value) external {
+        uint256 balance = _balances[msg.sender];
+        require(balance >= value, "INSUFFICIENT_BALANCE");
+
+        unchecked {
+            _balances[msg.sender] = balance - value;
+            _totalSupply -= value;
+        }
+
+        emit Transfer(msg.sender, address(0), value);
+
+        (bool success,) = payable(msg.sender).call{value: value}("");
+        require(success, "NATIVE_TRANSFER_FAILED");
+    }
+}
+
+contract RejectingNativeReceiver {
+    receive() external payable {
+        revert("REJECT_NATIVE");
+    }
+}
+
+abstract contract AMMRouterFixture is AMMPairCoreFixture {
+    uint256 internal constant DEADLINE = type(uint256).max;
+
+    AMMRouter internal router;
+    MockWrappedNative internal wrappedNativeToken;
+    MockAMMToken internal token2;
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        wrappedNativeToken = new MockWrappedNative("Wrapped Native", "WNATIVE", 18);
+        token2 = new MockAMMToken("Token 2", "TK2", 18);
+        router = new AMMRouter(address(factory), address(wrappedNativeToken));
+    }
+
+    function _mintOrWrapTo(MockAMMToken token, address recipient, uint256 amount) internal {
+        if (address(token) == address(wrappedNativeToken)) {
+            VM.deal(recipient, recipient.balance + amount);
+            VM.prank(recipient);
+            wrappedNativeToken.deposit{value: amount}();
+            return;
+        }
+
+        token.mint(recipient, amount);
+    }
+
+    function _provideRouterLiquidity(
+        MockAMMToken tokenA_,
+        MockAMMToken tokenB_,
+        address provider,
+        uint256 amountA,
+        uint256 amountB,
+        address recipient
+    ) internal returns (AMMPair pair_, uint256 liquidity) {
+        address pairAddress = factory.getPair(address(tokenA_), address(tokenB_));
+        if (pairAddress == address(0)) {
+            pairAddress = factory.createPair(address(tokenA_), address(tokenB_));
+        }
+
+        pair_ = AMMPair(pairAddress);
+        (MockAMMToken pairToken0, MockAMMToken pairToken1, uint256 amount0, uint256 amount1) = address(tokenA_)
+                < address(tokenB_)
+            ? (tokenA_, tokenB_, amountA, amountB)
+            : (tokenB_, tokenA_, amountB, amountA);
+
+        _mintOrWrapTo(pairToken0, provider, amount0);
+        _mintOrWrapTo(pairToken1, provider, amount1);
+
+        VM.startPrank(provider);
+        assertTrue(pairToken0.transfer(address(pair_), amount0), "token0 transfer should succeed");
+        assertTrue(pairToken1.transfer(address(pair_), amount1), "token1 transfer should succeed");
+        VM.stopPrank();
+
+        liquidity = pair_.mint(recipient);
+    }
+
+    function _path(address tokenA_, address tokenB_) internal pure returns (address[] memory path_) {
+        path_ = new address[](2);
+        path_[0] = tokenA_;
+        path_[1] = tokenB_;
+    }
+
+    function _path(address tokenA_, address tokenB_, address tokenC_) internal pure returns (address[] memory path_) {
+        path_ = new address[](3);
+        path_[0] = tokenA_;
+        path_[1] = tokenB_;
+        path_[2] = tokenC_;
+    }
+
+    function _deployFalseReturningToken() internal returns (FalseReturningAMMToken token_) {
+        token_ = new FalseReturningAMMToken("False Token", "FTK", 18);
+    }
+}

--- a/test/helpers/AMMTestHarness.sol
+++ b/test/helpers/AMMTestHarness.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {AMMFixedPoint} from "../../src/amm/libraries/AMMFixedPoint.sol";
+import {AMMMath} from "../../src/amm/libraries/AMMMath.sol";
+import {AMMLpToken} from "../../src/amm/AMMLpToken.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+
+contract AMMLpTokenHarness is AMMLpToken {
+    function initializeAmmLpToken() external {
+        _initializeAmmLpToken();
+    }
+
+    function mint(address to, uint256 value) external {
+        _mintLp(to, value);
+    }
+
+    function burn(address from, uint256 value) external {
+        _burnLp(from, value);
+    }
+
+    function initialized() external view returns (bool) {
+        return _ammLpInitialized;
+    }
+}
+
+abstract contract AMMFoundationFixture is TestBase {
+    bytes32 internal constant EIP712_DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    bytes32 internal constant PERMIT_TYPEHASH =
+        keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+    bytes32 internal constant NAME_HASH = keccak256("Auralis V2 LP");
+    bytes32 internal constant VERSION_HASH = keccak256("1");
+    uint256 internal constant ALICE_PK = 0xA11CE;
+    uint256 internal constant BOB_PK = 0xB0B;
+    uint256 internal constant CAROL_PK = 0xCAFE;
+
+    AMMLpTokenHarness internal lpToken;
+    address internal alice;
+    address internal bob;
+    address internal carol;
+
+    function setUp() public virtual {
+        lpToken = new AMMLpTokenHarness();
+        alice = VM.addr(ALICE_PK);
+        bob = VM.addr(BOB_PK);
+        carol = VM.addr(CAROL_PK);
+    }
+
+    function _domainSeparator(address token) internal view returns (bytes32) {
+        return keccak256(abi.encode(EIP712_DOMAIN_TYPEHASH, NAME_HASH, VERSION_HASH, block.chainid, token));
+    }
+
+    function _permitDigest(address token, address owner, address spender, uint256 value, uint256 nonce_, uint256 deadline)
+        internal
+        view
+        returns (bytes32)
+    {
+        bytes32 structHash = keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, nonce_, deadline));
+        return keccak256(abi.encodePacked("\x19\x01", _domainSeparator(token), structHash));
+    }
+
+    function _signPermit(
+        uint256 signerKey,
+        address token,
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 nonce_,
+        uint256 deadline
+    ) internal returns (uint8 v, bytes32 r, bytes32 s) {
+        return VM.sign(signerKey, _permitDigest(token, owner, spender, value, nonce_, deadline));
+    }
+
+    function _recoverPermitSigner(
+        address token,
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 nonce_,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) internal view returns (address) {
+        return ecrecover(_permitDigest(token, owner, spender, value, nonce_, deadline), v, r, s);
+    }
+
+    function _invalidHighS(bytes32 s) internal pure returns (bytes32) {
+        return bytes32(
+            0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141 - uint256(s)
+        );
+    }
+
+    function _mathMin(uint256 x, uint256 y) internal pure returns (uint256) {
+        return AMMMath.min(x, y);
+    }
+
+    function _mathSqrt(uint256 value) internal pure returns (uint256) {
+        return AMMMath.sqrt(value);
+    }
+
+    function _encodeUq112x112(uint112 value) internal pure returns (uint224) {
+        return AMMFixedPoint.encode(value).value;
+    }
+
+    function _uqdiv(uint112 value, uint112 divisor) internal pure returns (uint224) {
+        return AMMFixedPoint.uqdiv(AMMFixedPoint.encode(value), divisor).value;
+    }
+}

--- a/test/helpers/AMMTestHarness.sol
+++ b/test/helpers/AMMTestHarness.sol
@@ -51,11 +51,14 @@ abstract contract AMMFoundationFixture is TestBase {
         return keccak256(abi.encode(EIP712_DOMAIN_TYPEHASH, NAME_HASH, VERSION_HASH, block.chainid, token));
     }
 
-    function _permitDigest(address token, address owner, address spender, uint256 value, uint256 nonce_, uint256 deadline)
-        internal
-        view
-        returns (bytes32)
-    {
+    function _permitDigest(
+        address token,
+        address owner,
+        address spender,
+        uint256 value,
+        uint256 nonce_,
+        uint256 deadline
+    ) internal view returns (bytes32) {
         bytes32 structHash = keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, nonce_, deadline));
         return keccak256(abi.encodePacked("\x19\x01", _domainSeparator(token), structHash));
     }
@@ -87,9 +90,7 @@ abstract contract AMMFoundationFixture is TestBase {
     }
 
     function _invalidHighS(bytes32 s) internal pure returns (bytes32) {
-        return bytes32(
-            0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141 - uint256(s)
-        );
+        return bytes32(0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141 - uint256(s));
     }
 
     function _mathMin(uint256 x, uint256 y) internal pure returns (uint256) {


### PR DESCRIPTION
## Summary
- add the standalone Uniswap V2-style AMM stack: LP token base, factory registry, pair core, router, math helpers, and wrapped-native interface
- add AMM core, fuzz, invariant, timing, and hardening coverage plus helper harnesses
- add reviewer-facing AMM documentation and thread the subsystem into the root README, docs map, local workflow, security checks, and threat model

## Verification
- `FOUNDRY_INVARIANT_RUNS=64 FOUNDRY_INVARIANT_DEPTH=32 forge test --offline --match-path 'test/AMM*.t.sol'`

## Linked Issue
Closes #127
