### PR TITLE
feat: add async vault foundation

### DIFF
--- a/src/interfaces/IERC7540Deposit.sol
+++ b/src/interfaces/IERC7540Deposit.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title IERC7540Deposit
+/// @notice ERC-7540 asynchronous deposit request surface.
+interface IERC7540Deposit {
+    /// @notice Locks `assets` and creates an asynchronous deposit request.
+    /// @param assets Underlying asset amount.
+    /// @param controller Request controller account.
+    /// @param owner Asset owner account.
+    /// @return requestId Request discriminator.
+    function requestDeposit(uint256 assets, address controller, address owner) external returns (uint256 requestId);
+
+    /// @notice Returns the pending deposit-request assets for `controller` and `requestId`.
+    /// @param requestId Request discriminator.
+    /// @param controller Request controller account.
+    /// @return assets Pending asset amount.
+    function pendingDepositRequest(uint256 requestId, address controller) external view returns (uint256 assets);
+
+    /// @notice Returns the claimable deposit-request assets for `controller` and `requestId`.
+    /// @param requestId Request discriminator.
+    /// @param controller Request controller account.
+    /// @return assets Claimable asset amount.
+    function claimableDepositRequest(uint256 requestId, address controller) external view returns (uint256 assets);
+
+    /// @notice Claims asynchronous deposit assets into shares for `receiver`.
+    /// @param assets Claim asset amount.
+    /// @param receiver Share receiver.
+    /// @param controller Request controller account.
+    /// @return shares Minted shares.
+    function deposit(uint256 assets, address receiver, address controller) external returns (uint256 shares);
+
+    /// @notice Claims asynchronous deposit assets by targeting an exact share amount for `receiver`.
+    /// @param shares Target share amount.
+    /// @param receiver Share receiver.
+    /// @param controller Request controller account.
+    /// @return assets Consumed claimable asset amount.
+    function mint(uint256 shares, address receiver, address controller) external returns (uint256 assets);
+}

--- a/src/interfaces/IERC7540Operators.sol
+++ b/src/interfaces/IERC7540Operators.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title IERC7540Operators
+/// @notice ERC-7540 operator approval surface shared by async deposit and redeem vaults.
+interface IERC7540Operators {
+    /// @notice Returns true when `operator` is approved to manage requests for `controller`.
+    /// @param controller Request controller account.
+    /// @param operator Candidate operator account.
+    /// @return status True when the operator is approved.
+    function isOperator(address controller, address operator) external view returns (bool status);
+
+    /// @notice Grants or revokes request-management approval for `operator`.
+    /// @param operator Operator account.
+    /// @param approved Whether the operator should be approved.
+    /// @return success True when the update succeeds.
+    function setOperator(address operator, bool approved) external returns (bool success);
+}

--- a/src/interfaces/IERC7540Redeem.sol
+++ b/src/interfaces/IERC7540Redeem.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title IERC7540Redeem
+/// @notice ERC-7540 asynchronous redeem request surface.
+interface IERC7540Redeem {
+    /// @notice Locks `shares` and creates an asynchronous redeem request.
+    /// @param shares Share amount.
+    /// @param controller Request controller account.
+    /// @param owner Share owner account.
+    /// @return requestId Request discriminator.
+    function requestRedeem(uint256 shares, address controller, address owner) external returns (uint256 requestId);
+
+    /// @notice Returns the pending redeem-request shares for `controller` and `requestId`.
+    /// @param requestId Request discriminator.
+    /// @param controller Request controller account.
+    /// @return shares Pending share amount.
+    function pendingRedeemRequest(uint256 requestId, address controller) external view returns (uint256 shares);
+
+    /// @notice Returns the claimable redeem-request shares for `controller` and `requestId`.
+    /// @param requestId Request discriminator.
+    /// @param controller Request controller account.
+    /// @return shares Claimable share amount.
+    function claimableRedeemRequest(uint256 requestId, address controller) external view returns (uint256 shares);
+}

--- a/src/interfaces/IERC7540VaultFacet.sol
+++ b/src/interfaces/IERC7540VaultFacet.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC7540Deposit} from "./IERC7540Deposit.sol";
+import {IERC7540Operators} from "./IERC7540Operators.sol";
+import {IERC7540Redeem} from "./IERC7540Redeem.sol";
+
+/// @title IERC7540VaultFacet
+/// @notice Hosted async-vault extension surface for ERC-7540-style request flows.
+interface IERC7540VaultFacet is IERC7540Operators, IERC7540Deposit, IERC7540Redeem {
+    /// @notice Emitted when a deposit request is submitted.
+    event DepositRequest(
+        address indexed controller, address indexed owner, uint256 indexed requestId, address sender, uint256 assets
+    );
+
+    /// @notice Emitted when a redeem request is submitted.
+    event RedeemRequest(
+        address indexed controller, address indexed owner, uint256 indexed requestId, address sender, uint256 shares
+    );
+
+    /// @notice Emitted when `controller` updates `operator` approval.
+    event OperatorSet(address indexed controller, address indexed operator, bool approved);
+}

--- a/src/vault/libraries/LibERC7540RequestAccounting.sol
+++ b/src/vault/libraries/LibERC7540RequestAccounting.sol
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {LibERC7540VaultStorage} from "../storage/LibERC7540VaultStorage.sol";
+
+/// @title LibERC7540RequestAccounting
+/// @notice Shared async request bookkeeping helpers for the hosted vault track.
+library LibERC7540RequestAccounting {
+    /// @notice Canonical request id for the hosted vault's aggregated request model.
+    uint256 internal constant AGGREGATE_REQUEST_ID = 0;
+
+    /// @notice Thrown when a caller attempts to use a non-aggregate request id with the aggregated model.
+    /// @param requestId The unsupported request id.
+    error ERC7540VaultInvalidRequestId(uint256 requestId);
+
+    /// @notice Thrown when a request update is attempted for the zero controller address.
+    error ERC7540VaultZeroController();
+
+    /// @notice Thrown when an operator update uses the zero operator address.
+    error ERC7540VaultZeroOperator();
+
+    /// @notice Thrown when a pending deposit move exceeds the controller's pending assets.
+    /// @param controller Request controller account.
+    /// @param available Available pending asset amount.
+    /// @param required Requested asset amount.
+    error ERC7540VaultInsufficientPendingDepositRequest(address controller, uint256 available, uint256 required);
+
+    /// @notice Thrown when a claimable deposit consume exceeds the controller's claimable assets.
+    /// @param controller Request controller account.
+    /// @param available Available claimable asset amount.
+    /// @param required Requested asset amount.
+    error ERC7540VaultInsufficientClaimableDepositRequest(address controller, uint256 available, uint256 required);
+
+    /// @notice Thrown when a pending redeem move exceeds the controller's pending shares.
+    /// @param controller Request controller account.
+    /// @param available Available pending share amount.
+    /// @param required Requested share amount.
+    error ERC7540VaultInsufficientPendingRedeemRequest(address controller, uint256 available, uint256 required);
+
+    /// @notice Thrown when a claimable redeem consume exceeds the controller's claimable shares.
+    /// @param controller Request controller account.
+    /// @param available Available claimable share amount.
+    /// @param required Requested share amount.
+    error ERC7540VaultInsufficientClaimableRedeemRequest(address controller, uint256 available, uint256 required);
+
+    /// @notice Returns the hosted vault's aggregated request id.
+    /// @return requestId The canonical request id.
+    function aggregateRequestId() internal pure returns (uint256 requestId) {
+        return AGGREGATE_REQUEST_ID;
+    }
+
+    /// @notice Reverts when `requestId` is not supported by the aggregated request model.
+    /// @param requestId Request id to validate.
+    function requireAggregateRequestId(uint256 requestId) internal pure {
+        if (requestId != AGGREGATE_REQUEST_ID) {
+            revert ERC7540VaultInvalidRequestId(requestId);
+        }
+    }
+
+    /// @notice Returns the pending deposit-request assets for `controller` and `requestId`.
+    /// @param requestId Request discriminator.
+    /// @param controller Request controller account.
+    /// @return assets Pending asset amount.
+    function pendingDepositRequest(uint256 requestId, address controller) internal view returns (uint256 assets) {
+        if (requestId != AGGREGATE_REQUEST_ID || controller == address(0)) {
+            return 0;
+        }
+        return LibERC7540VaultStorage.layout().pendingDepositRequestAssets[controller];
+    }
+
+    /// @notice Returns the claimable deposit-request assets for `controller` and `requestId`.
+    /// @param requestId Request discriminator.
+    /// @param controller Request controller account.
+    /// @return assets Claimable asset amount.
+    function claimableDepositRequest(uint256 requestId, address controller) internal view returns (uint256 assets) {
+        if (requestId != AGGREGATE_REQUEST_ID || controller == address(0)) {
+            return 0;
+        }
+        return LibERC7540VaultStorage.layout().claimableDepositRequestAssets[controller];
+    }
+
+    /// @notice Returns the pending redeem-request shares for `controller` and `requestId`.
+    /// @param requestId Request discriminator.
+    /// @param controller Request controller account.
+    /// @return shares Pending share amount.
+    function pendingRedeemRequest(uint256 requestId, address controller) internal view returns (uint256 shares) {
+        if (requestId != AGGREGATE_REQUEST_ID || controller == address(0)) {
+            return 0;
+        }
+        return LibERC7540VaultStorage.layout().pendingRedeemRequestShares[controller];
+    }
+
+    /// @notice Returns the claimable redeem-request shares for `controller` and `requestId`.
+    /// @param requestId Request discriminator.
+    /// @param controller Request controller account.
+    /// @return shares Claimable share amount.
+    function claimableRedeemRequest(uint256 requestId, address controller) internal view returns (uint256 shares) {
+        if (requestId != AGGREGATE_REQUEST_ID || controller == address(0)) {
+            return 0;
+        }
+        return LibERC7540VaultStorage.layout().claimableRedeemRequestShares[controller];
+    }
+
+    /// @notice Returns true when `operator` is approved for `controller`.
+    /// @param controller Request controller account.
+    /// @param operator Candidate operator account.
+    /// @return status True when approved.
+    function isOperator(address controller, address operator) internal view returns (bool status) {
+        if (controller == address(0) || operator == address(0)) {
+            return false;
+        }
+        return LibERC7540VaultStorage.layout().operatorApprovals[controller][operator];
+    }
+
+    /// @notice Updates operator approval for `controller`.
+    /// @param controller Request controller account.
+    /// @param operator Operator account.
+    /// @param approved Approval status to store.
+    function setOperator(address controller, address operator, bool approved) internal {
+        _requireController(controller);
+        if (operator == address(0)) {
+            revert ERC7540VaultZeroOperator();
+        }
+
+        LibERC7540VaultStorage.layout().operatorApprovals[controller][operator] = approved;
+    }
+
+    /// @notice Increases pending deposit assets for `controller`.
+    /// @param controller Request controller account.
+    /// @param assets Added pending asset amount.
+    function increasePendingDeposit(address controller, uint256 assets) internal {
+        _requireController(controller);
+        if (assets == 0) {
+            return;
+        }
+
+        LibERC7540VaultStorage.Layout storage layout = LibERC7540VaultStorage.layout();
+        layout.pendingDepositRequestAssets[controller] += assets;
+        layout.totalPendingDepositRequestAssets += assets;
+    }
+
+    /// @notice Moves pending deposit assets into claimable state for `controller`.
+    /// @param controller Request controller account.
+    /// @param assets Asset amount to move.
+    function movePendingDepositToClaimable(address controller, uint256 assets) internal {
+        _requireController(controller);
+        if (assets == 0) {
+            return;
+        }
+
+        LibERC7540VaultStorage.Layout storage layout = LibERC7540VaultStorage.layout();
+        uint256 available = layout.pendingDepositRequestAssets[controller];
+        if (assets > available) {
+            revert ERC7540VaultInsufficientPendingDepositRequest(controller, available, assets);
+        }
+
+        layout.pendingDepositRequestAssets[controller] = available - assets;
+        layout.claimableDepositRequestAssets[controller] += assets;
+        layout.totalPendingDepositRequestAssets -= assets;
+        layout.totalClaimableDepositRequestAssets += assets;
+    }
+
+    /// @notice Consumes claimable deposit assets for `controller`.
+    /// @param controller Request controller account.
+    /// @param assets Asset amount to consume.
+    function consumeClaimableDeposit(address controller, uint256 assets) internal {
+        _requireController(controller);
+        if (assets == 0) {
+            return;
+        }
+
+        LibERC7540VaultStorage.Layout storage layout = LibERC7540VaultStorage.layout();
+        uint256 available = layout.claimableDepositRequestAssets[controller];
+        if (assets > available) {
+            revert ERC7540VaultInsufficientClaimableDepositRequest(controller, available, assets);
+        }
+
+        layout.claimableDepositRequestAssets[controller] = available - assets;
+        layout.totalClaimableDepositRequestAssets -= assets;
+    }
+
+    /// @notice Increases pending redeem shares for `controller`.
+    /// @param controller Request controller account.
+    /// @param shares Added pending share amount.
+    function increasePendingRedeem(address controller, uint256 shares) internal {
+        _requireController(controller);
+        if (shares == 0) {
+            return;
+        }
+
+        LibERC7540VaultStorage.Layout storage layout = LibERC7540VaultStorage.layout();
+        layout.pendingRedeemRequestShares[controller] += shares;
+        layout.totalPendingRedeemRequestShares += shares;
+    }
+
+    /// @notice Moves pending redeem shares into claimable state for `controller`.
+    /// @param controller Request controller account.
+    /// @param shares Share amount to move.
+    function movePendingRedeemToClaimable(address controller, uint256 shares) internal {
+        _requireController(controller);
+        if (shares == 0) {
+            return;
+        }
+
+        LibERC7540VaultStorage.Layout storage layout = LibERC7540VaultStorage.layout();
+        uint256 available = layout.pendingRedeemRequestShares[controller];
+        if (shares > available) {
+            revert ERC7540VaultInsufficientPendingRedeemRequest(controller, available, shares);
+        }
+
+        layout.pendingRedeemRequestShares[controller] = available - shares;
+        layout.claimableRedeemRequestShares[controller] += shares;
+        layout.totalPendingRedeemRequestShares -= shares;
+        layout.totalClaimableRedeemRequestShares += shares;
+    }
+
+    /// @notice Consumes claimable redeem shares for `controller`.
+    /// @param controller Request controller account.
+    /// @param shares Share amount to consume.
+    function consumeClaimableRedeem(address controller, uint256 shares) internal {
+        _requireController(controller);
+        if (shares == 0) {
+            return;
+        }
+
+        LibERC7540VaultStorage.Layout storage layout = LibERC7540VaultStorage.layout();
+        uint256 available = layout.claimableRedeemRequestShares[controller];
+        if (shares > available) {
+            revert ERC7540VaultInsufficientClaimableRedeemRequest(controller, available, shares);
+        }
+
+        layout.claimableRedeemRequestShares[controller] = available - shares;
+        layout.totalClaimableRedeemRequestShares -= shares;
+    }
+
+    /// @notice Returns the aggregate pending deposit-request assets across all controllers.
+    /// @return assets Total pending deposit-request assets.
+    function totalPendingDepositRequestAssets() internal view returns (uint256 assets) {
+        return LibERC7540VaultStorage.layout().totalPendingDepositRequestAssets;
+    }
+
+    /// @notice Returns the aggregate claimable deposit-request assets across all controllers.
+    /// @return assets Total claimable deposit-request assets.
+    function totalClaimableDepositRequestAssets() internal view returns (uint256 assets) {
+        return LibERC7540VaultStorage.layout().totalClaimableDepositRequestAssets;
+    }
+
+    /// @notice Returns the aggregate pending redeem-request shares across all controllers.
+    /// @return shares Total pending redeem-request shares.
+    function totalPendingRedeemRequestShares() internal view returns (uint256 shares) {
+        return LibERC7540VaultStorage.layout().totalPendingRedeemRequestShares;
+    }
+
+    /// @notice Returns the aggregate claimable redeem-request shares across all controllers.
+    /// @return shares Total claimable redeem-request shares.
+    function totalClaimableRedeemRequestShares() internal view returns (uint256 shares) {
+        return LibERC7540VaultStorage.layout().totalClaimableRedeemRequestShares;
+    }
+
+    function _requireController(address controller) private pure {
+        if (controller == address(0)) {
+            revert ERC7540VaultZeroController();
+        }
+    }
+}

--- a/src/vault/libraries/LibVaultFacetSelectors.sol
+++ b/src/vault/libraries/LibVaultFacetSelectors.sol
@@ -7,6 +7,9 @@ import {IERC20} from "../../interfaces/IERC20.sol";
 import {IERC20Metadata} from "../../interfaces/IERC20Metadata.sol";
 import {IERC165} from "../../interfaces/IERC165.sol";
 import {IERC4626} from "../../interfaces/IERC4626.sol";
+import {IERC7540Deposit} from "../../interfaces/IERC7540Deposit.sol";
+import {IERC7540Operators} from "../../interfaces/IERC7540Operators.sol";
+import {IERC7540Redeem} from "../../interfaces/IERC7540Redeem.sol";
 import {IERC7535VaultFacet} from "../../interfaces/IERC7535VaultFacet.sol";
 import {IERC4626VaultBase} from "../../interfaces/IERC4626VaultBase.sol";
 import {IERC4626VaultControls} from "../../interfaces/IERC4626VaultControls.sol";
@@ -56,6 +59,21 @@ library LibVaultFacetSelectors {
         selectors = new bytes4[](2);
         selectors[0] = IERC7535VaultFacet.depositNative.selector;
         selectors[1] = IERC7535VaultFacet.mintNative.selector;
+    }
+
+    /// @notice Returns the hosted vault async selector group.
+    function vaultAsyncSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](10);
+        selectors[0] = IERC7540Deposit.requestDeposit.selector;
+        selectors[1] = IERC7540Deposit.pendingDepositRequest.selector;
+        selectors[2] = IERC7540Deposit.claimableDepositRequest.selector;
+        selectors[3] = IERC7540Deposit.deposit.selector;
+        selectors[4] = IERC7540Deposit.mint.selector;
+        selectors[5] = IERC7540Redeem.requestRedeem.selector;
+        selectors[6] = IERC7540Redeem.pendingRedeemRequest.selector;
+        selectors[7] = IERC7540Redeem.claimableRedeemRequest.selector;
+        selectors[8] = IERC7540Operators.isOperator.selector;
+        selectors[9] = IERC7540Operators.setOperator.selector;
     }
 
     /// @notice Returns the hosted vault controls selector group.

--- a/src/vault/storage/LibERC7540VaultStorage.sol
+++ b/src/vault/storage/LibERC7540VaultStorage.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title LibERC7540VaultStorage
+/// @notice Storage layout for hosted ERC-7540 async request accounting.
+library LibERC7540VaultStorage {
+    /// @dev Storage slot for async-vault request layout.
+    bytes32 internal constant STORAGE_SLOT = keccak256("auralis.erc7540-vault.storage");
+
+    /// @notice Async request accounting layout.
+    struct Layout {
+        mapping(address => mapping(address => bool)) operatorApprovals;
+        mapping(address => uint256) pendingDepositRequestAssets;
+        mapping(address => uint256) claimableDepositRequestAssets;
+        mapping(address => uint256) pendingRedeemRequestShares;
+        mapping(address => uint256) claimableRedeemRequestShares;
+        uint256 totalPendingDepositRequestAssets;
+        uint256 totalClaimableDepositRequestAssets;
+        uint256 totalPendingRedeemRequestShares;
+        uint256 totalClaimableRedeemRequestShares;
+    }
+
+    /// @notice Returns the storage layout for async request accounting.
+    /// @return l The storage layout pointer.
+    function layout() internal pure returns (Layout storage l) {
+        bytes32 slot = STORAGE_SLOT;
+        assembly {
+            l.slot := slot
+        }
+    }
+}

--- a/test/ERC7540VaultFoundationCore.t.sol
+++ b/test/ERC7540VaultFoundationCore.t.sol
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC165} from "../src/interfaces/IERC165.sol";
+import {IERC4626} from "../src/interfaces/IERC4626.sol";
+import {IERC7540Deposit} from "../src/interfaces/IERC7540Deposit.sol";
+import {IERC7540Operators} from "../src/interfaces/IERC7540Operators.sol";
+import {IERC7540Redeem} from "../src/interfaces/IERC7540Redeem.sol";
+import {IERC7535VaultFacet} from "../src/interfaces/IERC7535VaultFacet.sol";
+import {IAccessControlTime} from "../src/interfaces/IAccessControlTime.sol";
+import {IERC4626VaultBase} from "../src/interfaces/IERC4626VaultBase.sol";
+import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol";
+import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
+import {IReentrancyGuard} from "../src/interfaces/IReentrancyGuard.sol";
+import {LibERC7540RequestAccounting} from "../src/vault/libraries/LibERC7540RequestAccounting.sol";
+import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
+import {ERC7540VaultFoundationFixture} from "./helpers/ERC7540VaultFoundationTestHarness.sol";
+
+contract ERC7540VaultFoundationCoreTest is ERC7540VaultFoundationFixture {
+    function testErc7540InterfaceIdsMatchSpecConstants() public pure {
+        assertTrue(type(IERC7540Operators).interfaceId == 0xe3bc4e65, "operator interface id mismatch");
+        assertTrue(type(IERC7540Deposit).interfaceId == 0xce3bbe50, "deposit interface id mismatch");
+        assertTrue(type(IERC7540Redeem).interfaceId == 0x620ee8e4, "redeem interface id mismatch");
+    }
+
+    function testAsyncSelectorGroupCoversExpectedSurface() public pure {
+        bytes4[] memory asyncSelectors = LibVaultFacetSelectors.vaultAsyncSelectors();
+        bytes4[] memory coreSelectors = LibVaultFacetSelectors.vaultCoreSelectors();
+        bytes4[] memory nativeSelectors = LibVaultFacetSelectors.vaultNativeSelectors();
+        bytes4[] memory controlSelectors = LibVaultFacetSelectors.vaultControlsSelectors();
+        bytes4[] memory integrationSelectors = LibVaultFacetSelectors.vaultIntegrationSelectors();
+
+        assertTrue(asyncSelectors.length == 10, "unexpected async selector count");
+
+        _assertContains(asyncSelectors, IERC7540Deposit.requestDeposit.selector);
+        _assertContains(asyncSelectors, IERC7540Deposit.pendingDepositRequest.selector);
+        _assertContains(asyncSelectors, IERC7540Deposit.claimableDepositRequest.selector);
+        _assertContains(asyncSelectors, IERC7540Deposit.deposit.selector);
+        _assertContains(asyncSelectors, IERC7540Deposit.mint.selector);
+        _assertContains(asyncSelectors, IERC7540Redeem.requestRedeem.selector);
+        _assertContains(asyncSelectors, IERC7540Redeem.pendingRedeemRequest.selector);
+        _assertContains(asyncSelectors, IERC7540Redeem.claimableRedeemRequest.selector);
+        _assertContains(asyncSelectors, IERC7540Operators.isOperator.selector);
+        _assertContains(asyncSelectors, IERC7540Operators.setOperator.selector);
+
+        _assertUnique(asyncSelectors);
+        _assertDisjoint(asyncSelectors, coreSelectors);
+        _assertDisjoint(asyncSelectors, nativeSelectors);
+        _assertDisjoint(asyncSelectors, controlSelectors);
+        _assertDisjoint(asyncSelectors, integrationSelectors);
+    }
+
+    function testZeroStateReturnsZeroAcrossAllBuckets() public view {
+        assertTrue(harness.aggregateRequestId() == 0, "aggregate request id mismatch");
+        assertTrue(harness.pendingDepositRequest(0, bob) == 0, "pending deposit should start at zero");
+        assertTrue(harness.claimableDepositRequest(0, bob) == 0, "claimable deposit should start at zero");
+        assertTrue(harness.pendingRedeemRequest(0, bob) == 0, "pending redeem should start at zero");
+        assertTrue(harness.claimableRedeemRequest(0, bob) == 0, "claimable redeem should start at zero");
+        assertFalse(harness.isOperator(bob, eve), "operator approval should start unset");
+        assertTrue(harness.totalPendingDepositRequestAssets() == 0, "pending deposit total should start at zero");
+        assertTrue(harness.totalClaimableDepositRequestAssets() == 0, "claimable deposit total should start at zero");
+        assertTrue(harness.totalPendingRedeemRequestShares() == 0, "pending redeem total should start at zero");
+        assertTrue(harness.totalClaimableRedeemRequestShares() == 0, "claimable redeem total should start at zero");
+    }
+
+    function testAggregateRequestViewsIgnoreUnsupportedRequestIds() public {
+        harness.increasePendingDeposit(bob, 40);
+        harness.increasePendingRedeem(bob, 15);
+
+        assertTrue(harness.pendingDepositRequest(0, bob) == 40, "aggregate pending deposit mismatch");
+        assertTrue(harness.pendingRedeemRequest(0, bob) == 15, "aggregate pending redeem mismatch");
+        assertTrue(harness.pendingDepositRequest(1, bob) == 0, "non-aggregate deposit id should read zero");
+        assertTrue(harness.pendingRedeemRequest(1, bob) == 0, "non-aggregate redeem id should read zero");
+    }
+
+    function testRequireAggregateRequestIdRevertsForNonZeroIds() public {
+        VM.expectRevert(
+            abi.encodeWithSelector(LibERC7540RequestAccounting.ERC7540VaultInvalidRequestId.selector, 7)
+        );
+        harness.requireAggregateRequestId(7);
+    }
+
+    function testDepositAccountingUpdatesControllerAndTotals() public {
+        harness.increasePendingDeposit(bob, 40);
+        harness.movePendingDepositToClaimable(bob, 25);
+        harness.consumeClaimableDeposit(bob, 10);
+
+        assertTrue(harness.pendingDepositRequest(0, bob) == 15, "pending deposit mismatch");
+        assertTrue(harness.claimableDepositRequest(0, bob) == 15, "claimable deposit mismatch");
+        assertTrue(harness.totalPendingDepositRequestAssets() == 15, "pending deposit total mismatch");
+        assertTrue(harness.totalClaimableDepositRequestAssets() == 15, "claimable deposit total mismatch");
+        assertTrue(harness.pendingRedeemRequest(0, bob) == 0, "redeem state should stay isolated");
+        assertTrue(harness.totalPendingRedeemRequestShares() == 0, "redeem total should stay isolated");
+    }
+
+    function testRedeemAccountingUpdatesControllerAndTotals() public {
+        harness.increasePendingRedeem(carol, 30);
+        harness.movePendingRedeemToClaimable(carol, 12);
+        harness.consumeClaimableRedeem(carol, 5);
+
+        assertTrue(harness.pendingRedeemRequest(0, carol) == 18, "pending redeem mismatch");
+        assertTrue(harness.claimableRedeemRequest(0, carol) == 7, "claimable redeem mismatch");
+        assertTrue(harness.totalPendingRedeemRequestShares() == 18, "pending redeem total mismatch");
+        assertTrue(harness.totalClaimableRedeemRequestShares() == 7, "claimable redeem total mismatch");
+        assertTrue(harness.pendingDepositRequest(0, carol) == 0, "deposit state should stay isolated");
+        assertTrue(harness.totalPendingDepositRequestAssets() == 0, "deposit total should stay isolated");
+    }
+
+    function testDepositAccountingRevertsWhenMovingOrConsumingBeyondBalance() public {
+        harness.increasePendingDeposit(bob, 5);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                LibERC7540RequestAccounting.ERC7540VaultInsufficientPendingDepositRequest.selector, bob, 5, 6
+            )
+        );
+        harness.movePendingDepositToClaimable(bob, 6);
+
+        harness.movePendingDepositToClaimable(bob, 5);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                LibERC7540RequestAccounting.ERC7540VaultInsufficientClaimableDepositRequest.selector, bob, 5, 6
+            )
+        );
+        harness.consumeClaimableDeposit(bob, 6);
+    }
+
+    function testRedeemAccountingRevertsWhenMovingOrConsumingBeyondBalance() public {
+        harness.increasePendingRedeem(carol, 8);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                LibERC7540RequestAccounting.ERC7540VaultInsufficientPendingRedeemRequest.selector, carol, 8, 9
+            )
+        );
+        harness.movePendingRedeemToClaimable(carol, 9);
+
+        harness.movePendingRedeemToClaimable(carol, 8);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                LibERC7540RequestAccounting.ERC7540VaultInsufficientClaimableRedeemRequest.selector, carol, 8, 9
+            )
+        );
+        harness.consumeClaimableRedeem(carol, 9);
+    }
+
+    function testSetOperatorTracksApprovalAndRevocation() public {
+        VM.prank(bob);
+        bool approved = harness.setOperator(eve, true);
+
+        assertTrue(approved, "setOperator should return true");
+        assertTrue(harness.isOperator(bob, eve), "operator should be approved");
+
+        VM.prank(bob);
+        harness.setOperator(eve, false);
+
+        assertFalse(harness.isOperator(bob, eve), "operator should be revoked");
+    }
+
+    function testSetOperatorRevertsOnZeroOperator() public {
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(LibERC7540RequestAccounting.ERC7540VaultZeroOperator.selector));
+        harness.setOperator(address(0), true);
+    }
+
+    function _assertContains(bytes4[] memory selectors, bytes4 target) internal pure {
+        for (uint256 i = 0; i < selectors.length; i++) {
+            if (selectors[i] == target) {
+                return;
+            }
+        }
+        revert("missing selector");
+    }
+
+    function _assertUnique(bytes4[] memory selectors) internal pure {
+        for (uint256 i = 0; i < selectors.length; i++) {
+            for (uint256 j = i + 1; j < selectors.length; j++) {
+                if (selectors[i] == selectors[j]) {
+                    revert("duplicate selector");
+                }
+            }
+        }
+    }
+
+    function _assertDisjoint(bytes4[] memory left, bytes4[] memory right) internal pure {
+        for (uint256 i = 0; i < left.length; i++) {
+            for (uint256 j = 0; j < right.length; j++) {
+                if (left[i] == right[j]) {
+                    revert("selector overlap");
+                }
+            }
+        }
+    }
+}

--- a/test/ERC7540VaultFoundationCore.t.sol
+++ b/test/ERC7540VaultFoundationCore.t.sol
@@ -74,9 +74,7 @@ contract ERC7540VaultFoundationCoreTest is ERC7540VaultFoundationFixture {
     }
 
     function testRequireAggregateRequestIdRevertsForNonZeroIds() public {
-        VM.expectRevert(
-            abi.encodeWithSelector(LibERC7540RequestAccounting.ERC7540VaultInvalidRequestId.selector, 7)
-        );
+        VM.expectRevert(abi.encodeWithSelector(LibERC7540RequestAccounting.ERC7540VaultInvalidRequestId.selector, 7));
         harness.requireAggregateRequestId(7);
     }
 

--- a/test/helpers/ERC7540VaultFoundationTestHarness.sol
+++ b/test/helpers/ERC7540VaultFoundationTestHarness.sol
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {LibERC7540RequestAccounting} from "../../src/vault/libraries/LibERC7540RequestAccounting.sol";
+import {TestBase} from "./AccessControlTestHarness.sol";
+
+contract ERC7540VaultFoundationHarness {
+    function aggregateRequestId() external pure returns (uint256 requestId) {
+        return LibERC7540RequestAccounting.aggregateRequestId();
+    }
+
+    function requireAggregateRequestId(uint256 requestId) external pure {
+        LibERC7540RequestAccounting.requireAggregateRequestId(requestId);
+    }
+
+    function pendingDepositRequest(uint256 requestId, address controller) external view returns (uint256 assets) {
+        return LibERC7540RequestAccounting.pendingDepositRequest(requestId, controller);
+    }
+
+    function claimableDepositRequest(uint256 requestId, address controller) external view returns (uint256 assets) {
+        return LibERC7540RequestAccounting.claimableDepositRequest(requestId, controller);
+    }
+
+    function pendingRedeemRequest(uint256 requestId, address controller) external view returns (uint256 shares) {
+        return LibERC7540RequestAccounting.pendingRedeemRequest(requestId, controller);
+    }
+
+    function claimableRedeemRequest(uint256 requestId, address controller) external view returns (uint256 shares) {
+        return LibERC7540RequestAccounting.claimableRedeemRequest(requestId, controller);
+    }
+
+    function isOperator(address controller, address operator) external view returns (bool status) {
+        return LibERC7540RequestAccounting.isOperator(controller, operator);
+    }
+
+    function setOperator(address operator, bool approved) external returns (bool success) {
+        LibERC7540RequestAccounting.setOperator(msg.sender, operator, approved);
+        return true;
+    }
+
+    function increasePendingDeposit(address controller, uint256 assets) external {
+        LibERC7540RequestAccounting.increasePendingDeposit(controller, assets);
+    }
+
+    function movePendingDepositToClaimable(address controller, uint256 assets) external {
+        LibERC7540RequestAccounting.movePendingDepositToClaimable(controller, assets);
+    }
+
+    function consumeClaimableDeposit(address controller, uint256 assets) external {
+        LibERC7540RequestAccounting.consumeClaimableDeposit(controller, assets);
+    }
+
+    function increasePendingRedeem(address controller, uint256 shares) external {
+        LibERC7540RequestAccounting.increasePendingRedeem(controller, shares);
+    }
+
+    function movePendingRedeemToClaimable(address controller, uint256 shares) external {
+        LibERC7540RequestAccounting.movePendingRedeemToClaimable(controller, shares);
+    }
+
+    function consumeClaimableRedeem(address controller, uint256 shares) external {
+        LibERC7540RequestAccounting.consumeClaimableRedeem(controller, shares);
+    }
+
+    function totalPendingDepositRequestAssets() external view returns (uint256 assets) {
+        return LibERC7540RequestAccounting.totalPendingDepositRequestAssets();
+    }
+
+    function totalClaimableDepositRequestAssets() external view returns (uint256 assets) {
+        return LibERC7540RequestAccounting.totalClaimableDepositRequestAssets();
+    }
+
+    function totalPendingRedeemRequestShares() external view returns (uint256 shares) {
+        return LibERC7540RequestAccounting.totalPendingRedeemRequestShares();
+    }
+
+    function totalClaimableRedeemRequestShares() external view returns (uint256 shares) {
+        return LibERC7540RequestAccounting.totalClaimableRedeemRequestShares();
+    }
+}
+
+abstract contract ERC7540VaultFoundationFixture is TestBase {
+    address internal bob = address(0xB0B);
+    address internal carol = address(0xCA401);
+    address internal eve = address(0xE11E);
+
+    ERC7540VaultFoundationHarness internal harness;
+
+    function setUp() public virtual {
+        harness = new ERC7540VaultFoundationHarness();
+    }
+}


### PR DESCRIPTION
## Summary
- add the ERC-7540 async-vault interface foundation for the hosted vault track
- add isolated async request storage and accounting helpers for pending and claimable lifecycle state
- add focused foundation tests for interface ids, selector grouping, aggregate request ids, operator approvals, and request bookkeeping

## Testing
- forge test --match-contract ERC7540VaultFoundationCoreTest
- forge test --match-contract VaultFacetFoundationCoreTest
- forge test --match-contract ERC4626VaultFacetCoreTest
- forge test --match-contract DiamondVaultDeploymentIntegrationTest
- forge test --match-contract DiamondVaultHostHardeningTest
- forge test --match-contract DiamondNativeVaultHostHardeningTest

## Linked Issue
Closes #193
