### PR TITLE
feat: add ERC-7540 async redeem support to hosted vault

### DIFF
--- a/script/DeployDiamondNativeVaultHost.s.sol
+++ b/script/DeployDiamondNativeVaultHost.s.sol
@@ -89,6 +89,7 @@ contract DeployDiamondNativeVaultHostScript is DiamondVaultHostScriptBase {
                 diamondLoupeFacet: state.loupeFacetAddress,
                 vaultCoreFacet: state.vaultCoreFacetAddress,
                 vaultAsyncDepositFacet: address(0),
+                vaultAsyncRedeemFacet: address(0),
                 vaultNativeFacet: state.vaultNativeFacetAddress,
                 vaultControlsFacet: state.vaultControlsFacetAddress,
                 vaultIntegrationFacet: state.vaultIntegrationFacetAddress,

--- a/script/DeployDiamondVaultHost.s.sol
+++ b/script/DeployDiamondVaultHost.s.sol
@@ -13,11 +13,13 @@ import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
 import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
 import {IERC7540Deposit} from "../src/interfaces/IERC7540Deposit.sol";
 import {IERC7540Operators} from "../src/interfaces/IERC7540Operators.sol";
+import {IERC7540Redeem} from "../src/interfaces/IERC7540Redeem.sol";
 import {IERC4626VaultStrategy} from "../src/interfaces/IERC4626VaultStrategy.sol";
 import {IOracleAdapter} from "../src/interfaces/IOracleAdapter.sol";
 import {ERC4626VaultControlsFacet} from "../src/vault/facets/ERC4626VaultControlsFacet.sol";
 import {ERC4626VaultFacet} from "../src/vault/facets/ERC4626VaultFacet.sol";
 import {ERC7540VaultDepositFacet} from "../src/vault/facets/ERC7540VaultDepositFacet.sol";
+import {ERC7540VaultRedeemFacet} from "../src/vault/facets/ERC7540VaultRedeemFacet.sol";
 import {ERC4626VaultIntegrationFacet} from "../src/vault/facets/ERC4626VaultIntegrationFacet.sol";
 import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {DiamondVaultHostScriptBase} from "./common/DiamondVaultHostScriptBase.sol";
@@ -37,6 +39,7 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
         address loupeFacetAddress;
         address vaultCoreFacetAddress;
         address vaultAsyncDepositFacetAddress;
+        address vaultAsyncRedeemFacetAddress;
         address vaultControlsFacetAddress;
         address vaultIntegrationFacetAddress;
         address vaultAssetAddress;
@@ -89,6 +92,7 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
                 diamondLoupeFacet: state.loupeFacetAddress,
                 vaultCoreFacet: state.vaultCoreFacetAddress,
                 vaultAsyncDepositFacet: state.vaultAsyncDepositFacetAddress,
+                vaultAsyncRedeemFacet: state.vaultAsyncRedeemFacetAddress,
                 vaultNativeFacet: address(0),
                 vaultControlsFacet: state.vaultControlsFacetAddress,
                 vaultIntegrationFacet: state.vaultIntegrationFacetAddress,
@@ -119,6 +123,7 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
     {
         state.vaultCoreFacetAddress = address(new ERC4626VaultFacet());
         state.vaultAsyncDepositFacetAddress = address(new ERC7540VaultDepositFacet());
+        state.vaultAsyncRedeemFacetAddress = address(new ERC7540VaultRedeemFacet());
         state.vaultControlsFacetAddress = address(new ERC4626VaultControlsFacet());
         state.vaultIntegrationFacetAddress = address(new ERC4626VaultIntegrationFacet());
         state.vaultAssetAddress = address(new LocalMintableVaultAsset("Mock USD", "mUSD", 6));
@@ -130,11 +135,11 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
     }
 
     function _installVaultHostFacets(VaultHostDeploymentState memory state) internal {
-        IDiamondCut.FacetCut[] memory vaultCut = new IDiamondCut.FacetCut[](4);
+        IDiamondCut.FacetCut[] memory vaultCut = new IDiamondCut.FacetCut[](5);
         vaultCut[0] = IDiamondCut.FacetCut({
             facetAddress: state.vaultCoreFacetAddress,
             action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: LibVaultFacetSelectors.vaultAsyncHostCoreSelectors()
+            functionSelectors: LibVaultFacetSelectors.vaultFullyAsyncHostCoreSelectors()
         });
         vaultCut[1] = IDiamondCut.FacetCut({
             facetAddress: state.vaultAsyncDepositFacetAddress,
@@ -142,11 +147,16 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
             functionSelectors: LibVaultFacetSelectors.vaultAsyncDepositHostSelectors()
         });
         vaultCut[2] = IDiamondCut.FacetCut({
+            facetAddress: state.vaultAsyncRedeemFacetAddress,
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultAsyncRedeemHostSelectors()
+        });
+        vaultCut[3] = IDiamondCut.FacetCut({
             facetAddress: state.vaultControlsFacetAddress,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: LibVaultFacetSelectors.vaultControlsSelectors()
         });
-        vaultCut[3] = IDiamondCut.FacetCut({
+        vaultCut[4] = IDiamondCut.FacetCut({
             facetAddress: state.vaultIntegrationFacetAddress,
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: LibVaultFacetSelectors.vaultIntegrationSelectors()
@@ -164,13 +174,17 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
         IERC4626VaultStrategy strategy = IERC4626VaultStrategy(state.strategyAddress);
         address[] memory facetAddresses = loupe.facetAddresses();
 
-        require(facetAddresses.length == 6, "vault host facet count mismatch");
+        require(facetAddresses.length == 7, "vault host facet count mismatch");
         require(_containsAddress(facetAddresses, state.cutFacetAddress), "vault host missing cut facet");
         require(_containsAddress(facetAddresses, state.loupeFacetAddress), "vault host missing loupe facet");
         require(_containsAddress(facetAddresses, state.vaultCoreFacetAddress), "vault host missing core facet");
         require(
             _containsAddress(facetAddresses, state.vaultAsyncDepositFacetAddress),
             "vault host missing async deposit facet"
+        );
+        require(
+            _containsAddress(facetAddresses, state.vaultAsyncRedeemFacetAddress),
+            "vault host missing async redeem facet"
         );
         require(_containsAddress(facetAddresses, state.vaultControlsFacetAddress), "vault host missing controls facet");
         require(
@@ -179,13 +193,18 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
 
         require(
             loupe.facetFunctionSelectors(state.vaultCoreFacetAddress).length
-                == LibVaultFacetSelectors.vaultAsyncHostCoreSelectors().length,
+                == LibVaultFacetSelectors.vaultFullyAsyncHostCoreSelectors().length,
             "vault host core selector count mismatch"
         );
         require(
             loupe.facetFunctionSelectors(state.vaultAsyncDepositFacetAddress).length
                 == LibVaultFacetSelectors.vaultAsyncDepositHostSelectors().length,
             "vault host async deposit selector count mismatch"
+        );
+        require(
+            loupe.facetFunctionSelectors(state.vaultAsyncRedeemFacetAddress).length
+                == LibVaultFacetSelectors.vaultAsyncRedeemHostSelectors().length,
+            "vault host async redeem selector count mismatch"
         );
         require(
             loupe.facetFunctionSelectors(state.vaultControlsFacetAddress).length
@@ -241,6 +260,10 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
             "vault host missing async deposit interface"
         );
         require(
+            IERC165(state.diamondAddress).supportsInterface(type(IERC7540Redeem).interfaceId),
+            "vault host missing async redeem interface"
+        );
+        require(
             IERC165(state.diamondAddress).supportsInterface(type(IERC7540Operators).interfaceId),
             "vault host missing operator interface"
         );
@@ -259,6 +282,9 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
             IERC7540Deposit.requestDeposit.selector,
             state.vaultAsyncDepositFacetAddress,
             "vault async deposit owner"
+        );
+        _requireSelectorOwner(
+            loupe, IERC7540Redeem.requestRedeem.selector, state.vaultAsyncRedeemFacetAddress, "vault async redeem owner"
         );
         _requireSelectorOwner(
             loupe,

--- a/script/common/DiamondVaultHostScriptBase.sol
+++ b/script/common/DiamondVaultHostScriptBase.sol
@@ -19,6 +19,7 @@ abstract contract DiamondVaultHostScriptBase is DiamondCoreScriptBase {
         address diamondLoupeFacet;
         address vaultCoreFacet;
         address vaultAsyncDepositFacet;
+        address vaultAsyncRedeemFacet;
         address vaultNativeFacet;
         address vaultControlsFacet;
         address vaultIntegrationFacet;
@@ -90,6 +91,7 @@ abstract contract DiamondVaultHostScriptBase is DiamondCoreScriptBase {
         json = VM.serializeAddress(objectKey, "diamondLoupeFacet", artifact.diamondLoupeFacet);
         json = VM.serializeAddress(objectKey, "vaultCoreFacet", artifact.vaultCoreFacet);
         json = VM.serializeAddress(objectKey, "vaultAsyncDepositFacet", artifact.vaultAsyncDepositFacet);
+        json = VM.serializeAddress(objectKey, "vaultAsyncRedeemFacet", artifact.vaultAsyncRedeemFacet);
         json = VM.serializeAddress(objectKey, "vaultNativeFacet", artifact.vaultNativeFacet);
         json = VM.serializeAddress(objectKey, "vaultControlsFacet", artifact.vaultControlsFacet);
         json = VM.serializeAddress(objectKey, "vaultIntegrationFacet", artifact.vaultIntegrationFacet);

--- a/src/vault/facets/ERC7540VaultRedeemFacet.sol
+++ b/src/vault/facets/ERC7540VaultRedeemFacet.sol
@@ -1,0 +1,311 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC7540Redeem} from "../../interfaces/IERC7540Redeem.sol";
+import {IERC4626VaultControls} from "../../interfaces/IERC4626VaultControls.sol";
+import {LibDiamond} from "../../diamond/libraries/LibDiamond.sol";
+import {ERC4626Vault} from "../ERC4626Vault.sol";
+import {ERC4626VaultControlledCore, LibERC4626VaultControlLogic} from "../ERC4626VaultControlLogic.sol";
+import {VaultFacetControl} from "../VaultFacetControl.sol";
+import {LibERC7540RequestAccounting} from "../libraries/LibERC7540RequestAccounting.sol";
+import {LibVaultAsset} from "../libraries/LibVaultAsset.sol";
+
+/// @title ERC7540VaultRedeemFacet
+/// @notice Hosted async redeem extension facet for ERC-7540-style request flows.
+contract ERC7540VaultRedeemFacet is ERC4626VaultControlledCore, VaultFacetControl, IERC7540Redeem {
+    /// @notice Emitted when a redeem request is submitted.
+    event RedeemRequest(
+        address indexed controller, address indexed owner, uint256 indexed requestId, address sender, uint256 shares
+    );
+
+    /// @notice Thrown when an async redeem entrypoint is used before the async redeem extension is active.
+    error ERC7540VaultAsyncRedeemDisabled();
+
+    /// @notice Thrown when async redeem preview helpers are queried on an async redeem vault.
+    error ERC7540VaultAsyncRedeemPreviewUnsupported();
+
+    /// @notice Thrown when `sender` is not approved to manage requests for `account`.
+    error ERC7540VaultUnauthorizedOperator(address account, address sender);
+
+    /// @notice Returns max assets that can currently be claimed for `controller`.
+    /// @param controller Request controller account.
+    /// @return assets Max net asset amount claimable at the current exchange rate.
+    function maxWithdraw(address controller)
+        public
+        view
+        virtual
+        override(ERC4626VaultControlledCore)
+        returns (uint256 assets)
+    {
+        if (controller == address(0) || paused()) {
+            return 0;
+        }
+
+        uint256 claimableShares = LibERC7540RequestAccounting.claimableRedeemRequest(
+            LibERC7540RequestAccounting.aggregateRequestId(), controller
+        );
+        uint256 grossAssets = _convertToAssets(claimableShares, Rounding.Down);
+        (assets,) = LibERC4626VaultControlLogic.withdrawNetFromGross(grossAssets);
+    }
+
+    /// @notice Returns max shares that can currently be claimed for `controller`.
+    /// @param controller Request controller account.
+    /// @return shares Max claimable redeem share amount.
+    function maxRedeem(address controller)
+        public
+        view
+        virtual
+        override(ERC4626VaultControlledCore)
+        returns (uint256 shares)
+    {
+        if (controller == address(0) || paused()) {
+            return 0;
+        }
+
+        return LibERC7540RequestAccounting.claimableRedeemRequest(
+            LibERC7540RequestAccounting.aggregateRequestId(), controller
+        );
+    }
+
+    /// @notice Returns shares for an async withdraw preview.
+    /// @param assets Asset amount.
+    /// @return shares Preview share amount.
+    function previewWithdraw(uint256 assets)
+        public
+        view
+        virtual
+        override(ERC4626VaultControlledCore)
+        returns (uint256)
+    {
+        assets;
+        revert ERC7540VaultAsyncRedeemPreviewUnsupported();
+    }
+
+    /// @notice Returns assets for an async redeem preview.
+    /// @param shares Share amount.
+    /// @return assets Preview asset amount.
+    function previewRedeem(uint256 shares) public view virtual override(ERC4626VaultControlledCore) returns (uint256) {
+        shares;
+        revert ERC7540VaultAsyncRedeemPreviewUnsupported();
+    }
+
+    /// @notice Claims asynchronous redeem shares into an exact asset amount for `receiver`.
+    /// @param assets Target net asset amount.
+    /// @param receiver Asset receiver.
+    /// @param controller Request controller account.
+    /// @return shares Consumed claimable share amount.
+    function withdraw(uint256 assets, address receiver, address controller)
+        public
+        virtual
+        override(ERC4626Vault)
+        whenNotPaused
+        nonReentrant
+        returns (uint256 shares)
+    {
+        _requireInitialized();
+        _requireAsyncRedeemEnabled();
+        _requireNonZeroAddress(receiver);
+        _requireNonZeroAddress(controller);
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        _requireControllerOrOperator(controller);
+
+        uint256 maxAssets = maxWithdraw(controller);
+        if (assets > maxAssets) {
+            revert IERC4626VaultControls.ERC4626VaultWithdrawLimitExceeded(assets, maxAssets);
+        }
+
+        (uint256 grossAssets, uint256 feeAssets) = LibERC4626VaultControlLogic.withdrawGrossFromNet(assets);
+        _sourceStrategyLiquidity(grossAssets);
+
+        uint256 availableIdleAssets = _idleAssetBalance();
+        if (grossAssets > availableIdleAssets) {
+            revert ERC4626VaultInsufficientLiquidity(grossAssets, availableIdleAssets);
+        }
+
+        shares = _convertToShares(grossAssets, Rounding.Up);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        LibERC7540RequestAccounting.consumeClaimableRedeem(controller, shares);
+        _burnShares(address(this), shares);
+        _decreaseManagedAssetsForAssetExit(grossAssets);
+        _safeTransferAsset(receiver, assets);
+        _payoutFee(feeAssets);
+
+        emit Withdraw(msg.sender, receiver, controller, assets, shares);
+    }
+
+    /// @notice Claims asynchronous redeem shares into assets for `receiver`.
+    /// @param shares Claimable share amount.
+    /// @param receiver Asset receiver.
+    /// @param controller Request controller account.
+    /// @return assets Returned net asset amount.
+    function redeem(uint256 shares, address receiver, address controller)
+        public
+        virtual
+        override(ERC4626Vault)
+        whenNotPaused
+        nonReentrant
+        returns (uint256 assets)
+    {
+        _requireInitialized();
+        _requireAsyncRedeemEnabled();
+        _requireNonZeroAddress(receiver);
+        _requireNonZeroAddress(controller);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        _requireControllerOrOperator(controller);
+
+        uint256 maxShares = maxRedeem(controller);
+        if (shares > maxShares) {
+            revert IERC4626VaultControls.ERC4626VaultRedeemLimitExceeded(shares, maxShares);
+        }
+
+        uint256 grossAssets = _convertToAssets(shares, Rounding.Down);
+        _sourceStrategyLiquidity(grossAssets);
+
+        uint256 availableIdleAssets = _idleAssetBalance();
+        if (grossAssets > availableIdleAssets) {
+            revert ERC4626VaultInsufficientLiquidity(grossAssets, availableIdleAssets);
+        }
+
+        uint256 feeAssets;
+        (assets, feeAssets) = LibERC4626VaultControlLogic.withdrawNetFromGross(grossAssets);
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        LibERC7540RequestAccounting.consumeClaimableRedeem(controller, shares);
+        _burnShares(address(this), shares);
+        _decreaseManagedAssetsForAssetExit(grossAssets);
+        _safeTransferAsset(receiver, assets);
+        _payoutFee(feeAssets);
+
+        emit Withdraw(msg.sender, receiver, controller, assets, shares);
+    }
+
+    /// @notice Locks `shares` for an asynchronous redeem request.
+    /// @param shares Requested share amount.
+    /// @param controller Request controller account.
+    /// @param owner Share owner account.
+    /// @return requestId Canonical aggregated request id.
+    function requestRedeem(uint256 shares, address controller, address owner)
+        public
+        virtual
+        whenNotPaused
+        nonReentrant
+        returns (uint256 requestId)
+    {
+        _requireInitialized();
+        _requireAsyncRedeemEnabled();
+        _requireNonZeroAddress(controller);
+        _requireNonZeroAddress(owner);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        uint256 maxShares = _maxRequestRedeemShares(owner);
+        if (shares > maxShares) {
+            revert IERC4626VaultControls.ERC4626VaultRedeemLimitExceeded(shares, maxShares);
+        }
+
+        if (msg.sender != owner && !LibERC7540RequestAccounting.isOperator(owner, msg.sender)) {
+            _spendAllowance(owner, msg.sender, shares);
+        }
+
+        requestId = LibERC7540RequestAccounting.aggregateRequestId();
+        _transferShares(owner, address(this), shares);
+        LibERC7540RequestAccounting.increasePendingRedeem(controller, shares);
+
+        emit RedeemRequest(controller, owner, requestId, msg.sender, shares);
+    }
+
+    /// @notice Returns pending redeem-request shares for `controller`.
+    /// @param requestId Request discriminator.
+    /// @param controller Request controller account.
+    /// @return shares Pending share amount.
+    function pendingRedeemRequest(uint256 requestId, address controller) public view virtual returns (uint256 shares) {
+        return LibERC7540RequestAccounting.pendingRedeemRequest(requestId, controller);
+    }
+
+    /// @notice Returns claimable redeem-request shares for `controller`.
+    /// @param requestId Request discriminator.
+    /// @param controller Request controller account.
+    /// @return shares Claimable share amount.
+    function claimableRedeemRequest(uint256 requestId, address controller)
+        public
+        view
+        virtual
+        returns (uint256 shares)
+    {
+        return LibERC7540RequestAccounting.claimableRedeemRequest(requestId, controller);
+    }
+
+    function _vaultOperationsPaused() internal view virtual override returns (bool) {
+        return paused();
+    }
+
+    function _asyncRedeemModeEnabled() internal view virtual returns (bool) {
+        return !LibVaultAsset.isNativeAsset(ERC4626Vault.asset())
+            && LibDiamond.selectorExists(IERC7540Redeem.requestRedeem.selector);
+    }
+
+    function _maxRequestRedeemShares(address owner) internal view returns (uint256 maxShares) {
+        if (owner == address(0) || paused()) {
+            return 0;
+        }
+
+        maxShares = balanceOf(owner);
+        (,,,, uint128 maxRedeem_) = LibERC4626VaultControlLogic.limitConfig();
+        if (maxRedeem_ != 0 && maxRedeem_ < maxShares) {
+            maxShares = maxRedeem_;
+        }
+    }
+
+    function _sourceStrategyLiquidity(uint256 requiredGrossAssets) internal {
+        if (requiredGrossAssets == 0) {
+            return;
+        }
+
+        uint256 idleAssets = _idleAssetBalance();
+        while (idleAssets < requiredGrossAssets) {
+            uint256 strategyLiquidity = _strategyWithdrawableAssets();
+            if (strategyLiquidity == 0) {
+                break;
+            }
+
+            uint256 requestedAssets = requiredGrossAssets - idleAssets;
+            if (requestedAssets > strategyLiquidity) {
+                requestedAssets = strategyLiquidity;
+            }
+
+            (uint256 returnedAssets, uint256 postCallLiveAssets) = _withdrawStrategyAssets(requestedAssets);
+            _reconcileStrategyWithdrawalAccounting(returnedAssets, postCallLiveAssets);
+
+            uint256 nextIdleAssets = _idleAssetBalance();
+            if (nextIdleAssets <= idleAssets) {
+                break;
+            }
+
+            idleAssets = nextIdleAssets;
+        }
+    }
+
+    function _requireAsyncRedeemEnabled() internal view {
+        if (!_asyncRedeemModeEnabled()) {
+            revert ERC7540VaultAsyncRedeemDisabled();
+        }
+    }
+
+    function _requireControllerOrOperator(address controller) internal view {
+        if (msg.sender != controller && !LibERC7540RequestAccounting.isOperator(controller, msg.sender)) {
+            revert ERC7540VaultUnauthorizedOperator(controller, msg.sender);
+        }
+    }
+}

--- a/src/vault/libraries/LibVaultFacetSelectors.sol
+++ b/src/vault/libraries/LibVaultFacetSelectors.sol
@@ -81,6 +81,27 @@ library LibVaultFacetSelectors {
         selectors[21] = IERC4626.redeem.selector;
     }
 
+    /// @notice Returns the hosted vault core selector group when both async deposit and async redeem are split out.
+    function vaultFullyAsyncHostCoreSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](16);
+        selectors[0] = IERC4626VaultFacet.initializeVault.selector;
+        selectors[1] = IERC4626VaultBase.isVaultInitialized.selector;
+        selectors[2] = IERC4626.asset.selector;
+        selectors[3] = IERC4626VaultBase.totalManagedAssets.selector;
+        selectors[4] = IERC20Metadata.name.selector;
+        selectors[5] = IERC20Metadata.symbol.selector;
+        selectors[6] = IERC20Metadata.decimals.selector;
+        selectors[7] = IERC20.totalSupply.selector;
+        selectors[8] = IERC20.balanceOf.selector;
+        selectors[9] = IERC20.allowance.selector;
+        selectors[10] = IERC20.transfer.selector;
+        selectors[11] = IERC20.approve.selector;
+        selectors[12] = IERC20.transferFrom.selector;
+        selectors[13] = IERC4626.totalAssets.selector;
+        selectors[14] = IERC4626.convertToShares.selector;
+        selectors[15] = IERC4626.convertToAssets.selector;
+    }
+
     /// @notice Returns the hosted vault native selector group.
     function vaultNativeSelectors() internal pure returns (bytes4[] memory selectors) {
         selectors = new bytes4[](2);
@@ -90,9 +111,9 @@ library LibVaultFacetSelectors {
 
     /// @notice Returns the hosted vault async selector group.
     function vaultAsyncSelectors() internal pure returns (bytes4[] memory selectors) {
-        selectors = new bytes4[](10);
-        bytes4[] memory depositSelectors = vaultAsyncDepositSelectors();
-        bytes4[] memory redeemSelectors = vaultAsyncRedeemSelectors();
+        selectors = new bytes4[](22);
+        bytes4[] memory depositSelectors = vaultAsyncDepositHostSelectors();
+        bytes4[] memory redeemSelectors = vaultAsyncRedeemHostSelectors();
 
         for (uint256 i = 0; i < depositSelectors.length; i++) {
             selectors[i] = depositSelectors[i];
@@ -101,6 +122,17 @@ library LibVaultFacetSelectors {
         for (uint256 i = 0; i < redeemSelectors.length; i++) {
             selectors[depositSelectors.length + i] = redeemSelectors[i];
         }
+    }
+
+    /// @notice Returns the standard ERC-4626 selectors whose behavior becomes async-claim-aware for redeem flows.
+    function vaultAsyncRedeemClaimSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](6);
+        selectors[0] = IERC4626.maxWithdraw.selector;
+        selectors[1] = IERC4626.previewWithdraw.selector;
+        selectors[2] = IERC4626.withdraw.selector;
+        selectors[3] = IERC4626.maxRedeem.selector;
+        selectors[4] = IERC4626.previewRedeem.selector;
+        selectors[5] = IERC4626.redeem.selector;
     }
 
     /// @notice Returns the standard ERC-4626 selectors whose behavior becomes async-claim-aware.
@@ -119,6 +151,21 @@ library LibVaultFacetSelectors {
         selectors = new bytes4[](13);
         bytes4[] memory claimSelectors = vaultAsyncDepositClaimSelectors();
         bytes4[] memory requestSelectors = vaultAsyncDepositSelectors();
+
+        for (uint256 i = 0; i < claimSelectors.length; i++) {
+            selectors[i] = claimSelectors[i];
+        }
+
+        for (uint256 i = 0; i < requestSelectors.length; i++) {
+            selectors[claimSelectors.length + i] = requestSelectors[i];
+        }
+    }
+
+    /// @notice Returns the full selector group owned by the async redeem host facet.
+    function vaultAsyncRedeemHostSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](9);
+        bytes4[] memory claimSelectors = vaultAsyncRedeemClaimSelectors();
+        bytes4[] memory requestSelectors = vaultAsyncRedeemSelectors();
 
         for (uint256 i = 0; i < claimSelectors.length; i++) {
             selectors[i] = claimSelectors[i];

--- a/test/DiamondVaultDeploymentIntegration.t.sol
+++ b/test/DiamondVaultDeploymentIntegration.t.sol
@@ -8,6 +8,7 @@ import {IERC165} from "../src/interfaces/IERC165.sol";
 import {IERC20Metadata} from "../src/interfaces/IERC20Metadata.sol";
 import {IERC7540Deposit} from "../src/interfaces/IERC7540Deposit.sol";
 import {IERC7540Operators} from "../src/interfaces/IERC7540Operators.sol";
+import {IERC7540Redeem} from "../src/interfaces/IERC7540Redeem.sol";
 import {IERC4626VaultBase} from "../src/interfaces/IERC4626VaultBase.sol";
 import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol";
 import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControlsFacet.sol";
@@ -20,10 +21,11 @@ import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelect
 import {LibVaultAsset} from "../src/vault/libraries/LibVaultAsset.sol";
 import {DiamondVaultDeploymentFixture} from "./helpers/DiamondVaultDeploymentTestHarness.sol";
 import {ERC7540VaultDepositFacetHarness} from "./helpers/ERC7540VaultDepositFacetTestHarness.sol";
+import {ERC7540VaultRedeemFacetHarness} from "./helpers/ERC7540VaultRedeemFacetTestHarness.sol";
 
 contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture {
     function testVaultHostDeployInstallInitOracleAndStrategyWiring() public {
-        _installVaultHostFacets();
+        _installFullyAsyncVaultHostFacets();
         _initializeVaultHost();
         _wireOracleAdapter();
         _wireStrategy();
@@ -32,23 +34,29 @@ contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture 
         address[] memory facetAddresses = loupe.facetAddresses();
         IOracleAdapter.OracleQuote memory quotePayload = integrationFacetInterface().oracleQuote();
 
-        assertTrue(facetAddresses.length == 6, "vault host facet count mismatch");
+        assertTrue(facetAddresses.length == 7, "vault host facet count mismatch");
         assertTrue(_containsAddress(facetAddresses, address(cutFacet)), "missing cut facet");
         assertTrue(_containsAddress(facetAddresses, address(loupeFacet)), "missing loupe facet");
         assertTrue(_containsAddress(facetAddresses, address(coreFacet)), "missing core facet");
         assertTrue(_containsAddress(facetAddresses, address(asyncDepositFacet)), "missing async deposit facet");
+        assertTrue(_containsAddress(facetAddresses, address(asyncRedeemFacet)), "missing async redeem facet");
         assertTrue(_containsAddress(facetAddresses, address(controlsFacet)), "missing controls facet");
         assertTrue(_containsAddress(facetAddresses, address(integrationFacet)), "missing integration facet");
 
         assertTrue(
             loupe.facetFunctionSelectors(address(coreFacet)).length
-                == LibVaultFacetSelectors.vaultAsyncHostCoreSelectors().length,
+                == LibVaultFacetSelectors.vaultFullyAsyncHostCoreSelectors().length,
             "unexpected core selector count"
         );
         assertTrue(
             loupe.facetFunctionSelectors(address(asyncDepositFacet)).length
                 == LibVaultFacetSelectors.vaultAsyncDepositHostSelectors().length,
             "unexpected async selector count"
+        );
+        assertTrue(
+            loupe.facetFunctionSelectors(address(asyncRedeemFacet)).length
+                == LibVaultFacetSelectors.vaultAsyncRedeemHostSelectors().length,
+            "unexpected async redeem selector count"
         );
         assertTrue(
             loupe.facetFunctionSelectors(address(controlsFacet)).length
@@ -61,10 +69,11 @@ contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture 
             "unexpected integration selector count"
         );
 
-        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultAsyncHostCoreSelectors(), address(coreFacet));
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultFullyAsyncHostCoreSelectors(), address(coreFacet));
         _assertSelectorsOwnedByFacet(
             LibVaultFacetSelectors.vaultAsyncDepositHostSelectors(), address(asyncDepositFacet)
         );
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultAsyncRedeemHostSelectors(), address(asyncRedeemFacet));
         _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultControlsSelectors(), address(controlsFacet));
         _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultIntegrationSelectors(), address(integrationFacet));
 
@@ -76,6 +85,10 @@ contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture 
         assertTrue(
             loupe.facetAddress(IERC7540Deposit.requestDeposit.selector) == address(asyncDepositFacet),
             "async deposit owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC7540Redeem.requestRedeem.selector) == address(asyncRedeemFacet),
+            "async redeem owner mismatch"
         );
         assertTrue(
             loupe.facetAddress(IERC4626VaultControls.VAULT_MANAGER_ROLE.selector) == address(controlsFacet),
@@ -139,6 +152,10 @@ contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture 
             "missing async deposit interface"
         );
         assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC7540Redeem).interfaceId),
+            "missing async redeem interface"
+        );
+        assertTrue(
             IERC165(address(diamond)).supportsInterface(type(IERC7540Operators).interfaceId),
             "missing operator interface"
         );
@@ -153,8 +170,9 @@ contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture 
     }
 
     function testVaultHostSmokeCoversStrategyLifecycle() public {
-        _installVaultHostFacets();
+        _installFullyAsyncVaultHostFacets();
         _installVaultAsyncDepositTestSelector();
+        _installVaultAsyncRedeemTestSelector();
         _initializeVaultHost();
         _wireOracleAdapter();
         _wireStrategy();
@@ -186,6 +204,10 @@ contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture 
         );
 
         VM.prank(admin);
+        IERC7540Redeem(address(diamond)).requestRedeem(700_000_000, admin, admin);
+        ERC7540VaultRedeemFacetHarness(address(diamond)).harnessSettleRedeemRequest(admin, 700_000_000);
+
+        VM.prank(admin);
         coreFacetInterface().withdraw(700_000_000, admin, admin);
 
         assertTrue(
@@ -194,6 +216,7 @@ contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture 
         assertTrue(integrationFacetInterface().liveStrategyAssets() == 400_000_000, "live strategy assets mismatch");
         assertTrue(integrationFacetInterface().idleAssets() == 0, "idle assets should be exhausted after auto-pull");
         assertTrue(coreFacetInterface().totalManagedAssets() == 400_000_000, "book value mismatch after user withdraw");
+        assertTrue(IERC7540Redeem(address(diamond)).claimableRedeemRequest(0, admin) > 0, "claimable redeem mismatch");
 
         VM.prank(admin);
         uint256 emergencyAssets = integrationFacetInterface().emergencyExitStrategy();

--- a/test/ERC7540VaultFoundationCore.t.sol
+++ b/test/ERC7540VaultFoundationCore.t.sol
@@ -25,18 +25,24 @@ contract ERC7540VaultFoundationCoreTest is ERC7540VaultFoundationFixture {
 
     function testAsyncSelectorGroupCoversExpectedSurface() public pure {
         bytes4[] memory asyncSelectors = LibVaultFacetSelectors.vaultAsyncSelectors();
-        bytes4[] memory coreSelectors = LibVaultFacetSelectors.vaultCoreSelectors();
+        bytes4[] memory coreSelectors = LibVaultFacetSelectors.vaultFullyAsyncHostCoreSelectors();
         bytes4[] memory nativeSelectors = LibVaultFacetSelectors.vaultNativeSelectors();
         bytes4[] memory controlSelectors = LibVaultFacetSelectors.vaultControlsSelectors();
         bytes4[] memory integrationSelectors = LibVaultFacetSelectors.vaultIntegrationSelectors();
 
-        assertTrue(asyncSelectors.length == 10, "unexpected async selector count");
+        assertTrue(asyncSelectors.length == 22, "unexpected async selector count");
 
         _assertContains(asyncSelectors, IERC7540Deposit.requestDeposit.selector);
         _assertContains(asyncSelectors, IERC7540Deposit.pendingDepositRequest.selector);
         _assertContains(asyncSelectors, IERC7540Deposit.claimableDepositRequest.selector);
         _assertContains(asyncSelectors, IERC7540Deposit.deposit.selector);
         _assertContains(asyncSelectors, IERC7540Deposit.mint.selector);
+        _assertContains(asyncSelectors, IERC4626.maxWithdraw.selector);
+        _assertContains(asyncSelectors, IERC4626.previewWithdraw.selector);
+        _assertContains(asyncSelectors, IERC4626.withdraw.selector);
+        _assertContains(asyncSelectors, IERC4626.maxRedeem.selector);
+        _assertContains(asyncSelectors, IERC4626.previewRedeem.selector);
+        _assertContains(asyncSelectors, IERC4626.redeem.selector);
         _assertContains(asyncSelectors, IERC7540Redeem.requestRedeem.selector);
         _assertContains(asyncSelectors, IERC7540Redeem.pendingRedeemRequest.selector);
         _assertContains(asyncSelectors, IERC7540Redeem.claimableRedeemRequest.selector);

--- a/test/ERC7540VaultRedeemCore.t.sol
+++ b/test/ERC7540VaultRedeemCore.t.sol
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC4626} from "../src/interfaces/IERC4626.sol";
+import {IERC4626VaultBase} from "../src/interfaces/IERC4626VaultBase.sol";
+import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol";
+import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControlsFacet.sol";
+import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
+import {IERC7540Deposit} from "../src/interfaces/IERC7540Deposit.sol";
+import {IERC7540Operators} from "../src/interfaces/IERC7540Operators.sol";
+import {IERC7540Redeem} from "../src/interfaces/IERC7540Redeem.sol";
+import {ERC7540VaultDepositFacetHarness} from "./helpers/ERC7540VaultDepositFacetTestHarness.sol";
+import {ERC7540VaultRedeemFacetHarness} from "./helpers/ERC7540VaultRedeemFacetTestHarness.sol";
+import {ERC7540VaultRedeemFacet} from "../src/vault/facets/ERC7540VaultRedeemFacet.sol";
+import {ERC4626VaultFacetFixture} from "./helpers/ERC4626VaultFacetTestHarness.sol";
+
+contract ERC7540VaultRedeemCoreTest is ERC4626VaultFacetFixture {
+    function _initializeDiamondFullAsyncVault() internal {
+        _installHostedVaultFullyAsyncFacetsToDiamond();
+        _installVaultAsyncDepositTestSelectorToDiamond();
+        _installVaultAsyncRedeemTestSelectorToDiamond();
+
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond)).initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function _seedClaimedShares(address controller, uint256 assets) internal {
+        _approveAsset(controller, address(diamond), assets);
+
+        VM.prank(controller);
+        IERC7540Deposit(address(diamond)).requestDeposit(assets, controller, controller);
+        ERC7540VaultDepositFacetHarness(address(diamond)).harnessSettleDepositRequest(controller, assets);
+
+        VM.prank(controller);
+        IERC4626(address(diamond)).deposit(assets, controller);
+    }
+
+    function testRequestRedeemLocksSharesWithoutChangingManagedAssets() public {
+        _initializeDiamondFullAsyncVault();
+        _seedClaimedShares(bob, 80);
+
+        VM.prank(bob);
+        uint256 requestId = IERC7540Redeem(address(diamond)).requestRedeem(30, bob, bob);
+
+        assertTrue(requestId == 0, "request id mismatch");
+        assertTrue(IERC7540Redeem(address(diamond)).pendingRedeemRequest(0, bob) == 30, "pending redeem mismatch");
+        assertTrue(
+            IERC7540Redeem(address(diamond)).claimableRedeemRequest(0, bob) == 0, "claimable redeem should stay zero"
+        );
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 80, "managed assets should stay unchanged");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 80, "book assets should stay unchanged");
+        assertTrue(IERC4626(address(diamond)).balanceOf(bob) == 50, "owner share balance mismatch");
+        assertTrue(IERC4626(address(diamond)).balanceOf(address(diamond)) == 30, "vault escrow balance mismatch");
+        assertTrue(IERC4626(address(diamond)).totalSupply() == 80, "share supply should stay unchanged");
+    }
+
+    function testAsyncRedeemPreviewHelpersRevertAndMaxHelpersTrackClaimableShares() public {
+        _initializeDiamondFullAsyncVault();
+        _seedClaimedShares(bob, 80);
+
+        VM.prank(bob);
+        IERC7540Redeem(address(diamond)).requestRedeem(40, bob, bob);
+        ERC7540VaultRedeemFacetHarness(address(diamond)).harnessSettleRedeemRequest(bob, 25);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(ERC7540VaultRedeemFacet.ERC7540VaultAsyncRedeemPreviewUnsupported.selector)
+        );
+        IERC4626(address(diamond)).previewWithdraw(1);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(ERC7540VaultRedeemFacet.ERC7540VaultAsyncRedeemPreviewUnsupported.selector)
+        );
+        IERC4626(address(diamond)).previewRedeem(1);
+
+        uint256 maxAssets = IERC4626(address(diamond)).maxWithdraw(bob);
+        uint256 maxShares = IERC4626(address(diamond)).maxRedeem(bob);
+
+        assertTrue(maxAssets == 25, "max withdraw should match claimable assets");
+        assertTrue(maxShares == 25, "max redeem should match claimable shares");
+    }
+
+    function testAsyncRedeemClaimConsumesEscrowedSharesAndReturnsAssets() public {
+        _initializeDiamondFullAsyncVault();
+        _seedClaimedShares(bob, 80);
+
+        VM.prank(bob);
+        IERC7540Redeem(address(diamond)).requestRedeem(40, bob, bob);
+        ERC7540VaultRedeemFacetHarness(address(diamond)).harnessSettleRedeemRequest(bob, 40);
+
+        uint256 eveAssetsBefore = asset.balanceOf(eve);
+
+        VM.prank(bob);
+        uint256 assets = IERC4626(address(diamond)).redeem(25, eve, bob);
+
+        assertTrue(assets == 25, "claimed assets mismatch");
+        assertTrue(
+            IERC7540Redeem(address(diamond)).claimableRedeemRequest(0, bob) == 15, "remaining claimable mismatch"
+        );
+        assertTrue(IERC7540Redeem(address(diamond)).pendingRedeemRequest(0, bob) == 0, "pending redeem should be empty");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 55, "managed assets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 55, "total assets mismatch");
+        assertTrue(IERC4626(address(diamond)).balanceOf(bob) == 40, "owner balance should stay escrow-adjusted");
+        assertTrue(IERC4626(address(diamond)).balanceOf(address(diamond)) == 15, "escrow share balance mismatch");
+        assertTrue(IERC4626(address(diamond)).totalSupply() == 55, "share supply mismatch");
+        assertTrue(asset.balanceOf(eve) == eveAssetsBefore + 25, "receiver asset balance mismatch");
+    }
+
+    function testRequestOwnerCanAssignSeparateControllerAndControllerCanClaim() public {
+        _initializeDiamondFullAsyncVault();
+        _seedClaimedShares(bob, 30);
+
+        VM.prank(bob);
+        IERC7540Redeem(address(diamond)).requestRedeem(10, eve, bob);
+        ERC7540VaultRedeemFacetHarness(address(diamond)).harnessSettleRedeemRequest(eve, 10);
+
+        uint256 eveAssetsBefore = asset.balanceOf(eve);
+
+        VM.prank(eve);
+        uint256 assets = IERC4626(address(diamond)).redeem(10, eve, eve);
+
+        assertTrue(assets == 10, "controller claim assets mismatch");
+        assertTrue(IERC4626(address(diamond)).balanceOf(bob) == 20, "owner share balance mismatch");
+        assertTrue(IERC7540Redeem(address(diamond)).claimableRedeemRequest(0, eve) == 0, "claimable should clear");
+        assertTrue(asset.balanceOf(eve) == eveAssetsBefore + 10, "controller receiver balance mismatch");
+    }
+
+    function testAllowanceHolderCanSubmitRedeemRequestForOwner() public {
+        _initializeDiamondFullAsyncVault();
+        _seedClaimedShares(bob, 20);
+
+        VM.prank(bob);
+        IERC4626VaultFacet(address(diamond)).approve(eve, 10);
+
+        VM.prank(eve);
+        IERC7540Redeem(address(diamond)).requestRedeem(10, bob, bob);
+
+        assertTrue(IERC4626(address(diamond)).allowance(bob, eve) == 0, "allowance should be spent");
+        assertTrue(IERC4626(address(diamond)).balanceOf(bob) == 10, "owner share balance mismatch");
+        assertTrue(IERC4626(address(diamond)).balanceOf(address(diamond)) == 10, "vault escrow balance mismatch");
+        assertTrue(IERC7540Redeem(address(diamond)).pendingRedeemRequest(0, bob) == 10, "pending redeem mismatch");
+    }
+
+    function testUnauthorizedRequestAndClaimActorsRevert() public {
+        _initializeDiamondFullAsyncVault();
+        _seedClaimedShares(bob, 30);
+
+        VM.prank(eve);
+        VM.expectRevert(
+            abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultInsufficientAllowance.selector, bob, eve, 0, 10)
+        );
+        IERC7540Redeem(address(diamond)).requestRedeem(10, bob, bob);
+
+        VM.prank(bob);
+        IERC7540Redeem(address(diamond)).requestRedeem(10, bob, bob);
+        ERC7540VaultRedeemFacetHarness(address(diamond)).harnessSettleRedeemRequest(bob, 10);
+
+        VM.prank(eve);
+        VM.expectRevert(
+            abi.encodeWithSelector(ERC7540VaultRedeemFacet.ERC7540VaultUnauthorizedOperator.selector, bob, eve)
+        );
+        IERC4626(address(diamond)).redeem(10, eve, bob);
+    }
+
+    function testDiamondAsyncRequestRedeemRespectsRequestLimitConfig() public {
+        _initializeDiamondFullAsyncVault();
+        _seedClaimedShares(bob, 40);
+
+        VM.prank(admin);
+        IERC4626VaultControlsFacet(address(diamond)).setLimitConfig(0, 0, 0, 0, 25);
+
+        VM.prank(bob);
+        VM.expectRevert(abi.encodeWithSelector(IERC4626VaultControls.ERC4626VaultRedeemLimitExceeded.selector, 30, 25));
+        IERC7540Redeem(address(diamond)).requestRedeem(30, bob, bob);
+    }
+
+    function testDiamondAsyncRedeemClaimUsesStandardWithdrawEntrypoint() public {
+        _initializeDiamondFullAsyncVault();
+        _seedClaimedShares(bob, 35);
+
+        VM.prank(bob);
+        IERC7540Redeem(address(diamond)).requestRedeem(35, bob, bob);
+        ERC7540VaultRedeemFacetHarness(address(diamond)).harnessSettleRedeemRequest(bob, 35);
+
+        uint256 eveAssetsBefore = asset.balanceOf(eve);
+
+        VM.prank(bob);
+        uint256 shares = IERC4626(address(diamond)).withdraw(20, eve, bob);
+
+        assertTrue(shares == 20, "claimed shares mismatch");
+        assertTrue(
+            IERC7540Redeem(address(diamond)).claimableRedeemRequest(0, bob) == 15, "remaining claimable mismatch"
+        );
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 15, "managed assets mismatch");
+        assertTrue(IERC4626(address(diamond)).balanceOf(address(diamond)) == 15, "remaining escrow mismatch");
+        assertTrue(asset.balanceOf(eve) == eveAssetsBefore + 20, "receiver assets mismatch");
+    }
+
+    function testControllerOperatorCanClaimRedeemRequest() public {
+        _initializeDiamondFullAsyncVault();
+        _seedClaimedShares(bob, 25);
+
+        VM.prank(bob);
+        IERC7540Redeem(address(diamond)).requestRedeem(10, bob, bob);
+        ERC7540VaultRedeemFacetHarness(address(diamond)).harnessSettleRedeemRequest(bob, 10);
+
+        VM.prank(bob);
+        bool approved = IERC7540Operators(address(diamond)).setOperator(eve, true);
+        assertTrue(approved, "operator approval should succeed");
+
+        uint256 eveAssetsBefore = asset.balanceOf(eve);
+
+        VM.prank(eve);
+        uint256 assets = IERC4626(address(diamond)).redeem(10, eve, bob);
+
+        assertTrue(assets == 10, "operator claim assets mismatch");
+        assertTrue(asset.balanceOf(eve) == eveAssetsBefore + 10, "operator receiver balance mismatch");
+        assertTrue(IERC7540Redeem(address(diamond)).claimableRedeemRequest(0, bob) == 0, "claimable should clear");
+    }
+}

--- a/test/helpers/DiamondVaultDeploymentTestHarness.sol
+++ b/test/helpers/DiamondVaultDeploymentTestHarness.sol
@@ -8,6 +8,7 @@ import {ERC7535VaultFacet} from "../../src/vault/facets/ERC7535VaultFacet.sol";
 import {ERC4626VaultControlsFacetHarness} from "./ERC4626VaultControlsFacetTestHarness.sol";
 import {ERC4626VaultFacetHarness} from "./ERC4626VaultFacetTestHarness.sol";
 import {ERC7540VaultDepositFacetHarness} from "./ERC7540VaultDepositFacetTestHarness.sol";
+import {ERC7540VaultRedeemFacetHarness} from "./ERC7540VaultRedeemFacetTestHarness.sol";
 import {ERC4626VaultIntegrationFacetHarness} from "./ERC4626VaultIntegrationFacetTestHarness.sol";
 import {MockVaultAsset} from "./ERC4626CoreTestHarness.sol";
 import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
@@ -29,6 +30,7 @@ abstract contract DiamondVaultDeploymentFixture is TestBase {
     DiamondLoupeFacet internal loupeFacet;
     ERC4626VaultFacetHarness internal coreFacet;
     ERC7540VaultDepositFacetHarness internal asyncDepositFacet;
+    ERC7540VaultRedeemFacetHarness internal asyncRedeemFacet;
     ERC7535VaultFacet internal nativeFacet;
     ERC4626VaultControlsFacetHarness internal controlsFacet;
     ERC4626VaultIntegrationFacetHarness internal integrationFacet;
@@ -46,6 +48,7 @@ abstract contract DiamondVaultDeploymentFixture is TestBase {
         loupeFacet = new DiamondLoupeFacet();
         coreFacet = new ERC4626VaultFacetHarness();
         asyncDepositFacet = new ERC7540VaultDepositFacetHarness();
+        asyncRedeemFacet = new ERC7540VaultRedeemFacetHarness();
         nativeFacet = new ERC7535VaultFacet();
         controlsFacet = new ERC4626VaultControlsFacetHarness();
         integrationFacet = new ERC4626VaultIntegrationFacetHarness();
@@ -114,6 +117,21 @@ abstract contract DiamondVaultDeploymentFixture is TestBase {
         IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
     }
 
+    function _installVaultAsyncRedeemTestSelector() internal {
+        bytes4[] memory selectors = new bytes4[](1);
+        selectors[0] = ERC7540VaultRedeemFacetHarness.harnessSettleRedeemRequest.selector;
+
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(asyncRedeemFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: selectors
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
     function _installNativeVaultHostFacets() internal {
         IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](4);
         cut[0] = IDiamondCut.FacetCut({
@@ -132,6 +150,38 @@ abstract contract DiamondVaultDeploymentFixture is TestBase {
             functionSelectors: LibVaultFacetSelectors.vaultControlsSelectors()
         });
         cut[3] = IDiamondCut.FacetCut({
+            facetAddress: address(integrationFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultIntegrationSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installFullyAsyncVaultHostFacets() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](5);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(coreFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultFullyAsyncHostCoreSelectors()
+        });
+        cut[1] = IDiamondCut.FacetCut({
+            facetAddress: address(asyncDepositFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultAsyncDepositHostSelectors()
+        });
+        cut[2] = IDiamondCut.FacetCut({
+            facetAddress: address(asyncRedeemFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultAsyncRedeemHostSelectors()
+        });
+        cut[3] = IDiamondCut.FacetCut({
+            facetAddress: address(controlsFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultControlsSelectors()
+        });
+        cut[4] = IDiamondCut.FacetCut({
             facetAddress: address(integrationFacet),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: LibVaultFacetSelectors.vaultIntegrationSelectors()
@@ -173,6 +223,10 @@ abstract contract DiamondVaultDeploymentFixture is TestBase {
 
     function asyncDepositFacetInterface() internal view returns (ERC7540VaultDepositFacetHarness) {
         return ERC7540VaultDepositFacetHarness(address(diamond));
+    }
+
+    function asyncRedeemFacetInterface() internal view returns (ERC7540VaultRedeemFacetHarness) {
+        return ERC7540VaultRedeemFacetHarness(address(diamond));
     }
 
     function controlsFacetInterface() internal view returns (ERC4626VaultControlsFacetHarness) {

--- a/test/helpers/ERC4626VaultFacetTestHarness.sol
+++ b/test/helpers/ERC4626VaultFacetTestHarness.sol
@@ -13,6 +13,7 @@ import {LibERC4626VaultStorage} from "../../src/vault/storage/LibERC4626VaultSto
 import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
 import {TestBase} from "./AccessControlTestHarness.sol";
 import {ERC7540VaultDepositFacetHarness} from "./ERC7540VaultDepositFacetTestHarness.sol";
+import {ERC7540VaultRedeemFacetHarness} from "./ERC7540VaultRedeemFacetTestHarness.sol";
 import {ReentrantMockVaultAsset} from "./ERC4626VaultControlsTestHarness.sol";
 
 contract ERC4626VaultFacetHarness is ERC4626VaultFacet {
@@ -39,6 +40,7 @@ abstract contract ERC4626VaultFacetFixture is TestBase {
     ReentrantMockVaultAsset internal asset;
     ERC4626VaultFacetHarness internal facet;
     ERC7540VaultDepositFacetHarness internal asyncDepositFacet;
+    ERC7540VaultRedeemFacetHarness internal asyncRedeemFacet;
     ERC7535VaultFacet internal nativeFacet;
     ERC4626VaultControlsFacet internal controlsFacet;
     DiamondCutFacet internal cutFacet;
@@ -49,6 +51,7 @@ abstract contract ERC4626VaultFacetFixture is TestBase {
         asset = new ReentrantMockVaultAsset();
         facet = new ERC4626VaultFacetHarness();
         asyncDepositFacet = new ERC7540VaultDepositFacetHarness();
+        asyncRedeemFacet = new ERC7540VaultRedeemFacetHarness();
         nativeFacet = new ERC7535VaultFacet();
         controlsFacet = new ERC4626VaultControlsFacet();
         cutFacet = new DiamondCutFacet();
@@ -149,6 +152,21 @@ abstract contract ERC4626VaultFacetFixture is TestBase {
         IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
     }
 
+    function _installVaultAsyncRedeemTestSelectorToDiamond() internal {
+        bytes4[] memory selectors = new bytes4[](1);
+        selectors[0] = ERC7540VaultRedeemFacetHarness.harnessSettleRedeemRequest.selector;
+
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(asyncRedeemFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: selectors
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
     function _installHostedVaultFacetsToDiamond() internal {
         _installVaultCoreFacetToDiamond();
         _installVaultControlsFacetToDiamond();
@@ -167,6 +185,33 @@ abstract contract ERC4626VaultFacetFixture is TestBase {
             functionSelectors: LibVaultFacetSelectors.vaultAsyncDepositHostSelectors()
         });
         cut[2] = IDiamondCut.FacetCut({
+            facetAddress: address(controlsFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultControlsSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installHostedVaultFullyAsyncFacetsToDiamond() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](4);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(facet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultFullyAsyncHostCoreSelectors()
+        });
+        cut[1] = IDiamondCut.FacetCut({
+            facetAddress: address(asyncDepositFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultAsyncDepositHostSelectors()
+        });
+        cut[2] = IDiamondCut.FacetCut({
+            facetAddress: address(asyncRedeemFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultAsyncRedeemHostSelectors()
+        });
+        cut[3] = IDiamondCut.FacetCut({
             facetAddress: address(controlsFacet),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: LibVaultFacetSelectors.vaultControlsSelectors()

--- a/test/helpers/ERC7540VaultRedeemFacetTestHarness.sol
+++ b/test/helpers/ERC7540VaultRedeemFacetTestHarness.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {ERC7540VaultRedeemFacet} from "../../src/vault/facets/ERC7540VaultRedeemFacet.sol";
+import {LibERC7540RequestAccounting} from "../../src/vault/libraries/LibERC7540RequestAccounting.sol";
+
+contract ERC7540VaultRedeemFacetHarness is ERC7540VaultRedeemFacet {
+    function harnessSettleRedeemRequest(address controller, uint256 shares) external {
+        LibERC7540RequestAccounting.movePendingRedeemToClaimable(controller, shares);
+    }
+}


### PR DESCRIPTION
## Summary
- add the hosted ERC-7540 async redeem request surface through a dedicated redeem facet and full-async selector wiring
- implement redeem request creation, pending and claimable redeem accounting, vault share escrow, and claim settlement through the standard withdraw and redeem paths
- extend deployment, integration, and core coverage for hosted async redeem behavior while preserving the existing deposit-only hardening and invariant fixtures

## Testing
- `forge test --match-contract ERC7540VaultRedeemCoreTest`
- `forge test --match-contract ERC7540VaultFoundationCoreTest`
- `forge test --match-contract DiamondVaultDeploymentIntegrationTest`
- `forge test --match-contract ERC7540VaultDepositCoreTest`
- `forge test --match-contract DiamondVaultHostHardeningTest`
- `forge test --match-contract DiamondVaultHostInvariantTest`

## Linked Issue
Closes #195