### PR TITLE
feat: add ERC-7540 async deposit support to hosted vault

### DIFF
--- a/script/DeployDiamondNativeVaultHost.s.sol
+++ b/script/DeployDiamondNativeVaultHost.s.sol
@@ -88,6 +88,7 @@ contract DeployDiamondNativeVaultHostScript is DiamondVaultHostScriptBase {
                 diamondCutFacet: state.cutFacetAddress,
                 diamondLoupeFacet: state.loupeFacetAddress,
                 vaultCoreFacet: state.vaultCoreFacetAddress,
+                vaultAsyncDepositFacet: address(0),
                 vaultNativeFacet: state.vaultNativeFacetAddress,
                 vaultControlsFacet: state.vaultControlsFacetAddress,
                 vaultIntegrationFacet: state.vaultIntegrationFacetAddress,

--- a/script/DeployDiamondVaultHost.s.sol
+++ b/script/DeployDiamondVaultHost.s.sol
@@ -11,6 +11,8 @@ import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol
 import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControlsFacet.sol";
 import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
 import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
+import {IERC7540Deposit} from "../src/interfaces/IERC7540Deposit.sol";
+import {IERC7540Operators} from "../src/interfaces/IERC7540Operators.sol";
 import {IERC4626VaultStrategy} from "../src/interfaces/IERC4626VaultStrategy.sol";
 import {IOracleAdapter} from "../src/interfaces/IOracleAdapter.sol";
 import {ERC4626VaultControlsFacet} from "../src/vault/facets/ERC4626VaultControlsFacet.sol";
@@ -124,18 +126,23 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
     }
 
     function _installVaultHostFacets(VaultHostDeploymentState memory state) internal {
-        IDiamondCut.FacetCut[] memory vaultCut = new IDiamondCut.FacetCut[](3);
+        IDiamondCut.FacetCut[] memory vaultCut = new IDiamondCut.FacetCut[](4);
         vaultCut[0] = IDiamondCut.FacetCut({
             facetAddress: state.vaultCoreFacetAddress,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: LibVaultFacetSelectors.vaultCoreSelectors()
         });
         vaultCut[1] = IDiamondCut.FacetCut({
+            facetAddress: state.vaultCoreFacetAddress,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultAsyncDepositSelectors()
+        });
+        vaultCut[2] = IDiamondCut.FacetCut({
             facetAddress: state.vaultControlsFacetAddress,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: LibVaultFacetSelectors.vaultControlsSelectors()
         });
-        vaultCut[2] = IDiamondCut.FacetCut({
+        vaultCut[3] = IDiamondCut.FacetCut({
             facetAddress: state.vaultIntegrationFacetAddress,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: LibVaultFacetSelectors.vaultIntegrationSelectors()
@@ -164,7 +171,7 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
 
         require(
             loupe.facetFunctionSelectors(state.vaultCoreFacetAddress).length
-                == LibVaultFacetSelectors.vaultCoreSelectors().length,
+                == LibVaultFacetSelectors.vaultCoreSelectors().length + LibVaultFacetSelectors.vaultAsyncDepositSelectors().length,
             "vault host core selector count mismatch"
         );
         require(
@@ -217,6 +224,14 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
             "vault host missing controls interface"
         );
         require(
+            IERC165(state.diamondAddress).supportsInterface(type(IERC7540Deposit).interfaceId),
+            "vault host missing async deposit interface"
+        );
+        require(
+            IERC165(state.diamondAddress).supportsInterface(type(IERC7540Operators).interfaceId),
+            "vault host missing operator interface"
+        );
+        require(
             IERC165(state.diamondAddress).supportsInterface(type(IERC4626VaultIntegrationFacet).interfaceId),
             "vault host missing integration interface"
         );
@@ -225,6 +240,9 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
         _requireSelectorOwner(loupe, DiamondLoupeFacet.facets.selector, state.loupeFacetAddress, "vault loupe owner");
         _requireSelectorOwner(
             loupe, IERC4626VaultFacet.initializeVault.selector, state.vaultCoreFacetAddress, "vault init owner"
+        );
+        _requireSelectorOwner(
+            loupe, IERC7540Deposit.requestDeposit.selector, state.vaultCoreFacetAddress, "vault async deposit owner"
         );
         _requireSelectorOwner(
             loupe,

--- a/script/DeployDiamondVaultHost.s.sol
+++ b/script/DeployDiamondVaultHost.s.sol
@@ -17,6 +17,7 @@ import {IERC4626VaultStrategy} from "../src/interfaces/IERC4626VaultStrategy.sol
 import {IOracleAdapter} from "../src/interfaces/IOracleAdapter.sol";
 import {ERC4626VaultControlsFacet} from "../src/vault/facets/ERC4626VaultControlsFacet.sol";
 import {ERC4626VaultFacet} from "../src/vault/facets/ERC4626VaultFacet.sol";
+import {ERC7540VaultDepositFacet} from "../src/vault/facets/ERC7540VaultDepositFacet.sol";
 import {ERC4626VaultIntegrationFacet} from "../src/vault/facets/ERC4626VaultIntegrationFacet.sol";
 import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {DiamondVaultHostScriptBase} from "./common/DiamondVaultHostScriptBase.sol";
@@ -35,6 +36,7 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
         address cutFacetAddress;
         address loupeFacetAddress;
         address vaultCoreFacetAddress;
+        address vaultAsyncDepositFacetAddress;
         address vaultControlsFacetAddress;
         address vaultIntegrationFacetAddress;
         address vaultAssetAddress;
@@ -86,6 +88,7 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
                 diamondCutFacet: state.cutFacetAddress,
                 diamondLoupeFacet: state.loupeFacetAddress,
                 vaultCoreFacet: state.vaultCoreFacetAddress,
+                vaultAsyncDepositFacet: state.vaultAsyncDepositFacetAddress,
                 vaultNativeFacet: address(0),
                 vaultControlsFacet: state.vaultControlsFacetAddress,
                 vaultIntegrationFacet: state.vaultIntegrationFacetAddress,
@@ -115,6 +118,7 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
         returns (VaultHostDeploymentState memory)
     {
         state.vaultCoreFacetAddress = address(new ERC4626VaultFacet());
+        state.vaultAsyncDepositFacetAddress = address(new ERC7540VaultDepositFacet());
         state.vaultControlsFacetAddress = address(new ERC4626VaultControlsFacet());
         state.vaultIntegrationFacetAddress = address(new ERC4626VaultIntegrationFacet());
         state.vaultAssetAddress = address(new LocalMintableVaultAsset("Mock USD", "mUSD", 6));
@@ -130,12 +134,12 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
         vaultCut[0] = IDiamondCut.FacetCut({
             facetAddress: state.vaultCoreFacetAddress,
             action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: LibVaultFacetSelectors.vaultCoreSelectors()
+            functionSelectors: LibVaultFacetSelectors.vaultAsyncHostCoreSelectors()
         });
         vaultCut[1] = IDiamondCut.FacetCut({
-            facetAddress: state.vaultCoreFacetAddress,
+            facetAddress: state.vaultAsyncDepositFacetAddress,
             action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: LibVaultFacetSelectors.vaultAsyncDepositSelectors()
+            functionSelectors: LibVaultFacetSelectors.vaultAsyncDepositHostSelectors()
         });
         vaultCut[2] = IDiamondCut.FacetCut({
             facetAddress: state.vaultControlsFacetAddress,
@@ -160,10 +164,14 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
         IERC4626VaultStrategy strategy = IERC4626VaultStrategy(state.strategyAddress);
         address[] memory facetAddresses = loupe.facetAddresses();
 
-        require(facetAddresses.length == 5, "vault host facet count mismatch");
+        require(facetAddresses.length == 6, "vault host facet count mismatch");
         require(_containsAddress(facetAddresses, state.cutFacetAddress), "vault host missing cut facet");
         require(_containsAddress(facetAddresses, state.loupeFacetAddress), "vault host missing loupe facet");
         require(_containsAddress(facetAddresses, state.vaultCoreFacetAddress), "vault host missing core facet");
+        require(
+            _containsAddress(facetAddresses, state.vaultAsyncDepositFacetAddress),
+            "vault host missing async deposit facet"
+        );
         require(_containsAddress(facetAddresses, state.vaultControlsFacetAddress), "vault host missing controls facet");
         require(
             _containsAddress(facetAddresses, state.vaultIntegrationFacetAddress), "vault host missing integration facet"
@@ -171,8 +179,13 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
 
         require(
             loupe.facetFunctionSelectors(state.vaultCoreFacetAddress).length
-                == LibVaultFacetSelectors.vaultCoreSelectors().length + LibVaultFacetSelectors.vaultAsyncDepositSelectors().length,
+                == LibVaultFacetSelectors.vaultAsyncHostCoreSelectors().length,
             "vault host core selector count mismatch"
+        );
+        require(
+            loupe.facetFunctionSelectors(state.vaultAsyncDepositFacetAddress).length
+                == LibVaultFacetSelectors.vaultAsyncDepositHostSelectors().length,
+            "vault host async deposit selector count mismatch"
         );
         require(
             loupe.facetFunctionSelectors(state.vaultControlsFacetAddress).length
@@ -242,7 +255,10 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
             loupe, IERC4626VaultFacet.initializeVault.selector, state.vaultCoreFacetAddress, "vault init owner"
         );
         _requireSelectorOwner(
-            loupe, IERC7540Deposit.requestDeposit.selector, state.vaultCoreFacetAddress, "vault async deposit owner"
+            loupe,
+            IERC7540Deposit.requestDeposit.selector,
+            state.vaultAsyncDepositFacetAddress,
+            "vault async deposit owner"
         );
         _requireSelectorOwner(
             loupe,

--- a/script/common/DiamondVaultHostScriptBase.sol
+++ b/script/common/DiamondVaultHostScriptBase.sol
@@ -18,6 +18,7 @@ abstract contract DiamondVaultHostScriptBase is DiamondCoreScriptBase {
         address diamondCutFacet;
         address diamondLoupeFacet;
         address vaultCoreFacet;
+        address vaultAsyncDepositFacet;
         address vaultNativeFacet;
         address vaultControlsFacet;
         address vaultIntegrationFacet;
@@ -88,6 +89,7 @@ abstract contract DiamondVaultHostScriptBase is DiamondCoreScriptBase {
         json = VM.serializeAddress(objectKey, "diamondCutFacet", artifact.diamondCutFacet);
         json = VM.serializeAddress(objectKey, "diamondLoupeFacet", artifact.diamondLoupeFacet);
         json = VM.serializeAddress(objectKey, "vaultCoreFacet", artifact.vaultCoreFacet);
+        json = VM.serializeAddress(objectKey, "vaultAsyncDepositFacet", artifact.vaultAsyncDepositFacet);
         json = VM.serializeAddress(objectKey, "vaultNativeFacet", artifact.vaultNativeFacet);
         json = VM.serializeAddress(objectKey, "vaultControlsFacet", artifact.vaultControlsFacet);
         json = VM.serializeAddress(objectKey, "vaultIntegrationFacet", artifact.vaultIntegrationFacet);

--- a/src/vault/facets/ERC4626VaultControlsFacet.sol
+++ b/src/vault/facets/ERC4626VaultControlsFacet.sol
@@ -4,6 +4,9 @@ pragma solidity ^0.8.30;
 import {IAccessControl} from "../../interfaces/IAccessControl.sol";
 import {IAccessControlTime} from "../../interfaces/IAccessControlTime.sol";
 import {IERC165} from "../../interfaces/IERC165.sol";
+import {IERC7540Deposit} from "../../interfaces/IERC7540Deposit.sol";
+import {IERC7540Operators} from "../../interfaces/IERC7540Operators.sol";
+import {IERC7540Redeem} from "../../interfaces/IERC7540Redeem.sol";
 import {IERC7535VaultFacet} from "../../interfaces/IERC7535VaultFacet.sol";
 import {IERC4626VaultControls} from "../../interfaces/IERC4626VaultControls.sol";
 import {IERC4626VaultControlsFacet} from "../../interfaces/IERC4626VaultControlsFacet.sol";
@@ -32,6 +35,12 @@ contract ERC4626VaultControlsFacet is ERC4626VaultControlSurface {
             || interfaceId == type(IERC4626VaultControlsFacet).interfaceId
             || (interfaceId == type(IERC4626VaultFacet).interfaceId
                 && LibDiamond.selectorExists(IERC4626VaultFacet.initializeVault.selector))
+            || (interfaceId == type(IERC7540Operators).interfaceId
+                && LibDiamond.selectorExists(IERC7540Operators.setOperator.selector))
+            || (interfaceId == type(IERC7540Deposit).interfaceId
+                && LibDiamond.selectorExists(IERC7540Deposit.requestDeposit.selector))
+            || (interfaceId == type(IERC7540Redeem).interfaceId
+                && LibDiamond.selectorExists(IERC7540Redeem.requestRedeem.selector))
             || (interfaceId == type(IERC7535VaultFacet).interfaceId
                 && LibDiamond.selectorExists(IERC7535VaultFacet.depositNative.selector))
             || (interfaceId == type(IERC4626VaultIntegrationFacet).interfaceId

--- a/src/vault/facets/ERC4626VaultFacet.sol
+++ b/src/vault/facets/ERC4626VaultFacet.sol
@@ -2,12 +2,16 @@
 pragma solidity ^0.8.30;
 
 import {IERC4626} from "../../interfaces/IERC4626.sol";
+import {IERC7540Deposit} from "../../interfaces/IERC7540Deposit.sol";
+import {IERC7540Operators} from "../../interfaces/IERC7540Operators.sol";
 import {IERC4626VaultControls} from "../../interfaces/IERC4626VaultControls.sol";
 import {IERC4626VaultFacet} from "../../interfaces/IERC4626VaultFacet.sol";
 import {IERC4626VaultStrategy} from "../../interfaces/IERC4626VaultStrategy.sol";
+import {LibDiamond} from "../../diamond/libraries/LibDiamond.sol";
 import {ERC4626Vault} from "../ERC4626Vault.sol";
 import {ERC4626VaultBase} from "../ERC4626VaultBase.sol";
 import {ERC4626VaultControlledCore, LibERC4626VaultControlLogic} from "../ERC4626VaultControlLogic.sol";
+import {LibERC7540RequestAccounting} from "../libraries/LibERC7540RequestAccounting.sol";
 import {VaultFacetControl} from "../VaultFacetControl.sol";
 import {LibVaultAsset} from "../libraries/LibVaultAsset.sol";
 import {LibERC4626VaultStorage} from "../storage/LibERC4626VaultStorage.sol";
@@ -15,6 +19,23 @@ import {LibERC4626VaultStorage} from "../storage/LibERC4626VaultStorage.sol";
 /// @title ERC4626VaultFacet
 /// @notice Hosted ERC-4626 core facet with constructor-free initialization.
 contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IERC4626VaultFacet {
+    /// @notice Emitted when a deposit request is submitted.
+    event DepositRequest(
+        address indexed controller, address indexed owner, uint256 indexed requestId, address sender, uint256 assets
+    );
+
+    /// @notice Emitted when `controller` updates `operator` approval.
+    event OperatorSet(address indexed controller, address indexed operator, bool approved);
+
+    /// @notice Thrown when async deposit preview helpers are queried on an async deposit vault.
+    error ERC7540VaultAsyncDepositPreviewUnsupported();
+
+    /// @notice Thrown when an async deposit entrypoint is used before the async deposit extension is active.
+    error ERC7540VaultAsyncDepositDisabled();
+
+    /// @notice Thrown when `sender` is not approved to manage requests for `account`.
+    error ERC7540VaultUnauthorizedOperator(address account, address sender);
+
     /// @notice Returns true when vault storage is initialized.
     /// @return True if initialized.
     function isVaultInitialized() public view virtual override(IERC4626VaultFacet, ERC4626VaultBase) returns (bool) {
@@ -31,6 +52,90 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
     /// @return The tracked managed asset amount.
     function totalManagedAssets() public view virtual override(IERC4626VaultFacet, ERC4626VaultBase) returns (uint256) {
         return ERC4626VaultBase.totalManagedAssets();
+    }
+
+    /// @notice Returns max assets that can currently be claimed for `receiver`.
+    /// @param receiver Receiver of minted shares.
+    /// @return assets Max gross claimable asset amount.
+    function maxDeposit(address receiver)
+        public
+        view
+        virtual
+        override(ERC4626VaultControlledCore, IERC4626)
+        returns (uint256 assets)
+    {
+        if (_asyncDepositModeEnabled()) {
+            if (receiver == address(0) || paused()) {
+                return 0;
+            }
+
+            return LibERC7540RequestAccounting.claimableDepositRequest(
+                LibERC7540RequestAccounting.aggregateRequestId(), msg.sender
+            );
+        }
+
+        return super.maxDeposit(receiver);
+    }
+
+    /// @notice Returns max shares that can currently be claimed for `receiver`.
+    /// @param receiver Receiver of minted shares.
+    /// @return shares Max claimable share amount at the current exchange rate.
+    function maxMint(address receiver)
+        public
+        view
+        virtual
+        override(ERC4626VaultControlledCore, IERC4626)
+        returns (uint256 shares)
+    {
+        if (_asyncDepositModeEnabled()) {
+            if (receiver == address(0) || paused()) {
+                return 0;
+            }
+
+            uint256 claimableAssets = LibERC7540RequestAccounting.claimableDepositRequest(
+                LibERC7540RequestAccounting.aggregateRequestId(), msg.sender
+            );
+            (uint256 netAssets,) = LibERC4626VaultControlLogic.netAfterDepositFee(claimableAssets);
+            return _convertToShares(netAssets, Rounding.Down);
+        }
+
+        return super.maxMint(receiver);
+    }
+
+    /// @notice Returns shares for a synchronous deposit preview.
+    /// @param assets Asset amount.
+    /// @return shares Preview share amount.
+    function previewDeposit(uint256 assets)
+        public
+        view
+        virtual
+        override(ERC4626VaultControlledCore, IERC4626)
+        returns (uint256 shares)
+    {
+        assets;
+        if (_asyncDepositModeEnabled()) {
+            revert ERC7540VaultAsyncDepositPreviewUnsupported();
+        }
+
+        return super.previewDeposit(assets);
+    }
+
+    /// @notice Returns assets for a synchronous mint preview.
+    /// @param shares Share amount.
+    /// @return assets Preview asset amount.
+    function previewMint(uint256 shares)
+        public
+        view
+        virtual
+        override(ERC4626VaultControlledCore, IERC4626)
+        returns (uint256 assets)
+    {
+        shares;
+        if (_asyncDepositModeEnabled()) {
+            revert ERC7540VaultAsyncDepositPreviewUnsupported();
+        }
+
+        return super.previewMint(shares);
     }
 
     /// @notice Initializes the hosted vault core and shared control plane.
@@ -65,6 +170,10 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
         nonReentrant
         returns (uint256 shares)
     {
+        if (_asyncDepositModeEnabled()) {
+            return _claimAsyncDeposit(assets, receiver, msg.sender);
+        }
+
         if (LibVaultAsset.isNativeAsset(ERC4626Vault.asset())) {
             revert ERC4626VaultNativeAssetUseNativeEntrypoint();
         }
@@ -84,11 +193,125 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
         nonReentrant
         returns (uint256 assets)
     {
+        if (_asyncDepositModeEnabled()) {
+            return _claimAsyncMint(shares, receiver, msg.sender);
+        }
+
         if (LibVaultAsset.isNativeAsset(ERC4626Vault.asset())) {
             revert ERC4626VaultNativeAssetUseNativeEntrypoint();
         }
 
         return _mintWithControls(shares, receiver);
+    }
+
+    /// @notice Locks `assets` for an asynchronous deposit request.
+    /// @param assets Requested asset amount.
+    /// @param controller Request controller account.
+    /// @param owner Asset owner account.
+    /// @return requestId Canonical aggregated request id.
+    function requestDeposit(uint256 assets, address controller, address owner)
+        public
+        virtual
+        whenNotPaused
+        nonReentrant
+        returns (uint256 requestId)
+    {
+        _requireInitialized();
+        _requireAsyncDepositEnabled();
+        _requireNonZeroAddress(controller);
+        _requireNonZeroAddress(owner);
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        if (msg.sender != owner && !LibERC7540RequestAccounting.isOperator(owner, msg.sender)) {
+            revert ERC7540VaultUnauthorizedOperator(owner, msg.sender);
+        }
+
+        uint256 maxAssets = _maxRequestDepositAssets(controller);
+        if (assets > maxAssets) {
+            revert IERC4626VaultControls.ERC4626VaultDepositLimitExceeded(assets, maxAssets);
+        }
+
+        requestId = LibERC7540RequestAccounting.aggregateRequestId();
+        _safeTransferFromAsset(owner, address(this), assets);
+        LibERC7540RequestAccounting.increasePendingDeposit(controller, assets);
+
+        emit DepositRequest(controller, owner, requestId, msg.sender, assets);
+    }
+
+    /// @notice Returns pending deposit-request assets for `controller`.
+    /// @param requestId Request discriminator.
+    /// @param controller Request controller account.
+    /// @return assets Pending gross asset amount.
+    function pendingDepositRequest(uint256 requestId, address controller)
+        public
+        view
+        virtual
+        returns (uint256 assets)
+    {
+        return LibERC7540RequestAccounting.pendingDepositRequest(requestId, controller);
+    }
+
+    /// @notice Returns claimable deposit-request assets for `controller`.
+    /// @param requestId Request discriminator.
+    /// @param controller Request controller account.
+    /// @return assets Claimable gross asset amount.
+    function claimableDepositRequest(uint256 requestId, address controller)
+        public
+        view
+        virtual
+        returns (uint256 assets)
+    {
+        return LibERC7540RequestAccounting.claimableDepositRequest(requestId, controller);
+    }
+
+    /// @notice Returns whether `operator` is approved for `controller`.
+    /// @param controller Request controller account.
+    /// @param operator Operator account.
+    /// @return status True when approved.
+    function isOperator(address controller, address operator) public view virtual returns (bool status) {
+        return LibERC7540RequestAccounting.isOperator(controller, operator);
+    }
+
+    /// @notice Grants or revokes operator approval for the caller's requests.
+    /// @param operator Operator account.
+    /// @param approved Approval status.
+    /// @return success True when stored.
+    function setOperator(address operator, bool approved) public virtual returns (bool success) {
+        LibERC7540RequestAccounting.setOperator(msg.sender, operator, approved);
+        emit OperatorSet(msg.sender, operator, approved);
+        return true;
+    }
+
+    /// @notice Claims asynchronous deposit assets into shares for `receiver`.
+    /// @param assets Claimable gross asset amount.
+    /// @param receiver Share receiver.
+    /// @param controller Request controller account.
+    /// @return shares Minted share amount.
+    function deposit(uint256 assets, address receiver, address controller)
+        public
+        virtual
+        whenNotPaused
+        nonReentrant
+        returns (uint256 shares)
+    {
+        return _claimAsyncDeposit(assets, receiver, controller);
+    }
+
+    /// @notice Claims asynchronous deposit assets into an exact share amount for `receiver`.
+    /// @param shares Target share amount.
+    /// @param receiver Share receiver.
+    /// @param controller Request controller account.
+    /// @return assets Consumed claimable gross asset amount.
+    function mint(uint256 shares, address receiver, address controller)
+        public
+        virtual
+        whenNotPaused
+        nonReentrant
+        returns (uint256 assets)
+    {
+        return _claimAsyncMint(shares, receiver, controller);
     }
 
     /// @notice Withdraws `assets` to `receiver` from `owner`.
@@ -217,6 +440,103 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
 
     function _vaultOperationsPaused() internal view virtual override returns (bool) {
         return paused();
+    }
+
+    function _asyncDepositModeEnabled() internal view virtual returns (bool) {
+        return !LibVaultAsset.isNativeAsset(ERC4626Vault.asset())
+            && LibDiamond.selectorExists(IERC7540Deposit.requestDeposit.selector);
+    }
+
+    function _maxRequestDepositAssets(address controller) internal view returns (uint256 maxAssets) {
+        if (controller == address(0) || paused()) {
+            return 0;
+        }
+
+        maxAssets = type(uint256).max;
+        (uint128 maxTotalAssets_, uint128 maxDeposit_,,,) = LibERC4626VaultControlLogic.limitConfig();
+
+        if (maxDeposit_ != 0) {
+            maxAssets = maxDeposit_;
+        }
+
+        if (maxTotalAssets_ != 0) {
+            uint256 currentCommittedAssets = totalAssets()
+                + LibERC7540RequestAccounting.totalPendingDepositRequestAssets()
+                + LibERC7540RequestAccounting.totalClaimableDepositRequestAssets();
+
+            if (currentCommittedAssets >= maxTotalAssets_) {
+                return 0;
+            }
+
+            uint256 remainingAssets = maxTotalAssets_ - currentCommittedAssets;
+            if (remainingAssets < maxAssets) {
+                maxAssets = remainingAssets;
+            }
+        }
+    }
+
+    function _claimAsyncDeposit(uint256 assets, address receiver, address controller) internal returns (uint256 shares) {
+        _requireInitialized();
+        _requireAsyncDepositEnabled();
+        _requireNonZeroAddress(receiver);
+        _requireNonZeroAddress(controller);
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        _requireControllerOrOperator(controller);
+
+        (uint256 netAssets, uint256 feeAssets) = LibERC4626VaultControlLogic.netAfterDepositFee(assets);
+        shares = _convertToShares(netAssets, Rounding.Down);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        LibERC7540RequestAccounting.consumeClaimableDeposit(controller, assets);
+        _increaseManagedAssets(netAssets);
+        _mintShares(receiver, shares);
+        _payoutFee(feeAssets);
+
+        emit Deposit(controller, receiver, assets, shares);
+    }
+
+    function _claimAsyncMint(uint256 shares, address receiver, address controller) internal returns (uint256 assets) {
+        _requireInitialized();
+        _requireAsyncDepositEnabled();
+        _requireNonZeroAddress(receiver);
+        _requireNonZeroAddress(controller);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        _requireControllerOrOperator(controller);
+
+        uint256 netAssets = _convertToAssets(shares, Rounding.Up);
+        if (netAssets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        assets = LibERC4626VaultControlLogic.grossUpForDepositFee(netAssets);
+        uint256 feeAssets = assets - netAssets;
+
+        LibERC7540RequestAccounting.consumeClaimableDeposit(controller, assets);
+        _increaseManagedAssets(netAssets);
+        _mintShares(receiver, shares);
+        _payoutFee(feeAssets);
+
+        emit Deposit(controller, receiver, assets, shares);
+    }
+
+    function _requireAsyncDepositEnabled() internal view {
+        if (!_asyncDepositModeEnabled()) {
+            revert ERC7540VaultAsyncDepositDisabled();
+        }
+    }
+
+    function _requireControllerOrOperator(address controller) internal view {
+        if (msg.sender != controller && !LibERC7540RequestAccounting.isOperator(controller, msg.sender)) {
+            revert ERC7540VaultUnauthorizedOperator(controller, msg.sender);
+        }
     }
 
     function _sourceStrategyLiquidity(uint256 requiredGrossAssets) internal {

--- a/src/vault/facets/ERC4626VaultFacet.sol
+++ b/src/vault/facets/ERC4626VaultFacet.sol
@@ -2,16 +2,12 @@
 pragma solidity ^0.8.30;
 
 import {IERC4626} from "../../interfaces/IERC4626.sol";
-import {IERC7540Deposit} from "../../interfaces/IERC7540Deposit.sol";
-import {IERC7540Operators} from "../../interfaces/IERC7540Operators.sol";
 import {IERC4626VaultControls} from "../../interfaces/IERC4626VaultControls.sol";
 import {IERC4626VaultFacet} from "../../interfaces/IERC4626VaultFacet.sol";
 import {IERC4626VaultStrategy} from "../../interfaces/IERC4626VaultStrategy.sol";
-import {LibDiamond} from "../../diamond/libraries/LibDiamond.sol";
 import {ERC4626Vault} from "../ERC4626Vault.sol";
 import {ERC4626VaultBase} from "../ERC4626VaultBase.sol";
 import {ERC4626VaultControlledCore, LibERC4626VaultControlLogic} from "../ERC4626VaultControlLogic.sol";
-import {LibERC7540RequestAccounting} from "../libraries/LibERC7540RequestAccounting.sol";
 import {VaultFacetControl} from "../VaultFacetControl.sol";
 import {LibVaultAsset} from "../libraries/LibVaultAsset.sol";
 import {LibERC4626VaultStorage} from "../storage/LibERC4626VaultStorage.sol";
@@ -19,23 +15,6 @@ import {LibERC4626VaultStorage} from "../storage/LibERC4626VaultStorage.sol";
 /// @title ERC4626VaultFacet
 /// @notice Hosted ERC-4626 core facet with constructor-free initialization.
 contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IERC4626VaultFacet {
-    /// @notice Emitted when a deposit request is submitted.
-    event DepositRequest(
-        address indexed controller, address indexed owner, uint256 indexed requestId, address sender, uint256 assets
-    );
-
-    /// @notice Emitted when `controller` updates `operator` approval.
-    event OperatorSet(address indexed controller, address indexed operator, bool approved);
-
-    /// @notice Thrown when async deposit preview helpers are queried on an async deposit vault.
-    error ERC7540VaultAsyncDepositPreviewUnsupported();
-
-    /// @notice Thrown when an async deposit entrypoint is used before the async deposit extension is active.
-    error ERC7540VaultAsyncDepositDisabled();
-
-    /// @notice Thrown when `sender` is not approved to manage requests for `account`.
-    error ERC7540VaultUnauthorizedOperator(address account, address sender);
-
     /// @notice Returns true when vault storage is initialized.
     /// @return True if initialized.
     function isVaultInitialized() public view virtual override(IERC4626VaultFacet, ERC4626VaultBase) returns (bool) {
@@ -52,90 +31,6 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
     /// @return The tracked managed asset amount.
     function totalManagedAssets() public view virtual override(IERC4626VaultFacet, ERC4626VaultBase) returns (uint256) {
         return ERC4626VaultBase.totalManagedAssets();
-    }
-
-    /// @notice Returns max assets that can currently be claimed for `receiver`.
-    /// @param receiver Receiver of minted shares.
-    /// @return assets Max gross claimable asset amount.
-    function maxDeposit(address receiver)
-        public
-        view
-        virtual
-        override(ERC4626VaultControlledCore, IERC4626)
-        returns (uint256 assets)
-    {
-        if (_asyncDepositModeEnabled()) {
-            if (receiver == address(0) || paused()) {
-                return 0;
-            }
-
-            return LibERC7540RequestAccounting.claimableDepositRequest(
-                LibERC7540RequestAccounting.aggregateRequestId(), msg.sender
-            );
-        }
-
-        return super.maxDeposit(receiver);
-    }
-
-    /// @notice Returns max shares that can currently be claimed for `receiver`.
-    /// @param receiver Receiver of minted shares.
-    /// @return shares Max claimable share amount at the current exchange rate.
-    function maxMint(address receiver)
-        public
-        view
-        virtual
-        override(ERC4626VaultControlledCore, IERC4626)
-        returns (uint256 shares)
-    {
-        if (_asyncDepositModeEnabled()) {
-            if (receiver == address(0) || paused()) {
-                return 0;
-            }
-
-            uint256 claimableAssets = LibERC7540RequestAccounting.claimableDepositRequest(
-                LibERC7540RequestAccounting.aggregateRequestId(), msg.sender
-            );
-            (uint256 netAssets,) = LibERC4626VaultControlLogic.netAfterDepositFee(claimableAssets);
-            return _convertToShares(netAssets, Rounding.Down);
-        }
-
-        return super.maxMint(receiver);
-    }
-
-    /// @notice Returns shares for a synchronous deposit preview.
-    /// @param assets Asset amount.
-    /// @return shares Preview share amount.
-    function previewDeposit(uint256 assets)
-        public
-        view
-        virtual
-        override(ERC4626VaultControlledCore, IERC4626)
-        returns (uint256 shares)
-    {
-        assets;
-        if (_asyncDepositModeEnabled()) {
-            revert ERC7540VaultAsyncDepositPreviewUnsupported();
-        }
-
-        return super.previewDeposit(assets);
-    }
-
-    /// @notice Returns assets for a synchronous mint preview.
-    /// @param shares Share amount.
-    /// @return assets Preview asset amount.
-    function previewMint(uint256 shares)
-        public
-        view
-        virtual
-        override(ERC4626VaultControlledCore, IERC4626)
-        returns (uint256 assets)
-    {
-        shares;
-        if (_asyncDepositModeEnabled()) {
-            revert ERC7540VaultAsyncDepositPreviewUnsupported();
-        }
-
-        return super.previewMint(shares);
     }
 
     /// @notice Initializes the hosted vault core and shared control plane.
@@ -170,10 +65,6 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
         nonReentrant
         returns (uint256 shares)
     {
-        if (_asyncDepositModeEnabled()) {
-            return _claimAsyncDeposit(assets, receiver, msg.sender);
-        }
-
         if (LibVaultAsset.isNativeAsset(ERC4626Vault.asset())) {
             revert ERC4626VaultNativeAssetUseNativeEntrypoint();
         }
@@ -193,125 +84,11 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
         nonReentrant
         returns (uint256 assets)
     {
-        if (_asyncDepositModeEnabled()) {
-            return _claimAsyncMint(shares, receiver, msg.sender);
-        }
-
         if (LibVaultAsset.isNativeAsset(ERC4626Vault.asset())) {
             revert ERC4626VaultNativeAssetUseNativeEntrypoint();
         }
 
         return _mintWithControls(shares, receiver);
-    }
-
-    /// @notice Locks `assets` for an asynchronous deposit request.
-    /// @param assets Requested asset amount.
-    /// @param controller Request controller account.
-    /// @param owner Asset owner account.
-    /// @return requestId Canonical aggregated request id.
-    function requestDeposit(uint256 assets, address controller, address owner)
-        public
-        virtual
-        whenNotPaused
-        nonReentrant
-        returns (uint256 requestId)
-    {
-        _requireInitialized();
-        _requireAsyncDepositEnabled();
-        _requireNonZeroAddress(controller);
-        _requireNonZeroAddress(owner);
-        if (assets == 0) {
-            revert ERC4626VaultZeroAssets();
-        }
-
-        if (msg.sender != owner && !LibERC7540RequestAccounting.isOperator(owner, msg.sender)) {
-            revert ERC7540VaultUnauthorizedOperator(owner, msg.sender);
-        }
-
-        uint256 maxAssets = _maxRequestDepositAssets(controller);
-        if (assets > maxAssets) {
-            revert IERC4626VaultControls.ERC4626VaultDepositLimitExceeded(assets, maxAssets);
-        }
-
-        requestId = LibERC7540RequestAccounting.aggregateRequestId();
-        _safeTransferFromAsset(owner, address(this), assets);
-        LibERC7540RequestAccounting.increasePendingDeposit(controller, assets);
-
-        emit DepositRequest(controller, owner, requestId, msg.sender, assets);
-    }
-
-    /// @notice Returns pending deposit-request assets for `controller`.
-    /// @param requestId Request discriminator.
-    /// @param controller Request controller account.
-    /// @return assets Pending gross asset amount.
-    function pendingDepositRequest(uint256 requestId, address controller)
-        public
-        view
-        virtual
-        returns (uint256 assets)
-    {
-        return LibERC7540RequestAccounting.pendingDepositRequest(requestId, controller);
-    }
-
-    /// @notice Returns claimable deposit-request assets for `controller`.
-    /// @param requestId Request discriminator.
-    /// @param controller Request controller account.
-    /// @return assets Claimable gross asset amount.
-    function claimableDepositRequest(uint256 requestId, address controller)
-        public
-        view
-        virtual
-        returns (uint256 assets)
-    {
-        return LibERC7540RequestAccounting.claimableDepositRequest(requestId, controller);
-    }
-
-    /// @notice Returns whether `operator` is approved for `controller`.
-    /// @param controller Request controller account.
-    /// @param operator Operator account.
-    /// @return status True when approved.
-    function isOperator(address controller, address operator) public view virtual returns (bool status) {
-        return LibERC7540RequestAccounting.isOperator(controller, operator);
-    }
-
-    /// @notice Grants or revokes operator approval for the caller's requests.
-    /// @param operator Operator account.
-    /// @param approved Approval status.
-    /// @return success True when stored.
-    function setOperator(address operator, bool approved) public virtual returns (bool success) {
-        LibERC7540RequestAccounting.setOperator(msg.sender, operator, approved);
-        emit OperatorSet(msg.sender, operator, approved);
-        return true;
-    }
-
-    /// @notice Claims asynchronous deposit assets into shares for `receiver`.
-    /// @param assets Claimable gross asset amount.
-    /// @param receiver Share receiver.
-    /// @param controller Request controller account.
-    /// @return shares Minted share amount.
-    function deposit(uint256 assets, address receiver, address controller)
-        public
-        virtual
-        whenNotPaused
-        nonReentrant
-        returns (uint256 shares)
-    {
-        return _claimAsyncDeposit(assets, receiver, controller);
-    }
-
-    /// @notice Claims asynchronous deposit assets into an exact share amount for `receiver`.
-    /// @param shares Target share amount.
-    /// @param receiver Share receiver.
-    /// @param controller Request controller account.
-    /// @return assets Consumed claimable gross asset amount.
-    function mint(uint256 shares, address receiver, address controller)
-        public
-        virtual
-        whenNotPaused
-        nonReentrant
-        returns (uint256 assets)
-    {
-        return _claimAsyncMint(shares, receiver, controller);
     }
 
     /// @notice Withdraws `assets` to `receiver` from `owner`.
@@ -440,103 +217,6 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
 
     function _vaultOperationsPaused() internal view virtual override returns (bool) {
         return paused();
-    }
-
-    function _asyncDepositModeEnabled() internal view virtual returns (bool) {
-        return !LibVaultAsset.isNativeAsset(ERC4626Vault.asset())
-            && LibDiamond.selectorExists(IERC7540Deposit.requestDeposit.selector);
-    }
-
-    function _maxRequestDepositAssets(address controller) internal view returns (uint256 maxAssets) {
-        if (controller == address(0) || paused()) {
-            return 0;
-        }
-
-        maxAssets = type(uint256).max;
-        (uint128 maxTotalAssets_, uint128 maxDeposit_,,,) = LibERC4626VaultControlLogic.limitConfig();
-
-        if (maxDeposit_ != 0) {
-            maxAssets = maxDeposit_;
-        }
-
-        if (maxTotalAssets_ != 0) {
-            uint256 currentCommittedAssets = totalAssets()
-                + LibERC7540RequestAccounting.totalPendingDepositRequestAssets()
-                + LibERC7540RequestAccounting.totalClaimableDepositRequestAssets();
-
-            if (currentCommittedAssets >= maxTotalAssets_) {
-                return 0;
-            }
-
-            uint256 remainingAssets = maxTotalAssets_ - currentCommittedAssets;
-            if (remainingAssets < maxAssets) {
-                maxAssets = remainingAssets;
-            }
-        }
-    }
-
-    function _claimAsyncDeposit(uint256 assets, address receiver, address controller) internal returns (uint256 shares) {
-        _requireInitialized();
-        _requireAsyncDepositEnabled();
-        _requireNonZeroAddress(receiver);
-        _requireNonZeroAddress(controller);
-        if (assets == 0) {
-            revert ERC4626VaultZeroAssets();
-        }
-
-        _requireControllerOrOperator(controller);
-
-        (uint256 netAssets, uint256 feeAssets) = LibERC4626VaultControlLogic.netAfterDepositFee(assets);
-        shares = _convertToShares(netAssets, Rounding.Down);
-        if (shares == 0) {
-            revert ERC4626VaultZeroShares();
-        }
-
-        LibERC7540RequestAccounting.consumeClaimableDeposit(controller, assets);
-        _increaseManagedAssets(netAssets);
-        _mintShares(receiver, shares);
-        _payoutFee(feeAssets);
-
-        emit Deposit(controller, receiver, assets, shares);
-    }
-
-    function _claimAsyncMint(uint256 shares, address receiver, address controller) internal returns (uint256 assets) {
-        _requireInitialized();
-        _requireAsyncDepositEnabled();
-        _requireNonZeroAddress(receiver);
-        _requireNonZeroAddress(controller);
-        if (shares == 0) {
-            revert ERC4626VaultZeroShares();
-        }
-
-        _requireControllerOrOperator(controller);
-
-        uint256 netAssets = _convertToAssets(shares, Rounding.Up);
-        if (netAssets == 0) {
-            revert ERC4626VaultZeroAssets();
-        }
-
-        assets = LibERC4626VaultControlLogic.grossUpForDepositFee(netAssets);
-        uint256 feeAssets = assets - netAssets;
-
-        LibERC7540RequestAccounting.consumeClaimableDeposit(controller, assets);
-        _increaseManagedAssets(netAssets);
-        _mintShares(receiver, shares);
-        _payoutFee(feeAssets);
-
-        emit Deposit(controller, receiver, assets, shares);
-    }
-
-    function _requireAsyncDepositEnabled() internal view {
-        if (!_asyncDepositModeEnabled()) {
-            revert ERC7540VaultAsyncDepositDisabled();
-        }
-    }
-
-    function _requireControllerOrOperator(address controller) internal view {
-        if (msg.sender != controller && !LibERC7540RequestAccounting.isOperator(controller, msg.sender)) {
-            revert ERC7540VaultUnauthorizedOperator(controller, msg.sender);
-        }
     }
 
     function _sourceStrategyLiquidity(uint256 requiredGrossAssets) internal {

--- a/src/vault/facets/ERC7540VaultDepositFacet.sol
+++ b/src/vault/facets/ERC7540VaultDepositFacet.sol
@@ -1,0 +1,328 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC7540Deposit} from "../../interfaces/IERC7540Deposit.sol";
+import {IERC7540Operators} from "../../interfaces/IERC7540Operators.sol";
+import {IERC4626VaultControls} from "../../interfaces/IERC4626VaultControls.sol";
+import {LibDiamond} from "../../diamond/libraries/LibDiamond.sol";
+import {ERC4626Vault} from "../ERC4626Vault.sol";
+import {ERC4626VaultControlledCore, LibERC4626VaultControlLogic} from "../ERC4626VaultControlLogic.sol";
+import {VaultFacetControl} from "../VaultFacetControl.sol";
+import {LibERC7540RequestAccounting} from "../libraries/LibERC7540RequestAccounting.sol";
+import {LibVaultAsset} from "../libraries/LibVaultAsset.sol";
+
+/// @title ERC7540VaultDepositFacet
+/// @notice Hosted async deposit and operator extension facet for ERC-7540-style request flows.
+contract ERC7540VaultDepositFacet is ERC4626VaultControlledCore, VaultFacetControl, IERC7540Deposit, IERC7540Operators {
+    /// @notice Emitted when a deposit request is submitted.
+    event DepositRequest(
+        address indexed controller, address indexed owner, uint256 indexed requestId, address sender, uint256 assets
+    );
+
+    /// @notice Emitted when `controller` updates `operator` approval.
+    event OperatorSet(address indexed controller, address indexed operator, bool approved);
+
+    /// @notice Thrown when an async deposit entrypoint is used before the async deposit extension is active.
+    error ERC7540VaultAsyncDepositDisabled();
+
+    /// @notice Thrown when async deposit preview helpers are queried on an async deposit vault.
+    error ERC7540VaultAsyncDepositPreviewUnsupported();
+
+    /// @notice Thrown when `sender` is not approved to manage requests for `account`.
+    error ERC7540VaultUnauthorizedOperator(address account, address sender);
+
+    /// @notice Returns max assets that can currently be claimed for `receiver`.
+    /// @param receiver Receiver of minted shares.
+    /// @return assets Max gross claimable asset amount.
+    function maxDeposit(address receiver)
+        public
+        view
+        virtual
+        override(ERC4626VaultControlledCore)
+        returns (uint256 assets)
+    {
+        if (receiver == address(0) || paused()) {
+            return 0;
+        }
+
+        return LibERC7540RequestAccounting.claimableDepositRequest(
+            LibERC7540RequestAccounting.aggregateRequestId(), msg.sender
+        );
+    }
+
+    /// @notice Returns max shares that can currently be claimed for `receiver`.
+    /// @param receiver Receiver of minted shares.
+    /// @return shares Max claimable share amount at the current exchange rate.
+    function maxMint(address receiver)
+        public
+        view
+        virtual
+        override(ERC4626VaultControlledCore)
+        returns (uint256 shares)
+    {
+        if (receiver == address(0) || paused()) {
+            return 0;
+        }
+
+        uint256 claimableAssets = LibERC7540RequestAccounting.claimableDepositRequest(
+            LibERC7540RequestAccounting.aggregateRequestId(), msg.sender
+        );
+        (uint256 netAssets,) = LibERC4626VaultControlLogic.netAfterDepositFee(claimableAssets);
+        return _convertToShares(netAssets, Rounding.Down);
+    }
+
+    /// @notice Returns shares for an async deposit preview.
+    /// @param assets Asset amount.
+    /// @return shares Preview share amount.
+    function previewDeposit(uint256 assets) public view virtual override(ERC4626VaultControlledCore) returns (uint256) {
+        assets;
+        revert ERC7540VaultAsyncDepositPreviewUnsupported();
+    }
+
+    /// @notice Returns assets for an async mint preview.
+    /// @param shares Share amount.
+    /// @return assets Preview asset amount.
+    function previewMint(uint256 shares) public view virtual override(ERC4626VaultControlledCore) returns (uint256) {
+        shares;
+        revert ERC7540VaultAsyncDepositPreviewUnsupported();
+    }
+
+    /// @notice Claims asynchronous deposit assets into shares for `receiver`.
+    /// @param assets Claimable gross asset amount.
+    /// @param receiver Share receiver.
+    /// @return shares Minted share amount.
+    function deposit(uint256 assets, address receiver)
+        public
+        virtual
+        override(ERC4626Vault)
+        whenNotPaused
+        nonReentrant
+        returns (uint256 shares)
+    {
+        return _claimAsyncDeposit(assets, receiver, msg.sender);
+    }
+
+    /// @notice Claims asynchronous deposit assets into an exact share amount for `receiver`.
+    /// @param shares Target share amount.
+    /// @param receiver Share receiver.
+    /// @return assets Consumed claimable gross asset amount.
+    function mint(uint256 shares, address receiver)
+        public
+        virtual
+        override(ERC4626Vault)
+        whenNotPaused
+        nonReentrant
+        returns (uint256 assets)
+    {
+        return _claimAsyncMint(shares, receiver, msg.sender);
+    }
+
+    /// @notice Locks `assets` for an asynchronous deposit request.
+    /// @param assets Requested asset amount.
+    /// @param controller Request controller account.
+    /// @param owner Asset owner account.
+    /// @return requestId Canonical aggregated request id.
+    function requestDeposit(uint256 assets, address controller, address owner)
+        public
+        virtual
+        whenNotPaused
+        nonReentrant
+        returns (uint256 requestId)
+    {
+        _requireInitialized();
+        _requireAsyncDepositEnabled();
+        _requireNonZeroAddress(controller);
+        _requireNonZeroAddress(owner);
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        if (msg.sender != owner && !LibERC7540RequestAccounting.isOperator(owner, msg.sender)) {
+            revert ERC7540VaultUnauthorizedOperator(owner, msg.sender);
+        }
+
+        uint256 maxAssets = _maxRequestDepositAssets(controller);
+        if (assets > maxAssets) {
+            revert IERC4626VaultControls.ERC4626VaultDepositLimitExceeded(assets, maxAssets);
+        }
+
+        requestId = LibERC7540RequestAccounting.aggregateRequestId();
+        _safeTransferFromAsset(owner, address(this), assets);
+        LibERC7540RequestAccounting.increasePendingDeposit(controller, assets);
+
+        emit DepositRequest(controller, owner, requestId, msg.sender, assets);
+    }
+
+    /// @notice Returns pending deposit-request assets for `controller`.
+    /// @param requestId Request discriminator.
+    /// @param controller Request controller account.
+    /// @return assets Pending gross asset amount.
+    function pendingDepositRequest(uint256 requestId, address controller) public view virtual returns (uint256 assets) {
+        return LibERC7540RequestAccounting.pendingDepositRequest(requestId, controller);
+    }
+
+    /// @notice Returns claimable deposit-request assets for `controller`.
+    /// @param requestId Request discriminator.
+    /// @param controller Request controller account.
+    /// @return assets Claimable gross asset amount.
+    function claimableDepositRequest(uint256 requestId, address controller)
+        public
+        view
+        virtual
+        returns (uint256 assets)
+    {
+        return LibERC7540RequestAccounting.claimableDepositRequest(requestId, controller);
+    }
+
+    /// @notice Returns whether `operator` is approved for `controller`.
+    /// @param controller Request controller account.
+    /// @param operator Operator account.
+    /// @return status True when approved.
+    function isOperator(address controller, address operator) public view virtual returns (bool status) {
+        return LibERC7540RequestAccounting.isOperator(controller, operator);
+    }
+
+    /// @notice Grants or revokes operator approval for the caller's requests.
+    /// @param operator Operator account.
+    /// @param approved Approval status.
+    /// @return success True when stored.
+    function setOperator(address operator, bool approved) public virtual returns (bool success) {
+        LibERC7540RequestAccounting.setOperator(msg.sender, operator, approved);
+        emit OperatorSet(msg.sender, operator, approved);
+        return true;
+    }
+
+    /// @notice Claims asynchronous deposit assets into shares for `receiver`.
+    /// @param assets Claimable gross asset amount.
+    /// @param receiver Share receiver.
+    /// @param controller Request controller account.
+    /// @return shares Minted share amount.
+    function deposit(uint256 assets, address receiver, address controller)
+        public
+        virtual
+        whenNotPaused
+        nonReentrant
+        returns (uint256 shares)
+    {
+        return _claimAsyncDeposit(assets, receiver, controller);
+    }
+
+    /// @notice Claims asynchronous deposit assets into an exact share amount for `receiver`.
+    /// @param shares Target share amount.
+    /// @param receiver Share receiver.
+    /// @param controller Request controller account.
+    /// @return assets Consumed claimable gross asset amount.
+    function mint(uint256 shares, address receiver, address controller)
+        public
+        virtual
+        whenNotPaused
+        nonReentrant
+        returns (uint256 assets)
+    {
+        return _claimAsyncMint(shares, receiver, controller);
+    }
+
+    function _vaultOperationsPaused() internal view virtual override returns (bool) {
+        return paused();
+    }
+
+    function _asyncDepositModeEnabled() internal view virtual returns (bool) {
+        return !LibVaultAsset.isNativeAsset(ERC4626Vault.asset())
+            && LibDiamond.selectorExists(IERC7540Deposit.requestDeposit.selector);
+    }
+
+    function _maxRequestDepositAssets(address controller) internal view returns (uint256 maxAssets) {
+        if (controller == address(0) || paused()) {
+            return 0;
+        }
+
+        maxAssets = type(uint256).max;
+        (uint128 maxTotalAssets_, uint128 maxDeposit_,,,) = LibERC4626VaultControlLogic.limitConfig();
+
+        if (maxDeposit_ != 0) {
+            maxAssets = maxDeposit_;
+        }
+
+        if (maxTotalAssets_ != 0) {
+            uint256 currentCommittedAssets = totalAssets()
+                + LibERC7540RequestAccounting.totalPendingDepositRequestAssets()
+                + LibERC7540RequestAccounting.totalClaimableDepositRequestAssets();
+
+            if (currentCommittedAssets >= maxTotalAssets_) {
+                return 0;
+            }
+
+            uint256 remainingAssets = maxTotalAssets_ - currentCommittedAssets;
+            if (remainingAssets < maxAssets) {
+                maxAssets = remainingAssets;
+            }
+        }
+    }
+
+    function _claimAsyncDeposit(uint256 assets, address receiver, address controller)
+        internal
+        returns (uint256 shares)
+    {
+        _requireInitialized();
+        _requireAsyncDepositEnabled();
+        _requireNonZeroAddress(receiver);
+        _requireNonZeroAddress(controller);
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        _requireControllerOrOperator(controller);
+
+        (uint256 netAssets, uint256 feeAssets) = LibERC4626VaultControlLogic.netAfterDepositFee(assets);
+        shares = _convertToShares(netAssets, Rounding.Down);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        LibERC7540RequestAccounting.consumeClaimableDeposit(controller, assets);
+        _increaseManagedAssets(netAssets);
+        _mintShares(receiver, shares);
+        _payoutFee(feeAssets);
+
+        emit Deposit(controller, receiver, assets, shares);
+    }
+
+    function _claimAsyncMint(uint256 shares, address receiver, address controller) internal returns (uint256 assets) {
+        _requireInitialized();
+        _requireAsyncDepositEnabled();
+        _requireNonZeroAddress(receiver);
+        _requireNonZeroAddress(controller);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        _requireControllerOrOperator(controller);
+
+        uint256 netAssets = _convertToAssets(shares, Rounding.Up);
+        if (netAssets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        assets = LibERC4626VaultControlLogic.grossUpForDepositFee(netAssets);
+        uint256 feeAssets = assets - netAssets;
+
+        LibERC7540RequestAccounting.consumeClaimableDeposit(controller, assets);
+        _increaseManagedAssets(netAssets);
+        _mintShares(receiver, shares);
+        _payoutFee(feeAssets);
+
+        emit Deposit(controller, receiver, assets, shares);
+    }
+
+    function _requireAsyncDepositEnabled() internal view {
+        if (!_asyncDepositModeEnabled()) {
+            revert ERC7540VaultAsyncDepositDisabled();
+        }
+    }
+
+    function _requireControllerOrOperator(address controller) internal view {
+        if (msg.sender != controller && !LibERC7540RequestAccounting.isOperator(controller, msg.sender)) {
+            revert ERC7540VaultUnauthorizedOperator(controller, msg.sender);
+        }
+    }
+}

--- a/src/vault/libraries/LibVaultFacetSelectors.sol
+++ b/src/vault/libraries/LibVaultFacetSelectors.sol
@@ -64,16 +64,36 @@ library LibVaultFacetSelectors {
     /// @notice Returns the hosted vault async selector group.
     function vaultAsyncSelectors() internal pure returns (bytes4[] memory selectors) {
         selectors = new bytes4[](10);
+        bytes4[] memory depositSelectors = vaultAsyncDepositSelectors();
+        bytes4[] memory redeemSelectors = vaultAsyncRedeemSelectors();
+
+        for (uint256 i = 0; i < depositSelectors.length; i++) {
+            selectors[i] = depositSelectors[i];
+        }
+
+        for (uint256 i = 0; i < redeemSelectors.length; i++) {
+            selectors[depositSelectors.length + i] = redeemSelectors[i];
+        }
+    }
+
+    /// @notice Returns the hosted vault async deposit selector group.
+    function vaultAsyncDepositSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](7);
         selectors[0] = IERC7540Deposit.requestDeposit.selector;
         selectors[1] = IERC7540Deposit.pendingDepositRequest.selector;
         selectors[2] = IERC7540Deposit.claimableDepositRequest.selector;
         selectors[3] = IERC7540Deposit.deposit.selector;
         selectors[4] = IERC7540Deposit.mint.selector;
-        selectors[5] = IERC7540Redeem.requestRedeem.selector;
-        selectors[6] = IERC7540Redeem.pendingRedeemRequest.selector;
-        selectors[7] = IERC7540Redeem.claimableRedeemRequest.selector;
-        selectors[8] = IERC7540Operators.isOperator.selector;
-        selectors[9] = IERC7540Operators.setOperator.selector;
+        selectors[5] = IERC7540Operators.isOperator.selector;
+        selectors[6] = IERC7540Operators.setOperator.selector;
+    }
+
+    /// @notice Returns the hosted vault async redeem selector group.
+    function vaultAsyncRedeemSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](3);
+        selectors[0] = IERC7540Redeem.requestRedeem.selector;
+        selectors[1] = IERC7540Redeem.pendingRedeemRequest.selector;
+        selectors[2] = IERC7540Redeem.claimableRedeemRequest.selector;
     }
 
     /// @notice Returns the hosted vault controls selector group.

--- a/src/vault/libraries/LibVaultFacetSelectors.sol
+++ b/src/vault/libraries/LibVaultFacetSelectors.sol
@@ -54,6 +54,33 @@ library LibVaultFacetSelectors {
         selectors[27] = IERC4626.redeem.selector;
     }
 
+    /// @notice Returns the hosted vault core selector group when async deposit entrypoints are split out.
+    function vaultAsyncHostCoreSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](22);
+        selectors[0] = IERC4626VaultFacet.initializeVault.selector;
+        selectors[1] = IERC4626VaultBase.isVaultInitialized.selector;
+        selectors[2] = IERC4626.asset.selector;
+        selectors[3] = IERC4626VaultBase.totalManagedAssets.selector;
+        selectors[4] = IERC20Metadata.name.selector;
+        selectors[5] = IERC20Metadata.symbol.selector;
+        selectors[6] = IERC20Metadata.decimals.selector;
+        selectors[7] = IERC20.totalSupply.selector;
+        selectors[8] = IERC20.balanceOf.selector;
+        selectors[9] = IERC20.allowance.selector;
+        selectors[10] = IERC20.transfer.selector;
+        selectors[11] = IERC20.approve.selector;
+        selectors[12] = IERC20.transferFrom.selector;
+        selectors[13] = IERC4626.totalAssets.selector;
+        selectors[14] = IERC4626.convertToShares.selector;
+        selectors[15] = IERC4626.convertToAssets.selector;
+        selectors[16] = IERC4626.maxWithdraw.selector;
+        selectors[17] = IERC4626.previewWithdraw.selector;
+        selectors[18] = IERC4626.withdraw.selector;
+        selectors[19] = IERC4626.maxRedeem.selector;
+        selectors[20] = IERC4626.previewRedeem.selector;
+        selectors[21] = IERC4626.redeem.selector;
+    }
+
     /// @notice Returns the hosted vault native selector group.
     function vaultNativeSelectors() internal pure returns (bytes4[] memory selectors) {
         selectors = new bytes4[](2);
@@ -73,6 +100,32 @@ library LibVaultFacetSelectors {
 
         for (uint256 i = 0; i < redeemSelectors.length; i++) {
             selectors[depositSelectors.length + i] = redeemSelectors[i];
+        }
+    }
+
+    /// @notice Returns the standard ERC-4626 selectors whose behavior becomes async-claim-aware.
+    function vaultAsyncDepositClaimSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](6);
+        selectors[0] = IERC4626.maxDeposit.selector;
+        selectors[1] = IERC4626.previewDeposit.selector;
+        selectors[2] = IERC4626.deposit.selector;
+        selectors[3] = IERC4626.maxMint.selector;
+        selectors[4] = IERC4626.previewMint.selector;
+        selectors[5] = IERC4626.mint.selector;
+    }
+
+    /// @notice Returns the full selector group owned by the async deposit host facet.
+    function vaultAsyncDepositHostSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](13);
+        bytes4[] memory claimSelectors = vaultAsyncDepositClaimSelectors();
+        bytes4[] memory requestSelectors = vaultAsyncDepositSelectors();
+
+        for (uint256 i = 0; i < claimSelectors.length; i++) {
+            selectors[i] = claimSelectors[i];
+        }
+
+        for (uint256 i = 0; i < requestSelectors.length; i++) {
+            selectors[claimSelectors.length + i] = requestSelectors[i];
         }
     }
 

--- a/test/DiamondVaultDeploymentIntegration.t.sol
+++ b/test/DiamondVaultDeploymentIntegration.t.sol
@@ -6,6 +6,8 @@ import {DiamondLoupeFacet} from "../src/diamond/facets/DiamondLoupeFacet.sol";
 import {IDiamondLoupe} from "../src/interfaces/IDiamondLoupe.sol";
 import {IERC165} from "../src/interfaces/IERC165.sol";
 import {IERC20Metadata} from "../src/interfaces/IERC20Metadata.sol";
+import {IERC7540Deposit} from "../src/interfaces/IERC7540Deposit.sol";
+import {IERC7540Operators} from "../src/interfaces/IERC7540Operators.sol";
 import {IERC4626VaultBase} from "../src/interfaces/IERC4626VaultBase.sol";
 import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol";
 import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControlsFacet.sol";
@@ -38,7 +40,7 @@ contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture 
 
         assertTrue(
             loupe.facetFunctionSelectors(address(coreFacet)).length
-                == LibVaultFacetSelectors.vaultCoreSelectors().length,
+                == LibVaultFacetSelectors.vaultCoreSelectors().length + LibVaultFacetSelectors.vaultAsyncDepositSelectors().length,
             "unexpected core selector count"
         );
         assertTrue(
@@ -53,6 +55,7 @@ contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture 
         );
 
         _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultCoreSelectors(), address(coreFacet));
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultAsyncDepositSelectors(), address(coreFacet));
         _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultControlsSelectors(), address(controlsFacet));
         _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultIntegrationSelectors(), address(integrationFacet));
 
@@ -60,6 +63,10 @@ contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture 
         assertTrue(loupe.facetAddress(DiamondLoupeFacet.facets.selector) == address(loupeFacet), "loupe owner mismatch");
         assertTrue(
             loupe.facetAddress(IERC4626VaultFacet.initializeVault.selector) == address(coreFacet), "init owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC7540Deposit.requestDeposit.selector) == address(coreFacet),
+            "async deposit owner mismatch"
         );
         assertTrue(
             loupe.facetAddress(IERC4626VaultControls.VAULT_MANAGER_ROLE.selector) == address(controlsFacet),
@@ -119,6 +126,14 @@ contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture 
             "missing controls interface"
         );
         assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC7540Deposit).interfaceId),
+            "missing async deposit interface"
+        );
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC7540Operators).interfaceId),
+            "missing operator interface"
+        );
+        assertTrue(
             IERC165(address(diamond)).supportsInterface(type(IERC4626VaultIntegrationFacet).interfaceId),
             "missing integration interface"
         );
@@ -130,6 +145,7 @@ contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture 
 
     function testVaultHostSmokeCoversStrategyLifecycle() public {
         _installVaultHostFacets();
+        _installVaultAsyncDepositTestSelector();
         _initializeVaultHost();
         _wireOracleAdapter();
         _wireStrategy();
@@ -137,6 +153,9 @@ contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture 
         asset.mint(admin, 1_500_000_000);
         VM.prank(admin);
         asset.approve(address(diamond), 1_500_000_000);
+        VM.prank(admin);
+        IERC7540Deposit(address(diamond)).requestDeposit(1_000_000_000, admin, admin);
+        coreFacetInterface().harnessSettleDepositRequest(admin, 1_000_000_000);
         VM.prank(admin);
         coreFacetInterface().deposit(1_000_000_000, admin);
 

--- a/test/DiamondVaultDeploymentIntegration.t.sol
+++ b/test/DiamondVaultDeploymentIntegration.t.sol
@@ -19,6 +19,7 @@ import {IOracleAdapter} from "../src/interfaces/IOracleAdapter.sol";
 import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {LibVaultAsset} from "../src/vault/libraries/LibVaultAsset.sol";
 import {DiamondVaultDeploymentFixture} from "./helpers/DiamondVaultDeploymentTestHarness.sol";
+import {ERC7540VaultDepositFacetHarness} from "./helpers/ERC7540VaultDepositFacetTestHarness.sol";
 
 contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture {
     function testVaultHostDeployInstallInitOracleAndStrategyWiring() public {
@@ -31,17 +32,23 @@ contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture 
         address[] memory facetAddresses = loupe.facetAddresses();
         IOracleAdapter.OracleQuote memory quotePayload = integrationFacetInterface().oracleQuote();
 
-        assertTrue(facetAddresses.length == 5, "vault host facet count mismatch");
+        assertTrue(facetAddresses.length == 6, "vault host facet count mismatch");
         assertTrue(_containsAddress(facetAddresses, address(cutFacet)), "missing cut facet");
         assertTrue(_containsAddress(facetAddresses, address(loupeFacet)), "missing loupe facet");
         assertTrue(_containsAddress(facetAddresses, address(coreFacet)), "missing core facet");
+        assertTrue(_containsAddress(facetAddresses, address(asyncDepositFacet)), "missing async deposit facet");
         assertTrue(_containsAddress(facetAddresses, address(controlsFacet)), "missing controls facet");
         assertTrue(_containsAddress(facetAddresses, address(integrationFacet)), "missing integration facet");
 
         assertTrue(
             loupe.facetFunctionSelectors(address(coreFacet)).length
-                == LibVaultFacetSelectors.vaultCoreSelectors().length + LibVaultFacetSelectors.vaultAsyncDepositSelectors().length,
+                == LibVaultFacetSelectors.vaultAsyncHostCoreSelectors().length,
             "unexpected core selector count"
+        );
+        assertTrue(
+            loupe.facetFunctionSelectors(address(asyncDepositFacet)).length
+                == LibVaultFacetSelectors.vaultAsyncDepositHostSelectors().length,
+            "unexpected async selector count"
         );
         assertTrue(
             loupe.facetFunctionSelectors(address(controlsFacet)).length
@@ -54,8 +61,10 @@ contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture 
             "unexpected integration selector count"
         );
 
-        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultCoreSelectors(), address(coreFacet));
-        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultAsyncDepositSelectors(), address(coreFacet));
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultAsyncHostCoreSelectors(), address(coreFacet));
+        _assertSelectorsOwnedByFacet(
+            LibVaultFacetSelectors.vaultAsyncDepositHostSelectors(), address(asyncDepositFacet)
+        );
         _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultControlsSelectors(), address(controlsFacet));
         _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultIntegrationSelectors(), address(integrationFacet));
 
@@ -65,7 +74,7 @@ contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture 
             loupe.facetAddress(IERC4626VaultFacet.initializeVault.selector) == address(coreFacet), "init owner mismatch"
         );
         assertTrue(
-            loupe.facetAddress(IERC7540Deposit.requestDeposit.selector) == address(coreFacet),
+            loupe.facetAddress(IERC7540Deposit.requestDeposit.selector) == address(asyncDepositFacet),
             "async deposit owner mismatch"
         );
         assertTrue(
@@ -155,7 +164,7 @@ contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture 
         asset.approve(address(diamond), 1_500_000_000);
         VM.prank(admin);
         IERC7540Deposit(address(diamond)).requestDeposit(1_000_000_000, admin, admin);
-        coreFacetInterface().harnessSettleDepositRequest(admin, 1_000_000_000);
+        ERC7540VaultDepositFacetHarness(address(diamond)).harnessSettleDepositRequest(admin, 1_000_000_000);
         VM.prank(admin);
         coreFacetInterface().deposit(1_000_000_000, admin);
 

--- a/test/DiamondVaultHostHardening.t.sol
+++ b/test/DiamondVaultHostHardening.t.sol
@@ -137,8 +137,7 @@ contract DiamondVaultHostHardeningTest is DiamondVaultHostHardeningFixture {
         );
         _unpauseVault();
 
-        VM.prank(dave);
-        coreFacetInterface().deposit(1, dave);
+        _settleAndClaimDeposit(dave, 1);
         assertTrue(coreFacetInterface().balanceOf(dave) == 1, "dave should receive shares after unpause");
     }
 

--- a/test/DiamondVaultHostHardening.t.sol
+++ b/test/DiamondVaultHostHardening.t.sol
@@ -26,7 +26,7 @@ contract DiamondVaultHostHardeningTest is DiamondVaultHostHardeningFixture {
         _replaceCoreFacet(address(coreReplacement));
         _addCoreReplacementMarker(address(coreReplacement));
 
-        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultCoreSelectors(), address(coreReplacement));
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultAsyncHostCoreSelectors(), address(coreReplacement));
         assertTrue(
             IDiamondLoupe(address(diamond)).facetAddress(IFacetVersionMarker.facetVersion.selector)
                 == address(coreReplacement),
@@ -70,7 +70,7 @@ contract DiamondVaultHostHardeningTest is DiamondVaultHostHardeningFixture {
 
         _reAddCoreFacetWithMarker(address(coreReplacement));
 
-        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultCoreSelectors(), address(coreReplacement));
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultAsyncHostCoreSelectors(), address(coreReplacement));
         assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "core marker mismatch after re-add");
         assertTrue(
             IERC165(address(diamond)).supportsInterface(type(IERC4626VaultFacet).interfaceId),

--- a/test/ERC7540VaultDepositCore.t.sol
+++ b/test/ERC7540VaultDepositCore.t.sol
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC4626} from "../src/interfaces/IERC4626.sol";
+import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol";
+import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControlsFacet.sol";
+import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
+import {IERC7540Deposit} from "../src/interfaces/IERC7540Deposit.sol";
+import {ERC4626Vault} from "../src/vault/ERC4626Vault.sol";
+import {ERC4626VaultFacet} from "../src/vault/facets/ERC4626VaultFacet.sol";
+import {
+    ERC4626VaultFacetFixture,
+    ERC4626VaultFacetHarness
+} from "./helpers/ERC4626VaultFacetTestHarness.sol";
+
+contract ERC7540VaultDepositCoreTest is ERC4626VaultFacetFixture {
+    function testRequestDepositLocksAssetsWithoutChangingManagedAssets() public {
+        _initializeHostedVault(address(facet));
+        facet.harnessSetAsyncDepositMode(true);
+        _approveAsset(bob, address(facet), 100);
+
+        VM.prank(bob);
+        uint256 requestId = facet.requestDeposit(40, bob, bob);
+
+        assertTrue(requestId == 0, "request id mismatch");
+        assertTrue(facet.pendingDepositRequest(0, bob) == 40, "pending deposit mismatch");
+        assertTrue(facet.claimableDepositRequest(0, bob) == 0, "claimable deposit should stay zero");
+        assertTrue(facet.totalAssets() == 0, "managed assets should stay unchanged");
+        assertTrue(facet.totalManagedAssets() == 0, "book assets should stay unchanged");
+        assertTrue(asset.balanceOf(address(facet)) == 40, "vault balance mismatch");
+    }
+
+    function testAsyncDepositPreviewHelpersRevertAndMaxHelpersTrackClaimableAssets() public {
+        _initializeHostedVault(address(facet));
+        facet.harnessSetAsyncDepositMode(true);
+        _approveAsset(bob, address(facet), 100);
+
+        VM.prank(bob);
+        facet.requestDeposit(40, bob, bob);
+        facet.harnessSettleDepositRequest(bob, 25);
+
+        VM.expectRevert(abi.encodeWithSelector(ERC4626VaultFacet.ERC7540VaultAsyncDepositPreviewUnsupported.selector));
+        facet.previewDeposit(1);
+
+        VM.expectRevert(abi.encodeWithSelector(ERC4626VaultFacet.ERC7540VaultAsyncDepositPreviewUnsupported.selector));
+        facet.previewMint(1);
+
+        VM.prank(bob);
+        uint256 maxAssets = facet.maxDeposit(bob);
+        VM.prank(bob);
+        uint256 maxShares = facet.maxMint(bob);
+
+        assertTrue(maxAssets == 25, "max deposit should match claimable assets");
+        assertTrue(maxShares == 25, "max mint should match current share quote");
+    }
+
+    function testAsyncDepositClaimConsumesClaimableAssetsAndMintsShares() public {
+        _initializeHostedVault(address(facet));
+        facet.harnessSetAsyncDepositMode(true);
+        _approveAsset(bob, address(facet), 100);
+
+        VM.prank(bob);
+        facet.requestDeposit(40, bob, bob);
+        facet.harnessSettleDepositRequest(bob, 40);
+
+        VM.prank(bob);
+        uint256 shares = facet.deposit(25, eve);
+
+        assertTrue(shares == 25, "claimed shares mismatch");
+        assertTrue(facet.claimableDepositRequest(0, bob) == 15, "remaining claimable mismatch");
+        assertTrue(facet.pendingDepositRequest(0, bob) == 0, "pending deposit should be empty");
+        assertTrue(facet.totalManagedAssets() == 25, "managed assets mismatch");
+        assertTrue(facet.totalAssets() == 25, "total assets mismatch");
+        assertTrue(facet.balanceOf(eve) == 25, "receiver share balance mismatch");
+        assertTrue(asset.balanceOf(address(facet)) == 40, "vault balance should keep locked assets");
+    }
+
+    function testOperatorCanSubmitRequestForOwnerAndClaimForController() public {
+        _initializeHostedVault(address(facet));
+        facet.harnessSetAsyncDepositMode(true);
+        _approveAsset(bob, address(facet), 100);
+
+        VM.prank(bob);
+        bool approved = facet.setOperator(eve, true);
+        assertTrue(approved, "operator approval should succeed");
+
+        VM.prank(eve);
+        facet.requestDeposit(30, bob, bob);
+        facet.harnessSettleDepositRequest(bob, 30);
+
+        VM.prank(eve);
+        uint256 assets = facet.mint(10, admin, bob);
+
+        assertTrue(assets == 10, "claimed assets mismatch");
+        assertTrue(facet.balanceOf(admin) == 10, "receiver share balance mismatch");
+        assertTrue(facet.claimableDepositRequest(0, bob) == 20, "remaining claimable mismatch");
+        assertTrue(facet.totalManagedAssets() == 10, "managed assets mismatch");
+    }
+
+    function testUnauthorizedRequestAndClaimActorsRevert() public {
+        _initializeHostedVault(address(facet));
+        facet.harnessSetAsyncDepositMode(true);
+        _approveAsset(bob, address(facet), 100);
+
+        VM.prank(eve);
+        VM.expectRevert(
+            abi.encodeWithSelector(ERC4626VaultFacet.ERC7540VaultUnauthorizedOperator.selector, bob, eve)
+        );
+        facet.requestDeposit(10, bob, bob);
+
+        VM.prank(bob);
+        facet.requestDeposit(10, bob, bob);
+        facet.harnessSettleDepositRequest(bob, 10);
+
+        VM.prank(eve);
+        VM.expectRevert(
+            abi.encodeWithSelector(ERC4626VaultFacet.ERC7540VaultUnauthorizedOperator.selector, bob, eve)
+        );
+        facet.deposit(10, eve, bob);
+    }
+
+    function testDiamondAsyncRequestDepositRespectsRequestLimitConfig() public {
+        _installHostedVaultAsyncDepositFacetsToDiamond();
+
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond)).initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+
+        VM.prank(admin);
+        IERC4626VaultControlsFacet(address(diamond)).setLimitConfig(0, 25, 0, 0, 0);
+
+        _approveAsset(bob, address(diamond), 100);
+
+        VM.prank(bob);
+        VM.expectRevert(
+            abi.encodeWithSelector(IERC4626VaultControls.ERC4626VaultDepositLimitExceeded.selector, 30, 25)
+        );
+        IERC7540Deposit(address(diamond)).requestDeposit(30, bob, bob);
+    }
+
+    function testDiamondAsyncDepositClaimUsesStandardDepositEntrypoint() public {
+        _installHostedVaultAsyncDepositFacetsToDiamond();
+        _installVaultAsyncDepositTestSelectorToDiamond();
+
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond)).initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+
+        _approveAsset(bob, address(diamond), 100);
+
+        VM.prank(bob);
+        IERC7540Deposit(address(diamond)).requestDeposit(35, bob, bob);
+        ERC4626VaultFacetHarness(address(diamond)).harnessSettleDepositRequest(bob, 35);
+
+        VM.prank(bob);
+        uint256 shares = IERC4626(address(diamond)).deposit(20, eve);
+
+        assertTrue(shares == 20, "diamond claimed shares mismatch");
+        assertTrue(IERC7540Deposit(address(diamond)).claimableDepositRequest(0, bob) == 15, "remaining claimable mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 20, "managed assets mismatch");
+        assertTrue(IERC4626(address(diamond)).balanceOf(eve) == 20, "receiver shares mismatch");
+    }
+}

--- a/test/ERC7540VaultDepositCore.t.sol
+++ b/test/ERC7540VaultDepositCore.t.sol
@@ -6,124 +6,134 @@ import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol
 import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControlsFacet.sol";
 import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
 import {IERC7540Deposit} from "../src/interfaces/IERC7540Deposit.sol";
-import {ERC4626Vault} from "../src/vault/ERC4626Vault.sol";
-import {ERC4626VaultFacet} from "../src/vault/facets/ERC4626VaultFacet.sol";
-import {
-    ERC4626VaultFacetFixture,
-    ERC4626VaultFacetHarness
-} from "./helpers/ERC4626VaultFacetTestHarness.sol";
+import {IERC7540Operators} from "../src/interfaces/IERC7540Operators.sol";
+import {ERC7540VaultDepositFacet} from "../src/vault/facets/ERC7540VaultDepositFacet.sol";
+import {ERC4626VaultFacetFixture} from "./helpers/ERC4626VaultFacetTestHarness.sol";
+import {ERC7540VaultDepositFacetHarness} from "./helpers/ERC7540VaultDepositFacetTestHarness.sol";
 
 contract ERC7540VaultDepositCoreTest is ERC4626VaultFacetFixture {
+    function _initializeDiamondAsyncVault() internal {
+        _installHostedVaultAsyncDepositFacetsToDiamond();
+        _installVaultAsyncDepositTestSelectorToDiamond();
+
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond)).initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
     function testRequestDepositLocksAssetsWithoutChangingManagedAssets() public {
-        _initializeHostedVault(address(facet));
-        facet.harnessSetAsyncDepositMode(true);
-        _approveAsset(bob, address(facet), 100);
+        _initializeDiamondAsyncVault();
+        _approveAsset(bob, address(diamond), 100);
 
         VM.prank(bob);
-        uint256 requestId = facet.requestDeposit(40, bob, bob);
+        uint256 requestId = IERC7540Deposit(address(diamond)).requestDeposit(40, bob, bob);
 
         assertTrue(requestId == 0, "request id mismatch");
-        assertTrue(facet.pendingDepositRequest(0, bob) == 40, "pending deposit mismatch");
-        assertTrue(facet.claimableDepositRequest(0, bob) == 0, "claimable deposit should stay zero");
-        assertTrue(facet.totalAssets() == 0, "managed assets should stay unchanged");
-        assertTrue(facet.totalManagedAssets() == 0, "book assets should stay unchanged");
-        assertTrue(asset.balanceOf(address(facet)) == 40, "vault balance mismatch");
+        assertTrue(IERC7540Deposit(address(diamond)).pendingDepositRequest(0, bob) == 40, "pending deposit mismatch");
+        assertTrue(
+            IERC7540Deposit(address(diamond)).claimableDepositRequest(0, bob) == 0, "claimable deposit should stay zero"
+        );
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 0, "managed assets should stay unchanged");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 0, "book assets should stay unchanged");
+        assertTrue(asset.balanceOf(address(diamond)) == 40, "vault balance mismatch");
     }
 
     function testAsyncDepositPreviewHelpersRevertAndMaxHelpersTrackClaimableAssets() public {
-        _initializeHostedVault(address(facet));
-        facet.harnessSetAsyncDepositMode(true);
-        _approveAsset(bob, address(facet), 100);
+        _initializeDiamondAsyncVault();
+        _approveAsset(bob, address(diamond), 100);
 
         VM.prank(bob);
-        facet.requestDeposit(40, bob, bob);
-        facet.harnessSettleDepositRequest(bob, 25);
+        IERC7540Deposit(address(diamond)).requestDeposit(40, bob, bob);
+        ERC7540VaultDepositFacetHarness(address(diamond)).harnessSettleDepositRequest(bob, 25);
 
-        VM.expectRevert(abi.encodeWithSelector(ERC4626VaultFacet.ERC7540VaultAsyncDepositPreviewUnsupported.selector));
-        facet.previewDeposit(1);
+        VM.expectRevert(
+            abi.encodeWithSelector(ERC7540VaultDepositFacet.ERC7540VaultAsyncDepositPreviewUnsupported.selector)
+        );
+        IERC4626(address(diamond)).previewDeposit(1);
 
-        VM.expectRevert(abi.encodeWithSelector(ERC4626VaultFacet.ERC7540VaultAsyncDepositPreviewUnsupported.selector));
-        facet.previewMint(1);
+        VM.expectRevert(
+            abi.encodeWithSelector(ERC7540VaultDepositFacet.ERC7540VaultAsyncDepositPreviewUnsupported.selector)
+        );
+        IERC4626(address(diamond)).previewMint(1);
 
         VM.prank(bob);
-        uint256 maxAssets = facet.maxDeposit(bob);
+        uint256 maxAssets = IERC4626(address(diamond)).maxDeposit(bob);
         VM.prank(bob);
-        uint256 maxShares = facet.maxMint(bob);
+        uint256 maxShares = IERC4626(address(diamond)).maxMint(bob);
 
         assertTrue(maxAssets == 25, "max deposit should match claimable assets");
         assertTrue(maxShares == 25, "max mint should match current share quote");
     }
 
     function testAsyncDepositClaimConsumesClaimableAssetsAndMintsShares() public {
-        _initializeHostedVault(address(facet));
-        facet.harnessSetAsyncDepositMode(true);
-        _approveAsset(bob, address(facet), 100);
+        _initializeDiamondAsyncVault();
+        _approveAsset(bob, address(diamond), 100);
 
         VM.prank(bob);
-        facet.requestDeposit(40, bob, bob);
-        facet.harnessSettleDepositRequest(bob, 40);
+        IERC7540Deposit(address(diamond)).requestDeposit(40, bob, bob);
+        ERC7540VaultDepositFacetHarness(address(diamond)).harnessSettleDepositRequest(bob, 40);
 
         VM.prank(bob);
-        uint256 shares = facet.deposit(25, eve);
+        uint256 shares = IERC4626(address(diamond)).deposit(25, eve);
 
         assertTrue(shares == 25, "claimed shares mismatch");
-        assertTrue(facet.claimableDepositRequest(0, bob) == 15, "remaining claimable mismatch");
-        assertTrue(facet.pendingDepositRequest(0, bob) == 0, "pending deposit should be empty");
-        assertTrue(facet.totalManagedAssets() == 25, "managed assets mismatch");
-        assertTrue(facet.totalAssets() == 25, "total assets mismatch");
-        assertTrue(facet.balanceOf(eve) == 25, "receiver share balance mismatch");
-        assertTrue(asset.balanceOf(address(facet)) == 40, "vault balance should keep locked assets");
+        assertTrue(
+            IERC7540Deposit(address(diamond)).claimableDepositRequest(0, bob) == 15, "remaining claimable mismatch"
+        );
+        assertTrue(
+            IERC7540Deposit(address(diamond)).pendingDepositRequest(0, bob) == 0, "pending deposit should be empty"
+        );
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 25, "managed assets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 25, "total assets mismatch");
+        assertTrue(IERC4626(address(diamond)).balanceOf(eve) == 25, "receiver share balance mismatch");
+        assertTrue(asset.balanceOf(address(diamond)) == 40, "vault balance should keep locked assets");
     }
 
     function testOperatorCanSubmitRequestForOwnerAndClaimForController() public {
-        _initializeHostedVault(address(facet));
-        facet.harnessSetAsyncDepositMode(true);
-        _approveAsset(bob, address(facet), 100);
+        _initializeDiamondAsyncVault();
+        _approveAsset(bob, address(diamond), 100);
 
         VM.prank(bob);
-        bool approved = facet.setOperator(eve, true);
+        bool approved = IERC7540Operators(address(diamond)).setOperator(eve, true);
         assertTrue(approved, "operator approval should succeed");
 
         VM.prank(eve);
-        facet.requestDeposit(30, bob, bob);
-        facet.harnessSettleDepositRequest(bob, 30);
+        IERC7540Deposit(address(diamond)).requestDeposit(30, bob, bob);
+        ERC7540VaultDepositFacetHarness(address(diamond)).harnessSettleDepositRequest(bob, 30);
 
         VM.prank(eve);
-        uint256 assets = facet.mint(10, admin, bob);
+        uint256 assets = IERC7540Deposit(address(diamond)).mint(10, admin, bob);
 
         assertTrue(assets == 10, "claimed assets mismatch");
-        assertTrue(facet.balanceOf(admin) == 10, "receiver share balance mismatch");
-        assertTrue(facet.claimableDepositRequest(0, bob) == 20, "remaining claimable mismatch");
-        assertTrue(facet.totalManagedAssets() == 10, "managed assets mismatch");
+        assertTrue(IERC4626(address(diamond)).balanceOf(admin) == 10, "receiver share balance mismatch");
+        assertTrue(
+            IERC7540Deposit(address(diamond)).claimableDepositRequest(0, bob) == 20, "remaining claimable mismatch"
+        );
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 10, "managed assets mismatch");
     }
 
     function testUnauthorizedRequestAndClaimActorsRevert() public {
-        _initializeHostedVault(address(facet));
-        facet.harnessSetAsyncDepositMode(true);
-        _approveAsset(bob, address(facet), 100);
+        _initializeDiamondAsyncVault();
+        _approveAsset(bob, address(diamond), 100);
 
         VM.prank(eve);
         VM.expectRevert(
-            abi.encodeWithSelector(ERC4626VaultFacet.ERC7540VaultUnauthorizedOperator.selector, bob, eve)
+            abi.encodeWithSelector(ERC7540VaultDepositFacet.ERC7540VaultUnauthorizedOperator.selector, bob, eve)
         );
-        facet.requestDeposit(10, bob, bob);
+        IERC7540Deposit(address(diamond)).requestDeposit(10, bob, bob);
 
         VM.prank(bob);
-        facet.requestDeposit(10, bob, bob);
-        facet.harnessSettleDepositRequest(bob, 10);
+        IERC7540Deposit(address(diamond)).requestDeposit(10, bob, bob);
+        ERC7540VaultDepositFacetHarness(address(diamond)).harnessSettleDepositRequest(bob, 10);
 
         VM.prank(eve);
         VM.expectRevert(
-            abi.encodeWithSelector(ERC4626VaultFacet.ERC7540VaultUnauthorizedOperator.selector, bob, eve)
+            abi.encodeWithSelector(ERC7540VaultDepositFacet.ERC7540VaultUnauthorizedOperator.selector, bob, eve)
         );
-        facet.deposit(10, eve, bob);
+        IERC7540Deposit(address(diamond)).deposit(10, eve, bob);
     }
 
     function testDiamondAsyncRequestDepositRespectsRequestLimitConfig() public {
-        _installHostedVaultAsyncDepositFacetsToDiamond();
-
-        VM.prank(admin);
-        IERC4626VaultFacet(address(diamond)).initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+        _initializeDiamondAsyncVault();
 
         VM.prank(admin);
         IERC4626VaultControlsFacet(address(diamond)).setLimitConfig(0, 25, 0, 0, 0);
@@ -131,30 +141,26 @@ contract ERC7540VaultDepositCoreTest is ERC4626VaultFacetFixture {
         _approveAsset(bob, address(diamond), 100);
 
         VM.prank(bob);
-        VM.expectRevert(
-            abi.encodeWithSelector(IERC4626VaultControls.ERC4626VaultDepositLimitExceeded.selector, 30, 25)
-        );
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultControls.ERC4626VaultDepositLimitExceeded.selector, 30, 25));
         IERC7540Deposit(address(diamond)).requestDeposit(30, bob, bob);
     }
 
     function testDiamondAsyncDepositClaimUsesStandardDepositEntrypoint() public {
-        _installHostedVaultAsyncDepositFacetsToDiamond();
-        _installVaultAsyncDepositTestSelectorToDiamond();
-
-        VM.prank(admin);
-        IERC4626VaultFacet(address(diamond)).initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+        _initializeDiamondAsyncVault();
 
         _approveAsset(bob, address(diamond), 100);
 
         VM.prank(bob);
         IERC7540Deposit(address(diamond)).requestDeposit(35, bob, bob);
-        ERC4626VaultFacetHarness(address(diamond)).harnessSettleDepositRequest(bob, 35);
+        ERC7540VaultDepositFacetHarness(address(diamond)).harnessSettleDepositRequest(bob, 35);
 
         VM.prank(bob);
         uint256 shares = IERC4626(address(diamond)).deposit(20, eve);
 
         assertTrue(shares == 20, "diamond claimed shares mismatch");
-        assertTrue(IERC7540Deposit(address(diamond)).claimableDepositRequest(0, bob) == 15, "remaining claimable mismatch");
+        assertTrue(
+            IERC7540Deposit(address(diamond)).claimableDepositRequest(0, bob) == 15, "remaining claimable mismatch"
+        );
         assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 20, "managed assets mismatch");
         assertTrue(IERC4626(address(diamond)).balanceOf(eve) == 20, "receiver shares mismatch");
     }

--- a/test/helpers/DiamondVaultDeploymentTestHarness.sol
+++ b/test/helpers/DiamondVaultDeploymentTestHarness.sol
@@ -70,21 +70,41 @@ abstract contract DiamondVaultDeploymentFixture is TestBase {
     }
 
     function _installVaultHostFacets() internal {
-        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](3);
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](4);
         cut[0] = IDiamondCut.FacetCut({
             facetAddress: address(coreFacet),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: LibVaultFacetSelectors.vaultCoreSelectors()
         });
         cut[1] = IDiamondCut.FacetCut({
+            facetAddress: address(coreFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultAsyncDepositSelectors()
+        });
+        cut[2] = IDiamondCut.FacetCut({
             facetAddress: address(controlsFacet),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: LibVaultFacetSelectors.vaultControlsSelectors()
         });
-        cut[2] = IDiamondCut.FacetCut({
+        cut[3] = IDiamondCut.FacetCut({
             facetAddress: address(integrationFacet),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: LibVaultFacetSelectors.vaultIntegrationSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installVaultAsyncDepositTestSelector() internal {
+        bytes4[] memory selectors = new bytes4[](1);
+        selectors[0] = ERC4626VaultFacetHarness.harnessSettleDepositRequest.selector;
+
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(coreFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: selectors
         });
 
         VM.prank(admin);

--- a/test/helpers/DiamondVaultDeploymentTestHarness.sol
+++ b/test/helpers/DiamondVaultDeploymentTestHarness.sol
@@ -7,6 +7,7 @@ import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
 import {ERC7535VaultFacet} from "../../src/vault/facets/ERC7535VaultFacet.sol";
 import {ERC4626VaultControlsFacetHarness} from "./ERC4626VaultControlsFacetTestHarness.sol";
 import {ERC4626VaultFacetHarness} from "./ERC4626VaultFacetTestHarness.sol";
+import {ERC7540VaultDepositFacetHarness} from "./ERC7540VaultDepositFacetTestHarness.sol";
 import {ERC4626VaultIntegrationFacetHarness} from "./ERC4626VaultIntegrationFacetTestHarness.sol";
 import {MockVaultAsset} from "./ERC4626CoreTestHarness.sol";
 import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
@@ -27,6 +28,7 @@ abstract contract DiamondVaultDeploymentFixture is TestBase {
     DiamondCutFacet internal cutFacet;
     DiamondLoupeFacet internal loupeFacet;
     ERC4626VaultFacetHarness internal coreFacet;
+    ERC7540VaultDepositFacetHarness internal asyncDepositFacet;
     ERC7535VaultFacet internal nativeFacet;
     ERC4626VaultControlsFacetHarness internal controlsFacet;
     ERC4626VaultIntegrationFacetHarness internal integrationFacet;
@@ -43,6 +45,7 @@ abstract contract DiamondVaultDeploymentFixture is TestBase {
         cutFacet = new DiamondCutFacet();
         loupeFacet = new DiamondLoupeFacet();
         coreFacet = new ERC4626VaultFacetHarness();
+        asyncDepositFacet = new ERC7540VaultDepositFacetHarness();
         nativeFacet = new ERC7535VaultFacet();
         controlsFacet = new ERC4626VaultControlsFacetHarness();
         integrationFacet = new ERC4626VaultIntegrationFacetHarness();
@@ -74,12 +77,12 @@ abstract contract DiamondVaultDeploymentFixture is TestBase {
         cut[0] = IDiamondCut.FacetCut({
             facetAddress: address(coreFacet),
             action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: LibVaultFacetSelectors.vaultCoreSelectors()
+            functionSelectors: LibVaultFacetSelectors.vaultAsyncHostCoreSelectors()
         });
         cut[1] = IDiamondCut.FacetCut({
-            facetAddress: address(coreFacet),
+            facetAddress: address(asyncDepositFacet),
             action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: LibVaultFacetSelectors.vaultAsyncDepositSelectors()
+            functionSelectors: LibVaultFacetSelectors.vaultAsyncDepositHostSelectors()
         });
         cut[2] = IDiamondCut.FacetCut({
             facetAddress: address(controlsFacet),
@@ -98,11 +101,11 @@ abstract contract DiamondVaultDeploymentFixture is TestBase {
 
     function _installVaultAsyncDepositTestSelector() internal {
         bytes4[] memory selectors = new bytes4[](1);
-        selectors[0] = ERC4626VaultFacetHarness.harnessSettleDepositRequest.selector;
+        selectors[0] = ERC7540VaultDepositFacetHarness.harnessSettleDepositRequest.selector;
 
         IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
         cut[0] = IDiamondCut.FacetCut({
-            facetAddress: address(coreFacet),
+            facetAddress: address(asyncDepositFacet),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: selectors
         });

--- a/test/helpers/DiamondVaultDeploymentTestHarness.sol
+++ b/test/helpers/DiamondVaultDeploymentTestHarness.sol
@@ -171,6 +171,10 @@ abstract contract DiamondVaultDeploymentFixture is TestBase {
         return ERC4626VaultFacetHarness(address(diamond));
     }
 
+    function asyncDepositFacetInterface() internal view returns (ERC7540VaultDepositFacetHarness) {
+        return ERC7540VaultDepositFacetHarness(address(diamond));
+    }
+
     function controlsFacetInterface() internal view returns (ERC4626VaultControlsFacetHarness) {
         return ERC4626VaultControlsFacetHarness(address(diamond));
     }

--- a/test/helpers/DiamondVaultHostHardeningTestHarness.sol
+++ b/test/helpers/DiamondVaultHostHardeningTestHarness.sol
@@ -119,6 +119,7 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
 
     function _installAndSeedVaultHost() internal {
         _installVaultHostFacets();
+        _installVaultAsyncDepositTestSelector();
         _initializeVaultHost();
         _wireOracleAdapter();
         _seedCoreState();
@@ -127,14 +128,20 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
     }
 
     function _seedCoreState() internal {
-        VM.prank(bob);
-        coreFacetInterface().deposit(BOB_DEPOSIT, bob);
-
-        VM.prank(carol);
-        coreFacetInterface().deposit(CAROL_DEPOSIT, carol);
+        _settleAndClaimDeposit(bob, BOB_DEPOSIT);
+        _settleAndClaimDeposit(carol, CAROL_DEPOSIT);
 
         VM.prank(bob);
         coreFacetInterface().approve(eve, SHARE_ALLOWANCE);
+    }
+
+    function _settleAndClaimDeposit(address controller, uint256 assets) internal {
+        VM.prank(controller);
+        asyncDepositFacetInterface().requestDeposit(assets, controller, controller);
+        asyncDepositFacetInterface().harnessSettleDepositRequest(controller, assets);
+
+        VM.prank(controller);
+        coreFacetInterface().deposit(assets, controller);
     }
 
     function _seedControlsState() internal {

--- a/test/helpers/DiamondVaultHostHardeningTestHarness.sol
+++ b/test/helpers/DiamondVaultHostHardeningTestHarness.sol
@@ -175,7 +175,7 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
     }
 
     function _replaceCoreFacet(address facetAddress_) internal {
-        _replaceFacet(facetAddress_, LibVaultFacetSelectors.vaultCoreSelectors());
+        _replaceFacet(facetAddress_, LibVaultFacetSelectors.vaultAsyncHostCoreSelectors());
     }
 
     function _replaceControlsFacet(address facetAddress_) internal {
@@ -199,7 +199,7 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
     }
 
     function _removeCoreFacetWithMarker() internal {
-        _removeSelectors(_concat(LibVaultFacetSelectors.vaultCoreSelectors(), _markerSelectors()));
+        _removeSelectors(_concat(LibVaultFacetSelectors.vaultAsyncHostCoreSelectors(), _markerSelectors()));
     }
 
     function _removeControlsFacetWithMarker() internal {
@@ -211,7 +211,7 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
     }
 
     function _reAddCoreFacetWithMarker(address facetAddress_) internal {
-        _addFacet(facetAddress_, _concat(LibVaultFacetSelectors.vaultCoreSelectors(), _markerSelectors()));
+        _addFacet(facetAddress_, _concat(LibVaultFacetSelectors.vaultAsyncHostCoreSelectors(), _markerSelectors()));
     }
 
     function _reAddControlsFacetWithMarker(address facetAddress_) internal {

--- a/test/helpers/ERC4626VaultFacetTestHarness.sol
+++ b/test/helpers/ERC4626VaultFacetTestHarness.sol
@@ -8,33 +8,19 @@ import {IERC4626VaultFacet} from "../../src/interfaces/IERC4626VaultFacet.sol";
 import {ERC4626VaultControlsFacet} from "../../src/vault/facets/ERC4626VaultControlsFacet.sol";
 import {ERC4626VaultFacet} from "../../src/vault/facets/ERC4626VaultFacet.sol";
 import {ERC7535VaultFacet} from "../../src/vault/facets/ERC7535VaultFacet.sol";
-import {LibERC7540RequestAccounting} from "../../src/vault/libraries/LibERC7540RequestAccounting.sol";
 import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {LibERC4626VaultStorage} from "../../src/vault/storage/LibERC4626VaultStorage.sol";
 import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
 import {TestBase} from "./AccessControlTestHarness.sol";
+import {ERC7540VaultDepositFacetHarness} from "./ERC7540VaultDepositFacetTestHarness.sol";
 import {ReentrantMockVaultAsset} from "./ERC4626VaultControlsTestHarness.sol";
 
 contract ERC4626VaultFacetHarness is ERC4626VaultFacet {
-    bool internal asyncDepositModeEnabledForHarness;
-
     function feeRecipient() external view returns (address) {
         return LibERC4626VaultStorage.layout().fees.feeRecipient;
     }
 
     function probeNonReentrant() external nonReentrant {}
-
-    function harnessSetAsyncDepositMode(bool enabled) external {
-        asyncDepositModeEnabledForHarness = enabled;
-    }
-
-    function harnessSettleDepositRequest(address controller, uint256 assets) external {
-        LibERC7540RequestAccounting.movePendingDepositToClaimable(controller, assets);
-    }
-
-    function _asyncDepositModeEnabled() internal view override returns (bool) {
-        return asyncDepositModeEnabledForHarness || super._asyncDepositModeEnabled();
-    }
 }
 
 contract RejectingNativeReceiver {
@@ -52,6 +38,7 @@ abstract contract ERC4626VaultFacetFixture is TestBase {
 
     ReentrantMockVaultAsset internal asset;
     ERC4626VaultFacetHarness internal facet;
+    ERC7540VaultDepositFacetHarness internal asyncDepositFacet;
     ERC7535VaultFacet internal nativeFacet;
     ERC4626VaultControlsFacet internal controlsFacet;
     DiamondCutFacet internal cutFacet;
@@ -61,6 +48,7 @@ abstract contract ERC4626VaultFacetFixture is TestBase {
     function setUp() public virtual {
         asset = new ReentrantMockVaultAsset();
         facet = new ERC4626VaultFacetHarness();
+        asyncDepositFacet = new ERC7540VaultDepositFacetHarness();
         nativeFacet = new ERC7535VaultFacet();
         controlsFacet = new ERC4626VaultControlsFacet();
         cutFacet = new DiamondCutFacet();
@@ -137,9 +125,9 @@ abstract contract ERC4626VaultFacetFixture is TestBase {
     function _installVaultAsyncDepositSelectorsToDiamond() internal {
         IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
         cut[0] = IDiamondCut.FacetCut({
-            facetAddress: address(facet),
+            facetAddress: address(asyncDepositFacet),
             action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: LibVaultFacetSelectors.vaultAsyncDepositSelectors()
+            functionSelectors: LibVaultFacetSelectors.vaultAsyncDepositHostSelectors()
         });
 
         VM.prank(admin);
@@ -148,11 +136,11 @@ abstract contract ERC4626VaultFacetFixture is TestBase {
 
     function _installVaultAsyncDepositTestSelectorToDiamond() internal {
         bytes4[] memory selectors = new bytes4[](1);
-        selectors[0] = ERC4626VaultFacetHarness.harnessSettleDepositRequest.selector;
+        selectors[0] = ERC7540VaultDepositFacetHarness.harnessSettleDepositRequest.selector;
 
         IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
         cut[0] = IDiamondCut.FacetCut({
-            facetAddress: address(facet),
+            facetAddress: address(asyncDepositFacet),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: selectors
         });
@@ -167,8 +155,25 @@ abstract contract ERC4626VaultFacetFixture is TestBase {
     }
 
     function _installHostedVaultAsyncDepositFacetsToDiamond() internal {
-        _installHostedVaultFacetsToDiamond();
-        _installVaultAsyncDepositSelectorsToDiamond();
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](3);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(facet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultAsyncHostCoreSelectors()
+        });
+        cut[1] = IDiamondCut.FacetCut({
+            facetAddress: address(asyncDepositFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultAsyncDepositHostSelectors()
+        });
+        cut[2] = IDiamondCut.FacetCut({
+            facetAddress: address(controlsFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultControlsSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
     }
 
     function _installHostedVaultNativeFacetsToDiamond() internal {

--- a/test/helpers/ERC4626VaultFacetTestHarness.sol
+++ b/test/helpers/ERC4626VaultFacetTestHarness.sol
@@ -8,6 +8,7 @@ import {IERC4626VaultFacet} from "../../src/interfaces/IERC4626VaultFacet.sol";
 import {ERC4626VaultControlsFacet} from "../../src/vault/facets/ERC4626VaultControlsFacet.sol";
 import {ERC4626VaultFacet} from "../../src/vault/facets/ERC4626VaultFacet.sol";
 import {ERC7535VaultFacet} from "../../src/vault/facets/ERC7535VaultFacet.sol";
+import {LibERC7540RequestAccounting} from "../../src/vault/libraries/LibERC7540RequestAccounting.sol";
 import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {LibERC4626VaultStorage} from "../../src/vault/storage/LibERC4626VaultStorage.sol";
 import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
@@ -15,11 +16,25 @@ import {TestBase} from "./AccessControlTestHarness.sol";
 import {ReentrantMockVaultAsset} from "./ERC4626VaultControlsTestHarness.sol";
 
 contract ERC4626VaultFacetHarness is ERC4626VaultFacet {
+    bool internal asyncDepositModeEnabledForHarness;
+
     function feeRecipient() external view returns (address) {
         return LibERC4626VaultStorage.layout().fees.feeRecipient;
     }
 
     function probeNonReentrant() external nonReentrant {}
+
+    function harnessSetAsyncDepositMode(bool enabled) external {
+        asyncDepositModeEnabledForHarness = enabled;
+    }
+
+    function harnessSettleDepositRequest(address controller, uint256 assets) external {
+        LibERC7540RequestAccounting.movePendingDepositToClaimable(controller, assets);
+    }
+
+    function _asyncDepositModeEnabled() internal view override returns (bool) {
+        return asyncDepositModeEnabledForHarness || super._asyncDepositModeEnabled();
+    }
 }
 
 contract RejectingNativeReceiver {
@@ -119,9 +134,41 @@ abstract contract ERC4626VaultFacetFixture is TestBase {
         IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
     }
 
+    function _installVaultAsyncDepositSelectorsToDiamond() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(facet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultAsyncDepositSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installVaultAsyncDepositTestSelectorToDiamond() internal {
+        bytes4[] memory selectors = new bytes4[](1);
+        selectors[0] = ERC4626VaultFacetHarness.harnessSettleDepositRequest.selector;
+
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(facet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: selectors
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
     function _installHostedVaultFacetsToDiamond() internal {
         _installVaultCoreFacetToDiamond();
         _installVaultControlsFacetToDiamond();
+    }
+
+    function _installHostedVaultAsyncDepositFacetsToDiamond() internal {
+        _installHostedVaultFacetsToDiamond();
+        _installVaultAsyncDepositSelectorsToDiamond();
     }
 
     function _installHostedVaultNativeFacetsToDiamond() internal {

--- a/test/helpers/ERC7540VaultDepositFacetTestHarness.sol
+++ b/test/helpers/ERC7540VaultDepositFacetTestHarness.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {ERC7540VaultDepositFacet} from "../../src/vault/facets/ERC7540VaultDepositFacet.sol";
+import {LibERC7540RequestAccounting} from "../../src/vault/libraries/LibERC7540RequestAccounting.sol";
+
+contract ERC7540VaultDepositFacetHarness is ERC7540VaultDepositFacet {
+    function harnessSettleDepositRequest(address controller, uint256 assets) external {
+        LibERC7540RequestAccounting.movePendingDepositToClaimable(controller, assets);
+    }
+}


### PR DESCRIPTION
## Summary
- add the hosted ERC-7540 async deposit request and operator surface through dedicated facet wiring
- implement request creation, pending and claimable deposit accounting, operator approvals, and claim settlement through the standard deposit path
- extend deployment, integration, and hardening coverage for hosted async deposit behavior

## Testing
- `forge fmt --check`
- `forge build --use 0.8.30 --sizes --skip script`
- `forge test --use 0.8.30 --offline --match-path test/ERC7540VaultDepositCore.t.sol`
- `forge test --use 0.8.30 --offline --match-path test/DiamondVaultDeploymentIntegration.t.sol`
- `forge test --use 0.8.30 --offline --match-path test/DiamondVaultHostHardening.t.sol`

## Linked Issue
Closes #194