### PR TITLE
Document async vault reviewer surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ reviewable engineering system.
 - Canonical docs map: `docs/README.md`
 - AMM architecture: `docs/amm.md`
 - Hosted vault architecture: `docs/vault-facets.md`
+- Async vault requests: `docs/erc7540-vault.md`
 - Smart-wallet architecture: `docs/multisig-wallet.md`
 - Security assumptions: `docs/threat-model.md`
 - Validation and CI policy: `docs/security-checks.md`
@@ -43,10 +44,11 @@ reviewable engineering system.
   protection, oracle validation, upgrade guardrails, and threshold-based wallet
   execution.
 - Protocol surfaces: ERC20 and ERC721 token hosts plus a hosted ERC-4626 vault
-  platform with controls, strategy integration, and native-asset support, plus
-  a standalone V2-style AMM with deterministic pair deployment, wrapped-native
-  routing, and protocol-fee controls, plus a standalone multisig wallet with
-  single-call, batch, and self-managed configuration flows.
+  platform with controls, strategy integration, native-asset support, and an
+  ERC-7540 async request track for ERC-20 hosts, plus a standalone V2-style
+  AMM with deterministic pair deployment, wrapped-native routing, and
+  protocol-fee controls, plus a standalone multisig wallet with single-call,
+  batch, and self-managed configuration flows.
 - Operational maturity: local bootstrap, smoke validation, activity flows,
   upgrade rehearsal, and matching CI/hardening gates.
 
@@ -58,8 +60,10 @@ reviewable engineering system.
   shaped this way.
 - `docs/diamond-core.md`: diamond routing, cut flow, selector ownership, and
   storage discipline.
-- `docs/vault-facets.md`: hosted vault facet split, lifecycle, and deployment
-  model.
+- `docs/vault-facets.md`: hosted vault family, facet split, lifecycle, and
+  deployment model.
+- `docs/erc7540-vault.md`: async request lifecycle, settlement surface,
+  controller/operator semantics, and reviewer entrypoints.
 - `docs/amm.md`: standalone AMM deployment model, pair/router behavior, math,
   and reviewer path.
 - `docs/multisig-wallet.md`: wallet deployment model, signature semantics,
@@ -72,9 +76,15 @@ reviewable engineering system.
 - `test/DiamondSelectorIntegrityCore.t.sol`: selector routing and loupe
   integrity regressions.
 - `test/DiamondVaultDeploymentIntegration.t.sol`: hosted vault deployment,
-  init, selector ownership, and oracle wiring.
+  init, async selector ownership, settlement surface, and oracle wiring.
 - `test/DiamondVaultHostHardening.t.sol`: replace/remove/re-add hardening
   across the hosted vault diamond path.
+- `test/ERC7540VaultFoundationCore.t.sol`: aggregate request model, selector
+  split, and operator bookkeeping coverage.
+- `test/ERC7540VaultDepositCore.t.sol`: async deposit request, settlement, and
+  claim coverage.
+- `test/ERC7540VaultRedeemCore.t.sol`: async redeem request, settlement, and
+  claim coverage.
 - `test/DiamondTokenDeploymentIntegration.t.sol`: ERC20 and ERC721 host
   deployment and selector ownership.
 - `test/AMMFactoryRegistry.t.sol`: AMM factory registry behavior, sorted pair
@@ -117,6 +127,9 @@ forge build --sizes --skip script
 forge test --offline --match-path test/DiamondSelectorIntegrityCore.t.sol
 forge test --offline --match-path test/DiamondVaultDeploymentIntegration.t.sol
 forge test --offline --match-path test/DiamondVaultHostHardening.t.sol
+forge test --offline --match-path test/ERC7540VaultFoundationCore.t.sol
+forge test --offline --match-path test/ERC7540VaultDepositCore.t.sol
+forge test --offline --match-path test/ERC7540VaultRedeemCore.t.sol
 forge test --offline --match-path test/DiamondTokenDeploymentIntegration.t.sol
 forge test --offline --match-path test/SystemOracleFailureScenarios.t.sol
 forge test --offline --match-path test/SystemVaultStressInvariant.t.sol
@@ -158,8 +171,8 @@ Recommended reviewer path:
 
 - Architecture decisions: `docs/adr/README.md`
 - Core architecture: `docs/diamond-core.md`, `docs/token-facets.md`,
-  `docs/vault-facets.md`, `docs/amm.md`, `docs/multisig-wallet.md`,
-  `docs/oracle-adapter.md`
+  `docs/vault-facets.md`, `docs/erc7540-vault.md`, `docs/amm.md`,
+  `docs/multisig-wallet.md`, `docs/oracle-adapter.md`
 - Security and validation: `docs/threat-model.md`, `docs/security-checks.md`
 - Operations and local workflow: `docs/ops/README.md`, `docs/auralis-local.md`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ runbooks live.
 The repo currently has four major protocol surfaces:
 
 - diamond-hosted token systems
-- diamond-hosted vault systems
+- diamond-hosted vault systems, including an ERC-7540 async request track
 - a standalone AMM track
 - a standalone multisig wallet track
 
@@ -20,7 +20,7 @@ flowchart TD
     ADR["ADRs<br/>accepted design choices"]
     Core["Diamond Core<br/>routing and upgrade base"]
     Token["Token Hosts<br/>ERC20 and ERC721 diamonds"]
-    Vault["Vault Hosts<br/>hosted ERC-4626 platform"]
+    Vault["Vault Hosts<br/>sync, native, and async request variants"]
     AMM["AMM Track<br/>standalone V2-style exchange"]
     Wallet["Wallet Track<br/>standalone multisig system"]
     Oracle["Oracle Adapter<br/>validation and breaker policy"]
@@ -50,6 +50,7 @@ flowchart TD
 - Diamond core architecture: `docs/diamond-core.md`
 - Hosted token architecture: `docs/token-facets.md`
 - Hosted vault architecture: `docs/vault-facets.md`
+- Async vault requests: `docs/erc7540-vault.md`
 - AMM architecture: `docs/amm.md`
 - Smart-wallet architecture: `docs/multisig-wallet.md`
 - Security assumptions: `docs/threat-model.md`
@@ -64,8 +65,10 @@ visual model materially improves comprehension.
   storage discipline.
 - `docs/token-facets.md`: separate ERC20 and ERC721 host model, initialization,
   role surface, and upgrade assumptions.
-- `docs/vault-facets.md`: hosted vault facet split, selector ownership, and
-  deployment model.
+- `docs/vault-facets.md`: hosted vault family, facet split, selector
+  ownership, and deployment model.
+- `docs/erc7540-vault.md`: async request lifecycle, settlement semantics,
+  controller/operator rules, and reviewer entrypoints.
 - `docs/amm.md`: standalone AMM deployment model, pair/router semantics, math,
   and reviewer-facing validation path.
 - `docs/multisig-wallet.md`: standalone multisig wallet deployment,

--- a/docs/erc4626-vault.md
+++ b/docs/erc4626-vault.md
@@ -12,7 +12,8 @@ For the accounting and native-asset decisions behind this module family, see
 `docs/adr/0005-exclude-force-sent-eth.md`.
 
 It covers the standalone vault modules and their math/control behavior. For the
-diamond-hosted vault platform, see `docs/vault-facets.md`.
+diamond-hosted vault platform, see `docs/vault-facets.md`. For the hosted
+ERC-7540 async request track, see `docs/erc7540-vault.md`.
 
 ## Accounting Model
 
@@ -36,6 +37,9 @@ flowchart TD
 
 Native-asset mode is only supported through the diamond-hosted vault platform.
 The standalone `ERC4626Vault` module remains an ERC-20 asset vault surface.
+The standalone module also remains synchronous: it does not implement
+controller-scoped async requests, manager settlement, or claimable request
+buckets.
 
 ## Contract Roles
 
@@ -171,6 +175,8 @@ Implications:
 - `deposit` and `mint` remain ERC-20 entrypoints only.
 - native funding, exact `msg.value` validation, and raw native payouts are
   documented in `docs/vault-facets.md`.
+- async request flows, settlement, and controller/operator semantics are
+  documented in `docs/erc7540-vault.md`.
 - forced native transfers are a hosted-vault accounting concern, not a
   standalone ERC-20 vault concern.
 

--- a/docs/erc7540-vault.md
+++ b/docs/erc7540-vault.md
@@ -1,0 +1,264 @@
+# ERC-7540 Async Vault
+
+This document is the canonical reviewer guide for the hosted ERC-7540 async
+request track in `Auralis`.
+
+It covers the shipped async request model for ERC-20 hosted vaults. For the
+broader hosted-vault architecture, selector ownership, native-mode behavior,
+and strategy model, see `docs/vault-facets.md`. For the standalone synchronous
+vault module, see `docs/erc4626-vault.md`.
+
+## Supported Host Variants
+
+The hosted vault family currently has three reviewer-relevant variants:
+
+- synchronous ERC-20 hosted vaults
+- synchronous native hosted vaults
+- async ERC-20 hosted vaults with ERC-7540-style request flows
+
+The async ERC-20 track uses two deployment shapes:
+
+- async-deposit host: async deposit requests plus synchronous withdraw/redeem
+- fully async host: async deposit requests plus async redeem requests
+
+The native hosted vault does not currently expose the async request surface.
+
+## Selector Ownership
+
+The async request model is implemented by splitting the hosted selector groups
+across the diamond.
+
+### Async-Deposit Host
+
+- `ERC4626VaultFacet`: initialization, metadata, share-token selectors,
+  `asset()`, `totalAssets()`, `totalManagedAssets()`, `convertToShares()`,
+  `convertToAssets()`, plus `withdraw` and `redeem` flows
+- `ERC7540VaultDepositFacet`: `requestDeposit`, pending/claimable deposit
+  views, operator approvals, and async-claim-aware `deposit`, `mint`,
+  `maxDeposit`, and `maxMint`
+- `ERC4626VaultControlsFacet`: roles, fee/limit config, pause, scoped pause,
+  and `supportsInterface(bytes4)`
+- `ERC4626VaultIntegrationFacet`: oracle/strategy selectors plus async
+  settlement selectors
+
+### Fully Async Host
+
+- `ERC4626VaultFacet`: initialization, metadata, share-token selectors,
+  `asset()`, `totalAssets()`, `totalManagedAssets()`, `convertToShares()`, and
+  `convertToAssets()`
+- `ERC7540VaultDepositFacet`: async deposit request and claim selectors
+- `ERC7540VaultRedeemFacet`: async redeem request and claim selectors,
+  including async-claim-aware `withdraw`, `redeem`, `maxWithdraw`, and
+  `maxRedeem`
+- `ERC4626VaultControlsFacet`: roles, fee/limit config, pause, scoped pause,
+  and `supportsInterface(bytes4)`
+- `ERC4626VaultIntegrationFacet`: oracle/strategy selectors plus async
+  settlement selectors
+
+## Request Model
+
+The current implementation uses an aggregate request model rather than
+per-request queue ids.
+
+- the only supported request id is `0`
+- pending and claimable balances are tracked per `controller`
+- nonzero request ids return zero from the view helpers and revert in internal
+  aggregate-id validation
+- reviewers should treat the implementation as controller-scoped buckets, not a
+  FIFO queue of independently claimable requests
+
+Request bookkeeping is shared by
+`src/vault/libraries/LibERC7540RequestAccounting.sol` and stored in
+`src/vault/storage/LibERC7540VaultStorage.sol`.
+
+## Deposit Lifecycle
+
+Async deposit requests follow this lifecycle:
+
+1. `requestDeposit(assets, controller, owner)` transfers ERC-20 assets into the
+   vault and increases the controller's pending deposit bucket.
+2. Pending assets remain locked in the vault balance but do not increase
+   `totalManagedAssets()` or `totalAssets()`.
+3. A vault manager calls `settleDepositRequest(controller, assets)` through the
+   integration facet to move assets from pending to claimable.
+4. The controller, or an approved operator for that controller, claims the
+   settled assets through the standard ERC-4626 entrypoints on the async
+   deposit facet:
+   - `deposit(assets, receiver)`
+   - `mint(shares, receiver)`
+   - `deposit(assets, receiver, controller)`
+   - `mint(shares, receiver, controller)`
+5. Claiming consumes claimable assets, increases managed assets by the net
+   post-fee amount, mints shares, and pays any configured deposit fee.
+
+Reviewer-visible implications:
+
+- assets are committed before they are priced into shares
+- claims use the current exchange rate at claim time rather than request time
+- `previewDeposit` and `previewMint` revert on async deposit hosts
+- `maxDeposit` and `maxMint` track the caller's current claimable bucket rather
+  than open-ended fresh deposits
+
+## Redeem Lifecycle
+
+Fully async hosts extend the model to redeem requests:
+
+1. `requestRedeem(shares, controller, owner)` moves shares from `owner` into
+   vault escrow and increases the controller's pending redeem bucket.
+2. Escrowed shares remain part of total supply and managed assets until claim;
+   they are not burned at request time.
+3. A vault manager calls `settleRedeemRequest(controller, shares)` through the
+   integration facet to move shares from pending to claimable.
+4. The controller, or an approved operator for that controller, claims the
+   settled shares through the async redeem facet:
+   - `withdraw(assets, receiver, controller)`
+   - `redeem(shares, receiver, controller)`
+5. Claiming consumes claimable shares, burns the escrowed shares, reduces
+   managed assets by the gross asset exit amount, transfers the net assets to
+   the receiver, and pays any configured withdraw fee.
+
+Reviewer-visible implications:
+
+- share escrow happens at request time, but burning happens at claim time
+- redeem claims can source immediately withdrawable strategy liquidity before
+  payout
+- `previewWithdraw` and `previewRedeem` revert on fully async hosts
+- `maxWithdraw` and `maxRedeem` are bounded by both claimable shares and
+  immediately sourceable liquidity
+
+## Authorization Model
+
+The async request track separates owner, controller, operator, and manager
+responsibilities.
+
+### Deposit Requests
+
+- `owner` is the asset owner whose ERC-20 balance funds the request
+- `controller` is the account whose pending/claimable deposit bucket is updated
+- `msg.sender` may be:
+  - the owner
+  - an operator approved by the owner through `setOperator`
+
+Claiming settled deposit requests requires:
+
+- the controller, or
+- an operator approved by the controller
+
+### Redeem Requests
+
+- `owner` is the share owner whose shares are escrowed
+- `controller` is the account whose pending/claimable redeem bucket is updated
+- `msg.sender` may be:
+  - the owner
+  - an operator approved by the owner
+  - an allowance holder spending the owner's share allowance
+
+Claiming settled redeem requests requires:
+
+- the controller, or
+- an operator approved by the controller
+
+### Settlement
+
+Settlement is manager-only:
+
+- `settleDepositRequest(controller, assets)`
+- `settleRedeemRequest(controller, shares)`
+
+Both settlement entrypoints require `VAULT_MANAGER_ROLE` and do not become
+available to operators.
+
+## Pause And Settlement Semantics
+
+The async request track uses both the global pause model and a dedicated
+settlement scope.
+
+- global pause blocks request and claim entrypoints
+- share-token flows (`approve`, `transfer`, `transferFrom`) remain outside the
+  write-path pause surface
+- settlement entrypoints are additionally gated by
+  `ASYNC_SETTLEMENT_SCOPE = keccak256("ASYNC_SETTLEMENT_SCOPE")`
+
+Important behavior:
+
+- pausing `ASYNC_SETTLEMENT_SCOPE` blocks new manager settlement transitions
+- already-claimable requests remain claimable while settlement is scope-paused
+- the settlement scope does not replace the global pause for request or claim
+  entrypoints
+
+## Accounting And Safety Assumptions
+
+The async request model introduces two extra committed-balance states that a
+reviewer needs to track.
+
+### Pending And Claimable Deposits
+
+- pending deposit assets are held by the vault but excluded from managed assets
+- claimable deposit assets are also excluded from managed assets until claimed
+- deposit limit checks account for committed assets by including:
+  - `totalAssets()`
+  - total pending deposit request assets
+  - total claimable deposit request assets
+
+### Pending And Claimable Redeems
+
+- pending redeem shares are escrowed in the vault and remain unburned
+- claimable redeem shares are still escrowed until claimed
+- redeem claims burn escrowed shares only when the controller executes the
+  claim flow
+
+### Liquidity Boundary
+
+- async redeem claims may pull immediately withdrawable assets from the active
+  strategy before paying the receiver
+- `maxWithdraw` and `maxRedeem` do not promise access to full mark-to-market
+  value when strategy liquidity is constrained
+
+## Known Limitations
+
+- ERC-20 hosted vaults only; native hosted vaults remain on the synchronous
+  surface
+- aggregate request model only; there is no per-request queue id surface beyond
+  `requestId == 0`
+- no FIFO or time-priority queue semantics are promised
+- no automatic or keeper-driven settlement loop is built in
+- async preview helpers intentionally revert instead of approximating future
+  settlement pricing
+- manager settlement is a trust and operations assumption that reviewers should
+  evaluate alongside the role model
+
+## Reviewer Entry Points
+
+Start here when reviewing the async request implementation:
+
+- Interfaces:
+  - `src/interfaces/IERC7540Deposit.sol`
+  - `src/interfaces/IERC7540Redeem.sol`
+  - `src/interfaces/IERC7540Operators.sol`
+  - `src/interfaces/IERC7540VaultSettlementFacet.sol`
+- Facets:
+  - `src/vault/facets/ERC7540VaultDepositFacet.sol`
+  - `src/vault/facets/ERC7540VaultRedeemFacet.sol`
+  - `src/vault/facets/ERC4626VaultIntegrationFacet.sol`
+- Libraries and storage:
+  - `src/vault/libraries/LibERC7540RequestAccounting.sol`
+  - `src/vault/libraries/LibVaultFacetSelectors.sol`
+  - `src/vault/libraries/LibVaultFacetConstants.sol`
+  - `src/vault/storage/LibERC7540VaultStorage.sol`
+
+## Validation References
+
+Use these suites to review the async request surface locally:
+
+- `test/ERC7540VaultFoundationCore.t.sol`: aggregate request model, selector
+  split, operator bookkeeping, and request-accounting helpers
+- `test/ERC7540VaultDepositCore.t.sol`: async deposit request, settlement,
+  claim, operator, limit, and settlement-pause behavior
+- `test/ERC7540VaultRedeemCore.t.sol`: async redeem request, settlement,
+  claim, allowance/operator behavior, limit, and settlement-pause behavior
+- `test/DiamondVaultDeploymentIntegration.t.sol`: fully async host deployment,
+  selector ownership, interface support, and strategy wiring
+- `test/DiamondVaultHostHardening.t.sol`: persistence across replace/remove
+  flows with async selectors installed
+- `test/DiamondVaultHostInvariant.t.sol`: diamond-routed invariant coverage for
+  the hosted async vault path

--- a/docs/security-checks.md
+++ b/docs/security-checks.md
@@ -81,12 +81,15 @@ reinstall persistence, and diamond-routed invariant coverage locally.
 
 ### Hosted Vault
 
-The hosted vault now has matching deployment, strategy lifecycle, hardening,
-and invariant coverage for the supported three-facet vault host with one active
-strategy per vault:
+The hosted vault family now has matching deployment, strategy lifecycle,
+async-request, hardening, and invariant coverage for the supported hosted vault
+variants with one active strategy per vault:
 
 ```bash
 forge test --offline --match-path test/DiamondVaultDeploymentIntegration.t.sol
+forge test --offline --match-path test/ERC7540VaultFoundationCore.t.sol
+forge test --offline --match-path test/ERC7540VaultDepositCore.t.sol
+forge test --offline --match-path test/ERC7540VaultRedeemCore.t.sol
 forge test --offline --match-path test/ERC4626VaultIntegrationFacetCore.t.sol
 forge test --offline --match-path test/ERC4626VaultStrategyAccountingCore.t.sol
 forge test --offline --match-path test/VaultStrategyFoundationCore.t.sol
@@ -95,9 +98,29 @@ forge test --offline --match-path test/DiamondVaultHostInvariant.t.sol
 ```
 
 Use these to reproduce hosted-vault deployment, strategy binding, live
-strategy-aware accounting, loss and emergency-exit behavior, selector
+strategy-aware accounting, async request lifecycle and settlement behavior,
+controller/operator authorization, loss and emergency-exit behavior, selector
 ownership, facet replacement persistence, and diamond-routed vault invariants
 locally.
+
+### Async Vault Requests
+
+The ERC-7540 reviewer path is intentionally separate from the broader hosted
+vault strategy suites:
+
+```bash
+forge test --offline --match-path test/ERC7540VaultFoundationCore.t.sol
+forge test --offline --match-path test/ERC7540VaultDepositCore.t.sol
+forge test --offline --match-path test/ERC7540VaultRedeemCore.t.sol
+forge test --offline --match-path test/DiamondVaultDeploymentIntegration.t.sol
+forge test --offline --match-path test/DiamondVaultHostHardening.t.sol
+forge test --offline --match-path test/DiamondVaultHostInvariant.t.sol
+```
+
+Use these when reviewing the aggregate request-id model, pending versus
+claimable request buckets, manager settlement, controller/operator semantics,
+settlement-scope pause behavior, async selector ownership, and strategy-aware
+redeem claims.
 
 ### Standalone AMM
 

--- a/docs/vault-facets.md
+++ b/docs/vault-facets.md
@@ -9,22 +9,22 @@ For the durable architecture decisions behind the hosted vault shape, see
 `docs/adr/0004-native-sentinel-and-facet.md`, and
 `docs/adr/0005-exclude-force-sent-eth.md`.
 
-It covers the supported diamond-hosted vault deployment:
+It covers the supported diamond-hosted vault family:
 
-- one diamond
-- one `ERC4626VaultFacet`
-- one `ERC7535VaultFacet` for native mode
-- one `ERC4626VaultControlsFacet`
-- one `ERC4626VaultIntegrationFacet`
+- synchronous ERC-20 hosts
+- synchronous native hosts
+- async ERC-20 hosts with ERC-7540-style request flows
 - one active strategy per vault
 
 For the standalone ERC-4626 module behavior and math reference, see
-`docs/erc4626-vault.md`.
+`docs/erc4626-vault.md`. For the async request lifecycle and reviewer entry
+surface, see `docs/erc7540-vault.md`.
 
 ## Supported Host Model
 
 The hosted vault diamond preserves a split between user-facing vault flows,
-control-plane selectors, and integration/config selectors.
+control-plane selectors, async request selectors when installed, and
+integration/config selectors.
 
 ### Host Structure
 
@@ -33,31 +33,62 @@ flowchart TD
     Diamond["Vault Diamond"]
     Cut["DiamondCutFacet<br/>diamondCut"]
     Loupe["DiamondLoupeFacet<br/>loupe and owner reads"]
-    Core["ERC4626VaultFacet<br/>user flows and max/preview helpers"]
+    Core["ERC4626VaultFacet<br/>core user flows and ERC-4626 helpers"]
+    Async["ERC7540 Async Facets<br/>request and claim selectors"]
     Controls["ERC4626VaultControlsFacet<br/>fees, limits, roles, pause"]
-    Integration["ERC4626VaultIntegrationFacet<br/>oracle and strategy config"]
+    Integration["ERC4626VaultIntegrationFacet<br/>oracle, strategy, settlement"]
 
     Diamond --> Cut
     Diamond --> Loupe
     Diamond --> Core
+    Diamond --> Async
     Diamond --> Controls
     Diamond --> Integration
 ```
 
 ### Core Facet
 
-`ERC4626VaultFacet` owns the ERC-4626/share-token selector group:
+`ERC4626VaultFacet` owns the initialization, accounting, and share-token base
+surface. The exact selector group depends on the host variant:
+
+- synchronous ERC-20 host:
+  - `deposit`, `mint`, `withdraw`, `redeem`
+  - conversion, preview, and `max*` helpers
+- async-deposit host:
+  - `withdraw`, `redeem`
+  - conversion and async-redeem-facing helpers
+- fully async host:
+  - initialization, metadata, share-token flows, `asset()`,
+    `totalManagedAssets()`, `totalAssets()`, `convertToShares()`, and
+    `convertToAssets()`
+
+Across the family, the core facet owns:
 
 - vault initialization
 - share metadata and share-token flows
-- `deposit`, `mint`, `withdraw`, `redeem`
-- conversion, preview, and `max*` helpers
 - `asset()` and `totalManagedAssets()`
 
 The core facet also owns runtime liquidity sourcing for user withdrawals and
 redemptions. When idle vault liquidity is insufficient, it will pull
 immediately withdrawable assets from the configured strategy before finishing
 `withdraw` or `redeem`.
+
+### Async Request Facets
+
+ERC-20 hosted vaults can install async request selectors:
+
+- `ERC7540VaultDepositFacet`:
+  - `requestDeposit`
+  - pending/claimable deposit request views
+  - operator approvals
+  - async-claim-aware `deposit`, `mint`, `maxDeposit`, and `maxMint`
+- `ERC7540VaultRedeemFacet`:
+  - `requestRedeem`
+  - pending/claimable redeem request views
+  - async-claim-aware `withdraw`, `redeem`, `maxWithdraw`, and `maxRedeem`
+
+The aggregate request model and exact async lifecycle are documented in
+`docs/erc7540-vault.md`.
 
 ### Native Facet
 
@@ -94,6 +125,7 @@ Native mode keeps the standard ERC-4626 surface unchanged:
 - oracle adapter reference
 - strategy reference and emergency-exit state
 - strategy lifecycle methods
+- async settlement methods when the async request track is installed
 - `idleAssets()`
 - `liveStrategyAssets()`
 - `strategyDebt()`
@@ -101,6 +133,12 @@ Native mode keeps the standard ERC-4626 surface unchanged:
 
 The integration facet is the manager-facing strategy surface. It does not own
 vault initialization and it does not own user ERC-4626 entrypoints.
+
+When async selectors are installed, the integration facet also owns:
+
+- `ASYNC_SETTLEMENT_SCOPE()`
+- `settleDepositRequest(address controller, uint256 assets)`
+- `settleRedeemRequest(address controller, uint256 shares)`
 
 ## Initialization And Deployment Model
 
@@ -110,12 +148,13 @@ Initialization sequence:
 
 1. Install loupe selectors.
 2. Install the core, controls, and integration selector groups.
-3. For native mode, also install the native selector group.
-4. Call
+3. For async ERC-20 hosts, also install the async request selector groups.
+4. For native mode, also install the native selector group.
+5. Call
    `initializeVault(address vaultAsset, string vaultName, string vaultSymbol, address admin)`
    through the diamond.
-5. Call `setOracleAdapter(address newAdapter)` through the integration facet.
-6. Call `setStrategy(address newStrategy)` through the integration facet.
+6. Call `setOracleAdapter(address newAdapter)` through the integration facet.
+7. Call `setStrategy(address newStrategy)` through the integration facet.
 
 Initialization behavior:
 
@@ -162,10 +201,14 @@ Hosted vault facets reuse the shared control plane.
 - `withdrawFromStrategy(...)`
 - `syncStrategyAssets()`
 - `emergencyExitStrategy()`
+- `settleDepositRequest(...)` when async deposit selectors are installed
+- `settleRedeemRequest(...)` when async redeem selectors are installed
 
 ### Pause Behavior
 
-The hosted vault currently uses a global pause model for vault entrypoints.
+The hosted vault currently uses a global pause model for request and claim
+entrypoints, plus a dedicated settlement scope when async selectors are
+installed.
 
 Global pause blocks:
 
@@ -175,6 +218,8 @@ Global pause blocks:
 - `mintNative`
 - `withdraw`
 - `redeem`
+- `requestDeposit`
+- `requestRedeem`
 
 Global pause does not block share-token flows:
 
@@ -183,7 +228,14 @@ Global pause does not block share-token flows:
 - `transferFrom`
 
 Scoped pause selectors still route through the controls facet, but the hosted
-vault does not currently use per-scope pause behavior for ERC-4626 entrypoints.
+vault does not currently use per-scope pause behavior for ERC-4626 request or
+claim entrypoints.
+
+When the async request track is installed:
+
+- `ASYNC_SETTLEMENT_SCOPE` gates manager settlement only
+- pausing that scope blocks `settleDepositRequest` and `settleRedeemRequest`
+- already-claimable requests remain claimable while settlement is scope-paused
 
 ## Strategy Model
 
@@ -196,8 +248,8 @@ flowchart LR
     Init["initializeVault"] --> Roles["grant admin, manager, pauser roles"]
     Roles --> Oracle["optional setOracleAdapter"]
     Oracle --> Strategy["optional setStrategy"]
-    Strategy --> Users["deposit / mint / withdraw / redeem"]
-    Strategy --> Manager["deploy / withdraw / sync / emergencyExit"]
+    Strategy --> Users["sync or async user flows"]
+    Strategy --> Manager["deploy / withdraw / sync / emergencyExit / settle"]
     Manager --> Book["strategyDebt and totalManagedAssets"]
     Users --> Pricing["ERC-4626 pricing and liquidity"]
     Strategy --> Live["liveStrategyAssets"]
@@ -208,8 +260,9 @@ flowchart LR
 - single-asset only
 - strategy instance is vault-bound and asset-bound
 - no allocator or multi-strategy routing
-- no async withdrawal queue
 - no automatic harvest or keeper loop
+- async request support is controller-scoped and aggregate-id based rather than
+  per-request queue based
 
 A strategy must satisfy `IERC4626VaultStrategy` and report:
 
@@ -231,6 +284,10 @@ Manager lifecycle methods live on the integration facet:
 - `withdrawFromStrategy(uint256)`
 - `syncStrategyAssets()`
 - `emergencyExitStrategy()`
+- `settleDepositRequest(address controller, uint256 assets)` when async deposit
+  selectors are installed
+- `settleRedeemRequest(address controller, uint256 shares)` when async redeem
+  selectors are installed
 
 Behavior:
 
@@ -279,6 +336,37 @@ Operationally:
 
 This means the hosted vault uses live strategy pricing for ERC-4626 conversions
 while still keeping explicit book accounting for deployed debt.
+
+## Async Request Model
+
+The ERC-20 hosted vault track supports controller-scoped async requests.
+
+### Async Deposits
+
+- `requestDeposit` transfers assets into the vault and increases the
+  controller's pending deposit bucket
+- pending and claimable deposit assets are excluded from managed assets until
+  claim
+- a manager settles deposits through the integration facet
+- the controller or its approved operator claims settled deposits through the
+  async deposit facet's `deposit` or `mint` entrypoints
+
+### Async Redeems
+
+- `requestRedeem` escrows shares in the vault and increases the controller's
+  pending redeem bucket
+- settled redeem requests become claimable by the controller
+- claim execution burns escrowed shares only at claim time
+- async redeem claims may source immediately withdrawable strategy liquidity
+  before paying the receiver
+
+### Reviewer Notes
+
+- the only supported request id is the aggregate id `0`
+- async preview helpers revert instead of estimating unsettled future pricing
+- `maxDeposit`, `maxMint`, `maxWithdraw`, and `maxRedeem` become
+  claimable-aware when async selectors are installed
+- native hosted vaults remain synchronous and do not install this async surface
 
 ## User-Facing Withdraw And Redeem Semantics
 
@@ -407,6 +495,9 @@ Reference local deployment flow:
 Reference deployment-backed validation:
 
 - `test/DiamondVaultDeploymentIntegration.t.sol`
+- `test/ERC7540VaultFoundationCore.t.sol`
+- `test/ERC7540VaultDepositCore.t.sol`
+- `test/ERC7540VaultRedeemCore.t.sol`
 - `test/ERC4626VaultIntegrationFacetCore.t.sol`
 - `test/ERC4626VaultStrategyAccountingCore.t.sol`
 - `test/VaultStrategyFoundationCore.t.sol`
@@ -420,8 +511,8 @@ Reference deployment-backed validation:
 The current hosted strategy model does not include:
 
 - multi-strategy allocation
-- async or queued withdrawals
 - automatic harvest or keeper-driven execution
 - wrapping native balances into WETH or another canonical ERC-20 asset inside
   the hosted vault
+- per-request queue ids or FIFO claim ordering for the async request track
 - extension-standard work deferred to `#24 Advanced Extensions`


### PR DESCRIPTION
## Summary

This PR adds the reviewer-facing documentation surface for the ERC-7540 async vault track.

It introduces a dedicated async vault doc, threads that surface through the root README and docs map, updates the hosted-vault architecture docs to reflect the shipped async request model, and expands the reviewer validation guidance for the async suites.

Closes #198.

## What Changed

- Added `docs/erc7540-vault.md` as the canonical reviewer guide for async deposit/redeem requests
- Updated the root README and `docs/README.md` so reviewers can discover the async vault track from the main documentation surface
- Updated `docs/vault-facets.md` to describe the current hosted vault family, async selector ownership, settlement scope behavior, and the aggregate request model
- Updated `docs/erc4626-vault.md` to keep the standalone module explicitly synchronous and link to the hosted async docs
- Updated `docs/security-checks.md` with the reviewer-facing async vault validation path

## Impact

This is a docs-only change. No runtime behavior, interfaces, selectors, or tests were modified.

## Validation

- `git diff --check`
- Manual docs consistency pass across the README, docs map, hosted vault docs, and validation guidance
