### PR TITLE
[audit] Verify ERC20 storage layout upgrade safety

### DIFF
--- a/docs/token-facets.md
+++ b/docs/token-facets.md
@@ -172,17 +172,33 @@ storage level. The repo still deploys them as separate hosts because the raw
 selector surfaces collide.
 
 Hosted token state lives in the diamond, not in the facet contract bytecode.
-That means the supported replace/remove/re-add flows preserve state as long as:
+For ERC20, the supported replace/remove/re-add flows are only claimed for
+deployments already created on the current
+`keccak256("auralis.token.erc20.storage")` namespace baseline. Older pre-public
+deployments created before the Permit/domain layout expansion or before the
+`smart-contracts.token.erc20.storage` to `auralis.token.erc20.storage`
+namespace rename are not claimed as in-place upgrade compatible and should be
+treated as redeploy-or-migrate surfaces if they ever matter.
+
+That means the supported ERC20 replace/remove/re-add flows preserve state as
+long as:
 
 - the replacement facet preserves the same storage layout
 - the relevant selectors are reinstalled
 - the upgrade does not rely on re-initialization
 
-Current hardening coverage explicitly validates persistence for:
+Current hardening coverage explicitly validates same-namespace ERC20
+persistence in `test/DiamondTokenHostHardening.t.sol` for:
 
 - ERC20 balances, allowances, Permit nonces, roles, and pause state
+
+The same hardening suite also validates ERC721 non-layout persistence for:
+
 - ERC721 ownership, approvals, operator approvals, metadata, roles, and pause
   state
+
+ERC721 storage-layout freezing is tracked separately. The narrowed storage
+compatibility claim in this section applies to ERC20 only.
 
 ## Selector Ownership Model
 
@@ -236,6 +252,9 @@ The ERC721 host exposes:
 - No selector namespacing is used.
 - Re-initialization is not part of replace/remove/re-add flows.
 - Facet upgrades must preserve storage layout and hosted selector intent.
+- ERC20 storage-layout compatibility claims in this document are limited to the
+  current `auralis.token.erc20.storage` baseline.
+- ERC721 storage-layout compatibility is separate follow-up work.
 - Shared control selectors are treated as part of the token host surface, not as
   independent infrastructure selectors.
 

--- a/test/ERC20TokenFacetCore.t.sol
+++ b/test/ERC20TokenFacetCore.t.sol
@@ -7,6 +7,7 @@ import {IERC20TokenBase} from "../src/interfaces/IERC20TokenBase.sol";
 import {IERC20TokenFacet} from "../src/interfaces/IERC20TokenFacet.sol";
 import {IPausable} from "../src/interfaces/IPausable.sol";
 import {IERC165} from "../src/interfaces/IERC165.sol";
+import {LibERC20TokenStorage} from "../src/token/storage/LibERC20TokenStorage.sol";
 import {ERC20TokenFacetFixture} from "./helpers/ERC20TokenFacetTestHarness.sol";
 
 contract ERC20TokenFacetCoreTest is ERC20TokenFacetFixture {
@@ -338,6 +339,53 @@ contract ERC20TokenFacetCoreTest is ERC20TokenFacetFixture {
         assertTrue(
             IERC20TokenFacet(address(facet)).DOMAIN_SEPARATOR() == expectedSeparator, "domain separator mismatch"
         );
+    }
+
+    function testErc20PermitStorageLayoutRemainsFrozen() public {
+        _erc20Init(address(facet));
+
+        VM.prank(admin);
+        IERC20TokenFacet(address(facet)).mint(bob, 100);
+
+        VM.prank(bob);
+        IERC20TokenFacet(address(facet)).approve(eve, 45);
+
+        uint256 deadline = block.timestamp + 1 days;
+        (uint8 v, bytes32 r, bytes32 s) = _signPermit(BOB_PK, address(facet), bob, dave, 77, 0, deadline);
+        IERC20TokenFacet(address(facet)).permit(bob, dave, 77, deadline, v, r, s);
+
+        bytes32 baseSlot = LibERC20TokenStorage.STORAGE_SLOT;
+        assertTrue(baseSlot == keccak256("auralis.token.erc20.storage"), "erc20 storage slot mismatch");
+        assertTrue(
+            VM.load(address(facet), bytes32(uint256(baseSlot) + 3)) == keccak256(bytes("Facet Token")),
+            "erc20 hashed name slot mismatch"
+        );
+        assertTrue(
+            VM.load(address(facet), bytes32(uint256(baseSlot) + 5)) == bytes32(uint256(block.chainid)),
+            "erc20 cached chain id slot mismatch"
+        );
+        assertTrue(
+            VM.load(address(facet), bytes32(uint256(baseSlot) + 6))
+                == IERC20TokenFacet(address(facet)).DOMAIN_SEPARATOR(),
+            "erc20 cached domain separator slot mismatch"
+        );
+
+        bytes32 balanceSlot = keccak256(abi.encode(bob, uint256(baseSlot) + 7));
+        assertTrue(VM.load(address(facet), balanceSlot) == bytes32(uint256(100)), "erc20 facet balance slot mismatch");
+
+        bytes32 allowanceOwnerBase = keccak256(abi.encode(bob, uint256(baseSlot) + 8));
+        bytes32 approvalSlot = keccak256(abi.encode(eve, uint256(allowanceOwnerBase)));
+        assertTrue(
+            VM.load(address(facet), approvalSlot) == bytes32(uint256(45)), "erc20 approval allowance slot mismatch"
+        );
+
+        bytes32 permitAllowanceSlot = keccak256(abi.encode(dave, uint256(allowanceOwnerBase)));
+        assertTrue(
+            VM.load(address(facet), permitAllowanceSlot) == bytes32(uint256(77)), "erc20 permit allowance slot mismatch"
+        );
+
+        bytes32 nonceSlot = keccak256(abi.encode(bob, uint256(baseSlot) + 9));
+        assertTrue(VM.load(address(facet), nonceSlot) == bytes32(uint256(1)), "erc20 nonce slot mismatch");
     }
 
     function testPermitRespectsApprovalPauseScope() public {

--- a/test/TokenFacetFoundationCore.t.sol
+++ b/test/TokenFacetFoundationCore.t.sol
@@ -7,6 +7,7 @@ import {IERC721} from "../src/interfaces/IERC721.sol";
 import {IERC721Metadata} from "../src/interfaces/IERC721Metadata.sol";
 import {IERC721Receiver} from "../src/interfaces/IERC721Receiver.sol";
 import {IERC721TokenBase} from "../src/interfaces/IERC721TokenBase.sol";
+import {LibERC20TokenStorage} from "../src/token/storage/LibERC20TokenStorage.sol";
 import {TokenFacetFoundationFixture} from "./helpers/TokenFacetFoundationTestHarness.sol";
 
 contract TokenFacetFoundationCoreTest is TokenFacetFoundationFixture {
@@ -18,6 +19,40 @@ contract TokenFacetFoundationCoreTest is TokenFacetFoundationFixture {
         assertTrue(erc20StorageSlot() != erc721StorageSlot(), "token storage slots should differ");
         assertTrue(tokenAdminRole() != erc20MinterRole(), "token roles should differ");
         assertTrue(erc20TransferScope() != erc721ApprovalScope(), "token pause scopes should differ");
+    }
+
+    function testErc20StorageSlotAndLayoutRemainFrozen() public {
+        bytes32 baseSlot = LibERC20TokenStorage.STORAGE_SLOT;
+        assertTrue(baseSlot == keccak256("auralis.token.erc20.storage"), "erc20 storage slot mismatch");
+
+        erc20.initialize("Facet Token", "FTKN", 18);
+        erc20.mint(admin, 100);
+        erc20.approveTokens(admin, bob, 40);
+
+        bytes32 packedSlot0 = VM.load(address(erc20), baseSlot);
+        assertTrue(uint8(uint256(packedSlot0)) == 1, "erc20 initialized offset mismatch");
+        // Decimals intentionally uses 18 here so a bool<uint8 field swap cannot pass accidentally.
+        assertTrue(uint8(uint256(packedSlot0 >> 8)) == 18, "erc20 decimals offset mismatch");
+
+        assertTrue(
+            VM.load(address(erc20), bytes32(uint256(baseSlot) + 1)) == _shortStringSlot("Facet Token"),
+            "erc20 name slot mismatch"
+        );
+        assertTrue(
+            VM.load(address(erc20), bytes32(uint256(baseSlot) + 2)) == _shortStringSlot("FTKN"),
+            "erc20 symbol slot mismatch"
+        );
+        assertTrue(
+            VM.load(address(erc20), bytes32(uint256(baseSlot) + 4)) == bytes32(uint256(100)),
+            "erc20 total supply slot mismatch"
+        );
+
+        bytes32 balanceSlot = keccak256(abi.encode(admin, uint256(baseSlot) + 7));
+        assertTrue(VM.load(address(erc20), balanceSlot) == bytes32(uint256(100)), "erc20 balance slot mismatch");
+
+        bytes32 allowanceOwnerBase = keccak256(abi.encode(admin, uint256(baseSlot) + 8));
+        bytes32 allowanceSlot = keccak256(abi.encode(bob, uint256(allowanceOwnerBase)));
+        assertTrue(VM.load(address(erc20), allowanceSlot) == bytes32(uint256(40)), "erc20 allowance slot mismatch");
     }
 
     function testErc20InitializerSetsMetadata() public {
@@ -197,5 +232,16 @@ contract TokenFacetFoundationCoreTest is TokenFacetFoundationFixture {
 
         VM.expectRevert(abi.encodeWithSelector(IERC721TokenBase.ERC721TokenInvalidOperator.selector, admin, admin));
         erc721.setApprovalForAll(admin, admin, true);
+    }
+
+    function _shortStringSlot(string memory value) internal pure returns (bytes32 slotValue) {
+        bytes memory data = bytes(value);
+        assertTrue(data.length <= 31, "short string expected");
+
+        assembly {
+            slotValue := mload(add(data, 32))
+        }
+
+        return bytes32((uint256(slotValue) & ~uint256(0xff)) | uint256(data.length * 2));
     }
 }


### PR DESCRIPTION
## Summary
- narrow ERC20 upgrade-compatibility claims to the current auralis storage baseline
- add storage-freeze regression coverage for the current ERC20 layout, permit cache, and nested allowance mapping
- preserve the existing token host hardening suite as the same-namespace persistence proof while explicitly separating ERC721 layout follow-up

## Testing
- forge test --offline --match-path test/TokenFacetFoundationCore.t.sol
- forge test --offline --match-path test/ERC20TokenFacetCore.t.sol
- forge test --offline --match-path test/DiamondTokenHostHardening.t.sol
- forge test --offline --match-path test/DiamondTokenDeploymentIntegration.t.sol
- forge fmt --check
- forge build --skip test

Refs #213