### PR TITLE
feat: add async vault settlement semantics

### DIFF
--- a/src/interfaces/IERC7540VaultSettlementFacet.sol
+++ b/src/interfaces/IERC7540VaultSettlementFacet.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC165} from "./IERC165.sol";
+
+/// @title IERC7540VaultSettlementFacet
+/// @notice Manager-facing settlement surface for hosted ERC-7540 async vault requests.
+interface IERC7540VaultSettlementFacet is IERC165 {
+    /// @notice Emitted when pending deposit assets are moved into claimable state.
+    event VaultDepositRequestSettled(address indexed controller, uint256 assets, address indexed sender);
+
+    /// @notice Emitted when pending redeem shares are moved into claimable state.
+    event VaultRedeemRequestSettled(address indexed controller, uint256 shares, address indexed sender);
+
+    /// @notice Returns the pause scope that gates manager settlement entrypoints.
+    /// @return The settlement pause scope identifier.
+    function ASYNC_SETTLEMENT_SCOPE() external view returns (bytes32);
+
+    /// @notice Moves pending deposit assets into claimable state for `controller`.
+    /// @param controller Request controller account.
+    /// @param assets Asset amount to settle.
+    function settleDepositRequest(address controller, uint256 assets) external;
+
+    /// @notice Moves pending redeem shares into claimable state for `controller`.
+    /// @param controller Request controller account.
+    /// @param shares Share amount to settle.
+    function settleRedeemRequest(address controller, uint256 shares) external;
+}

--- a/src/vault/VaultFacetControl.sol
+++ b/src/vault/VaultFacetControl.sol
@@ -370,6 +370,12 @@ abstract contract VaultFacetControl is IAccessControl, IAccessControlTime, IPaus
         }
     }
 
+    function _requireScopeNotPaused(bytes32 scope) internal view {
+        if (paused(scope)) {
+            revert PausableScopeEnforcedPause(scope);
+        }
+    }
+
     function _requirePaused() internal view {
         if (!paused()) {
             revert PausableExpectedPause();

--- a/src/vault/facets/ERC4626VaultControlsFacet.sol
+++ b/src/vault/facets/ERC4626VaultControlsFacet.sol
@@ -7,6 +7,7 @@ import {IERC165} from "../../interfaces/IERC165.sol";
 import {IERC7540Deposit} from "../../interfaces/IERC7540Deposit.sol";
 import {IERC7540Operators} from "../../interfaces/IERC7540Operators.sol";
 import {IERC7540Redeem} from "../../interfaces/IERC7540Redeem.sol";
+import {IERC7540VaultSettlementFacet} from "../../interfaces/IERC7540VaultSettlementFacet.sol";
 import {IERC7535VaultFacet} from "../../interfaces/IERC7535VaultFacet.sol";
 import {IERC4626VaultControls} from "../../interfaces/IERC4626VaultControls.sol";
 import {IERC4626VaultControlsFacet} from "../../interfaces/IERC4626VaultControlsFacet.sol";
@@ -41,6 +42,8 @@ contract ERC4626VaultControlsFacet is ERC4626VaultControlSurface {
                 && LibDiamond.selectorExists(IERC7540Deposit.requestDeposit.selector))
             || (interfaceId == type(IERC7540Redeem).interfaceId
                 && LibDiamond.selectorExists(IERC7540Redeem.requestRedeem.selector))
+            || (interfaceId == type(IERC7540VaultSettlementFacet).interfaceId
+                && LibDiamond.selectorExists(IERC7540VaultSettlementFacet.settleDepositRequest.selector))
             || (interfaceId == type(IERC7535VaultFacet).interfaceId
                 && LibDiamond.selectorExists(IERC7535VaultFacet.depositNative.selector))
             || (interfaceId == type(IERC4626VaultIntegrationFacet).interfaceId

--- a/src/vault/facets/ERC4626VaultIntegrationFacet.sol
+++ b/src/vault/facets/ERC4626VaultIntegrationFacet.sol
@@ -13,7 +13,12 @@ import {LibERC4626VaultStorage} from "../storage/LibERC4626VaultStorage.sol";
 
 /// @title ERC4626VaultIntegrationFacet
 /// @notice Hosted integration/config facet for oracle references and active strategy lifecycle operations.
-contract ERC4626VaultIntegrationFacet is ERC4626Vault, VaultFacetControl, IERC4626VaultIntegrationFacet, IERC7540VaultSettlementFacet {
+contract ERC4626VaultIntegrationFacet is
+    ERC4626Vault,
+    VaultFacetControl,
+    IERC4626VaultIntegrationFacet,
+    IERC7540VaultSettlementFacet
+{
     /// @notice Returns the pause scope that gates manager settlement entrypoints.
     /// @return The settlement pause scope identifier.
     function ASYNC_SETTLEMENT_SCOPE() public pure returns (bytes32) {

--- a/src/vault/facets/ERC4626VaultIntegrationFacet.sol
+++ b/src/vault/facets/ERC4626VaultIntegrationFacet.sol
@@ -3,14 +3,23 @@ pragma solidity ^0.8.30;
 
 import {IERC4626VaultIntegrationFacet} from "../../interfaces/IERC4626VaultIntegrationFacet.sol";
 import {IERC4626VaultStrategy} from "../../interfaces/IERC4626VaultStrategy.sol";
+import {IERC7540VaultSettlementFacet} from "../../interfaces/IERC7540VaultSettlementFacet.sol";
 import {IOracleAdapter} from "../../interfaces/IOracleAdapter.sol";
 import {ERC4626Vault} from "../ERC4626Vault.sol";
 import {VaultFacetControl} from "../VaultFacetControl.sol";
+import {LibERC7540RequestAccounting} from "../libraries/LibERC7540RequestAccounting.sol";
+import {LibVaultFacetConstants} from "../libraries/LibVaultFacetConstants.sol";
 import {LibERC4626VaultStorage} from "../storage/LibERC4626VaultStorage.sol";
 
 /// @title ERC4626VaultIntegrationFacet
 /// @notice Hosted integration/config facet for oracle references and active strategy lifecycle operations.
-contract ERC4626VaultIntegrationFacet is ERC4626Vault, VaultFacetControl, IERC4626VaultIntegrationFacet {
+contract ERC4626VaultIntegrationFacet is ERC4626Vault, VaultFacetControl, IERC4626VaultIntegrationFacet, IERC7540VaultSettlementFacet {
+    /// @notice Returns the pause scope that gates manager settlement entrypoints.
+    /// @return The settlement pause scope identifier.
+    function ASYNC_SETTLEMENT_SCOPE() public pure returns (bytes32) {
+        return LibVaultFacetConstants.ASYNC_SETTLEMENT_SCOPE;
+    }
+
     /// @notice Returns the configured external oracle adapter address.
     /// @return The adapter address, or zero when unset.
     function oracleAdapter() public view returns (address) {
@@ -180,6 +189,30 @@ contract ERC4626VaultIntegrationFacet is ERC4626Vault, VaultFacetControl, IERC46
         } catch (bytes memory revertData) {
             emit VaultStrategyEmergencyExitFailed(address(configuredStrategy), msg.sender, revertData);
         }
+    }
+
+    /// @notice Moves pending deposit assets into claimable state for `controller`.
+    /// @param controller Request controller account.
+    /// @param assets Asset amount to settle.
+    function settleDepositRequest(address controller, uint256 assets) public {
+        _requireInitialized();
+        _checkRole(VAULT_MANAGER_ROLE(), msg.sender);
+        _requireScopeNotPaused(ASYNC_SETTLEMENT_SCOPE());
+
+        LibERC7540RequestAccounting.movePendingDepositToClaimable(controller, assets);
+        emit VaultDepositRequestSettled(controller, assets, msg.sender);
+    }
+
+    /// @notice Moves pending redeem shares into claimable state for `controller`.
+    /// @param controller Request controller account.
+    /// @param shares Share amount to settle.
+    function settleRedeemRequest(address controller, uint256 shares) public {
+        _requireInitialized();
+        _checkRole(VAULT_MANAGER_ROLE(), msg.sender);
+        _requireScopeNotPaused(ASYNC_SETTLEMENT_SCOPE());
+
+        LibERC7540RequestAccounting.movePendingRedeemToClaimable(controller, shares);
+        emit VaultRedeemRequestSettled(controller, shares, msg.sender);
     }
 
     function _configuredStrategy() internal view returns (IERC4626VaultStrategy configuredStrategy) {

--- a/src/vault/libraries/LibVaultFacetConstants.sol
+++ b/src/vault/libraries/LibVaultFacetConstants.sol
@@ -6,4 +6,7 @@ pragma solidity ^0.8.30;
 library LibVaultFacetConstants {
     /// @dev Role that can manage vault fees and limits.
     bytes32 internal constant VAULT_MANAGER_ROLE = keccak256("VAULT_MANAGER_ROLE");
+
+    /// @dev Pause scope that gates manager settlement entrypoints for async requests.
+    bytes32 internal constant ASYNC_SETTLEMENT_SCOPE = keccak256("ASYNC_SETTLEMENT_SCOPE");
 }

--- a/src/vault/libraries/LibVaultFacetSelectors.sol
+++ b/src/vault/libraries/LibVaultFacetSelectors.sol
@@ -10,6 +10,7 @@ import {IERC4626} from "../../interfaces/IERC4626.sol";
 import {IERC7540Deposit} from "../../interfaces/IERC7540Deposit.sol";
 import {IERC7540Operators} from "../../interfaces/IERC7540Operators.sol";
 import {IERC7540Redeem} from "../../interfaces/IERC7540Redeem.sol";
+import {IERC7540VaultSettlementFacet} from "../../interfaces/IERC7540VaultSettlementFacet.sol";
 import {IERC7535VaultFacet} from "../../interfaces/IERC7535VaultFacet.sol";
 import {IERC4626VaultBase} from "../../interfaces/IERC4626VaultBase.sol";
 import {IERC4626VaultControls} from "../../interfaces/IERC4626VaultControls.sol";
@@ -122,6 +123,14 @@ library LibVaultFacetSelectors {
         for (uint256 i = 0; i < redeemSelectors.length; i++) {
             selectors[depositSelectors.length + i] = redeemSelectors[i];
         }
+    }
+
+    /// @notice Returns the manager-facing settlement selector group for async request transitions.
+    function vaultSettlementSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](3);
+        selectors[0] = IERC7540VaultSettlementFacet.ASYNC_SETTLEMENT_SCOPE.selector;
+        selectors[1] = IERC7540VaultSettlementFacet.settleDepositRequest.selector;
+        selectors[2] = IERC7540VaultSettlementFacet.settleRedeemRequest.selector;
     }
 
     /// @notice Returns the standard ERC-4626 selectors whose behavior becomes async-claim-aware for redeem flows.
@@ -245,5 +254,20 @@ library LibVaultFacetSelectors {
         selectors[10] = IERC4626VaultIntegrationFacet.withdrawFromStrategy.selector;
         selectors[11] = IERC4626VaultIntegrationFacet.syncStrategyAssets.selector;
         selectors[12] = IERC4626VaultIntegrationFacet.emergencyExitStrategy.selector;
+    }
+
+    /// @notice Returns the hosted vault integration selector group when async settlement entrypoints are installed.
+    function vaultAsyncIntegrationSelectors() internal pure returns (bytes4[] memory selectors) {
+        selectors = new bytes4[](16);
+        bytes4[] memory integrationSelectors = vaultIntegrationSelectors();
+        bytes4[] memory settlementSelectors = vaultSettlementSelectors();
+
+        for (uint256 i = 0; i < integrationSelectors.length; i++) {
+            selectors[i] = integrationSelectors[i];
+        }
+
+        for (uint256 i = 0; i < settlementSelectors.length; i++) {
+            selectors[integrationSelectors.length + i] = settlementSelectors[i];
+        }
     }
 }

--- a/test/DiamondVaultDeploymentIntegration.t.sol
+++ b/test/DiamondVaultDeploymentIntegration.t.sol
@@ -9,6 +9,7 @@ import {IERC20Metadata} from "../src/interfaces/IERC20Metadata.sol";
 import {IERC7540Deposit} from "../src/interfaces/IERC7540Deposit.sol";
 import {IERC7540Operators} from "../src/interfaces/IERC7540Operators.sol";
 import {IERC7540Redeem} from "../src/interfaces/IERC7540Redeem.sol";
+import {IERC7540VaultSettlementFacet} from "../src/interfaces/IERC7540VaultSettlementFacet.sol";
 import {IERC4626VaultBase} from "../src/interfaces/IERC4626VaultBase.sol";
 import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol";
 import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControlsFacet.sol";
@@ -20,8 +21,6 @@ import {IOracleAdapter} from "../src/interfaces/IOracleAdapter.sol";
 import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {LibVaultAsset} from "../src/vault/libraries/LibVaultAsset.sol";
 import {DiamondVaultDeploymentFixture} from "./helpers/DiamondVaultDeploymentTestHarness.sol";
-import {ERC7540VaultDepositFacetHarness} from "./helpers/ERC7540VaultDepositFacetTestHarness.sol";
-import {ERC7540VaultRedeemFacetHarness} from "./helpers/ERC7540VaultRedeemFacetTestHarness.sol";
 
 contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture {
     function testVaultHostDeployInstallInitOracleAndStrategyWiring() public {
@@ -65,7 +64,7 @@ contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture 
         );
         assertTrue(
             loupe.facetFunctionSelectors(address(integrationFacet)).length
-                == LibVaultFacetSelectors.vaultIntegrationSelectors().length,
+                == LibVaultFacetSelectors.vaultAsyncIntegrationSelectors().length,
             "unexpected integration selector count"
         );
 
@@ -75,7 +74,7 @@ contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture 
         );
         _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultAsyncRedeemHostSelectors(), address(asyncRedeemFacet));
         _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultControlsSelectors(), address(controlsFacet));
-        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultIntegrationSelectors(), address(integrationFacet));
+        _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultAsyncIntegrationSelectors(), address(integrationFacet));
 
         assertTrue(loupe.facetAddress(DiamondCutFacet.diamondCut.selector) == address(cutFacet), "cut owner mismatch");
         assertTrue(loupe.facetAddress(DiamondLoupeFacet.facets.selector) == address(loupeFacet), "loupe owner mismatch");
@@ -101,6 +100,10 @@ contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture 
         assertTrue(
             loupe.facetAddress(IERC4626VaultIntegrationFacet.deployToStrategy.selector) == address(integrationFacet),
             "deploy strategy selector owner mismatch"
+        );
+        assertTrue(
+            loupe.facetAddress(IERC7540VaultSettlementFacet.settleDepositRequest.selector) == address(integrationFacet),
+            "settle deposit selector owner mismatch"
         );
         assertTrue(
             loupe.facetAddress(IERC165.supportsInterface.selector) == address(controlsFacet),
@@ -163,6 +166,10 @@ contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture 
             IERC165(address(diamond)).supportsInterface(type(IERC4626VaultIntegrationFacet).interfaceId),
             "missing integration interface"
         );
+        assertTrue(
+            IERC165(address(diamond)).supportsInterface(type(IERC7540VaultSettlementFacet).interfaceId),
+            "missing settlement interface"
+        );
 
         VM.prank(admin);
         VM.expectRevert(abi.encodeWithSelector(IERC4626VaultBase.ERC4626VaultAlreadyInitialized.selector));
@@ -171,8 +178,6 @@ contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture 
 
     function testVaultHostSmokeCoversStrategyLifecycle() public {
         _installFullyAsyncVaultHostFacets();
-        _installVaultAsyncDepositTestSelector();
-        _installVaultAsyncRedeemTestSelector();
         _initializeVaultHost();
         _wireOracleAdapter();
         _wireStrategy();
@@ -182,7 +187,8 @@ contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture 
         asset.approve(address(diamond), 1_500_000_000);
         VM.prank(admin);
         IERC7540Deposit(address(diamond)).requestDeposit(1_000_000_000, admin, admin);
-        ERC7540VaultDepositFacetHarness(address(diamond)).harnessSettleDepositRequest(admin, 1_000_000_000);
+        VM.prank(admin);
+        IERC7540VaultSettlementFacet(address(diamond)).settleDepositRequest(admin, 1_000_000_000);
         VM.prank(admin);
         coreFacetInterface().deposit(1_000_000_000, admin);
 
@@ -205,7 +211,8 @@ contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture 
 
         VM.prank(admin);
         IERC7540Redeem(address(diamond)).requestRedeem(700_000_000, admin, admin);
-        ERC7540VaultRedeemFacetHarness(address(diamond)).harnessSettleRedeemRequest(admin, 700_000_000);
+        VM.prank(admin);
+        IERC7540VaultSettlementFacet(address(diamond)).settleRedeemRequest(admin, 700_000_000);
 
         VM.prank(admin);
         coreFacetInterface().withdraw(700_000_000, admin, admin);

--- a/test/DiamondVaultHostHardening.t.sol
+++ b/test/DiamondVaultHostHardening.t.sol
@@ -150,7 +150,7 @@ contract DiamondVaultHostHardeningTest is DiamondVaultHostHardeningFixture {
         _addIntegrationReplacementMarker(address(integrationReplacement));
 
         _assertSelectorsOwnedByFacet(
-            LibVaultFacetSelectors.vaultIntegrationSelectors(), address(integrationReplacement)
+            LibVaultFacetSelectors.vaultAsyncIntegrationSelectors(), address(integrationReplacement)
         );
         assertTrue(
             IDiamondLoupe(address(diamond)).facetAddress(IFacetVersionMarker.facetVersion.selector)
@@ -204,7 +204,7 @@ contract DiamondVaultHostHardeningTest is DiamondVaultHostHardeningFixture {
         _reAddIntegrationFacetWithMarker(address(integrationReplacement));
 
         _assertSelectorsOwnedByFacet(
-            LibVaultFacetSelectors.vaultIntegrationSelectors(), address(integrationReplacement)
+            LibVaultFacetSelectors.vaultAsyncIntegrationSelectors(), address(integrationReplacement)
         );
         assertTrue(
             IFacetVersionMarker(address(diamond)).facetVersion() == 2, "integration marker mismatch after re-add"

--- a/test/ERC7540VaultDepositCore.t.sol
+++ b/test/ERC7540VaultDepositCore.t.sol
@@ -1,23 +1,29 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
+import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
 import {IERC4626} from "../src/interfaces/IERC4626.sol";
 import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol";
 import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControlsFacet.sol";
 import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
 import {IERC7540Deposit} from "../src/interfaces/IERC7540Deposit.sol";
 import {IERC7540Operators} from "../src/interfaces/IERC7540Operators.sol";
+import {IERC7540VaultSettlementFacet} from "../src/interfaces/IERC7540VaultSettlementFacet.sol";
+import {IPausable} from "../src/interfaces/IPausable.sol";
 import {ERC7540VaultDepositFacet} from "../src/vault/facets/ERC7540VaultDepositFacet.sol";
 import {ERC4626VaultFacetFixture} from "./helpers/ERC4626VaultFacetTestHarness.sol";
-import {ERC7540VaultDepositFacetHarness} from "./helpers/ERC7540VaultDepositFacetTestHarness.sol";
 
 contract ERC7540VaultDepositCoreTest is ERC4626VaultFacetFixture {
     function _initializeDiamondAsyncVault() internal {
         _installHostedVaultAsyncDepositFacetsToDiamond();
-        _installVaultAsyncDepositTestSelectorToDiamond();
 
         VM.prank(admin);
         IERC4626VaultFacet(address(diamond)).initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function _settleDeposit(address controller, uint256 assets) internal {
+        VM.prank(admin);
+        IERC7540VaultSettlementFacet(address(diamond)).settleDepositRequest(controller, assets);
     }
 
     function testRequestDepositLocksAssetsWithoutChangingManagedAssets() public {
@@ -43,7 +49,8 @@ contract ERC7540VaultDepositCoreTest is ERC4626VaultFacetFixture {
 
         VM.prank(bob);
         IERC7540Deposit(address(diamond)).requestDeposit(40, bob, bob);
-        ERC7540VaultDepositFacetHarness(address(diamond)).harnessSettleDepositRequest(bob, 25);
+        _settleDeposit(bob, 10);
+        _settleDeposit(bob, 15);
 
         VM.expectRevert(
             abi.encodeWithSelector(ERC7540VaultDepositFacet.ERC7540VaultAsyncDepositPreviewUnsupported.selector)
@@ -70,7 +77,7 @@ contract ERC7540VaultDepositCoreTest is ERC4626VaultFacetFixture {
 
         VM.prank(bob);
         IERC7540Deposit(address(diamond)).requestDeposit(40, bob, bob);
-        ERC7540VaultDepositFacetHarness(address(diamond)).harnessSettleDepositRequest(bob, 40);
+        _settleDeposit(bob, 40);
 
         VM.prank(bob);
         uint256 shares = IERC4626(address(diamond)).deposit(25, eve);
@@ -88,6 +95,22 @@ contract ERC7540VaultDepositCoreTest is ERC4626VaultFacetFixture {
         assertTrue(asset.balanceOf(address(diamond)) == 40, "vault balance should keep locked assets");
     }
 
+    function testOnlyManagerCanSettleAsyncDepositRequests() public {
+        _initializeDiamondAsyncVault();
+        _approveAsset(bob, address(diamond), 100);
+
+        VM.prank(bob);
+        IERC7540Deposit(address(diamond)).requestDeposit(20, bob, bob);
+
+        bytes32 managerRole = IERC4626VaultControls(address(diamond)).VAULT_MANAGER_ROLE();
+
+        VM.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, eve, managerRole)
+        );
+        VM.prank(eve);
+        IERC7540VaultSettlementFacet(address(diamond)).settleDepositRequest(bob, 10);
+    }
+
     function testOperatorCanSubmitRequestForOwnerAndClaimForController() public {
         _initializeDiamondAsyncVault();
         _approveAsset(bob, address(diamond), 100);
@@ -98,7 +121,7 @@ contract ERC7540VaultDepositCoreTest is ERC4626VaultFacetFixture {
 
         VM.prank(eve);
         IERC7540Deposit(address(diamond)).requestDeposit(30, bob, bob);
-        ERC7540VaultDepositFacetHarness(address(diamond)).harnessSettleDepositRequest(bob, 30);
+        _settleDeposit(bob, 30);
 
         VM.prank(eve);
         uint256 assets = IERC7540Deposit(address(diamond)).mint(10, admin, bob);
@@ -123,13 +146,32 @@ contract ERC7540VaultDepositCoreTest is ERC4626VaultFacetFixture {
 
         VM.prank(bob);
         IERC7540Deposit(address(diamond)).requestDeposit(10, bob, bob);
-        ERC7540VaultDepositFacetHarness(address(diamond)).harnessSettleDepositRequest(bob, 10);
+        _settleDeposit(bob, 10);
 
         VM.prank(eve);
         VM.expectRevert(
             abi.encodeWithSelector(ERC7540VaultDepositFacet.ERC7540VaultUnauthorizedOperator.selector, bob, eve)
         );
         IERC7540Deposit(address(diamond)).deposit(10, eve, bob);
+    }
+
+    function testControllerOperatorCannotSettleAsyncDepositRequest() public {
+        _initializeDiamondAsyncVault();
+        _approveAsset(bob, address(diamond), 100);
+
+        VM.prank(bob);
+        IERC7540Operators(address(diamond)).setOperator(eve, true);
+
+        VM.prank(eve);
+        IERC7540Deposit(address(diamond)).requestDeposit(30, bob, bob);
+
+        bytes32 managerRole = IERC4626VaultControls(address(diamond)).VAULT_MANAGER_ROLE();
+
+        VM.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, eve, managerRole)
+        );
+        VM.prank(eve);
+        IERC7540VaultSettlementFacet(address(diamond)).settleDepositRequest(bob, 10);
     }
 
     function testDiamondAsyncRequestDepositRespectsRequestLimitConfig() public {
@@ -152,7 +194,7 @@ contract ERC7540VaultDepositCoreTest is ERC4626VaultFacetFixture {
 
         VM.prank(bob);
         IERC7540Deposit(address(diamond)).requestDeposit(35, bob, bob);
-        ERC7540VaultDepositFacetHarness(address(diamond)).harnessSettleDepositRequest(bob, 35);
+        _settleDeposit(bob, 35);
 
         VM.prank(bob);
         uint256 shares = IERC4626(address(diamond)).deposit(20, eve);
@@ -163,5 +205,30 @@ contract ERC7540VaultDepositCoreTest is ERC4626VaultFacetFixture {
         );
         assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 20, "managed assets mismatch");
         assertTrue(IERC4626(address(diamond)).balanceOf(eve) == 20, "receiver shares mismatch");
+    }
+
+    function testSettlementPauseBlocksSettlementButNotExistingDepositClaims() public {
+        _initializeDiamondAsyncVault();
+        _approveAsset(bob, address(diamond), 100);
+
+        VM.prank(bob);
+        IERC7540Deposit(address(diamond)).requestDeposit(40, bob, bob);
+        _settleDeposit(bob, 20);
+
+        bytes32 settlementScope = IERC7540VaultSettlementFacet(address(diamond)).ASYNC_SETTLEMENT_SCOPE();
+
+        VM.prank(admin);
+        IERC4626VaultControlsFacet(address(diamond)).pauseScope(settlementScope);
+
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, settlementScope));
+        VM.prank(admin);
+        IERC7540VaultSettlementFacet(address(diamond)).settleDepositRequest(bob, 10);
+
+        VM.prank(bob);
+        uint256 shares = IERC4626(address(diamond)).deposit(20, bob);
+
+        assertTrue(shares == 20, "claim should still succeed while settlement is paused");
+        assertTrue(IERC7540Deposit(address(diamond)).claimableDepositRequest(0, bob) == 0, "claimable should clear");
+        assertTrue(IERC7540Deposit(address(diamond)).pendingDepositRequest(0, bob) == 20, "pending should remain");
     }
 }

--- a/test/ERC7540VaultDepositCore.t.sol
+++ b/test/ERC7540VaultDepositCore.t.sol
@@ -104,9 +104,7 @@ contract ERC7540VaultDepositCoreTest is ERC4626VaultFacetFixture {
 
         bytes32 managerRole = IERC4626VaultControls(address(diamond)).VAULT_MANAGER_ROLE();
 
-        VM.expectRevert(
-            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, eve, managerRole)
-        );
+        VM.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, eve, managerRole));
         VM.prank(eve);
         IERC7540VaultSettlementFacet(address(diamond)).settleDepositRequest(bob, 10);
     }
@@ -167,9 +165,7 @@ contract ERC7540VaultDepositCoreTest is ERC4626VaultFacetFixture {
 
         bytes32 managerRole = IERC4626VaultControls(address(diamond)).VAULT_MANAGER_ROLE();
 
-        VM.expectRevert(
-            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, eve, managerRole)
-        );
+        VM.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, eve, managerRole));
         VM.prank(eve);
         IERC7540VaultSettlementFacet(address(diamond)).settleDepositRequest(bob, 10);
     }

--- a/test/ERC7540VaultFoundationCore.t.sol
+++ b/test/ERC7540VaultFoundationCore.t.sol
@@ -28,7 +28,7 @@ contract ERC7540VaultFoundationCoreTest is ERC7540VaultFoundationFixture {
         bytes4[] memory coreSelectors = LibVaultFacetSelectors.vaultFullyAsyncHostCoreSelectors();
         bytes4[] memory nativeSelectors = LibVaultFacetSelectors.vaultNativeSelectors();
         bytes4[] memory controlSelectors = LibVaultFacetSelectors.vaultControlsSelectors();
-        bytes4[] memory integrationSelectors = LibVaultFacetSelectors.vaultIntegrationSelectors();
+        bytes4[] memory integrationSelectors = LibVaultFacetSelectors.vaultAsyncIntegrationSelectors();
 
         assertTrue(asyncSelectors.length == 22, "unexpected async selector count");
 

--- a/test/ERC7540VaultRedeemCore.t.sol
+++ b/test/ERC7540VaultRedeemCore.t.sol
@@ -124,9 +124,7 @@ contract ERC7540VaultRedeemCoreTest is ERC4626VaultFacetFixture {
 
         bytes32 managerRole = IERC4626VaultControls(address(diamond)).VAULT_MANAGER_ROLE();
 
-        VM.expectRevert(
-            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, eve, managerRole)
-        );
+        VM.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, eve, managerRole));
         VM.prank(eve);
         IERC7540VaultSettlementFacet(address(diamond)).settleRedeemRequest(bob, 10);
     }
@@ -255,9 +253,7 @@ contract ERC7540VaultRedeemCoreTest is ERC4626VaultFacetFixture {
 
         bytes32 managerRole = IERC4626VaultControls(address(diamond)).VAULT_MANAGER_ROLE();
 
-        VM.expectRevert(
-            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, eve, managerRole)
-        );
+        VM.expectRevert(abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, eve, managerRole));
         VM.prank(eve);
         IERC7540VaultSettlementFacet(address(diamond)).settleRedeemRequest(bob, 10);
     }

--- a/test/ERC7540VaultRedeemCore.t.sol
+++ b/test/ERC7540VaultRedeemCore.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
+import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
 import {IERC4626} from "../src/interfaces/IERC4626.sol";
 import {IERC4626VaultBase} from "../src/interfaces/IERC4626VaultBase.sol";
 import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol";
@@ -9,19 +10,27 @@ import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
 import {IERC7540Deposit} from "../src/interfaces/IERC7540Deposit.sol";
 import {IERC7540Operators} from "../src/interfaces/IERC7540Operators.sol";
 import {IERC7540Redeem} from "../src/interfaces/IERC7540Redeem.sol";
-import {ERC7540VaultDepositFacetHarness} from "./helpers/ERC7540VaultDepositFacetTestHarness.sol";
-import {ERC7540VaultRedeemFacetHarness} from "./helpers/ERC7540VaultRedeemFacetTestHarness.sol";
+import {IERC7540VaultSettlementFacet} from "../src/interfaces/IERC7540VaultSettlementFacet.sol";
+import {IPausable} from "../src/interfaces/IPausable.sol";
 import {ERC7540VaultRedeemFacet} from "../src/vault/facets/ERC7540VaultRedeemFacet.sol";
 import {ERC4626VaultFacetFixture} from "./helpers/ERC4626VaultFacetTestHarness.sol";
 
 contract ERC7540VaultRedeemCoreTest is ERC4626VaultFacetFixture {
     function _initializeDiamondFullAsyncVault() internal {
         _installHostedVaultFullyAsyncFacetsToDiamond();
-        _installVaultAsyncDepositTestSelectorToDiamond();
-        _installVaultAsyncRedeemTestSelectorToDiamond();
 
         VM.prank(admin);
         IERC4626VaultFacet(address(diamond)).initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+    }
+
+    function _settleDeposit(address controller, uint256 assets) internal {
+        VM.prank(admin);
+        IERC7540VaultSettlementFacet(address(diamond)).settleDepositRequest(controller, assets);
+    }
+
+    function _settleRedeem(address controller, uint256 shares) internal {
+        VM.prank(admin);
+        IERC7540VaultSettlementFacet(address(diamond)).settleRedeemRequest(controller, shares);
     }
 
     function _seedClaimedShares(address controller, uint256 assets) internal {
@@ -29,7 +38,7 @@ contract ERC7540VaultRedeemCoreTest is ERC4626VaultFacetFixture {
 
         VM.prank(controller);
         IERC7540Deposit(address(diamond)).requestDeposit(assets, controller, controller);
-        ERC7540VaultDepositFacetHarness(address(diamond)).harnessSettleDepositRequest(controller, assets);
+        _settleDeposit(controller, assets);
 
         VM.prank(controller);
         IERC4626(address(diamond)).deposit(assets, controller);
@@ -60,7 +69,8 @@ contract ERC7540VaultRedeemCoreTest is ERC4626VaultFacetFixture {
 
         VM.prank(bob);
         IERC7540Redeem(address(diamond)).requestRedeem(40, bob, bob);
-        ERC7540VaultRedeemFacetHarness(address(diamond)).harnessSettleRedeemRequest(bob, 25);
+        _settleRedeem(bob, 10);
+        _settleRedeem(bob, 15);
 
         VM.expectRevert(
             abi.encodeWithSelector(ERC7540VaultRedeemFacet.ERC7540VaultAsyncRedeemPreviewUnsupported.selector)
@@ -85,7 +95,7 @@ contract ERC7540VaultRedeemCoreTest is ERC4626VaultFacetFixture {
 
         VM.prank(bob);
         IERC7540Redeem(address(diamond)).requestRedeem(40, bob, bob);
-        ERC7540VaultRedeemFacetHarness(address(diamond)).harnessSettleRedeemRequest(bob, 40);
+        _settleRedeem(bob, 40);
 
         uint256 eveAssetsBefore = asset.balanceOf(eve);
 
@@ -105,13 +115,29 @@ contract ERC7540VaultRedeemCoreTest is ERC4626VaultFacetFixture {
         assertTrue(asset.balanceOf(eve) == eveAssetsBefore + 25, "receiver asset balance mismatch");
     }
 
+    function testOnlyManagerCanSettleAsyncRedeemRequests() public {
+        _initializeDiamondFullAsyncVault();
+        _seedClaimedShares(bob, 30);
+
+        VM.prank(bob);
+        IERC7540Redeem(address(diamond)).requestRedeem(10, bob, bob);
+
+        bytes32 managerRole = IERC4626VaultControls(address(diamond)).VAULT_MANAGER_ROLE();
+
+        VM.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, eve, managerRole)
+        );
+        VM.prank(eve);
+        IERC7540VaultSettlementFacet(address(diamond)).settleRedeemRequest(bob, 10);
+    }
+
     function testRequestOwnerCanAssignSeparateControllerAndControllerCanClaim() public {
         _initializeDiamondFullAsyncVault();
         _seedClaimedShares(bob, 30);
 
         VM.prank(bob);
         IERC7540Redeem(address(diamond)).requestRedeem(10, eve, bob);
-        ERC7540VaultRedeemFacetHarness(address(diamond)).harnessSettleRedeemRequest(eve, 10);
+        _settleRedeem(eve, 10);
 
         uint256 eveAssetsBefore = asset.balanceOf(eve);
 
@@ -152,7 +178,7 @@ contract ERC7540VaultRedeemCoreTest is ERC4626VaultFacetFixture {
 
         VM.prank(bob);
         IERC7540Redeem(address(diamond)).requestRedeem(10, bob, bob);
-        ERC7540VaultRedeemFacetHarness(address(diamond)).harnessSettleRedeemRequest(bob, 10);
+        _settleRedeem(bob, 10);
 
         VM.prank(eve);
         VM.expectRevert(
@@ -179,7 +205,7 @@ contract ERC7540VaultRedeemCoreTest is ERC4626VaultFacetFixture {
 
         VM.prank(bob);
         IERC7540Redeem(address(diamond)).requestRedeem(35, bob, bob);
-        ERC7540VaultRedeemFacetHarness(address(diamond)).harnessSettleRedeemRequest(bob, 35);
+        _settleRedeem(bob, 35);
 
         uint256 eveAssetsBefore = asset.balanceOf(eve);
 
@@ -201,7 +227,7 @@ contract ERC7540VaultRedeemCoreTest is ERC4626VaultFacetFixture {
 
         VM.prank(bob);
         IERC7540Redeem(address(diamond)).requestRedeem(10, bob, bob);
-        ERC7540VaultRedeemFacetHarness(address(diamond)).harnessSettleRedeemRequest(bob, 10);
+        _settleRedeem(bob, 10);
 
         VM.prank(bob);
         bool approved = IERC7540Operators(address(diamond)).setOperator(eve, true);
@@ -215,5 +241,52 @@ contract ERC7540VaultRedeemCoreTest is ERC4626VaultFacetFixture {
         assertTrue(assets == 10, "operator claim assets mismatch");
         assertTrue(asset.balanceOf(eve) == eveAssetsBefore + 10, "operator receiver balance mismatch");
         assertTrue(IERC7540Redeem(address(diamond)).claimableRedeemRequest(0, bob) == 0, "claimable should clear");
+    }
+
+    function testControllerOperatorCannotSettleAsyncRedeemRequest() public {
+        _initializeDiamondFullAsyncVault();
+        _seedClaimedShares(bob, 25);
+
+        VM.prank(bob);
+        IERC7540Operators(address(diamond)).setOperator(eve, true);
+
+        VM.prank(bob);
+        IERC7540Redeem(address(diamond)).requestRedeem(10, bob, bob);
+
+        bytes32 managerRole = IERC4626VaultControls(address(diamond)).VAULT_MANAGER_ROLE();
+
+        VM.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorized.selector, eve, managerRole)
+        );
+        VM.prank(eve);
+        IERC7540VaultSettlementFacet(address(diamond)).settleRedeemRequest(bob, 10);
+    }
+
+    function testSettlementPauseBlocksSettlementButNotExistingRedeemClaims() public {
+        _initializeDiamondFullAsyncVault();
+        _seedClaimedShares(bob, 40);
+
+        VM.prank(bob);
+        IERC7540Redeem(address(diamond)).requestRedeem(30, bob, bob);
+        _settleRedeem(bob, 10);
+
+        bytes32 settlementScope = IERC7540VaultSettlementFacet(address(diamond)).ASYNC_SETTLEMENT_SCOPE();
+
+        VM.prank(admin);
+        IERC4626VaultControlsFacet(address(diamond)).pauseScope(settlementScope);
+
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, settlementScope));
+        VM.prank(admin);
+        IERC7540VaultSettlementFacet(address(diamond)).settleRedeemRequest(bob, 10);
+
+        uint256 bobAssetsBefore = asset.balanceOf(bob);
+
+        VM.prank(bob);
+        uint256 assets = IERC4626(address(diamond)).redeem(10, bob, bob);
+
+        assertTrue(assets == 10, "claim should still succeed while settlement is paused");
+        assertTrue(asset.balanceOf(bob) == bobAssetsBefore + 10, "claimed assets mismatch");
+        assertTrue(IERC7540Redeem(address(diamond)).claimableRedeemRequest(0, bob) == 0, "claimable should clear");
+        assertTrue(IERC7540Redeem(address(diamond)).pendingRedeemRequest(0, bob) == 20, "pending should remain");
     }
 }

--- a/test/helpers/DiamondVaultDeploymentTestHarness.sol
+++ b/test/helpers/DiamondVaultDeploymentTestHarness.sol
@@ -95,37 +95,7 @@ abstract contract DiamondVaultDeploymentFixture is TestBase {
         cut[3] = IDiamondCut.FacetCut({
             facetAddress: address(integrationFacet),
             action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: LibVaultFacetSelectors.vaultIntegrationSelectors()
-        });
-
-        VM.prank(admin);
-        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
-    }
-
-    function _installVaultAsyncDepositTestSelector() internal {
-        bytes4[] memory selectors = new bytes4[](1);
-        selectors[0] = ERC7540VaultDepositFacetHarness.harnessSettleDepositRequest.selector;
-
-        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
-        cut[0] = IDiamondCut.FacetCut({
-            facetAddress: address(asyncDepositFacet),
-            action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: selectors
-        });
-
-        VM.prank(admin);
-        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
-    }
-
-    function _installVaultAsyncRedeemTestSelector() internal {
-        bytes4[] memory selectors = new bytes4[](1);
-        selectors[0] = ERC7540VaultRedeemFacetHarness.harnessSettleRedeemRequest.selector;
-
-        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
-        cut[0] = IDiamondCut.FacetCut({
-            facetAddress: address(asyncRedeemFacet),
-            action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: selectors
+            functionSelectors: LibVaultFacetSelectors.vaultAsyncIntegrationSelectors()
         });
 
         VM.prank(admin);
@@ -184,7 +154,7 @@ abstract contract DiamondVaultDeploymentFixture is TestBase {
         cut[4] = IDiamondCut.FacetCut({
             facetAddress: address(integrationFacet),
             action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: LibVaultFacetSelectors.vaultIntegrationSelectors()
+            functionSelectors: LibVaultFacetSelectors.vaultAsyncIntegrationSelectors()
         });
 
         VM.prank(admin);

--- a/test/helpers/DiamondVaultHostHardeningTestHarness.sol
+++ b/test/helpers/DiamondVaultHostHardeningTestHarness.sol
@@ -119,7 +119,6 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
 
     function _installAndSeedVaultHost() internal {
         _installVaultHostFacets();
-        _installVaultAsyncDepositTestSelector();
         _initializeVaultHost();
         _wireOracleAdapter();
         _seedCoreState();
@@ -138,7 +137,8 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
     function _settleAndClaimDeposit(address controller, uint256 assets) internal {
         VM.prank(controller);
         asyncDepositFacetInterface().requestDeposit(assets, controller, controller);
-        asyncDepositFacetInterface().harnessSettleDepositRequest(controller, assets);
+        VM.prank(admin);
+        integrationFacetInterface().settleDepositRequest(controller, assets);
 
         VM.prank(controller);
         coreFacetInterface().deposit(assets, controller);
@@ -190,7 +190,7 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
     }
 
     function _replaceIntegrationFacet(address facetAddress_) internal {
-        _replaceFacet(facetAddress_, LibVaultFacetSelectors.vaultIntegrationSelectors());
+        _replaceFacet(facetAddress_, LibVaultFacetSelectors.vaultAsyncIntegrationSelectors());
     }
 
     function _addCoreReplacementMarker(address facetAddress_) internal {
@@ -214,7 +214,7 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
     }
 
     function _removeIntegrationFacetWithMarker() internal {
-        _removeSelectors(_concat(LibVaultFacetSelectors.vaultIntegrationSelectors(), _markerSelectors()));
+        _removeSelectors(_concat(LibVaultFacetSelectors.vaultAsyncIntegrationSelectors(), _markerSelectors()));
     }
 
     function _reAddCoreFacetWithMarker(address facetAddress_) internal {
@@ -226,7 +226,7 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
     }
 
     function _reAddIntegrationFacetWithMarker(address facetAddress_) internal {
-        _addFacet(facetAddress_, _concat(LibVaultFacetSelectors.vaultIntegrationSelectors(), _markerSelectors()));
+        _addFacet(facetAddress_, _concat(LibVaultFacetSelectors.vaultAsyncIntegrationSelectors(), _markerSelectors()));
     }
 
     function _pauseVault() internal {

--- a/test/helpers/ERC4626VaultFacetTestHarness.sol
+++ b/test/helpers/ERC4626VaultFacetTestHarness.sol
@@ -7,6 +7,7 @@ import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
 import {IERC4626VaultFacet} from "../../src/interfaces/IERC4626VaultFacet.sol";
 import {ERC4626VaultControlsFacet} from "../../src/vault/facets/ERC4626VaultControlsFacet.sol";
 import {ERC4626VaultFacet} from "../../src/vault/facets/ERC4626VaultFacet.sol";
+import {ERC4626VaultIntegrationFacet} from "../../src/vault/facets/ERC4626VaultIntegrationFacet.sol";
 import {ERC7535VaultFacet} from "../../src/vault/facets/ERC7535VaultFacet.sol";
 import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {LibERC4626VaultStorage} from "../../src/vault/storage/LibERC4626VaultStorage.sol";
@@ -43,6 +44,7 @@ abstract contract ERC4626VaultFacetFixture is TestBase {
     ERC7540VaultRedeemFacetHarness internal asyncRedeemFacet;
     ERC7535VaultFacet internal nativeFacet;
     ERC4626VaultControlsFacet internal controlsFacet;
+    ERC4626VaultIntegrationFacet internal integrationFacet;
     DiamondCutFacet internal cutFacet;
     DiamondLoupeFacet internal loupeFacet;
     DiamondProxyHarness internal diamond;
@@ -54,6 +56,7 @@ abstract contract ERC4626VaultFacetFixture is TestBase {
         asyncRedeemFacet = new ERC7540VaultRedeemFacetHarness();
         nativeFacet = new ERC7535VaultFacet();
         controlsFacet = new ERC4626VaultControlsFacet();
+        integrationFacet = new ERC4626VaultIntegrationFacet();
         cutFacet = new DiamondCutFacet();
         loupeFacet = new DiamondLoupeFacet();
         diamond = new DiamondProxyHarness(admin, address(cutFacet));
@@ -137,43 +140,13 @@ abstract contract ERC4626VaultFacetFixture is TestBase {
         IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
     }
 
-    function _installVaultAsyncDepositTestSelectorToDiamond() internal {
-        bytes4[] memory selectors = new bytes4[](1);
-        selectors[0] = ERC7540VaultDepositFacetHarness.harnessSettleDepositRequest.selector;
-
-        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
-        cut[0] = IDiamondCut.FacetCut({
-            facetAddress: address(asyncDepositFacet),
-            action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: selectors
-        });
-
-        VM.prank(admin);
-        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
-    }
-
-    function _installVaultAsyncRedeemTestSelectorToDiamond() internal {
-        bytes4[] memory selectors = new bytes4[](1);
-        selectors[0] = ERC7540VaultRedeemFacetHarness.harnessSettleRedeemRequest.selector;
-
-        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
-        cut[0] = IDiamondCut.FacetCut({
-            facetAddress: address(asyncRedeemFacet),
-            action: IDiamondCut.FacetCutAction.Add,
-            functionSelectors: selectors
-        });
-
-        VM.prank(admin);
-        IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
-    }
-
     function _installHostedVaultFacetsToDiamond() internal {
         _installVaultCoreFacetToDiamond();
         _installVaultControlsFacetToDiamond();
     }
 
     function _installHostedVaultAsyncDepositFacetsToDiamond() internal {
-        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](3);
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](4);
         cut[0] = IDiamondCut.FacetCut({
             facetAddress: address(facet),
             action: IDiamondCut.FacetCutAction.Add,
@@ -189,13 +162,18 @@ abstract contract ERC4626VaultFacetFixture is TestBase {
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: LibVaultFacetSelectors.vaultControlsSelectors()
         });
+        cut[3] = IDiamondCut.FacetCut({
+            facetAddress: address(integrationFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultAsyncIntegrationSelectors()
+        });
 
         VM.prank(admin);
         IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
     }
 
     function _installHostedVaultFullyAsyncFacetsToDiamond() internal {
-        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](4);
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](5);
         cut[0] = IDiamondCut.FacetCut({
             facetAddress: address(facet),
             action: IDiamondCut.FacetCutAction.Add,
@@ -215,6 +193,11 @@ abstract contract ERC4626VaultFacetFixture is TestBase {
             facetAddress: address(controlsFacet),
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: LibVaultFacetSelectors.vaultControlsSelectors()
+        });
+        cut[4] = IDiamondCut.FacetCut({
+            facetAddress: address(integrationFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultAsyncIntegrationSelectors()
         });
 
         VM.prank(admin);

--- a/test/helpers/ERC7540VaultDepositFacetTestHarness.sol
+++ b/test/helpers/ERC7540VaultDepositFacetTestHarness.sol
@@ -2,10 +2,5 @@
 pragma solidity ^0.8.30;
 
 import {ERC7540VaultDepositFacet} from "../../src/vault/facets/ERC7540VaultDepositFacet.sol";
-import {LibERC7540RequestAccounting} from "../../src/vault/libraries/LibERC7540RequestAccounting.sol";
 
-contract ERC7540VaultDepositFacetHarness is ERC7540VaultDepositFacet {
-    function harnessSettleDepositRequest(address controller, uint256 assets) external {
-        LibERC7540RequestAccounting.movePendingDepositToClaimable(controller, assets);
-    }
-}
+contract ERC7540VaultDepositFacetHarness is ERC7540VaultDepositFacet {}

--- a/test/helpers/ERC7540VaultRedeemFacetTestHarness.sol
+++ b/test/helpers/ERC7540VaultRedeemFacetTestHarness.sol
@@ -2,10 +2,5 @@
 pragma solidity ^0.8.30;
 
 import {ERC7540VaultRedeemFacet} from "../../src/vault/facets/ERC7540VaultRedeemFacet.sol";
-import {LibERC7540RequestAccounting} from "../../src/vault/libraries/LibERC7540RequestAccounting.sol";
 
-contract ERC7540VaultRedeemFacetHarness is ERC7540VaultRedeemFacet {
-    function harnessSettleRedeemRequest(address controller, uint256 shares) external {
-        LibERC7540RequestAccounting.movePendingRedeemToClaimable(controller, shares);
-    }
-}
+contract ERC7540VaultRedeemFacetHarness is ERC7540VaultRedeemFacet {}


### PR DESCRIPTION
## Summary

Implements issue `#196` by adding explicit production settlement semantics for hosted ERC-7540 async vault requests.

This introduces manager-only settlement entrypoints for pending deposit and redeem requests, adds a dedicated settlement pause scope, and removes the async core/deployment tests reliance on harness-only settlement selectors.

Closes #196.

## What changed

- add `IERC7540VaultSettlementFacet` with manager-facing settlement entrypoints and settlement events
- implement production settlement in `ERC4626VaultIntegrationFacet`
- add `ASYNC_SETTLEMENT_SCOPE` and enforce it on settlement entrypoints
- advertise settlement interface support from the controls facet only when the settlement selectors are installed
- split selector groups so async hosts install settlement selectors on the integration facet while native hosts keep the plain integration surface
- update async deposit/redeem/deployment/hardening tests to use production settlement instead of harness-only settlement helpers
- remove now-unused test-only settlement wrappers from the async facet harnesses

## Behavior

- only `VAULT_MANAGER_ROLE` can settle async requests
- ERC-7540 controller operators can still request and claim, but cannot settle
- settlement can be paused independently through `ASYNC_SETTLEMENT_SCOPE`
- already-claimable requests remain claimable even when new settlement is paused

## Verification

- `forge test`

## Notes

- base branch is `milestone/erc-7540-async-vault-requests`
- implementation is built on top of merged async deposit and async redeem milestone work