### PR TITLE
[audit] Harden hosted diamond bootstrap initialization

### DIFF
--- a/docs/erc4626-vault.md
+++ b/docs/erc4626-vault.md
@@ -15,6 +15,10 @@ It covers the standalone vault modules and their math/control behavior. For the
 diamond-hosted vault platform, see `docs/vault-facets.md`. For the hosted
 ERC-7540 async request track, see `docs/erc7540-vault.md`.
 
+For hosted diamonds, bootstrap still runs through `initializeVault(...)` on the
+core facet, but the reference deployment path is an atomic cut+init flow and
+the first hosted initialization is restricted to the current diamond owner.
+
 ## Accounting Model
 
 ```mermaid
@@ -173,6 +177,8 @@ module contract described here.
 
 Implications:
 - `deposit` and `mint` remain ERC-20 entrypoints only.
+- hosted native vaults use the same `initializeVault(...)` entrypoint with
+  `NATIVE_ASSET_SENTINEL`; there is no separate native-only initializer.
 - native funding, exact `msg.value` validation, and raw native payouts are
   documented in `docs/vault-facets.md`.
 - async request flows, settlement, and controller/operator semantics are

--- a/docs/erc7540-vault.md
+++ b/docs/erc7540-vault.md
@@ -23,6 +23,11 @@ The async ERC-20 track uses two deployment shapes:
 
 The native hosted vault does not currently expose the async request surface.
 
+Async hosts still bootstrap through `initializeVault(...)` on the core facet.
+The reference deployment path uses atomic cut+init, and the first hosted
+initialization on an uninitialized diamond is restricted to the current
+diamond owner.
+
 ## Selector Ownership
 
 The async request model is implemented by splitting the hosted selector groups

--- a/docs/token-facets.md
+++ b/docs/token-facets.md
@@ -57,8 +57,21 @@ Reference artifact:
 
 ## Initialization Model
 
-Each token standard owns its own one-time initializer and is initialized through
-the diamond after the facet selectors are installed.
+Each token standard owns its own one-time initializer.
+
+Hosted bootstrap authority is split into two phases:
+
+- on an uninitialized hosted diamond, first initialization is restricted to the
+  current diamond owner
+- once the shared control plane exists, bootstrap-authority checks resolve
+  through `DEFAULT_ADMIN_ROLE`
+
+The reference host deployment uses atomic cut+init through
+`diamondCut(..., init, initCalldata)` rather than a two-step "install selectors
+and then initialize" flow. Standalone and unit-harness facet deployment remains
+supported when no diamond owner is present in storage.
+Under atomic cut+init, the initializer runs via delegatecall with `msg.sender`
+preserved as the `diamondCut` caller, which is already the diamond owner.
 
 ### ERC20
 
@@ -77,6 +90,7 @@ Initialization expectations:
 
 - idempotent per ERC20 host
 - second initialization reverts
+- first hosted initialization on an uninitialized diamond is owner-only
 - Permit uses the token name, version `"1"`, current `chainid`, and diamond
   address for the domain separator
 
@@ -96,6 +110,7 @@ Initialization expectations:
 
 - idempotent per ERC721 host
 - second initialization reverts
+- first hosted initialization on an uninitialized diamond is owner-only
 
 ## Role Model And Pause Scopes
 

--- a/docs/vault-facets.md
+++ b/docs/vault-facets.md
@@ -147,18 +147,25 @@ The hosted vault uses one initializer on the core facet only.
 Initialization sequence:
 
 1. Install loupe selectors.
-2. Install the core, controls, and integration selector groups.
-3. For async ERC-20 hosts, also install the async request selector groups.
-4. For native mode, also install the native selector group.
-5. Call
+2. Build the hosted selector cut for the core, controls, and integration
+   groups.
+3. For async ERC-20 hosts, also include the async request selector groups in
+   the same cut.
+4. For native mode, also include the native selector group in the same cut.
+5. Execute the cut with the core facet as the init target so
    `initializeVault(address vaultAsset, string vaultName, string vaultSymbol, address admin)`
-   through the diamond.
+   runs atomically during `diamondCut(..., init, initCalldata)`.
 6. Call `setOracleAdapter(address newAdapter)` through the integration facet.
 7. Call `setStrategy(address newStrategy)` through the integration facet.
+
+Under atomic cut+init, the initializer runs via delegatecall with `msg.sender`
+preserved as the `diamondCut` caller, which is already the diamond owner.
 
 Initialization behavior:
 
 - `initializeVault(...)` initializes vault storage and shared control storage.
+- first hosted initialization on an uninitialized diamond is restricted to the
+  current diamond owner.
 - `DEFAULT_ADMIN_ROLE`, `PAUSER_ROLE`, and `VAULT_MANAGER_ROLE` are granted to
   `admin`.
 - `feeRecipient` defaults to `admin` at initialization.
@@ -177,9 +184,10 @@ state with:
 
 No funds are deployed to strategy during deployment.
 
-The native local reference deployment in `script/DeployDiamondNativeVaultHost.s.sol`
-uses the same init model, but passes the native asset sentinel as
-`vaultAsset` and installs the native selector group.
+The native local reference deployment in
+`script/DeployDiamondNativeVaultHost.s.sol` uses the same
+`initializeVault(...)` entrypoint, passes the native asset sentinel as
+`vaultAsset`, and installs the native selector group in the same atomic cut.
 
 ## Role Model And Pause Behavior
 

--- a/script/DeployDiamondErc20Host.s.sol
+++ b/script/DeployDiamondErc20Host.s.sol
@@ -39,8 +39,12 @@ contract DeployDiamondErc20HostScript is DiamondTokenHostScriptBase {
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: LibTokenFacetDeploymentSelectors.erc20HostSelectors()
         });
-        IDiamondCut(diamondAddress).diamondCut(tokenCut, address(0), "");
-        IERC20TokenFacet(diamondAddress).initializeErc20("Facet Token", "FTKN", 18, owner);
+        IDiamondCut(diamondAddress)
+            .diamondCut(
+                tokenCut,
+                tokenFacetAddress,
+                abi.encodeCall(IERC20TokenFacet.initializeErc20, ("Facet Token", "FTKN", 18, owner))
+            );
 
         VM.stopBroadcast();
 

--- a/script/DeployDiamondErc721Host.s.sol
+++ b/script/DeployDiamondErc721Host.s.sol
@@ -39,8 +39,12 @@ contract DeployDiamondErc721HostScript is DiamondTokenHostScriptBase {
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: LibTokenFacetDeploymentSelectors.erc721HostSelectors()
         });
-        IDiamondCut(diamondAddress).diamondCut(tokenCut, address(0), "");
-        IERC721TokenFacet(diamondAddress).initializeErc721("Facet NFT", "FNFT", "ipfs://facet/", owner);
+        IDiamondCut(diamondAddress)
+            .diamondCut(
+                tokenCut,
+                tokenFacetAddress,
+                abi.encodeCall(IERC721TokenFacet.initializeErc721, ("Facet NFT", "FNFT", "ipfs://facet/", owner))
+            );
 
         VM.stopBroadcast();
 

--- a/script/DeployDiamondNativeVaultHost.s.sol
+++ b/script/DeployDiamondNativeVaultHost.s.sol
@@ -70,10 +70,7 @@ contract DeployDiamondNativeVaultHostScript is DiamondVaultHostScriptBase {
 
         (state.diamondAddress, state.cutFacetAddress, state.loupeFacetAddress) = _deployDiamondCore(owner);
         state = _deployVaultSupportContracts(state, owner);
-        _installVaultHostFacets(state);
-
-        IERC4626VaultFacet(state.diamondAddress)
-            .initializeVault(state.vaultAssetAddress, VAULT_NAME, VAULT_SYMBOL, owner);
+        _installVaultHostFacets(state, owner);
         IERC4626VaultIntegrationFacet(state.diamondAddress).setOracleAdapter(state.oracleAdapterAddress);
         IERC4626VaultIntegrationFacet(state.diamondAddress).setStrategy(state.strategyAddress);
 
@@ -131,7 +128,7 @@ contract DeployDiamondNativeVaultHostScript is DiamondVaultHostScriptBase {
         return state;
     }
 
-    function _installVaultHostFacets(NativeVaultHostDeploymentState memory state) internal {
+    function _installVaultHostFacets(NativeVaultHostDeploymentState memory state, address owner) internal {
         IDiamondCut.FacetCut[] memory vaultCut = new IDiamondCut.FacetCut[](4);
         vaultCut[0] = IDiamondCut.FacetCut({
             facetAddress: state.vaultCoreFacetAddress,
@@ -153,7 +150,14 @@ contract DeployDiamondNativeVaultHostScript is DiamondVaultHostScriptBase {
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: LibVaultFacetSelectors.vaultIntegrationSelectors()
         });
-        IDiamondCut(state.diamondAddress).diamondCut(vaultCut, address(0), "");
+        IDiamondCut(state.diamondAddress)
+            .diamondCut(
+                vaultCut,
+                state.vaultCoreFacetAddress,
+                abi.encodeCall(
+                    IERC4626VaultFacet.initializeVault, (state.vaultAssetAddress, VAULT_NAME, VAULT_SYMBOL, owner)
+                )
+            );
     }
 
     function _validateVaultHost(NativeVaultHostDeploymentState memory state, address owner) internal view {

--- a/script/DeployDiamondVaultHost.s.sol
+++ b/script/DeployDiamondVaultHost.s.sol
@@ -73,10 +73,7 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
 
         (state.diamondAddress, state.cutFacetAddress, state.loupeFacetAddress) = _deployDiamondCore(owner);
         state = _deployVaultSupportContracts(state, owner);
-        _installVaultHostFacets(state);
-
-        IERC4626VaultFacet(state.diamondAddress)
-            .initializeVault(state.vaultAssetAddress, VAULT_NAME, VAULT_SYMBOL, owner);
+        _installVaultHostFacets(state, owner);
         IERC4626VaultIntegrationFacet(state.diamondAddress).setOracleAdapter(state.oracleAdapterAddress);
         IERC4626VaultIntegrationFacet(state.diamondAddress).setStrategy(state.strategyAddress);
 
@@ -134,7 +131,7 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
         return state;
     }
 
-    function _installVaultHostFacets(VaultHostDeploymentState memory state) internal {
+    function _installVaultHostFacets(VaultHostDeploymentState memory state, address owner) internal {
         IDiamondCut.FacetCut[] memory vaultCut = new IDiamondCut.FacetCut[](5);
         vaultCut[0] = IDiamondCut.FacetCut({
             facetAddress: state.vaultCoreFacetAddress,
@@ -161,7 +158,14 @@ contract DeployDiamondVaultHostScript is DiamondVaultHostScriptBase {
             action: IDiamondCut.FacetCutAction.Add,
             functionSelectors: LibVaultFacetSelectors.vaultIntegrationSelectors()
         });
-        IDiamondCut(state.diamondAddress).diamondCut(vaultCut, address(0), "");
+        IDiamondCut(state.diamondAddress)
+            .diamondCut(
+                vaultCut,
+                state.vaultCoreFacetAddress,
+                abi.encodeCall(
+                    IERC4626VaultFacet.initializeVault, (state.vaultAssetAddress, VAULT_NAME, VAULT_SYMBOL, owner)
+                )
+            );
     }
 
     function _validateVaultHost(VaultHostDeploymentState memory state, address owner) internal view {

--- a/src/token/TokenFacetControl.sol
+++ b/src/token/TokenFacetControl.sol
@@ -6,6 +6,7 @@ import {IERC165} from "../interfaces/IERC165.sol";
 import {IPausable} from "../interfaces/IPausable.sol";
 import {LibAccessControlStorage} from "../access/storage/LibAccessControlStorage.sol";
 import {LibPausableStorage} from "../access/storage/LibPausableStorage.sol";
+import {LibDiamond} from "../diamond/libraries/LibDiamond.sol";
 
 /// @title TokenFacetControl
 /// @notice Constructor-free access control and pausability layer for hosted token facets.
@@ -171,6 +172,26 @@ abstract contract TokenFacetControl is IAccessControl, IPausable {
         if (!_isPausableInitialized()) {
             _initializePausable(initialAdmin);
         }
+    }
+
+    /// @dev Enforces the hosted bootstrap authority model for one-time initializers.
+    function _enforceBootstrapInitializerAuthority() internal view {
+        if (_isAccessControlInitialized()) {
+            // Defense in depth for hosted bootstrap flows. The initializer itself is one-time, but
+            // keeping the post-bootstrap admin branch here makes the intended authority model explicit
+            // and keeps the helper reusable for future bootstrap-adjacent entrypoints.
+            _checkRole(DEFAULT_ADMIN_ROLE, msg.sender);
+            return;
+        }
+
+        address diamondOwner = LibDiamond.contractOwner();
+        if (diamondOwner != address(0)) {
+            LibDiamond.enforceIsContractOwner();
+            return;
+        }
+
+        // This branch intentionally preserves standalone and unit-harness facet initialization when
+        // no diamond owner is present in storage.
     }
 
     /// @dev Returns true if access control storage has already been initialized.

--- a/src/token/facets/ERC20TokenFacet.sol
+++ b/src/token/facets/ERC20TokenFacet.sol
@@ -45,10 +45,7 @@ contract ERC20TokenFacet is ERC20TokenBase, TokenFacetControl, IERC20TokenFacet 
             revert ERC20TokenAlreadyInitialized();
         }
 
-        if (_isAccessControlInitialized()) {
-            _checkRole(DEFAULT_ADMIN_ROLE, msg.sender);
-        }
-
+        _enforceBootstrapInitializerAuthority();
         _initializeTokenFacetControl(admin);
         _initializeErc20Token(tokenName, tokenSymbol, tokenDecimals);
         _initializePermitDomain(tokenName);

--- a/src/token/facets/ERC721TokenFacet.sol
+++ b/src/token/facets/ERC721TokenFacet.sol
@@ -39,10 +39,7 @@ contract ERC721TokenFacet is ERC721TokenBase, TokenFacetControl, IERC721TokenFac
             revert ERC721TokenAlreadyInitialized();
         }
 
-        if (_isAccessControlInitialized()) {
-            _checkRole(DEFAULT_ADMIN_ROLE, msg.sender);
-        }
-
+        _enforceBootstrapInitializerAuthority();
         _initializeTokenFacetControl(admin);
         _initializeErc721Token(tokenName, tokenSymbol, baseURI);
 

--- a/src/vault/VaultFacetControl.sol
+++ b/src/vault/VaultFacetControl.sol
@@ -202,6 +202,20 @@ abstract contract VaultFacetControl is IAccessControl, IAccessControlTime, IPaus
     /// @param initialAdmin The default admin, pauser, and initial vault manager.
     function _initializeVaultFacetControl(address initialAdmin) internal {
         if (!_isAccessControlInitialized()) {
+            address diamondOwner;
+            // This branch intentionally preserves standalone and unit-harness facet initialization when
+            // no diamond owner is present in storage.
+            assembly {
+                diamondOwner := sload(add(0xd18822d915e92c257217ed11ce402f38beb69a891f3cff0924389749c6ea4a47, 4))
+            }
+            if (diamondOwner != address(0) && msg.sender != diamondOwner) {
+                assembly {
+                    mstore(0x00, 0x3bd3ca2300000000000000000000000000000000000000000000000000000000)
+                    mstore(0x04, caller())
+                    mstore(0x24, diamondOwner)
+                    revert(0x00, 0x44)
+                }
+            }
             _initializeAccessControl(initialAdmin);
         }
         if (!_isPausableInitialized()) {

--- a/src/vault/facets/ERC4626VaultFacet.sol
+++ b/src/vault/facets/ERC4626VaultFacet.sol
@@ -41,12 +41,8 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
     function initializeVault(address vaultAsset, string calldata vaultName, string calldata vaultSymbol, address admin)
         external
     {
-        if (isVaultInitialized()) {
+        if (ERC4626VaultBase.isVaultInitialized()) {
             revert ERC4626VaultAlreadyInitialized();
-        }
-
-        if (_isAccessControlInitialized()) {
-            _checkRole(DEFAULT_ADMIN_ROLE, msg.sender);
         }
 
         _initializeVaultFacetControl(admin);

--- a/test/DiamondNativeVaultHostHardening.t.sol
+++ b/test/DiamondNativeVaultHostHardening.t.sol
@@ -10,12 +10,31 @@ import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
 import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
 import {IERC7535VaultFacet} from "../src/interfaces/IERC7535VaultFacet.sol";
 import {IPausable} from "../src/interfaces/IPausable.sol";
+import {LibDiamond} from "../src/diamond/libraries/LibDiamond.sol";
 import {LibVaultAsset} from "../src/vault/libraries/LibVaultAsset.sol";
 import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {DiamondNativeVaultHostHardeningFixture} from "./helpers/DiamondNativeVaultHostHardeningTestHarness.sol";
 import {IFacetVersionMarker} from "./helpers/DiamondVaultHostHardeningTestHarness.sol";
 
 contract DiamondNativeVaultHostHardeningTest is DiamondNativeVaultHostHardeningFixture {
+    function testNativeHostedVaultBootstrapRequiresDiamondOwnerBeforeSharedRbacExists() public {
+        _installNativeVaultHostFacets();
+
+        VM.prank(eve);
+        VM.expectRevert(abi.encodeWithSelector(LibDiamond.DiamondUnauthorized.selector, eve, admin));
+        coreFacetInterface().initializeVault(LibVaultAsset.NATIVE_ASSET_SENTINEL, "Native Vault Share", "nvSHARE", eve);
+
+        VM.prank(admin);
+        coreFacetInterface()
+            .initializeVault(LibVaultAsset.NATIVE_ASSET_SENTINEL, "Native Vault Share", "nvSHARE", admin);
+
+        assertTrue(coreFacetInterface().isVaultInitialized(), "native vault host should initialize");
+        assertTrue(
+            controlsFacetInterface().hasRole(controlsFacetInterface().DEFAULT_ADMIN_ROLE(), admin),
+            "native vault owner should receive admin role"
+        );
+    }
+
     function testNativeCoreFacetReplaceRemoveReAddPreservesState() public {
         _installAndSeedNativeVaultHost();
         _injectStrategyProfit(STRATEGY_PROFIT_ASSETS);
@@ -23,12 +42,12 @@ contract DiamondNativeVaultHostHardeningTest is DiamondNativeVaultHostHardeningF
         StrategyStateSnapshot memory initialState = _snapshotStrategyState();
 
         _replaceCoreFacet(address(coreReplacement));
-        _addCoreReplacementMarker(address(coreReplacement));
+        _addCoreReplacementMarker();
 
         _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultCoreSelectors(), address(coreReplacement));
         assertTrue(
             IDiamondLoupe(address(diamond)).facetAddress(IFacetVersionMarker.facetVersion.selector)
-                == address(coreReplacement),
+                == address(coreMarker),
             "core marker owner mismatch"
         );
         assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "core replacement marker mismatch");

--- a/test/DiamondTokenDeploymentIntegration.t.sol
+++ b/test/DiamondTokenDeploymentIntegration.t.sol
@@ -18,10 +18,8 @@ import {DiamondTokenDeploymentFixture} from "./helpers/DiamondTokenDeploymentTes
 
 contract DiamondTokenDeploymentIntegrationTest is DiamondTokenDeploymentFixture {
     function testErc20HostDeployInstallInitAndLoupeChecks() public {
-        _installErc20HostFacet();
-
-        VM.prank(admin);
-        IERC20TokenFacet(address(diamond)).initializeErc20("Facet Token", "FTKN", 18, admin);
+        _installErc20HostFacetAtomically();
+        assertTrue(IERC20TokenFacet(address(diamond)).isErc20Initialized(), "erc20 host should initialize inside cut");
 
         IDiamondLoupe loupe = IDiamondLoupe(address(diamond));
         address[] memory facetAddresses = loupe.facetAddresses();
@@ -75,10 +73,10 @@ contract DiamondTokenDeploymentIntegrationTest is DiamondTokenDeploymentFixture 
     }
 
     function testErc721HostDeployInstallInitAndLoupeChecks() public {
-        _installErc721HostFacet();
-
-        VM.prank(admin);
-        IERC721TokenFacet(address(diamond)).initializeErc721("Facet NFT", "FNFT", "ipfs://facet/", admin);
+        _installErc721HostFacetAtomically();
+        assertTrue(
+            IERC721TokenFacet(address(diamond)).isErc721Initialized(), "erc721 host should initialize inside cut"
+        );
 
         IDiamondLoupe loupe = IDiamondLoupe(address(diamond));
         address[] memory facetAddresses = loupe.facetAddresses();

--- a/test/DiamondTokenHostHardening.t.sol
+++ b/test/DiamondTokenHostHardening.t.sol
@@ -10,12 +10,48 @@ import {IERC721Metadata} from "../src/interfaces/IERC721Metadata.sol";
 import {IERC20TokenFacet} from "../src/interfaces/IERC20TokenFacet.sol";
 import {IERC721TokenFacet} from "../src/interfaces/IERC721TokenFacet.sol";
 import {IPausable} from "../src/interfaces/IPausable.sol";
+import {LibDiamond} from "../src/diamond/libraries/LibDiamond.sol";
 import {
     DiamondTokenHostHardeningFixture,
     IFacetVersionMarker
 } from "./helpers/DiamondTokenHostHardeningTestHarness.sol";
 
 contract DiamondTokenHostHardeningTest is DiamondTokenHostHardeningFixture {
+    function testErc20HostedBootstrapRequiresDiamondOwnerBeforeSharedRbacExists() public {
+        _installErc20HostFacet(address(erc20Facet));
+
+        VM.prank(eve);
+        VM.expectRevert(abi.encodeWithSelector(LibDiamond.DiamondUnauthorized.selector, eve, admin));
+        IERC20TokenFacet(address(diamond)).initializeErc20("Facet Token", "FTKN", 18, eve);
+
+        VM.prank(admin);
+        IERC20TokenFacet(address(diamond)).initializeErc20("Facet Token", "FTKN", 18, admin);
+
+        assertTrue(IERC20TokenFacet(address(diamond)).isErc20Initialized(), "erc20 host should initialize");
+        assertTrue(
+            IERC20TokenFacet(address(diamond)).hasRole(IERC20TokenFacet(address(diamond)).DEFAULT_ADMIN_ROLE(), admin),
+            "erc20 host owner should receive admin role"
+        );
+    }
+
+    function testErc721HostedBootstrapRequiresDiamondOwnerBeforeSharedRbacExists() public {
+        _installErc721HostFacet(address(erc721Facet));
+
+        VM.prank(eve);
+        VM.expectRevert(abi.encodeWithSelector(LibDiamond.DiamondUnauthorized.selector, eve, admin));
+        IERC721TokenFacet(address(diamond)).initializeErc721("Facet NFT", "FNFT", "ipfs://facet/", eve);
+
+        VM.prank(admin);
+        IERC721TokenFacet(address(diamond)).initializeErc721("Facet NFT", "FNFT", "ipfs://facet/", admin);
+
+        assertTrue(IERC721TokenFacet(address(diamond)).isErc721Initialized(), "erc721 host should initialize");
+        assertTrue(
+            IERC721TokenFacet(address(diamond))
+                .hasRole(IERC721TokenFacet(address(diamond)).DEFAULT_ADMIN_ROLE(), admin),
+            "erc721 host owner should receive admin role"
+        );
+    }
+
     function testErc20HostReplaceRemoveAndReAddPreservesState() public {
         _installErc20HostFacet(address(erc20Facet));
         _erc20InitDiamond();

--- a/test/DiamondVaultDeploymentIntegration.t.sol
+++ b/test/DiamondVaultDeploymentIntegration.t.sol
@@ -24,8 +24,8 @@ import {DiamondVaultDeploymentFixture} from "./helpers/DiamondVaultDeploymentTes
 
 contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture {
     function testVaultHostDeployInstallInitOracleAndStrategyWiring() public {
-        _installFullyAsyncVaultHostFacets();
-        _initializeVaultHost();
+        _installFullyAsyncVaultHostFacetsAtomically();
+        assertTrue(coreFacetInterface().isVaultInitialized(), "vault host should initialize inside cut");
         _wireOracleAdapter();
         _wireStrategy();
 
@@ -244,8 +244,8 @@ contract DiamondVaultDeploymentIntegrationTest is DiamondVaultDeploymentFixture 
     }
 
     function testNativeVaultHostDeployInstallInitOracleAndStrategyWiring() public {
-        _installNativeVaultHostFacets();
-        _initializeNativeVaultHost();
+        _installNativeVaultHostFacetsAtomically();
+        assertTrue(coreFacetInterface().isVaultInitialized(), "native vault host should initialize inside cut");
         _wireOracleAdapter();
         _wireNativeStrategy();
 

--- a/test/DiamondVaultHostHardening.t.sol
+++ b/test/DiamondVaultHostHardening.t.sol
@@ -10,6 +10,7 @@ import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControl
 import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
 import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
 import {IPausable} from "../src/interfaces/IPausable.sol";
+import {LibDiamond} from "../src/diamond/libraries/LibDiamond.sol";
 import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {
     DiamondVaultHostHardeningFixture,
@@ -17,6 +18,23 @@ import {
 } from "./helpers/DiamondVaultHostHardeningTestHarness.sol";
 
 contract DiamondVaultHostHardeningTest is DiamondVaultHostHardeningFixture {
+    function testHostedVaultBootstrapRequiresDiamondOwnerBeforeSharedRbacExists() public {
+        _installVaultHostFacets();
+
+        VM.prank(eve);
+        VM.expectRevert(abi.encodeWithSelector(LibDiamond.DiamondUnauthorized.selector, eve, admin));
+        coreFacetInterface().initializeVault(address(asset), "Vault Share", "vSHARE", eve);
+
+        VM.prank(admin);
+        coreFacetInterface().initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+
+        assertTrue(coreFacetInterface().isVaultInitialized(), "vault host should initialize");
+        assertTrue(
+            controlsFacetInterface().hasRole(controlsFacetInterface().DEFAULT_ADMIN_ROLE(), admin),
+            "vault owner should receive admin role"
+        );
+    }
+
     function testCoreFacetReplaceRemoveReAddPreservesState() public {
         _installAndSeedVaultHost();
         _injectStrategyProfit(STRATEGY_PROFIT_ASSETS);
@@ -24,12 +42,12 @@ contract DiamondVaultHostHardeningTest is DiamondVaultHostHardeningFixture {
         StrategyStateSnapshot memory initialState = _snapshotStrategyState();
 
         _replaceCoreFacet(address(coreReplacement));
-        _addCoreReplacementMarker(address(coreReplacement));
+        _addCoreReplacementMarker();
 
         _assertSelectorsOwnedByFacet(LibVaultFacetSelectors.vaultAsyncHostCoreSelectors(), address(coreReplacement));
         assertTrue(
             IDiamondLoupe(address(diamond)).facetAddress(IFacetVersionMarker.facetVersion.selector)
-                == address(coreReplacement),
+                == address(coreMarker),
             "core marker owner mismatch"
         );
         assertTrue(IFacetVersionMarker(address(diamond)).facetVersion() == 2, "core replacement marker mismatch");

--- a/test/ERC20TokenFacetCore.t.sol
+++ b/test/ERC20TokenFacetCore.t.sol
@@ -59,6 +59,16 @@ contract ERC20TokenFacetCoreTest is ERC20TokenFacetFixture {
         );
     }
 
+    function testStandaloneFacetInitializationRemainsAvailableWithoutDiamondOwner() public {
+        _erc20Init(address(facet));
+
+        assertTrue(IERC20TokenFacet(address(facet)).isErc20Initialized(), "standalone facet should initialize");
+        assertTrue(
+            IERC20TokenFacet(address(facet)).hasRole(IERC20TokenFacet(address(facet)).DEFAULT_ADMIN_ROLE(), admin),
+            "standalone facet should seed admin role"
+        );
+    }
+
     function testInitializeRevertsWhenCalledTwice() public {
         _erc20Init(address(facet));
 

--- a/test/ERC4626VaultFacetCore.t.sol
+++ b/test/ERC4626VaultFacetCore.t.sol
@@ -11,11 +11,8 @@ import {IPausable} from "../src/interfaces/IPausable.sol";
 import {ERC4626Vault} from "../src/vault/ERC4626Vault.sol";
 import {LibVaultAsset} from "../src/vault/libraries/LibVaultAsset.sol";
 import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
-import {
-    ERC4626VaultFacetFixture,
-    ERC4626VaultFacetHarness,
-    RejectingNativeReceiver
-} from "./helpers/ERC4626VaultFacetTestHarness.sol";
+import {LibERC4626VaultStorage} from "../src/vault/storage/LibERC4626VaultStorage.sol";
+import {ERC4626VaultFacetFixture, RejectingNativeReceiver} from "./helpers/ERC4626VaultFacetTestHarness.sol";
 
 contract ERC4626VaultFacetCoreTest is ERC4626VaultFacetFixture {
     function testInitializeVaultSeedsMetadataAndControlPlane() public {
@@ -26,11 +23,19 @@ contract ERC4626VaultFacetCoreTest is ERC4626VaultFacetFixture {
         assertTrue(keccak256(bytes(facet.name())) == keccak256(bytes("Vault Share")), "name mismatch");
         assertTrue(keccak256(bytes(facet.symbol())) == keccak256(bytes("vSHARE")), "symbol mismatch");
         assertTrue(facet.decimals() == 6, "decimals mismatch");
-        assertTrue(facet.feeRecipient() == admin, "fee recipient mismatch");
+        bytes32 feeWord = VM.load(address(facet), bytes32(uint256(LibERC4626VaultStorage.STORAGE_SLOT) + 7));
+        assertTrue(address(uint160(uint256(feeWord >> 32))) == admin, "fee recipient mismatch");
         assertTrue(facet.hasRole(facet.DEFAULT_ADMIN_ROLE(), admin), "missing default admin role");
         assertTrue(facet.hasRole(facet.PAUSER_ROLE(), admin), "missing pauser role");
         assertTrue(facet.hasRole(facet.VAULT_MANAGER_ROLE(), admin), "missing vault manager role");
         assertFalse(facet.reentrancyGuardEntered(), "reentrancy guard should be idle");
+    }
+
+    function testStandaloneFacetInitializationRemainsAvailableWithoutDiamondOwner() public {
+        _initializeHostedVault(address(facet));
+
+        assertTrue(facet.isVaultInitialized(), "standalone vault facet should initialize");
+        assertTrue(facet.hasRole(facet.DEFAULT_ADMIN_ROLE(), admin), "standalone vault facet should seed admin role");
     }
 
     function testInitializeVaultRevertsOnZeroAsset() public {
@@ -136,7 +141,7 @@ contract ERC4626VaultFacetCoreTest is ERC4626VaultFacetFixture {
 
     function testReentrantAttemptDuringDepositIsBlocked() public {
         _initializeHostedVault(address(facet));
-        bytes memory payload = abi.encodeCall(ERC4626VaultFacetHarness.probeNonReentrant, ());
+        bytes memory payload = abi.encodeCall(ERC4626Vault.withdraw, (1, bob, bob));
         asset.configureReentry(address(facet), payload, true);
 
         _approveAsset(bob, address(facet), 100);

--- a/test/ERC4626VaultStrategyAccountingCore.t.sol
+++ b/test/ERC4626VaultStrategyAccountingCore.t.sol
@@ -34,8 +34,7 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
         VM.prank(bob);
         facet.deposit(DEPOSIT_ASSETS, bob);
 
-        facet.setStrategyStateForTest(address(directProfitStrategy), STRATEGY_DEBT);
-        _simulateStrategyDeployment(address(facet), directProfitStrategy, STRATEGY_DEBT);
+        _setDirectStrategy(directProfitStrategy, STRATEGY_DEBT);
         directProfitStrategy.injectProfit(20);
 
         assertTrue(facet.totalManagedAssets() == DEPOSIT_ASSETS, "book value should remain unchanged");
@@ -57,8 +56,7 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
         VM.prank(bob);
         facet.deposit(DEPOSIT_ASSETS, bob);
 
-        facet.setStrategyStateForTest(address(directLossStrategy), STRATEGY_DEBT);
-        _simulateStrategyDeployment(address(facet), directLossStrategy, STRATEGY_DEBT);
+        _setDirectStrategy(directLossStrategy, STRATEGY_DEBT);
         directLossStrategy.applyLoss(30, 10);
 
         assertTrue(facet.totalManagedAssets() == DEPOSIT_ASSETS, "book value should remain unchanged");
@@ -80,8 +78,7 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
         VM.prank(bob);
         facet.deposit(DEPOSIT_ASSETS, bob);
 
-        facet.setStrategyStateForTest(address(directProfitStrategy), STRATEGY_DEBT);
-        _simulateStrategyDeployment(address(facet), directProfitStrategy, STRATEGY_DEBT);
+        _setDirectStrategy(directProfitStrategy, STRATEGY_DEBT);
 
         VM.prank(bob);
         uint256 burnedShares = facet.withdraw(80, bob, bob);
@@ -104,8 +101,7 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
         VM.prank(bob);
         facet.deposit(DEPOSIT_ASSETS, bob);
 
-        facet.setStrategyStateForTest(address(directProfitStrategy), STRATEGY_DEBT);
-        _simulateStrategyDeployment(address(facet), directProfitStrategy, STRATEGY_DEBT);
+        _setDirectStrategy(directProfitStrategy, STRATEGY_DEBT);
         directProfitStrategy.injectProfit(20);
 
         VM.prank(bob);
@@ -127,8 +123,7 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
         VM.prank(bob);
         facet.deposit(DEPOSIT_ASSETS, bob);
 
-        facet.setStrategyStateForTest(address(directLossStrategy), STRATEGY_DEBT);
-        _simulateStrategyDeployment(address(facet), directLossStrategy, STRATEGY_DEBT);
+        _setDirectStrategy(directLossStrategy, STRATEGY_DEBT);
         directLossStrategy.applyLoss(20, 10);
 
         VM.expectRevert(

--- a/test/ERC721TokenFacetCore.t.sol
+++ b/test/ERC721TokenFacetCore.t.sol
@@ -28,6 +28,16 @@ contract ERC721TokenFacetCoreTest is ERC721TokenFacetFixture {
         assertTrue(IERC721TokenFacet(address(facet)).totalSupply() == 0, "initial supply mismatch");
     }
 
+    function testStandaloneFacetInitializationRemainsAvailableWithoutDiamondOwner() public {
+        _erc721Init(address(facet));
+
+        assertTrue(IERC721TokenFacet(address(facet)).isErc721Initialized(), "standalone facet should initialize");
+        assertTrue(
+            IERC721TokenFacet(address(facet)).hasRole(IERC721TokenFacet(address(facet)).DEFAULT_ADMIN_ROLE(), admin),
+            "standalone facet should seed admin role"
+        );
+    }
+
     function testInitializeSeedsRoleHierarchyAndBaseUri() public {
         _erc721Init(address(facet));
         VM.prank(admin);

--- a/test/helpers/AccessControlTestHarness.sol
+++ b/test/helpers/AccessControlTestHarness.sol
@@ -17,6 +17,8 @@ interface Vm {
     function expectEmit(bool, bool, bool, bool) external;
     function expectEmit(bool, bool, bool, bool, address) external;
     function warp(uint256) external;
+    function load(address target, bytes32 slot) external view returns (bytes32);
+    function store(address target, bytes32 slot, bytes32 value) external;
 }
 
 contract TestBase {

--- a/test/helpers/DiamondNativeVaultHostHardeningTestHarness.sol
+++ b/test/helpers/DiamondNativeVaultHostHardeningTestHarness.sol
@@ -3,13 +3,14 @@ pragma solidity ^0.8.30;
 
 import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
 import {IERC7535VaultFacet} from "../../src/interfaces/IERC7535VaultFacet.sol";
+import {ERC4626VaultFacet} from "../../src/vault/facets/ERC4626VaultFacet.sol";
 import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {DiamondVaultDeploymentFixture} from "./DiamondVaultDeploymentTestHarness.sol";
 import {
     ERC4626VaultControlsFacetReplacement,
-    ERC4626VaultFacetReplacement,
     ERC4626VaultIntegrationFacetReplacement,
     ERC7535VaultFacetReplacement,
+    FacetVersionMarkerV2,
     IFacetVersionMarker
 } from "./DiamondVaultHostHardeningTestHarness.sol";
 import {MutableNativeMockVaultStrategy} from "./ERC4626VaultStrategyTestHarness.sol";
@@ -75,7 +76,8 @@ abstract contract DiamondNativeVaultHostHardeningFixture is DiamondVaultDeployme
     MutableNativeMockVaultStrategy internal strategyContract;
     MutableNativeMockVaultStrategy internal replacementStrategyContract;
 
-    ERC4626VaultFacetReplacement internal coreReplacement;
+    ERC4626VaultFacet internal coreReplacement;
+    FacetVersionMarkerV2 internal coreMarker;
     ERC7535VaultFacetReplacement internal nativeReplacement;
     ERC4626VaultControlsFacetReplacement internal controlsReplacement;
     ERC4626VaultIntegrationFacetReplacement internal integrationReplacement;
@@ -83,7 +85,8 @@ abstract contract DiamondNativeVaultHostHardeningFixture is DiamondVaultDeployme
     function setUp() public virtual override {
         super.setUp();
 
-        coreReplacement = new ERC4626VaultFacetReplacement();
+        coreReplacement = new ERC4626VaultFacet();
+        coreMarker = new FacetVersionMarkerV2();
         nativeReplacement = new ERC7535VaultFacetReplacement();
         controlsReplacement = new ERC4626VaultControlsFacetReplacement();
         integrationReplacement = new ERC4626VaultIntegrationFacetReplacement();
@@ -178,8 +181,8 @@ abstract contract DiamondNativeVaultHostHardeningFixture is DiamondVaultDeployme
         _replaceFacet(facetAddress_, LibVaultFacetSelectors.vaultIntegrationSelectors());
     }
 
-    function _addCoreReplacementMarker(address facetAddress_) internal {
-        _addFacet(facetAddress_, _markerSelectors());
+    function _addCoreReplacementMarker() internal {
+        _addFacet(address(coreMarker), _markerSelectors());
     }
 
     function _addNativeReplacementMarker(address facetAddress_) internal {
@@ -211,7 +214,8 @@ abstract contract DiamondNativeVaultHostHardeningFixture is DiamondVaultDeployme
     }
 
     function _reAddCoreFacetWithMarker(address facetAddress_) internal {
-        _addFacet(facetAddress_, _concat(LibVaultFacetSelectors.vaultCoreSelectors(), _markerSelectors()));
+        _addFacet(facetAddress_, LibVaultFacetSelectors.vaultCoreSelectors());
+        _addFacet(address(coreMarker), _markerSelectors());
     }
 
     function _reAddNativeFacetWithMarker(address facetAddress_) internal {

--- a/test/helpers/DiamondTokenDeploymentTestHarness.sol
+++ b/test/helpers/DiamondTokenDeploymentTestHarness.sol
@@ -62,6 +62,23 @@ abstract contract DiamondTokenDeploymentFixture is TestBase {
         IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
     }
 
+    function _installErc20HostFacetAtomically() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(erc20Facet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibTokenFacetDeploymentSelectors.erc20HostSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond))
+            .diamondCut(
+                cut,
+                address(erc20Facet),
+                abi.encodeCall(IERC20TokenFacet.initializeErc20, ("Facet Token", "FTKN", 18, admin))
+            );
+    }
+
     function _installErc721HostFacet() internal {
         IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
         cut[0] = IDiamondCut.FacetCut({
@@ -72,6 +89,23 @@ abstract contract DiamondTokenDeploymentFixture is TestBase {
 
         VM.prank(admin);
         IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installErc721HostFacetAtomically() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](1);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(erc721Facet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibTokenFacetDeploymentSelectors.erc721HostSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond))
+            .diamondCut(
+                cut,
+                address(erc721Facet),
+                abi.encodeCall(IERC721TokenFacet.initializeErc721, ("Facet NFT", "FNFT", "ipfs://facet/", admin))
+            );
     }
 
     function _containsAddress(address[] memory addresses, address expected) internal pure returns (bool) {

--- a/test/helpers/DiamondTokenHostHardeningTestHarness.sol
+++ b/test/helpers/DiamondTokenHostHardeningTestHarness.sol
@@ -117,10 +117,12 @@ abstract contract DiamondTokenHostHardeningFixture is TestBase {
     }
 
     function _erc20InitDiamond() internal {
+        VM.prank(admin);
         IERC20TokenFacet(address(diamond)).initializeErc20("Facet Token", "FTKN", 18, admin);
     }
 
     function _erc721InitDiamond() internal {
+        VM.prank(admin);
         IERC721TokenFacet(address(diamond)).initializeErc721("Facet NFT", "FNFT", "ipfs://facet/", admin);
     }
 

--- a/test/helpers/DiamondVaultDeploymentTestHarness.sol
+++ b/test/helpers/DiamondVaultDeploymentTestHarness.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.30;
 import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
 import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
 import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
+import {IERC4626VaultFacet} from "../../src/interfaces/IERC4626VaultFacet.sol";
 import {ERC7535VaultFacet} from "../../src/vault/facets/ERC7535VaultFacet.sol";
 import {ERC4626VaultControlsFacetHarness} from "./ERC4626VaultControlsFacetTestHarness.sol";
 import {ERC4626VaultFacetHarness} from "./ERC4626VaultFacetTestHarness.sol";
@@ -129,6 +130,41 @@ abstract contract DiamondVaultDeploymentFixture is TestBase {
         IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
     }
 
+    function _installNativeVaultHostFacetsAtomically() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](4);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(coreFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultCoreSelectors()
+        });
+        cut[1] = IDiamondCut.FacetCut({
+            facetAddress: address(nativeFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultNativeSelectors()
+        });
+        cut[2] = IDiamondCut.FacetCut({
+            facetAddress: address(controlsFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultControlsSelectors()
+        });
+        cut[3] = IDiamondCut.FacetCut({
+            facetAddress: address(integrationFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultIntegrationSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond))
+            .diamondCut(
+                cut,
+                address(coreFacet),
+                abi.encodeCall(
+                    IERC4626VaultFacet.initializeVault,
+                    (LibVaultAsset.NATIVE_ASSET_SENTINEL, "Native Vault Share", "nvSHARE", admin)
+                )
+            );
+    }
+
     function _installFullyAsyncVaultHostFacets() internal {
         IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](5);
         cut[0] = IDiamondCut.FacetCut({
@@ -159,6 +195,43 @@ abstract contract DiamondVaultDeploymentFixture is TestBase {
 
         VM.prank(admin);
         IDiamondCut(address(diamond)).diamondCut(cut, address(0), "");
+    }
+
+    function _installFullyAsyncVaultHostFacetsAtomically() internal {
+        IDiamondCut.FacetCut[] memory cut = new IDiamondCut.FacetCut[](5);
+        cut[0] = IDiamondCut.FacetCut({
+            facetAddress: address(coreFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultFullyAsyncHostCoreSelectors()
+        });
+        cut[1] = IDiamondCut.FacetCut({
+            facetAddress: address(asyncDepositFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultAsyncDepositHostSelectors()
+        });
+        cut[2] = IDiamondCut.FacetCut({
+            facetAddress: address(asyncRedeemFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultAsyncRedeemHostSelectors()
+        });
+        cut[3] = IDiamondCut.FacetCut({
+            facetAddress: address(controlsFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultControlsSelectors()
+        });
+        cut[4] = IDiamondCut.FacetCut({
+            facetAddress: address(integrationFacet),
+            action: IDiamondCut.FacetCutAction.Add,
+            functionSelectors: LibVaultFacetSelectors.vaultAsyncIntegrationSelectors()
+        });
+
+        VM.prank(admin);
+        IDiamondCut(address(diamond))
+            .diamondCut(
+                cut,
+                address(coreFacet),
+                abi.encodeCall(IERC4626VaultFacet.initializeVault, (address(asset), "Vault Share", "vSHARE", admin))
+            );
     }
 
     function _initializeVaultHost() internal {

--- a/test/helpers/DiamondVaultHostHardeningTestHarness.sol
+++ b/test/helpers/DiamondVaultHostHardeningTestHarness.sol
@@ -14,7 +14,7 @@ interface IFacetVersionMarker {
     function facetVersion() external view returns (uint256);
 }
 
-contract ERC4626VaultFacetReplacement is ERC4626VaultFacet {
+contract FacetVersionMarkerV2 {
     function facetVersion() external pure returns (uint256) {
         return 2;
     }
@@ -87,14 +87,16 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
 
     MutableMockVaultStrategy internal strategyContract;
 
-    ERC4626VaultFacetReplacement internal coreReplacement;
+    ERC4626VaultFacet internal coreReplacement;
+    FacetVersionMarkerV2 internal coreMarker;
     ERC4626VaultControlsFacetReplacement internal controlsReplacement;
     ERC4626VaultIntegrationFacetReplacement internal integrationReplacement;
 
     function setUp() public virtual override {
         super.setUp();
 
-        coreReplacement = new ERC4626VaultFacetReplacement();
+        coreReplacement = new ERC4626VaultFacet();
+        coreMarker = new FacetVersionMarkerV2();
         controlsReplacement = new ERC4626VaultControlsFacetReplacement();
         integrationReplacement = new ERC4626VaultIntegrationFacetReplacement();
 
@@ -285,8 +287,8 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
         _replaceFacet(facetAddress_, LibVaultFacetSelectors.vaultAsyncIntegrationSelectors());
     }
 
-    function _addCoreReplacementMarker(address facetAddress_) internal {
-        _addFacet(facetAddress_, _markerSelectors());
+    function _addCoreReplacementMarker() internal {
+        _addFacet(address(coreMarker), _markerSelectors());
     }
 
     function _addControlsReplacementMarker(address facetAddress_) internal {
@@ -310,7 +312,8 @@ abstract contract DiamondVaultHostHardeningFixture is DiamondVaultDeploymentFixt
     }
 
     function _reAddCoreFacetWithMarker(address facetAddress_) internal {
-        _addFacet(facetAddress_, _concat(LibVaultFacetSelectors.vaultAsyncHostCoreSelectors(), _markerSelectors()));
+        _addFacet(facetAddress_, LibVaultFacetSelectors.vaultAsyncHostCoreSelectors());
+        _addFacet(address(coreMarker), _markerSelectors());
     }
 
     function _reAddControlsFacetWithMarker(address facetAddress_) internal {

--- a/test/helpers/ERC4626VaultFacetTestHarness.sol
+++ b/test/helpers/ERC4626VaultFacetTestHarness.sol
@@ -10,20 +10,13 @@ import {ERC4626VaultFacet} from "../../src/vault/facets/ERC4626VaultFacet.sol";
 import {ERC4626VaultIntegrationFacet} from "../../src/vault/facets/ERC4626VaultIntegrationFacet.sol";
 import {ERC7535VaultFacet} from "../../src/vault/facets/ERC7535VaultFacet.sol";
 import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
-import {LibERC4626VaultStorage} from "../../src/vault/storage/LibERC4626VaultStorage.sol";
 import {DiamondProxyHarness} from "./DiamondTestHarness.sol";
 import {TestBase} from "./AccessControlTestHarness.sol";
 import {ERC7540VaultDepositFacetHarness} from "./ERC7540VaultDepositFacetTestHarness.sol";
 import {ERC7540VaultRedeemFacetHarness} from "./ERC7540VaultRedeemFacetTestHarness.sol";
 import {ReentrantMockVaultAsset} from "./ERC4626VaultControlsTestHarness.sol";
 
-contract ERC4626VaultFacetHarness is ERC4626VaultFacet {
-    function feeRecipient() external view returns (address) {
-        return LibERC4626VaultStorage.layout().fees.feeRecipient;
-    }
-
-    function probeNonReentrant() external nonReentrant {}
-}
+contract ERC4626VaultFacetHarness is ERC4626VaultFacet {}
 
 contract RejectingNativeReceiver {
     receive() external payable {
@@ -39,7 +32,7 @@ abstract contract ERC4626VaultFacetFixture is TestBase {
     address internal eve = address(0xE11E);
 
     ReentrantMockVaultAsset internal asset;
-    ERC4626VaultFacetHarness internal facet;
+    ERC4626VaultFacet internal facet;
     ERC7540VaultDepositFacetHarness internal asyncDepositFacet;
     ERC7540VaultRedeemFacetHarness internal asyncRedeemFacet;
     ERC7535VaultFacet internal nativeFacet;
@@ -51,7 +44,7 @@ abstract contract ERC4626VaultFacetFixture is TestBase {
 
     function setUp() public virtual {
         asset = new ReentrantMockVaultAsset();
-        facet = new ERC4626VaultFacetHarness();
+        facet = new ERC4626VaultFacet();
         asyncDepositFacet = new ERC7540VaultDepositFacetHarness();
         asyncRedeemFacet = new ERC7540VaultRedeemFacetHarness();
         nativeFacet = new ERC7535VaultFacet();

--- a/test/helpers/ERC4626VaultStrategyAccountingTestHarness.sol
+++ b/test/helpers/ERC4626VaultStrategyAccountingTestHarness.sol
@@ -24,14 +24,6 @@ import {
     ProfitMockVaultStrategy
 } from "./ERC4626VaultStrategyTestHarness.sol";
 
-contract ERC4626VaultStrategyAccountingFacetHarness is ERC4626VaultFacet {
-    function setStrategyStateForTest(address strategy_, uint256 strategyDebt_) external {
-        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
-        layout.strategy = strategy_;
-        layout.strategyDebt = strategyDebt_;
-    }
-}
-
 contract ERC4626VaultStrategyAccountingInitMock {
     function seedStrategyState(address strategy_, uint256 strategyDebt_) external {
         LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
@@ -50,7 +42,7 @@ abstract contract ERC4626VaultStrategyAccountingFixture is TestBase {
     address internal eve = address(0xE11E);
 
     ReentrantMockVaultAsset internal asset;
-    ERC4626VaultStrategyAccountingFacetHarness internal facet;
+    ERC4626VaultFacet internal facet;
     ERC7535VaultFacet internal nativeFacet;
     ERC4626VaultControlsFacetHarness internal controlsFacet;
     ERC4626VaultIntegrationFacetHarness internal integrationFacet;
@@ -66,7 +58,7 @@ abstract contract ERC4626VaultStrategyAccountingFixture is TestBase {
 
     function setUp() public virtual {
         asset = new ReentrantMockVaultAsset();
-        facet = new ERC4626VaultStrategyAccountingFacetHarness();
+        facet = new ERC4626VaultFacet();
         nativeFacet = new ERC7535VaultFacet();
         controlsFacet = new ERC4626VaultControlsFacetHarness();
         integrationFacet = new ERC4626VaultIntegrationFacetHarness();
@@ -99,6 +91,13 @@ abstract contract ERC4626VaultStrategyAccountingFixture is TestBase {
         VM.prank(admin);
         IERC4626VaultFacet(address(diamond))
             .initializeVault(LibVaultAsset.NATIVE_ASSET_SENTINEL, "Vault Share", "vSHARE", admin);
+    }
+
+    function _setDirectStrategy(IERC4626VaultStrategy strategy_, uint256 strategyDebt_) internal {
+        bytes32 baseSlot = LibERC4626VaultStorage.STORAGE_SLOT;
+        VM.store(address(facet), bytes32(uint256(baseSlot) + 12), bytes32(uint256(uint160(address(strategy_)))));
+        VM.store(address(facet), bytes32(uint256(baseSlot) + 14), bytes32(strategyDebt_));
+        _simulateStrategyDeployment(address(facet), strategy_, strategyDebt_);
     }
 
     function _approveAsset(address owner, address spender, uint256 amount) internal {


### PR DESCRIPTION
## Summary
- close the hosted first-initializer takeover window for vault, ERC20, and ERC721 diamonds
- switch the reference host deploy scripts to atomic diamondCut init calls
- add hostile-bootstrap, standalone-init, and atomic deploy-path regression coverage plus bootstrap doc updates

## Issue
- Closes #207

## Validation
- forge fmt --check
- forge build --sizes --skip script
- forge test --offline --match-path test/DiamondSelectorIntegrityCore.t.sol
- forge test --offline --match-path test/DiamondVaultDeploymentIntegration.t.sol
- forge test --offline --match-path test/DiamondVaultHostHardening.t.sol
- forge test --offline --match-path test/DiamondNativeVaultHostHardening.t.sol
- forge test --offline --match-path test/DiamondTokenDeploymentIntegration.t.sol
- forge test --offline --match-path test/SystemOracleFailureScenarios.t.sol
- forge test --offline --match-path test/DiamondTokenHostHardening.t.sol
- forge test --offline --match-path test/ERC20TokenFacetCore.t.sol
- forge test --offline --match-path test/ERC721TokenFacetCore.t.sol
- forge test --offline --match-path test/ERC4626VaultFacetCore.t.sol
- forge test --offline --match-path test/AMMPairFuzz.t.sol
- forge test --offline --match-path test/AMMRouterFuzz.t.sol
- FOUNDRY_INVARIANT_RUNS=64 FOUNDRY_INVARIANT_DEPTH=32 forge test --offline --match-path test/AMMInvariant.t.sol
- forge test --offline --match-path test/AMMHardening.t.sol
- forge test --offline --match-path test/SystemVaultStressInvariant.t.sol
- slither . --exclude-dependencies (local CLI shows Informational/Low/Medium only; no High results in JSON output)
