### PR TITLE
Harden async request coverage

### DIFF
--- a/src/vault/ERC4626Vault.sol
+++ b/src/vault/ERC4626Vault.sol
@@ -301,6 +301,16 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
         return LibVaultAsset.balanceOfSelf(asset());
     }
 
+    /// @dev Returns the tracked idle assets available to support exits when a strategy is active.
+    /// @dev Raw idle balances can exceed tracked idle because of pending async deposits or direct transfers.
+    ///      Exit paths that must preserve strategy-debt accounting use the smaller tracked value instead.
+    function _trackedIdleAssetBalance() internal view returns (uint256) {
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        uint256 actualIdleAssets = _idleAssetBalance();
+        uint256 idleBookAssets = layout.totalManagedAssets - layout.strategyDebt;
+        return actualIdleAssets < idleBookAssets ? actualIdleAssets : idleBookAssets;
+    }
+
     /// @dev Returns the configured strategy's immediately withdrawable assets.
     function _strategyWithdrawableAssets() internal view returns (uint256) {
         LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();

--- a/src/vault/facets/ERC4626VaultFacet.sol
+++ b/src/vault/facets/ERC4626VaultFacet.sol
@@ -119,7 +119,8 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
             revert IERC4626VaultControls.ERC4626VaultWithdrawLimitExceeded(assets, maxAssets);
         }
 
-        uint256 availableIdleAssets = _idleAssetBalance();
+        uint256 availableIdleAssets =
+            LibERC4626VaultStorage.layout().strategyDebt == 0 ? _idleAssetBalance() : _trackedIdleAssetBalance();
         if (grossAssets > availableIdleAssets) {
             revert ERC4626VaultInsufficientLiquidity(grossAssets, availableIdleAssets);
         }
@@ -169,7 +170,8 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
         uint256 grossAssets = _convertToAssets(shares, Rounding.Down);
         _sourceStrategyLiquidity(grossAssets);
 
-        uint256 availableIdleAssets = _idleAssetBalance();
+        uint256 availableIdleAssets =
+            LibERC4626VaultStorage.layout().strategyDebt == 0 ? _idleAssetBalance() : _trackedIdleAssetBalance();
         if (grossAssets > availableIdleAssets) {
             revert ERC4626VaultInsufficientLiquidity(grossAssets, availableIdleAssets);
         }
@@ -209,10 +211,7 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
             return type(uint256).max;
         }
 
-        uint256 actualIdleAssets = _idleAssetBalance();
-        uint256 idleBookAssets = layout.totalManagedAssets - layout.strategyDebt;
-        uint256 trackedIdleAssets = actualIdleAssets < idleBookAssets ? actualIdleAssets : idleBookAssets;
-        return trackedIdleAssets + _strategyWithdrawableAssets();
+        return _trackedIdleAssetBalance() + _strategyWithdrawableAssets();
     }
 
     function _vaultOperationsPaused() internal view virtual override returns (bool) {
@@ -229,7 +228,7 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
             return;
         }
 
-        uint256 idleAssets = _idleAssetBalance();
+        uint256 idleAssets = _trackedIdleAssetBalance();
         while (idleAssets < requiredGrossAssets) {
             uint256 strategyLiquidity = _strategyWithdrawableAssets();
             if (strategyLiquidity == 0) {
@@ -244,7 +243,7 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
             (uint256 returnedAssets, uint256 postCallLiveAssets) = _withdrawStrategyAssets(requestedAssets);
             _reconcileStrategyWithdrawalAccounting(returnedAssets, postCallLiveAssets);
 
-            uint256 nextIdleAssets = _idleAssetBalance();
+            uint256 nextIdleAssets = _trackedIdleAssetBalance();
             if (nextIdleAssets <= idleAssets) {
                 break;
             }

--- a/src/vault/facets/ERC7540VaultRedeemFacet.sol
+++ b/src/vault/facets/ERC7540VaultRedeemFacet.sol
@@ -9,6 +9,7 @@ import {ERC4626VaultControlledCore, LibERC4626VaultControlLogic} from "../ERC462
 import {VaultFacetControl} from "../VaultFacetControl.sol";
 import {LibERC7540RequestAccounting} from "../libraries/LibERC7540RequestAccounting.sol";
 import {LibVaultAsset} from "../libraries/LibVaultAsset.sol";
+import {LibERC4626VaultStorage} from "../storage/LibERC4626VaultStorage.sol";
 
 /// @title ERC7540VaultRedeemFacet
 /// @notice Hosted async redeem extension facet for ERC-7540-style request flows.
@@ -45,7 +46,16 @@ contract ERC7540VaultRedeemFacet is ERC4626VaultControlledCore, VaultFacetContro
             LibERC7540RequestAccounting.aggregateRequestId(), controller
         );
         uint256 grossAssets = _convertToAssets(claimableShares, Rounding.Down);
+        uint256 liquidityCapAssets = _withdrawLiquidityCapAssets();
+        if (grossAssets > liquidityCapAssets) {
+            grossAssets = liquidityCapAssets;
+        }
         (assets,) = LibERC4626VaultControlLogic.withdrawNetFromGross(grossAssets);
+
+        (,,, uint128 maxWithdraw_,) = LibERC4626VaultControlLogic.limitConfig();
+        if (maxWithdraw_ != 0 && assets > maxWithdraw_) {
+            return maxWithdraw_;
+        }
     }
 
     /// @notice Returns max shares that can currently be claimed for `controller`.
@@ -62,9 +72,22 @@ contract ERC7540VaultRedeemFacet is ERC4626VaultControlledCore, VaultFacetContro
             return 0;
         }
 
-        return LibERC7540RequestAccounting.claimableRedeemRequest(
+        shares = LibERC7540RequestAccounting.claimableRedeemRequest(
             LibERC7540RequestAccounting.aggregateRequestId(), controller
         );
+
+        uint256 liquidityCapAssets = _withdrawLiquidityCapAssets();
+        if (liquidityCapAssets != type(uint256).max) {
+            uint256 liquidityCappedShares = _convertToShares(liquidityCapAssets, Rounding.Down);
+            if (liquidityCappedShares < shares) {
+                shares = liquidityCappedShares;
+            }
+        }
+
+        (,,,, uint128 maxRedeem_) = LibERC4626VaultControlLogic.limitConfig();
+        if (maxRedeem_ != 0 && shares > maxRedeem_) {
+            return maxRedeem_;
+        }
     }
 
     /// @notice Returns shares for an async withdraw preview.
@@ -120,7 +143,8 @@ contract ERC7540VaultRedeemFacet is ERC4626VaultControlledCore, VaultFacetContro
         (uint256 grossAssets, uint256 feeAssets) = LibERC4626VaultControlLogic.withdrawGrossFromNet(assets);
         _sourceStrategyLiquidity(grossAssets);
 
-        uint256 availableIdleAssets = _idleAssetBalance();
+        uint256 availableIdleAssets =
+            LibERC4626VaultStorage.layout().strategyDebt == 0 ? _idleAssetBalance() : _trackedIdleAssetBalance();
         if (grossAssets > availableIdleAssets) {
             revert ERC4626VaultInsufficientLiquidity(grossAssets, availableIdleAssets);
         }
@@ -170,7 +194,8 @@ contract ERC7540VaultRedeemFacet is ERC4626VaultControlledCore, VaultFacetContro
         uint256 grossAssets = _convertToAssets(shares, Rounding.Down);
         _sourceStrategyLiquidity(grossAssets);
 
-        uint256 availableIdleAssets = _idleAssetBalance();
+        uint256 availableIdleAssets =
+            LibERC4626VaultStorage.layout().strategyDebt == 0 ? _idleAssetBalance() : _trackedIdleAssetBalance();
         if (grossAssets > availableIdleAssets) {
             revert ERC4626VaultInsufficientLiquidity(grossAssets, availableIdleAssets);
         }
@@ -256,6 +281,14 @@ contract ERC7540VaultRedeemFacet is ERC4626VaultControlledCore, VaultFacetContro
             && LibDiamond.selectorExists(IERC7540Redeem.requestRedeem.selector);
     }
 
+    function _withdrawLiquidityCapAssets() internal view virtual override returns (uint256) {
+        if (LibERC4626VaultStorage.layout().strategyDebt == 0) {
+            return type(uint256).max;
+        }
+
+        return _trackedIdleAssetBalance() + _strategyWithdrawableAssets();
+    }
+
     function _maxRequestRedeemShares(address owner) internal view returns (uint256 maxShares) {
         if (owner == address(0) || paused()) {
             return 0;
@@ -273,7 +306,7 @@ contract ERC7540VaultRedeemFacet is ERC4626VaultControlledCore, VaultFacetContro
             return;
         }
 
-        uint256 idleAssets = _idleAssetBalance();
+        uint256 idleAssets = _trackedIdleAssetBalance();
         while (idleAssets < requiredGrossAssets) {
             uint256 strategyLiquidity = _strategyWithdrawableAssets();
             if (strategyLiquidity == 0) {
@@ -288,7 +321,7 @@ contract ERC7540VaultRedeemFacet is ERC4626VaultControlledCore, VaultFacetContro
             (uint256 returnedAssets, uint256 postCallLiveAssets) = _withdrawStrategyAssets(requestedAssets);
             _reconcileStrategyWithdrawalAccounting(returnedAssets, postCallLiveAssets);
 
-            uint256 nextIdleAssets = _idleAssetBalance();
+            uint256 nextIdleAssets = _trackedIdleAssetBalance();
             if (nextIdleAssets <= idleAssets) {
                 break;
             }

--- a/test/DiamondVaultHostHardening.t.sol
+++ b/test/DiamondVaultHostHardening.t.sol
@@ -272,6 +272,112 @@ contract DiamondVaultHostHardeningTest is DiamondVaultHostHardeningFixture {
         assertTrue(integrationFacetInterface().strategyDebt() == 1, "deploy should work after strategy rebind");
     }
 
+    function testFullAsyncHostedVaultTracksInterleavedPendingAndClaimableRequestAccounting() public {
+        _installAndSeedFullyAsyncVaultHost();
+
+        _requestDeposit(dave, 40_000);
+        _requestDeposit(eve, 30_000);
+        _requestRedeem(bob, 60_000);
+        _requestRedeem(carol, 50_000);
+
+        _settleDepositRequest(dave, 15_000);
+        _settleDepositRequest(eve, 10_000);
+        _settleRedeemRequest(bob, 25_000);
+        _settleRedeemRequest(carol, 20_000);
+
+        assertTrue(_pendingDepositRequestAssets(dave) == 25_000, "dave pending deposit mismatch");
+        assertTrue(_claimableDepositRequestAssets(dave) == 15_000, "dave claimable deposit mismatch");
+        assertTrue(_pendingDepositRequestAssets(eve) == 20_000, "eve pending deposit mismatch");
+        assertTrue(_claimableDepositRequestAssets(eve) == 10_000, "eve claimable deposit mismatch");
+        assertTrue(_pendingRedeemRequestShares(bob) == 35_000, "bob pending redeem mismatch");
+        assertTrue(_claimableRedeemRequestShares(bob) == 25_000, "bob claimable redeem mismatch");
+        assertTrue(_pendingRedeemRequestShares(carol) == 30_000, "carol pending redeem mismatch");
+        assertTrue(_claimableRedeemRequestShares(carol) == 20_000, "carol claimable redeem mismatch");
+
+        assertTrue(_sumPendingDepositRequestAssets() == 45_000, "pending deposit total mismatch");
+        assertTrue(_sumClaimableDepositRequestAssets() == 25_000, "claimable deposit total mismatch");
+        assertTrue(_sumPendingRedeemRequestShares() == 65_000, "pending redeem total mismatch");
+        assertTrue(_sumClaimableRedeemRequestShares() == 45_000, "claimable redeem total mismatch");
+        assertTrue(coreFacetInterface().balanceOf(address(diamond)) == 110_000, "escrowed share total mismatch");
+
+        uint256 claimedDepositShares = _claimDeposit(dave, 10_000, dave);
+        uint256 claimedRedeemAssets = _claimRedeem(bob, 10_000, bob);
+
+        assertTrue(claimedDepositShares == 9_900, "claimed deposit shares mismatch");
+        assertTrue(claimedRedeemAssets == 9_950, "claimed redeem assets mismatch");
+
+        assertTrue(_pendingDepositRequestAssets(dave) == 25_000, "dave pending deposit should remain");
+        assertTrue(_claimableDepositRequestAssets(dave) == 5_000, "dave remaining claimable deposit mismatch");
+        assertTrue(_pendingDepositRequestAssets(eve) == 20_000, "eve pending deposit should remain");
+        assertTrue(_claimableDepositRequestAssets(eve) == 10_000, "eve claimable deposit should remain");
+        assertTrue(_pendingRedeemRequestShares(bob) == 35_000, "bob pending redeem should remain");
+        assertTrue(_claimableRedeemRequestShares(bob) == 15_000, "bob remaining claimable redeem mismatch");
+        assertTrue(_pendingRedeemRequestShares(carol) == 30_000, "carol pending redeem should remain");
+        assertTrue(_claimableRedeemRequestShares(carol) == 20_000, "carol claimable redeem should remain");
+
+        assertTrue(_sumPendingDepositRequestAssets() == 45_000, "pending deposit total should remain");
+        assertTrue(_sumClaimableDepositRequestAssets() == 15_000, "claimable deposit total mismatch after claim");
+        assertTrue(_sumPendingRedeemRequestShares() == 65_000, "pending redeem total should remain");
+        assertTrue(_sumClaimableRedeemRequestShares() == 35_000, "claimable redeem total mismatch after claim");
+        assertTrue(
+            coreFacetInterface().balanceOf(address(diamond)) == 100_000,
+            "escrowed shares should match remaining requests"
+        );
+        assertTrue(
+            asset.balanceOf(address(diamond))
+                == _bookIdleAssets() + _sumPendingDepositRequestAssets() + _sumClaimableDepositRequestAssets(),
+            "vault raw balance should equal book idle plus remaining deposit requests"
+        );
+    }
+
+    function testFullAsyncRedeemClaimsPreservePendingDepositLiquidityAccounting() public {
+        _installAndSeedFullyAsyncVaultHost();
+
+        _requestDeposit(dave, 40_000);
+
+        uint256 deployableIdle = _availableIdleAssetsForStrategyDeploy();
+        assertTrue(deployableIdle == 125_000, "deployable idle mismatch");
+        assertTrue(
+            asset.balanceOf(address(diamond)) == deployableIdle + 40_000, "pending deposit should sit in raw idle"
+        );
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IERC4626VaultIntegrationFacet.ERC4626VaultStrategyInsufficientIdleAssets.selector,
+                deployableIdle + 1,
+                deployableIdle
+            )
+        );
+        VM.prank(admin);
+        integrationFacetInterface().deployToStrategy(deployableIdle + 1);
+
+        _requestRedeem(bob, 180_000);
+        _settleRedeemRequest(bob, 180_000);
+
+        uint256 bobAssetsBefore = asset.balanceOf(bob);
+        uint256 redeemedAssets = _claimRedeem(bob, 180_000, bob);
+
+        assertTrue(redeemedAssets == 179_100, "redeemed assets mismatch");
+        assertTrue(asset.balanceOf(bob) == bobAssetsBefore + redeemedAssets, "bob asset balance mismatch");
+        assertTrue(integrationFacetInterface().strategyDebt() == 170_000, "strategy debt mismatch after redeem");
+        assertTrue(coreFacetInterface().totalManagedAssets() == 170_000, "managed assets mismatch after redeem");
+        assertTrue(_bookIdleAssets() == 0, "book idle should stay zero after redeem");
+        assertTrue(_pendingDepositRequestAssets(dave) == 40_000, "pending deposit should remain reserved");
+        assertTrue(_claimableDepositRequestAssets(dave) == 0, "claimable deposit should stay zero before settlement");
+        assertTrue(asset.balanceOf(address(diamond)) == 40_000, "pending deposit liquidity should remain in the vault");
+
+        _settleDepositRequest(dave, 40_000);
+        uint256 claimedDepositShares = _claimDeposit(dave, 40_000, dave);
+
+        assertTrue(claimedDepositShares == 39_600, "claimed deposit shares mismatch");
+        assertTrue(_pendingDepositRequestAssets(dave) == 0, "pending deposit should clear after settlement");
+        assertTrue(_claimableDepositRequestAssets(dave) == 0, "claimable deposit should clear after claim");
+        assertTrue(integrationFacetInterface().strategyDebt() == 170_000, "strategy debt should stay reconciled");
+        assertTrue(coreFacetInterface().totalManagedAssets() == 209_600, "managed assets mismatch after deposit claim");
+        assertTrue(_bookIdleAssets() == 39_600, "book idle should match post-claim managed idle");
+        assertTrue(asset.balanceOf(address(diamond)) == 39_600, "vault balance should match post-claim book idle");
+    }
+
     function _assertSelectorsOwnedByFacet(bytes4[] memory selectors, address expectedFacet) internal view {
         for (uint256 i = 0; i < selectors.length; i++) {
             assertTrue(

--- a/test/DiamondVaultHostInvariant.t.sol
+++ b/test/DiamondVaultHostInvariant.t.sol
@@ -11,7 +11,7 @@ contract DiamondVaultHostInvariantTest is DiamondVaultHostHardeningFixture {
 
     function setUp() public override {
         super.setUp();
-        _installVaultHostFacets();
+        _installFullyAsyncVaultHostFacets();
         _initializeVaultHost();
         _wireOracleAdapter();
         _wireStrategy();
@@ -25,11 +25,73 @@ contract DiamondVaultHostInvariantTest is DiamondVaultHostHardeningFixture {
         contracts[0] = address(this);
     }
 
+    function actionRequestDeposit(uint8 actorSeed, uint96 assetsRaw) external {
+        address actor = _actor(actorSeed);
+        uint256 maxAssets = _maxRequestDepositAssets(actor);
+        uint256 assets_ = _boundAmount(assetsRaw, _min(maxAssets, asset.balanceOf(actor)));
+        if (assets_ == 0) {
+            return;
+        }
+
+        VM.prank(actor);
+        asyncDepositFacetInterface().requestDeposit(assets_, actor, actor);
+    }
+
+    function actionSettleDepositRequest(uint8 actorSeed, uint96 assetsRaw) external {
+        address actor = _actor(actorSeed);
+        uint256 assets_ = _boundAmount(assetsRaw, _pendingDepositRequestAssets(actor));
+        if (assets_ == 0) {
+            return;
+        }
+
+        bytes32 settlementScope = integrationFacetInterface().ASYNC_SETTLEMENT_SCOPE();
+        if (controlsFacetInterface().scopePaused(settlementScope)) {
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, settlementScope));
+            VM.prank(admin);
+            integrationFacetInterface().settleDepositRequest(actor, assets_);
+            return;
+        }
+
+        VM.prank(admin);
+        integrationFacetInterface().settleDepositRequest(actor, assets_);
+    }
+
+    function actionSettleRedeemRequest(uint8 actorSeed, uint96 sharesRaw) external {
+        address actor = _actor(actorSeed);
+        uint256 shares = _boundAmount(sharesRaw, _pendingRedeemRequestShares(actor));
+        if (shares == 0) {
+            return;
+        }
+
+        bytes32 settlementScope = integrationFacetInterface().ASYNC_SETTLEMENT_SCOPE();
+        if (controlsFacetInterface().scopePaused(settlementScope)) {
+            VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, settlementScope));
+            VM.prank(admin);
+            integrationFacetInterface().settleRedeemRequest(actor, shares);
+            return;
+        }
+
+        VM.prank(admin);
+        integrationFacetInterface().settleRedeemRequest(actor, shares);
+    }
+
+    function actionRequestRedeem(uint8 actorSeed, uint96 sharesRaw) external {
+        address actor = _actor(actorSeed);
+        uint256 shares = _boundAmount(sharesRaw, _maxRequestRedeemShares(actor));
+        if (shares == 0) {
+            return;
+        }
+
+        VM.prank(actor);
+        asyncRedeemFacetInterface().requestRedeem(shares, actor, actor);
+    }
+
     function actionDeposit(uint8 actorSeed, uint96 assetsRaw) external {
         address actor = _actor(actorSeed);
-        uint256 maxAssets = _min(coreFacetInterface().maxDeposit(actor), asset.balanceOf(actor));
+        VM.prank(actor);
+        uint256 maxAssets = coreFacetInterface().maxDeposit(actor);
         uint256 assets_ = _boundAmount(assetsRaw, maxAssets);
-        if (assets_ == 0 || coreFacetInterface().previewDeposit(assets_) == 0) {
+        if (assets_ == 0) {
             return;
         }
 
@@ -47,15 +109,10 @@ contract DiamondVaultHostInvariantTest is DiamondVaultHostHardeningFixture {
 
     function actionMint(uint8 actorSeed, uint96 sharesRaw) external {
         address actor = _actor(actorSeed);
-        uint256 feasibleShares = coreFacetInterface().previewDeposit(asset.balanceOf(actor));
-        uint256 maxShares = _min(coreFacetInterface().maxMint(actor), feasibleShares);
+        VM.prank(actor);
+        uint256 maxShares = coreFacetInterface().maxMint(actor);
         uint256 shares = _boundAmount(sharesRaw, maxShares);
         if (shares == 0) {
-            return;
-        }
-
-        uint256 requiredAssets = coreFacetInterface().previewMint(shares);
-        if (requiredAssets == 0 || requiredAssets > asset.balanceOf(actor)) {
             return;
         }
 
@@ -93,7 +150,7 @@ contract DiamondVaultHostInvariantTest is DiamondVaultHostHardeningFixture {
     function actionRedeem(uint8 actorSeed, uint96 sharesRaw) external {
         address actor = _actor(actorSeed);
         uint256 shares = _boundAmount(sharesRaw, coreFacetInterface().maxRedeem(actor));
-        if (shares == 0 || coreFacetInterface().previewRedeem(shares) == 0) {
+        if (shares == 0) {
             return;
         }
 
@@ -157,6 +214,19 @@ contract DiamondVaultHostInvariantTest is DiamondVaultHostHardeningFixture {
         }
     }
 
+    function actionSettlementPauseToggle(bool shouldPause) external {
+        bytes32 settlementScope = integrationFacetInterface().ASYNC_SETTLEMENT_SCOPE();
+        bool isPaused = controlsFacetInterface().scopePaused(settlementScope);
+
+        if (shouldPause && !isPaused) {
+            VM.prank(admin);
+            controlsFacetInterface().pauseScope(settlementScope);
+        } else if (!shouldPause && isPaused) {
+            VM.prank(admin);
+            controlsFacetInterface().unpauseScope(settlementScope);
+        }
+    }
+
     function actionSetFeeConfig(uint16 depositFeeRaw, uint16 withdrawFeeRaw) external {
         AccountingSnapshot memory snapshot = _snapshotAccounting();
         uint16 depositFeeBps = uint16(uint256(depositFeeRaw) % 2_001);
@@ -177,10 +247,11 @@ contract DiamondVaultHostInvariantTest is DiamondVaultHostHardeningFixture {
     ) external {
         AccountingSnapshot memory snapshot = _snapshotAccounting();
 
-        uint256 currentAssets = coreFacetInterface().totalAssets();
+        uint256 currentCommittedAssets = coreFacetInterface().totalAssets() + _sumPendingDepositRequestAssets()
+            + _sumClaimableDepositRequestAssets();
         uint128 maxTotalAssets = totalCapRaw % 4 == 0
             ? 0
-            : uint128(currentAssets + (uint256(totalCapRaw) % EXPECTED_INITIAL_ASSET_SUPPLY) + 1);
+            : uint128(currentCommittedAssets + (uint256(totalCapRaw) % EXPECTED_INITIAL_ASSET_SUPPLY) + 1);
         uint128 maxDeposit = depositRaw % 4 == 0 ? 0 : uint128((uint256(depositRaw) % INITIAL_ASSETS) + 1);
         uint128 maxMint = mintRaw % 4 == 0 ? 0 : uint128((uint256(mintRaw) % INITIAL_ASSETS) + 1);
         uint128 maxWithdraw = withdrawRaw % 4 == 0 ? 0 : uint128((uint256(withdrawRaw) % INITIAL_ASSETS) + 1);
@@ -228,7 +299,7 @@ contract DiamondVaultHostInvariantTest is DiamondVaultHostHardeningFixture {
             return;
         }
 
-        uint256 assets_ = _boundAmount(assetsRaw, integrationFacetInterface().idleAssets());
+        uint256 assets_ = _boundAmount(assetsRaw, _availableIdleAssetsForStrategyDeploy());
         if (assets_ == 0) {
             return;
         }
@@ -322,13 +393,13 @@ contract DiamondVaultHostInvariantTest is DiamondVaultHostHardeningFixture {
         }
 
         address actor = _actor(actorSeed);
-        uint256 ownerShares = coreFacetInterface().balanceOf(actor);
-        if (ownerShares == 0) {
+        uint256 claimableShares = _claimableRedeemRequestShares(actor);
+        if (claimableShares == 0) {
             return;
         }
 
         uint256 maxWithdraw = coreFacetInterface().maxWithdraw(actor);
-        uint256 grossEntitlement = coreFacetInterface().previewRedeem(ownerShares);
+        uint256 grossEntitlement = coreFacetInterface().convertToAssets(claimableShares);
         if (grossEntitlement <= maxWithdraw) {
             return;
         }
@@ -345,33 +416,52 @@ contract DiamondVaultHostInvariantTest is DiamondVaultHostHardeningFixture {
         VM.stopPrank();
     }
 
-    function invariantIdleAssetsMatchVaultBalance() public view {
+    function invariantRawVaultBalanceCoversPendingAndClaimableDeposits() public view {
         assertTrue(
-            integrationFacetInterface().idleAssets() == asset.balanceOf(address(diamond)),
-            "idle assets should match vault-held underlying"
+            asset.balanceOf(address(diamond))
+                >= _sumPendingDepositRequestAssets() + _sumClaimableDepositRequestAssets(),
+            "raw vault balance should cover pending and claimable deposit requests"
         );
     }
 
-    function invariantBookAccountingMatchesIdlePlusStrategyDebt() public view {
+    function invariantBookAccountingMatchesTrackedIdlePlusStrategyDebt() public view {
+        uint256 trackedIdleAssets =
+            asset.balanceOf(address(diamond)) - _sumPendingDepositRequestAssets() - _sumClaimableDepositRequestAssets();
         assertTrue(
-            coreFacetInterface().totalManagedAssets()
-                == integrationFacetInterface().idleAssets() + integrationFacetInterface().strategyDebt(),
-            "book accounting should equal idle assets plus strategy debt"
+            coreFacetInterface().totalManagedAssets() == trackedIdleAssets + integrationFacetInterface().strategyDebt(),
+            "book accounting should equal tracked idle assets plus strategy debt"
         );
     }
 
-    function invariantLiveAccountingMatchesIdlePlusStrategyAssets() public view {
+    function invariantLiveAccountingMatchesTrackedIdlePlusStrategyAssets() public view {
+        uint256 trackedIdleAssets =
+            asset.balanceOf(address(diamond)) - _sumPendingDepositRequestAssets() - _sumClaimableDepositRequestAssets();
         assertTrue(
-            coreFacetInterface().totalAssets()
-                == integrationFacetInterface().idleAssets() + integrationFacetInterface().liveStrategyAssets(),
-            "live accounting should equal idle assets plus live strategy assets"
+            coreFacetInterface().totalAssets() == trackedIdleAssets + integrationFacetInterface().liveStrategyAssets(),
+            "live accounting should equal tracked idle assets plus live strategy assets"
         );
     }
 
-    function invariantShareSupplyMatchesTrackedActorBalances() public view {
+    function invariantManagedAssetsStayAboveStrategyDebt() public view {
         assertTrue(
-            coreFacetInterface().totalSupply() == _sumTrackedShareBalances(),
-            "share supply should remain equal to tracked balances"
+            coreFacetInterface().totalManagedAssets() >= integrationFacetInterface().strategyDebt(),
+            "managed assets should stay above strategy debt"
+        );
+    }
+
+    function invariantShareSupplyMatchesTrackedActorBalancesPlusEscrow() public view {
+        assertTrue(
+            coreFacetInterface().totalSupply()
+                == _sumTrackedShareBalances() + coreFacetInterface().balanceOf(address(diamond)),
+            "share supply should remain equal to tracked balances plus vault escrow"
+        );
+    }
+
+    function invariantEscrowedSharesMatchPendingAndClaimableRedeemRequests() public view {
+        assertTrue(
+            coreFacetInterface().balanceOf(address(diamond))
+                == _sumPendingRedeemRequestShares() + _sumClaimableRedeemRequestShares(),
+            "vault escrowed shares should equal pending and claimable redeem requests"
         );
     }
 
@@ -396,42 +486,51 @@ contract DiamondVaultHostInvariantTest is DiamondVaultHostHardeningFixture {
         }
     }
 
-    function invariantMaxWithdrawBoundedByImmediateLiquidity() public view {
-        uint256 immediateLiquidity = _immediateLiquidity();
-
-        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
-            address actor = actors[i];
-            uint256 actorBalance = coreFacetInterface().balanceOf(actor);
-            uint256 grossEntitlement = actorBalance == 0 ? 0 : coreFacetInterface().previewRedeem(actorBalance);
-            uint256 maxWithdraw = coreFacetInterface().maxWithdraw(actor);
-
-            assertTrue(maxWithdraw <= immediateLiquidity, "maxWithdraw should stay within immediate liquidity");
-            assertTrue(maxWithdraw <= grossEntitlement, "maxWithdraw should stay within live-priced entitlement");
-        }
-    }
-
-    function invariantPreviewRedeemOfMaxRedeemBoundedByImmediateLiquidity() public view {
-        uint256 immediateLiquidity = _immediateLiquidity();
-
+    function invariantMaxRedeemBoundedByClaimableShares() public view {
         for (uint256 i = 0; i < ACTOR_COUNT; i++) {
             address actor = actors[i];
             uint256 maxRedeem = coreFacetInterface().maxRedeem(actor);
             assertTrue(
-                coreFacetInterface().previewRedeem(maxRedeem) <= immediateLiquidity,
-                "previewRedeem(maxRedeem) should stay within immediate liquidity"
+                maxRedeem <= _claimableRedeemRequestShares(actor), "maxRedeem should stay within claimable shares"
             );
         }
     }
 
-    function _immediateLiquidity() internal view returns (uint256) {
-        if (integrationFacetInterface().strategyDebt() == 0) {
-            return coreFacetInterface().totalAssets();
+    function _maxRequestDepositAssets(address controller) internal view returns (uint256 maxAssets) {
+        if (controller == address(0) || controlsFacetInterface().paused()) {
+            return 0;
         }
 
-        uint256 liquidity = integrationFacetInterface().idleAssets();
-        if (integrationFacetInterface().strategy() == address(strategyContract)) {
-            liquidity += strategyContract.maxWithdrawableAssets();
+        maxAssets = type(uint256).max;
+        (uint128 maxTotalAssets_, uint128 maxDeposit_,,,) = controlsFacetInterface().limitConfig();
+
+        if (maxDeposit_ != 0) {
+            maxAssets = maxDeposit_;
         }
-        return liquidity;
+
+        if (maxTotalAssets_ != 0) {
+            uint256 currentCommittedAssets = coreFacetInterface().totalAssets() + _sumPendingDepositRequestAssets()
+                + _sumClaimableDepositRequestAssets();
+            if (currentCommittedAssets >= maxTotalAssets_) {
+                return 0;
+            }
+
+            uint256 remainingAssets = maxTotalAssets_ - currentCommittedAssets;
+            if (remainingAssets < maxAssets) {
+                maxAssets = remainingAssets;
+            }
+        }
+    }
+
+    function _maxRequestRedeemShares(address owner) internal view returns (uint256 maxShares) {
+        if (owner == address(0) || controlsFacetInterface().paused()) {
+            return 0;
+        }
+
+        maxShares = coreFacetInterface().balanceOf(owner);
+        (,,,, uint128 maxRedeem_) = controlsFacetInterface().limitConfig();
+        if (maxRedeem_ != 0 && maxRedeem_ < maxShares) {
+            maxShares = maxRedeem_;
+        }
     }
 }

--- a/test/helpers/DiamondVaultHostHardeningTestHarness.sol
+++ b/test/helpers/DiamondVaultHostHardeningTestHarness.sol
@@ -126,6 +126,15 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
         _seedIntegrationState();
     }
 
+    function _installAndSeedFullyAsyncVaultHost() internal {
+        _installFullyAsyncVaultHostFacets();
+        _initializeVaultHost();
+        _wireOracleAdapter();
+        _seedCoreState();
+        _seedControlsState();
+        _seedIntegrationState();
+    }
+
     function _seedCoreState() internal {
         _settleAndClaimDeposit(bob, BOB_DEPOSIT);
         _settleAndClaimDeposit(carol, CAROL_DEPOSIT);
@@ -135,13 +144,96 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
     }
 
     function _settleAndClaimDeposit(address controller, uint256 assets) internal {
+        _requestDeposit(controller, assets);
+        _settleDepositRequest(controller, assets);
+        _claimDeposit(controller, assets, controller);
+    }
+
+    function _requestDeposit(address controller, uint256 assets) internal {
         VM.prank(controller);
         asyncDepositFacetInterface().requestDeposit(assets, controller, controller);
+    }
+
+    function _settleDepositRequest(address controller, uint256 assets) internal {
         VM.prank(admin);
         integrationFacetInterface().settleDepositRequest(controller, assets);
+    }
 
+    function _claimDeposit(address controller, uint256 assets, address receiver) internal returns (uint256 shares) {
         VM.prank(controller);
-        coreFacetInterface().deposit(assets, controller);
+        shares = coreFacetInterface().deposit(assets, receiver);
+    }
+
+    function _requestRedeem(address controller, uint256 shares) internal {
+        VM.prank(controller);
+        asyncRedeemFacetInterface().requestRedeem(shares, controller, controller);
+    }
+
+    function _settleRedeemRequest(address controller, uint256 shares) internal {
+        VM.prank(admin);
+        integrationFacetInterface().settleRedeemRequest(controller, shares);
+    }
+
+    function _claimRedeem(address controller, uint256 shares, address receiver) internal returns (uint256 assets) {
+        VM.prank(controller);
+        assets = coreFacetInterface().redeem(shares, receiver, controller);
+    }
+
+    function _pendingDepositRequestAssets(address controller) internal view returns (uint256 assets) {
+        return asyncDepositFacetInterface().pendingDepositRequest(0, controller);
+    }
+
+    function _claimableDepositRequestAssets(address controller) internal view returns (uint256 assets) {
+        return asyncDepositFacetInterface().claimableDepositRequest(0, controller);
+    }
+
+    function _pendingRedeemRequestShares(address controller) internal view returns (uint256 shares) {
+        return asyncRedeemFacetInterface().pendingRedeemRequest(0, controller);
+    }
+
+    function _claimableRedeemRequestShares(address controller) internal view returns (uint256 shares) {
+        return asyncRedeemFacetInterface().claimableRedeemRequest(0, controller);
+    }
+
+    function _sumPendingDepositRequestAssets() internal view returns (uint256 assets) {
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            assets += _pendingDepositRequestAssets(actors[i]);
+        }
+    }
+
+    function _sumClaimableDepositRequestAssets() internal view returns (uint256 assets) {
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            assets += _claimableDepositRequestAssets(actors[i]);
+        }
+    }
+
+    function _sumPendingRedeemRequestShares() internal view returns (uint256 shares) {
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            shares += _pendingRedeemRequestShares(actors[i]);
+        }
+    }
+
+    function _sumClaimableRedeemRequestShares() internal view returns (uint256 shares) {
+        for (uint256 i = 0; i < ACTOR_COUNT; i++) {
+            shares += _claimableRedeemRequestShares(actors[i]);
+        }
+    }
+
+    function _bookIdleAssets() internal view returns (uint256) {
+        return coreFacetInterface().totalManagedAssets() - integrationFacetInterface().strategyDebt();
+    }
+
+    function _availableIdleAssetsForStrategyDeploy() internal view returns (uint256) {
+        uint256 actualIdleAssets = asset.balanceOf(address(diamond));
+        uint256 idleBookAssets = _bookIdleAssets();
+        return actualIdleAssets < idleBookAssets ? actualIdleAssets : idleBookAssets;
+    }
+
+    function _immediateTrackedLiquidity() internal view returns (uint256 liquidity) {
+        liquidity = _bookIdleAssets();
+        if (integrationFacetInterface().strategy() == address(strategyContract)) {
+            liquidity += strategyContract.maxWithdrawableAssets();
+        }
     }
 
     function _seedControlsState() internal {


### PR DESCRIPTION
## Summary
- harden hosted async request coverage with full-async host hardening and invariant suites
- add explicit interleaved pending/claimable deposit and redeem request tests
- fix tracked-idle redeem accounting so strategy-backed exits cannot consume pending async deposit liquidity

## Verification
- `forge test --match-path test/DiamondVaultHostHardening.t.sol --match-test testFullAsync`
- `forge test --match-path test/DiamondVaultHostInvariant.t.sol`
- `forge test --match-path test/ERC7540VaultRedeemCore.t.sol`
- `forge test --match-path test/ERC4626VaultStrategyAccountingCore.t.sol`
- `forge test --match-path test/DiamondVaultDeploymentIntegration.t.sol`
- `forge fmt --check`

## Context
Relates to #197.