### PR TITLE
[audit] Prevent non-operational multisig execution

### DIFF
--- a/src/interfaces/IMultisigWallet.sol
+++ b/src/interfaces/IMultisigWallet.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.30;
 /// @notice Foundation interface for the standalone multisig wallet.
 interface IMultisigWallet {
     error MultisigWalletAlreadyInitialized();
+    error MultisigWalletNotOperational();
     error MultisigWalletCallerNotSelf();
     error MultisigWalletInvalidThreshold(uint256 threshold, uint256 ownerCount);
     error MultisigWalletZeroOwner();

--- a/src/wallet/MultisigWallet.sol
+++ b/src/wallet/MultisigWallet.sol
@@ -69,6 +69,7 @@ contract MultisigWallet is IERC165, IERC1271, IMultisigWallet {
 
     // slither-disable-next-line reentrancy-events
     function executeTransaction(address to, uint256 value, bytes calldata data, bytes calldata signatures) external {
+        _requireOperational();
         if (to == address(0)) {
             revert MultisigWalletZeroTarget();
         }
@@ -92,6 +93,7 @@ contract MultisigWallet is IERC165, IERC1271, IMultisigWallet {
 
     // slither-disable-next-line reentrancy-events
     function executeBatch(bytes calldata transactions, bytes calldata signatures) external {
+        _requireOperational();
         uint256 currentNonce = _nonce;
         bytes32 digest = _getBatchHash(transactions, currentNonce);
 
@@ -139,6 +141,9 @@ contract MultisigWallet is IERC165, IERC1271, IMultisigWallet {
         override(IERC1271, IMultisigWallet)
         returns (bytes4)
     {
+        if (_threshold == 0) {
+            return ERC1271_INVALID_SIGNATURE;
+        }
         if (_hasValidSignatures(digest, signatures)) {
             return ERC1271_MAGIC_VALUE;
         }
@@ -172,6 +177,12 @@ contract MultisigWallet is IERC165, IERC1271, IMultisigWallet {
     function _requireSelfCall() internal view {
         if (msg.sender != address(this)) {
             revert MultisigWalletCallerNotSelf();
+        }
+    }
+
+    function _requireOperational() internal view {
+        if (_threshold == 0) {
+            revert MultisigWalletNotOperational();
         }
     }
 

--- a/test/MultisigWalletFoundationCore.t.sol
+++ b/test/MultisigWalletFoundationCore.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
+import {IERC1271} from "../src/interfaces/IERC1271.sol";
 import {IMultisigWallet} from "../src/interfaces/IMultisigWallet.sol";
 import {MultisigWalletFixture} from "./helpers/MultisigWalletTestHarness.sol";
 
@@ -63,6 +64,67 @@ contract MultisigWalletFoundationCoreTest is MultisigWalletFixture {
 
         VM.expectRevert(IMultisigWallet.MultisigWalletZeroMultiSend.selector);
         clone.initialize(_initialOwners(), 2, address(0));
+    }
+
+    function testUninitializedCloneCannotExecuteTransactionOrBatch() public {
+        IMultisigWallet clone = IMultisigWallet(_deployUninitializedClone(keccak256("uninitialized-execution")));
+
+        VM.expectRevert(IMultisigWallet.MultisigWalletNotOperational.selector);
+        clone.executeTransaction(actorAddresses[3], 0, "", "");
+
+        VM.expectRevert(IMultisigWallet.MultisigWalletNotOperational.selector);
+        clone.executeBatch("", "");
+    }
+
+    function testUninitializedCloneNeverReturnsErc1271Magic() public {
+        IMultisigWallet clone = IMultisigWallet(_deployUninitializedClone(keccak256("uninitialized-1271")));
+        bytes32 digest = keccak256("auralis.multisig.uninitialized");
+
+        assertTrue(
+            IERC1271(address(clone)).isValidSignature(digest, "") == ERC1271_INVALID_SIGNATURE,
+            "uninitialized clone should reject empty signatures"
+        );
+        assertTrue(
+            IERC1271(address(clone)).isValidSignature(digest, hex"deadbeef") == ERC1271_INVALID_SIGNATURE,
+            "uninitialized clone should reject garbage signatures"
+        );
+    }
+
+    function testInitializedCloneBecomesOperational() public {
+        IMultisigWallet clone = IMultisigWallet(_deployUninitializedClone(keccak256("initialized-operational")));
+        clone.initialize(_initialOwners(), 2, defaultMultiSend);
+
+        bytes32 digest = clone.getTransactionHash(actorAddresses[3], 0, "", 0);
+        bytes memory signatures = _packedSignaturesForDigestByIndexes(digest, _sortedOwnerIndexes(2));
+
+        clone.executeTransaction(actorAddresses[3], 0, "", signatures);
+
+        assertTrue(
+            IERC1271(address(clone)).isValidSignature(digest, signatures) == ERC1271_MAGIC_VALUE,
+            "initialized clone should return ERC1271 magic"
+        );
+        assertTrue(clone.nonce() == 1, "initialized clone should execute successfully");
+    }
+
+    function testImplementationCannotExecuteTransactionOrBatch() public {
+        VM.expectRevert(IMultisigWallet.MultisigWalletNotOperational.selector);
+        implementation.executeTransaction(actorAddresses[3], 0, "", "");
+
+        VM.expectRevert(IMultisigWallet.MultisigWalletNotOperational.selector);
+        implementation.executeBatch("", "");
+    }
+
+    function testImplementationNeverReturnsErc1271Magic() public view {
+        bytes32 digest = keccak256("auralis.multisig.implementation");
+
+        assertTrue(
+            IERC1271(address(implementation)).isValidSignature(digest, "") == ERC1271_INVALID_SIGNATURE,
+            "implementation should reject empty signatures"
+        );
+        assertTrue(
+            IERC1271(address(implementation)).isValidSignature(digest, hex"deadbeef") == ERC1271_INVALID_SIGNATURE,
+            "implementation should reject garbage signatures"
+        );
     }
 
     function testGetOwnersReturnsInitializedSet() public view {

--- a/test/MultisigWalletIntegration.t.sol
+++ b/test/MultisigWalletIntegration.t.sol
@@ -137,6 +137,25 @@ contract MultisigWalletIntegrationTest is MultisigWalletFixture {
         assertTrue(deployedWallet.multiSendCallOnly() == defaultMultiSend, "helper mismatch");
     }
 
+    function testFactoryDeployReturnsOperationalWalletImmediately() public {
+        bytes32 salt = keccak256("auralis.multisig.factory-operational");
+        IMultisigWallet deployedWallet =
+            IMultisigWallet(factory.deployWallet(salt, _initialOwners(), 2, defaultMultiSend));
+
+        assertTrue(deployedWallet.threshold() > 0, "wallet should be operational");
+        assertTrue(deployedWallet.ownerCount() > 0, "wallet should have owners");
+        assertTrue(deployedWallet.multiSendCallOnly() != address(0), "wallet should have helper");
+
+        bytes memory data = abi.encodeCall(BatchExecutionTarget.setNumber, (66));
+        bytes memory signatures =
+            _packedSignaturesForTransactionAtWallet(address(deployedWallet), address(firstTarget), 0, data, 0, 2);
+
+        deployedWallet.executeTransaction(address(firstTarget), 0, data, signatures);
+
+        assertTrue(firstTarget.storedNumber() == 66, "deployed wallet should execute immediately");
+        assertTrue(deployedWallet.nonce() == 1, "nonce should advance after immediate execution");
+    }
+
     function testFactoryDeployedWalletExecutesSignedSingleCall() public {
         bytes32 salt = keccak256("auralis.multisig.factory-single-call");
         IMultisigWallet deployedWallet =


### PR DESCRIPTION
## Summary
- gate multisig execution on operational state (`threshold > 0`)
- make uninitialized clones and the implementation contract inert for ERC-1271 success
- add regression coverage for uninitialized clones, the implementation contract, and immediate factory deploy usability

## Validation
- forge test --offline --match-path test/MultisigWalletFoundationCore.t.sol
- forge test --offline --match-path test/MultisigWalletCoreExecution.t.sol
- forge test --offline --match-path test/MultisigWalletIntegration.t.sol
- forge test --offline --match-path test/MultisigWalletInvariant.t.sol
- forge fmt --check
- forge build --skip test

Closes #208