### PR TITLE
[audit] Freeze vault storage upgrade baseline

### DIFF
--- a/docs/access-control.md
+++ b/docs/access-control.md
@@ -29,6 +29,17 @@ function init(address admin) external {
 }
 ```
 
+## Upgrade Compatibility Boundary
+
+The current hosted-vault upgrade story only claims compatibility for
+access-control state created on the current
+`keccak256("auralis.access-control.storage")` namespace.
+
+Older pre-public deployments created before the namespace rename from
+`smart-contracts.access-control.storage` are not claimed as in-place upgrade
+compatible. If those deployments ever matter, they require a redeploy or an
+explicit migration plan rather than a same-address facet replacement.
+
 ## Time Window Semantics
 
 - Time windows are optional and stored per `(role, account)`.

--- a/docs/diamond-core.md
+++ b/docs/diamond-core.md
@@ -79,6 +79,9 @@ To stay diamond-safe:
 3. Verify selector collisions are intentional and reviewed.
 4. Verify init target + calldata, including idempotency and access controls.
 5. Verify storage layout assumptions for every touched module.
+   - Treat current rehearsal and hardening coverage as proof of same-layout
+     persistence on the current namespace baseline, not as proof of storage
+     migration across renamed slot namespaces.
 6. Execute post-cut checks:
    - loupe snapshot matches expected routing.
    - critical external calls succeed.

--- a/docs/ops/local-diamond-upgrade-rehearsal.md
+++ b/docs/ops/local-diamond-upgrade-rehearsal.md
@@ -13,6 +13,10 @@ cut behavior before production-style operator changes.
 - executes deliberate selector-collision and init-failure cuts
 - confirms failed cuts do not leave partial selector routing behind
 
+The rehearsal validates cut mechanics and state persistence on the current
+storage-layout baseline. It does not validate storage migration across renamed
+slot namespaces from older pre-public deployments.
+
 ## Run
 
 ```shell

--- a/docs/vault-facets.md
+++ b/docs/vault-facets.md
@@ -480,11 +480,22 @@ One important implication:
 
 Hosted vault state lives in the diamond, not in facet bytecode.
 
-Supported replace/remove/re-add flows assume:
+Supported replace/remove/re-add flows are limited to vaults created on the
+current `auralis.*` storage namespace baseline:
 
-- replacement facets preserve the same storage layout
+- `LibERC4626VaultStorage` remains on
+  `keccak256("auralis.erc4626-vault.storage")`
+- `LibAccessControlStorage` remains on
+  `keccak256("auralis.access-control.storage")`
+- replacement facets preserve that same namespace and an append-only storage
+  layout
 - selectors are restored before the corresponding surface is expected to route
 - no re-initialization is performed during upgrades
+
+Older pre-public deployments created before the namespace rename from
+`smart-contracts.*` to `auralis.*` are not claimed as in-place upgrade
+compatible. If they ever matter, they require redeploy or explicit migration
+work rather than a same-address facet replacement.
 
 Current hardening coverage explicitly validates persistence for:
 
@@ -492,6 +503,14 @@ Current hardening coverage explicitly validates persistence for:
 - fee config, limit config, roles, role windows, and pause state
 - oracle adapter, strategy address, strategy debt, live strategy assets, and
   emergency-exit state
+
+Those persistence checks validate same-namespace replace/remove/re-add flows on
+the current baseline. They do not validate storage migration across renamed
+slot namespaces.
+
+This compatibility statement is only being frozen here for vault and
+access-control storage. Other renamed storage libraries remain separate
+follow-up work.
 
 ## Deployment References
 

--- a/test/AccessControlCore.t.sol
+++ b/test/AccessControlCore.t.sol
@@ -5,6 +5,7 @@ import {AccessControlHarness, AccessControlFixture} from "./helpers/AccessContro
 import {IAccessControl} from "../src/interfaces/IAccessControl.sol";
 import {IAccessControlTime} from "../src/interfaces/IAccessControlTime.sol";
 import {IERC165} from "../src/interfaces/IERC165.sol";
+import {LibAccessControlStorage} from "../src/access/storage/LibAccessControlStorage.sol";
 
 contract AccessControlCoreTest is AccessControlFixture {
     event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole);
@@ -36,6 +37,39 @@ contract AccessControlCoreTest is AccessControlFixture {
         assertTrue(ac.supportsInterface(type(IAccessControl).interfaceId), "access control not supported");
         assertTrue(ac.supportsInterface(type(IAccessControlTime).interfaceId), "access control time not supported");
         assertTrue(!ac.supportsInterface(0xffffffff), "unexpected interface supported");
+    }
+
+    function testAccessControlStorageSlotAndLayoutRemainFrozen() public {
+        assertTrue(
+            LibAccessControlStorage.STORAGE_SLOT == keccak256("auralis.access-control.storage"),
+            "access-control storage slot mismatch"
+        );
+        assertTrue(
+            VM.load(address(ac), LibAccessControlStorage.STORAGE_SLOT) == bytes32(uint256(1)),
+            "initialized flag slot mismatch"
+        );
+
+        bytes32 roleDataBase = keccak256(abi.encode(WRITER_ROLE, uint256(LibAccessControlStorage.STORAGE_SLOT) + 1));
+
+        VM.prank(admin);
+        ac.grantRole(WRITER_ROLE, bob);
+
+        bytes32 memberMappingSlot = keccak256(abi.encode(bob, uint256(roleDataBase)));
+        assertTrue(VM.load(address(ac), memberMappingSlot) == bytes32(uint256(1)), "member mapping slot mismatch");
+
+        bytes32 memberListLengthSlot = bytes32(uint256(roleDataBase) + 2);
+        assertTrue(
+            VM.load(address(ac), memberListLengthSlot) == bytes32(uint256(1)), "member list length slot mismatch"
+        );
+
+        bytes32 memberIndexSlot = keccak256(abi.encode(bob, uint256(roleDataBase) + 3));
+        assertTrue(VM.load(address(ac), memberIndexSlot) == bytes32(uint256(1)), "member index slot mismatch");
+
+        VM.prank(admin);
+        ac.setRoleAdmin(WRITER_ROLE, SPECIAL_ADMIN_ROLE);
+        assertTrue(
+            VM.load(address(ac), bytes32(uint256(roleDataBase) + 1)) == SPECIAL_ADMIN_ROLE, "role admin slot mismatch"
+        );
     }
 
     function testNonAdminCannotGrant() public {

--- a/test/ERC4626VaultControlsFacetCore.t.sol
+++ b/test/ERC4626VaultControlsFacetCore.t.sol
@@ -15,6 +15,7 @@ import {IPausable} from "../src/interfaces/IPausable.sol";
 import {IReentrancyGuard} from "../src/interfaces/IReentrancyGuard.sol";
 import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
 import {LibVaultAsset} from "../src/vault/libraries/LibVaultAsset.sol";
+import {LibERC4626VaultStorage} from "../src/vault/storage/LibERC4626VaultStorage.sol";
 import {ERC4626VaultControlsFacetFixture} from "./helpers/ERC4626VaultControlsFacetTestHarness.sol";
 
 contract ERC4626VaultControlsFacetCoreTest is ERC4626VaultControlsFacetFixture {
@@ -68,6 +69,34 @@ contract ERC4626VaultControlsFacetCoreTest is ERC4626VaultControlsFacetFixture {
         assertTrue(maxMint == 300, "max mint not updated");
         assertTrue(maxWithdraw == 200, "max withdraw not updated");
         assertTrue(maxRedeem == 100, "max redeem not updated");
+    }
+
+    function testDirectControlsFacetStorageLayoutRemainsFrozenForFeesAndLimits() public {
+        _initializeDirectControlsFacet();
+
+        VM.prank(admin);
+        controlsFacet.setFeeConfig(500, 250, eve);
+        VM.prank(admin);
+        controlsFacet.setLimitConfig(1_000, 500, 300, 200, 100);
+
+        bytes32 baseSlot = LibERC4626VaultStorage.STORAGE_SLOT;
+
+        uint256 feeSlot = uint256(VM.load(address(controlsFacet), bytes32(uint256(baseSlot) + 7)));
+        uint256 expectedFeeSlot = uint256(500) | (uint256(250) << 16) | (uint256(uint160(eve)) << 32);
+        assertTrue(feeSlot == expectedFeeSlot, "fee config slot mismatch");
+
+        uint256 limitSlot0 = uint256(VM.load(address(controlsFacet), bytes32(uint256(baseSlot) + 8)));
+        uint256 expectedLimitSlot0 = uint256(uint128(1_000)) | (uint256(uint128(500)) << 128);
+        assertTrue(limitSlot0 == expectedLimitSlot0, "limit config slot 0 mismatch");
+
+        uint256 limitSlot1 = uint256(VM.load(address(controlsFacet), bytes32(uint256(baseSlot) + 9)));
+        uint256 expectedLimitSlot1 = uint256(uint128(300)) | (uint256(uint128(200)) << 128);
+        assertTrue(limitSlot1 == expectedLimitSlot1, "limit config slot 1 mismatch");
+
+        assertTrue(
+            VM.load(address(controlsFacet), bytes32(uint256(baseSlot) + 10)) == bytes32(uint256(100)),
+            "limit config slot 2 mismatch"
+        );
     }
 
     function testDirectControlsFacetRejectsInvalidFeeConfigAndNonManagerCalls() public {

--- a/test/ERC4626VaultFacetCore.t.sol
+++ b/test/ERC4626VaultFacetCore.t.sol
@@ -31,6 +31,31 @@ contract ERC4626VaultFacetCoreTest is ERC4626VaultFacetFixture {
         assertFalse(facet.reentrancyGuardEntered(), "reentrancy guard should be idle");
     }
 
+    function testVaultStorageSlotAndPackedLayoutRemainFrozen() public {
+        assertTrue(
+            LibERC4626VaultStorage.STORAGE_SLOT == keccak256("auralis.erc4626-vault.storage"),
+            "vault storage slot mismatch"
+        );
+
+        _initializeHostedVault(address(facet));
+
+        uint256 packedSlot0 = uint256(VM.load(address(facet), bytes32(uint256(LibERC4626VaultStorage.STORAGE_SLOT))));
+        uint256 expectedPackedSlot0 =
+            1 | (uint256(1) << 8) | (uint256(uint160(address(asset))) << 16) | (uint256(facet.decimals()) << 176);
+
+        assertTrue(packedSlot0 == expectedPackedSlot0, "packed vault slot 0 mismatch");
+
+        _approveAsset(bob, address(facet), 100);
+        VM.prank(bob);
+        facet.deposit(40, bob);
+
+        assertTrue(
+            VM.load(address(facet), bytes32(uint256(LibERC4626VaultStorage.STORAGE_SLOT) + 6))
+                == bytes32(facet.totalManagedAssets()),
+            "totalManagedAssets slot mismatch"
+        );
+    }
+
     function testStandaloneFacetInitializationRemainsAvailableWithoutDiamondOwner() public {
         _initializeHostedVault(address(facet));
 

--- a/test/ERC4626VaultIntegrationFacetCore.t.sol
+++ b/test/ERC4626VaultIntegrationFacetCore.t.sol
@@ -11,9 +11,58 @@ import {IERC7535VaultFacet} from "../src/interfaces/IERC7535VaultFacet.sol";
 import {IOracleAdapter} from "../src/interfaces/IOracleAdapter.sol";
 import {LibVaultAsset} from "../src/vault/libraries/LibVaultAsset.sol";
 import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
+import {LibERC4626VaultStorage} from "../src/vault/storage/LibERC4626VaultStorage.sol";
 import {ERC4626VaultIntegrationFacetFixture} from "./helpers/ERC4626VaultIntegrationFacetTestHarness.sol";
 
 contract ERC4626VaultIntegrationFacetCoreTest is ERC4626VaultIntegrationFacetFixture {
+    function testDirectIntegrationFacetStorageLayoutRemainsFrozen() public {
+        _initializeDirectIntegrationFacet();
+
+        bytes32 baseSlot = LibERC4626VaultStorage.STORAGE_SLOT;
+
+        VM.prank(admin);
+        integrationFacet.setOracleAdapter(address(adapter));
+        assertTrue(
+            VM.load(address(integrationFacet), bytes32(uint256(baseSlot) + 11))
+                == bytes32(uint256(uint160(address(adapter)))),
+            "oracleAdapter slot mismatch"
+        );
+
+        VM.prank(admin);
+        integrationFacet.setStrategy(address(directProfitStrategy));
+        assertTrue(
+            VM.load(address(integrationFacet), bytes32(uint256(baseSlot) + 12))
+                == bytes32(uint256(uint160(address(directProfitStrategy)))),
+            "strategy slot mismatch"
+        );
+        assertTrue(
+            VM.load(address(integrationFacet), bytes32(uint256(baseSlot) + 13)) == bytes32(0),
+            "strategyReportedAssets slot mismatch"
+        );
+        assertTrue(
+            VM.load(address(integrationFacet), bytes32(uint256(baseSlot) + 15)) == bytes32(0),
+            "strategyEmergencyExit initial slot mismatch"
+        );
+
+        _approveAsset(bob, address(integrationFacet), 100);
+        VM.prank(bob);
+        integrationFacet.deposit(100, bob);
+
+        VM.prank(admin);
+        integrationFacet.deployToStrategy(40);
+        assertTrue(
+            VM.load(address(integrationFacet), bytes32(uint256(baseSlot) + 14)) == bytes32(uint256(40)),
+            "strategyDebt slot mismatch"
+        );
+
+        VM.prank(admin);
+        integrationFacet.emergencyExitStrategy();
+        assertTrue(
+            uint256(VM.load(address(integrationFacet), bytes32(uint256(baseSlot) + 15))) & 0xff == 1,
+            "strategyEmergencyExit slot mismatch"
+        );
+    }
+
     function testDirectIntegrationFacetRequiresManagerForConfigAndLifecycle() public {
         _initializeDirectIntegrationFacet();
         _approveAsset(bob, address(integrationFacet), 100);

--- a/test/VaultFacetFoundationCore.t.sol
+++ b/test/VaultFacetFoundationCore.t.sol
@@ -13,6 +13,7 @@ import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
 import {IPausable} from "../src/interfaces/IPausable.sol";
 import {IReentrancyGuard} from "../src/interfaces/IReentrancyGuard.sol";
 import {LibVaultFacetSelectors} from "../src/vault/libraries/LibVaultFacetSelectors.sol";
+import {LibERC4626VaultStorage} from "../src/vault/storage/LibERC4626VaultStorage.sol";
 import {NoMetadataAsset} from "./helpers/ERC4626VaultTestHarness.sol";
 import {VaultFacetFoundationFixture} from "./helpers/VaultFacetFoundationTestHarness.sol";
 
@@ -68,6 +69,27 @@ contract VaultFacetFoundationCoreTest is VaultFacetFoundationFixture {
 
         assertTrue(vault.isVaultInitialized(), "vault should initialize after control-only init");
         assertTrue(vault.asset() == address(asset), "asset mismatch after delayed vault init");
+    }
+
+    function testVaultPackedSlotZeroOffsetsRemainFrozenAcrossControlOnlyAndFullInit() public {
+        vault.initializeControlOnly(admin);
+
+        uint256 controlOnlySlot0 =
+            uint256(VM.load(address(vault), bytes32(uint256(LibERC4626VaultStorage.STORAGE_SLOT))));
+        assertTrue(uint8(controlOnlySlot0 & 0xff) == 0, "vault initialized byte should remain zero before vault init");
+        assertTrue(uint8((controlOnlySlot0 >> 8) & 0xff) == 1, "controlPlaneInitialized byte should occupy second byte");
+        assertTrue((controlOnlySlot0 >> 16) == 0, "asset and decimals bytes should remain unset before vault init");
+
+        vault.initializeVault(address(asset), "Vault Share", "vSHARE", admin);
+
+        uint256 initializedSlot0 =
+            uint256(VM.load(address(vault), bytes32(uint256(LibERC4626VaultStorage.STORAGE_SLOT))));
+        assertTrue(uint8(initializedSlot0 & 0xff) == 1, "vault initialized byte mismatch");
+        assertTrue(uint8((initializedSlot0 >> 8) & 0xff) == 1, "controlPlaneInitialized byte mismatch");
+        assertTrue(
+            uint160(initializedSlot0 >> 16) == uint160(address(asset)), "asset bytes should start at the third byte"
+        );
+        assertTrue(uint8((initializedSlot0 >> 176) & 0xff) == 6, "decimals byte mismatch");
     }
 
     function testSupportsHostedControlInterfaces() public view {


### PR DESCRIPTION
## Summary
- narrow vault and access-control upgrade compatibility claims to the current `auralis.*` namespace baseline
- freeze vault and access-control storage layout assumptions in tests
- document that current persistence coverage proves same-namespace replace/remove/re-add behavior, not migration from older pre-public namespaces

## Validation
- forge test --offline --match-path test/AccessControlCore.t.sol
- forge test --offline --match-path test/VaultFacetFoundationCore.t.sol
- forge test --offline --match-path test/ERC4626VaultFacetCore.t.sol
- forge test --offline --match-path test/ERC4626VaultControlsFacetCore.t.sol
- forge test --offline --match-path test/ERC4626VaultIntegrationFacetCore.t.sol
- forge test --offline --match-path test/DiamondVaultHostHardening.t.sol
- forge test --offline --match-path test/DiamondNativeVaultHostHardening.t.sol
- forge fmt --check
- forge build --skip test

Closes #212