### PR TITLE
Define strategy totalAssets trust boundary

### DIFF
--- a/docs/erc4626-vault.md
+++ b/docs/erc4626-vault.md
@@ -165,6 +165,19 @@ vault entrypoints. This is the primary emergency stop for vault write paths.
 - `_mulDiv` uses direct `x * y` math, so unrealistic extreme values can overflow.
 - `totalManagedAssets` assumes integrators use canonical vault flows for
   accounting updates.
+- while `strategyDebt() != 0`, hosted live pricing intentionally trusts the
+  bound strategy's `totalAssets()` as a mark-to-market input.
+- trust in a strategy is established by the account holding
+  `VAULT_MANAGER_ROLE`; that role is responsible for reviewing, binding, and
+  reconciling strategies.
+- if a bound strategy's `totalAssets()` reverts, live-priced reads such as
+  `totalAssets()`, conversions, previews, `maxMint()`, `maxWithdraw()`, and
+  `maxRedeem()` are expected to revert rather than silently fall back to book
+  value.
+- the expected mark-to-market behavior is covered by
+  `testDirectStrategyProfitMakesPricingMarkToMarketAndExtendsLiquidity()` and
+  `testDirectStrategyLossMovesPricingDownwardAndCapsLiquidityByWithdrawableAssets()`
+  in `test/ERC4626VaultStrategyAccountingCore.t.sol`.
 - No native slippage parameters are present on ERC-4626 functions; integrators
   should pre-check previews and enforce client-side constraints.
 - The controls layer applies global limits, not per-user risk limits.

--- a/docs/erc7540-vault.md
+++ b/docs/erc7540-vault.md
@@ -218,6 +218,18 @@ reviewer needs to track.
   strategy before paying the receiver
 - `maxWithdraw` and `maxRedeem` do not promise access to full mark-to-market
   value when strategy liquidity is constrained
+- async host reads that depend on live pricing inherit the same strategy trust
+  boundary as the sync vault surface
+- in practice that means the hosted `totalAssets()` read and the async redeem
+  `maxWithdraw` / `maxRedeem` helpers revert when the bound strategy's
+  `totalAssets()` reverts while debt is active
+- async deposit claim helpers remain claimable-request views; `maxDeposit` stays
+  claimable-asset-based and `maxMint` remains claimable/book-priced rather than
+  consulting live strategy totals
+- because `maxMint` resolves through the deposit facet's book-pricing chain
+  while `convertToShares` resolves through the core facet's live-pricing
+  override, the two can disagree while strategy debt is active; integrators
+  that need a single-source share quote should prefer `convertToShares`
 
 ## Known Limitations
 
@@ -231,6 +243,9 @@ reviewer needs to track.
   settlement pricing
 - manager settlement is a trust and operations assumption that reviewers should
   evaluate alongside the role model
+- manager-controlled strategy binding is also a pricing trust assumption:
+  `VAULT_MANAGER_ROLE` decides which strategy is trusted for live mark-to-market
+  reads while debt is active
 
 ## Reviewer Entry Points
 
@@ -261,6 +276,10 @@ Use these suites to review the async request surface locally:
   claim, operator, limit, and settlement-pause behavior
 - `test/ERC7540VaultRedeemCore.t.sol`: async redeem request, settlement,
   claim, allowance/operator behavior, limit, and settlement-pause behavior
+- `testAsyncDepositClaimHelpersStayClaimableBasedWhileHostTotalAssetsStillReverts()`
+  in `test/ERC7540VaultDepositCore.t.sol`: async deposit claim-path boundary
+- `testAsyncRedeemMaxReadsInheritStrategyPricingRevert()` in
+  `test/ERC7540VaultRedeemCore.t.sol`: async redeem trust-boundary freeze
 - `test/DiamondVaultDeploymentIntegration.t.sol`: fully async host deployment,
   selector ownership, interface support, and strategy wiring
 - `test/DiamondVaultHostHardening.t.sol`: persistence across replace/remove

--- a/docs/vault-facets.md
+++ b/docs/vault-facets.md
@@ -333,6 +333,18 @@ Live pricing:
 - hosted `totalAssets()` is priced as:
   `idleAssets() + liveStrategyAssets()`
 
+Trust boundary:
+
+- while `strategyDebt() != 0`, the bound strategy is a trusted accounting
+  module for live pricing
+- that trust is established when the account with `VAULT_MANAGER_ROLE` binds or
+  keeps a strategy active
+- inflated, stale, or otherwise incorrect strategy totals intentionally affect
+  hosted pricing and previews until a manager action reconciles or removes the
+  strategy
+- if the strategy's `totalAssets()` reverts, hosted live-priced reads are
+  expected to revert rather than silently fall back to stored debt
+
 Operationally:
 
 - after deploys, book value stays constant and debt increases
@@ -344,6 +356,13 @@ Operationally:
 
 This means the hosted vault uses live strategy pricing for ERC-4626 conversions
 while still keeping explicit book accounting for deployed debt.
+
+Reference pricing coverage:
+
+- `testDirectStrategyProfitMakesPricingMarkToMarketAndExtendsLiquidity()` in
+  `test/ERC4626VaultStrategyAccountingCore.t.sol`
+- `testDirectStrategyLossMovesPricingDownwardAndCapsLiquidityByWithdrawableAssets()`
+  in `test/ERC4626VaultStrategyAccountingCore.t.sol`
 
 ## Async Request Model
 
@@ -447,8 +466,14 @@ are strategy-aware.
 
 - `maxDeposit()` and `maxMint()` remain strategy-aware through live `totalAssets()`
   pricing and limit shaping
-- `maxWithdraw()` and `maxRedeem()` are bounded by immediate liquidity, not by
-  total mark-to-market assets alone
+- on the sync ERC-4626 surface, `maxWithdraw()` and `maxRedeem()` remain
+  live-priced entitlement views, then cap that entitlement by
+  `_withdrawLiquidityCapAssets()`
+- when strategy debt is active, that view-layer cap consults live strategy
+  withdrawable assets and can revert if the strategy's `totalAssets()` quote
+  reverts
+- the same immediate-liquidity sourcing boundary is enforced during actual sync
+  `withdraw()` / `redeem()` execution
 - in native mode, immediate liquidity excludes untracked force-sent ETH above
   tracked idle assets
 - `maxWithdraw()` and `maxRedeem()` are zero when `totalAssets() == 0`, even if

--- a/src/interfaces/IERC4626VaultStrategy.sol
+++ b/src/interfaces/IERC4626VaultStrategy.sol
@@ -18,6 +18,8 @@ interface IERC4626VaultStrategy {
     function asset() external view returns (address);
 
     /// @notice Returns the strategy's total tracked assets.
+    /// @dev Hosted vault pricing treats this as a trusted mark-to-market input while strategy debt is active.
+    ///      Vault reads intentionally do not fall back to stored debt when this strategy quote reverts.
     /// @return The total tracked asset amount.
     function totalAssets() external view returns (uint256);
 

--- a/src/vault/facets/ERC4626VaultFacet.sol
+++ b/src/vault/facets/ERC4626VaultFacet.sol
@@ -196,6 +196,8 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
             return layout.totalManagedAssets;
         }
 
+        // The base vault path is pure book pricing. Once strategy debt is active, hosted pricing
+        // intentionally trusts the bound strategy's live assets and does not fall back to stored debt.
         uint256 idleBookAssets = layout.totalManagedAssets - layout.strategyDebt;
         uint256 liveStrategyAssets = IERC4626VaultStrategy(layout.strategy).totalAssets();
         return idleBookAssets + liveStrategyAssets;

--- a/src/vault/facets/ERC4626VaultIntegrationFacet.sol
+++ b/src/vault/facets/ERC4626VaultIntegrationFacet.sol
@@ -57,6 +57,8 @@ contract ERC4626VaultIntegrationFacet is
     }
 
     /// @notice Returns the configured strategy's live reported assets.
+    /// @dev This is the same trusted mark-to-market input used by hosted vault pricing while debt is active.
+    ///      If the bound strategy's quote reverts, callers are expected to handle the revert rather than a fallback price.
     /// @return The live strategy asset amount, or zero when no strategy is configured.
     function liveStrategyAssets() public view returns (uint256) {
         _requireInitialized();

--- a/test/ERC4626VaultStrategyAccountingCore.t.sol
+++ b/test/ERC4626VaultStrategyAccountingCore.t.sol
@@ -6,6 +6,7 @@ import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControl
 import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
 import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
 import {IERC7535VaultFacet} from "../src/interfaces/IERC7535VaultFacet.sol";
+import {MockVaultStrategyForcedRevert} from "./helpers/ERC4626VaultStrategyTestHarness.sol";
 import {ERC4626VaultStrategyAccountingFixture} from "./helpers/ERC4626VaultStrategyAccountingTestHarness.sol";
 
 contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountingFixture {
@@ -133,6 +134,52 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
         facet.withdraw(70, bob, bob);
     }
 
+    function testDirectRevertingStrategyMakesLiveSyncPricingReadsRevert() public {
+        _initializeDirectVault();
+        _approveAsset(bob, address(facet), DEPOSIT_ASSETS);
+
+        VM.prank(bob);
+        facet.deposit(DEPOSIT_ASSETS, bob);
+
+        _setDirectStrategy(directRevertingStrategy, STRATEGY_DEBT);
+        directRevertingStrategy.setRevertModes(true, false, false, false);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(MockVaultStrategyForcedRevert.selector, directRevertingStrategy.totalAssets.selector)
+        );
+        facet.totalAssets();
+
+        VM.expectRevert(
+            abi.encodeWithSelector(MockVaultStrategyForcedRevert.selector, directRevertingStrategy.totalAssets.selector)
+        );
+        facet.previewDeposit(10);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(MockVaultStrategyForcedRevert.selector, directRevertingStrategy.totalAssets.selector)
+        );
+        facet.previewMint(10);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(MockVaultStrategyForcedRevert.selector, directRevertingStrategy.totalAssets.selector)
+        );
+        facet.previewWithdraw(10);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(MockVaultStrategyForcedRevert.selector, directRevertingStrategy.totalAssets.selector)
+        );
+        facet.previewRedeem(10);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(MockVaultStrategyForcedRevert.selector, directRevertingStrategy.totalAssets.selector)
+        );
+        facet.maxWithdraw(bob);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(MockVaultStrategyForcedRevert.selector, directRevertingStrategy.totalAssets.selector)
+        );
+        facet.maxRedeem(bob);
+    }
+
     function testDiamondHostedVaultStrategyAccountingUsesRealLifecycleAndAutoPull() public {
         _installHostedVaultFacetsToDiamond();
         _initializeDiamondVault();
@@ -177,6 +224,91 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
         );
         assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 40, "managed assets mismatch");
         assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 40, "post-withdraw totalAssets mismatch");
+    }
+
+    function testDiamondHostedRevertingStrategyMakesLiveSyncPricingReadsRevert() public {
+        _installHostedVaultFacetsToDiamond();
+        _initializeDiamondVault();
+        _approveAsset(bob, address(diamond), DEPOSIT_ASSETS);
+
+        VM.prank(bob);
+        IERC4626VaultFacet(address(diamond)).deposit(DEPOSIT_ASSETS, bob);
+
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(address(diamondRevertingStrategy));
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).deployToStrategy(STRATEGY_DEBT);
+        diamondRevertingStrategy.setRevertModes(true, false, false, false);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                MockVaultStrategyForcedRevert.selector, diamondRevertingStrategy.totalAssets.selector
+            )
+        );
+        IERC4626VaultFacet(address(diamond)).totalAssets();
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                MockVaultStrategyForcedRevert.selector, diamondRevertingStrategy.totalAssets.selector
+            )
+        );
+        IERC4626VaultFacet(address(diamond)).previewDeposit(10);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                MockVaultStrategyForcedRevert.selector, diamondRevertingStrategy.totalAssets.selector
+            )
+        );
+        IERC4626VaultFacet(address(diamond)).previewMint(10);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                MockVaultStrategyForcedRevert.selector, diamondRevertingStrategy.totalAssets.selector
+            )
+        );
+        IERC4626VaultFacet(address(diamond)).previewWithdraw(10);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                MockVaultStrategyForcedRevert.selector, diamondRevertingStrategy.totalAssets.selector
+            )
+        );
+        IERC4626VaultFacet(address(diamond)).previewRedeem(10);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                MockVaultStrategyForcedRevert.selector, diamondRevertingStrategy.totalAssets.selector
+            )
+        );
+        IERC4626VaultFacet(address(diamond)).maxWithdraw(bob);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                MockVaultStrategyForcedRevert.selector, diamondRevertingStrategy.totalAssets.selector
+            )
+        );
+        IERC4626VaultFacet(address(diamond)).maxRedeem(bob);
+    }
+
+    function testDiamondHostedConfiguredRevertingStrategyWithZeroDebtKeepsBookPricingAvailable() public {
+        _installHostedVaultFacetsToDiamond();
+        _initializeDiamondVault();
+        _approveAsset(bob, address(diamond), DEPOSIT_ASSETS);
+
+        VM.prank(bob);
+        IERC4626VaultFacet(address(diamond)).deposit(DEPOSIT_ASSETS, bob);
+
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(address(diamondRevertingStrategy));
+        diamondRevertingStrategy.setRevertModes(true, false, false, false);
+
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == DEPOSIT_ASSETS, "book pricing mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewDeposit(10) == 10, "previewDeposit mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewMint(10) == 10, "previewMint mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewWithdraw(10) == 10, "previewWithdraw mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewRedeem(10) == 10, "previewRedeem mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxWithdraw(bob) == DEPOSIT_ASSETS, "maxWithdraw mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxRedeem(bob) == DEPOSIT_ASSETS, "maxRedeem mismatch");
     }
 
     function testDiamondNativeHostedVaultStrategyAccountingUsesRealLifecycleAndAutoPull() public {
@@ -227,6 +359,70 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
         assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 40, "managed assets mismatch");
         assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 40, "post-withdraw totalAssets mismatch");
         assertTrue(address(diamond).balance == 0, "vault idle balance should be exhausted");
+    }
+
+    function testDiamondNativeHostedRevertingStrategyMakesLiveSyncPricingReadsRevert() public {
+        _installHostedVaultNativeFacetsToDiamond();
+        _initializeDiamondNativeVault();
+        VM.deal(bob, INITIAL_ASSETS);
+
+        VM.prank(bob);
+        IERC7535VaultFacet(address(diamond)).depositNative{value: DEPOSIT_ASSETS}(bob);
+
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(address(diamondNativeRevertingStrategy));
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).deployToStrategy(STRATEGY_DEBT);
+        diamondNativeRevertingStrategy.setRevertModes(true, false, false, false);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                MockVaultStrategyForcedRevert.selector, diamondNativeRevertingStrategy.totalAssets.selector
+            )
+        );
+        IERC4626VaultFacet(address(diamond)).totalAssets();
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                MockVaultStrategyForcedRevert.selector, diamondNativeRevertingStrategy.totalAssets.selector
+            )
+        );
+        IERC4626VaultFacet(address(diamond)).previewDeposit(10);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                MockVaultStrategyForcedRevert.selector, diamondNativeRevertingStrategy.totalAssets.selector
+            )
+        );
+        IERC4626VaultFacet(address(diamond)).previewMint(10);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                MockVaultStrategyForcedRevert.selector, diamondNativeRevertingStrategy.totalAssets.selector
+            )
+        );
+        IERC4626VaultFacet(address(diamond)).previewWithdraw(10);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                MockVaultStrategyForcedRevert.selector, diamondNativeRevertingStrategy.totalAssets.selector
+            )
+        );
+        IERC4626VaultFacet(address(diamond)).previewRedeem(10);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                MockVaultStrategyForcedRevert.selector, diamondNativeRevertingStrategy.totalAssets.selector
+            )
+        );
+        IERC4626VaultFacet(address(diamond)).maxWithdraw(bob);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                MockVaultStrategyForcedRevert.selector, diamondNativeRevertingStrategy.totalAssets.selector
+            )
+        );
+        IERC4626VaultFacet(address(diamond)).maxRedeem(bob);
     }
 
     function testDiamondNativeRedeemAutoPullsAndReturnsCurrentShareValue() public {

--- a/test/ERC7540VaultDepositCore.t.sol
+++ b/test/ERC7540VaultDepositCore.t.sol
@@ -6,12 +6,14 @@ import {IERC4626} from "../src/interfaces/IERC4626.sol";
 import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol";
 import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControlsFacet.sol";
 import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
+import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
 import {IERC7540Deposit} from "../src/interfaces/IERC7540Deposit.sol";
 import {IERC7540Operators} from "../src/interfaces/IERC7540Operators.sol";
 import {IERC7540VaultSettlementFacet} from "../src/interfaces/IERC7540VaultSettlementFacet.sol";
 import {IPausable} from "../src/interfaces/IPausable.sol";
 import {ERC7540VaultDepositFacet} from "../src/vault/facets/ERC7540VaultDepositFacet.sol";
 import {ERC4626VaultFacetFixture} from "./helpers/ERC4626VaultFacetTestHarness.sol";
+import {MockVaultStrategyForcedRevert, RevertingMockVaultStrategy} from "./helpers/ERC4626VaultStrategyTestHarness.sol";
 
 contract ERC7540VaultDepositCoreTest is ERC4626VaultFacetFixture {
     function _initializeDiamondAsyncVault() internal {
@@ -93,6 +95,37 @@ contract ERC7540VaultDepositCoreTest is ERC4626VaultFacetFixture {
         assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 25, "total assets mismatch");
         assertTrue(IERC4626(address(diamond)).balanceOf(eve) == 25, "receiver share balance mismatch");
         assertTrue(asset.balanceOf(address(diamond)) == 40, "vault balance should keep locked assets");
+    }
+
+    function testAsyncDepositClaimHelpersStayClaimableBasedWhileHostTotalAssetsStillReverts() public {
+        _initializeDiamondAsyncVault();
+        _approveAsset(bob, address(diamond), 100);
+
+        VM.prank(bob);
+        IERC7540Deposit(address(diamond)).requestDeposit(60, bob, bob);
+        _settleDeposit(bob, 60);
+
+        VM.prank(bob);
+        IERC4626(address(diamond)).deposit(40, bob);
+
+        RevertingMockVaultStrategy revertingStrategy = new RevertingMockVaultStrategy(address(diamond), address(asset));
+
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(address(revertingStrategy));
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).deployToStrategy(20);
+        revertingStrategy.setRevertModes(true, false, false, false);
+
+        VM.prank(bob);
+        assertTrue(IERC4626(address(diamond)).maxDeposit(bob) == 20, "maxDeposit should remain claimable-only");
+
+        VM.prank(bob);
+        assertTrue(IERC4626(address(diamond)).maxMint(bob) == 20, "maxMint should remain claimable/book priced");
+
+        VM.expectRevert(
+            abi.encodeWithSelector(MockVaultStrategyForcedRevert.selector, revertingStrategy.totalAssets.selector)
+        );
+        IERC4626(address(diamond)).totalAssets();
     }
 
     function testOnlyManagerCanSettleAsyncDepositRequests() public {

--- a/test/ERC7540VaultRedeemCore.t.sol
+++ b/test/ERC7540VaultRedeemCore.t.sol
@@ -7,6 +7,7 @@ import {IERC4626VaultBase} from "../src/interfaces/IERC4626VaultBase.sol";
 import {IERC4626VaultControls} from "../src/interfaces/IERC4626VaultControls.sol";
 import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControlsFacet.sol";
 import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
+import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
 import {IERC7540Deposit} from "../src/interfaces/IERC7540Deposit.sol";
 import {IERC7540Operators} from "../src/interfaces/IERC7540Operators.sol";
 import {IERC7540Redeem} from "../src/interfaces/IERC7540Redeem.sol";
@@ -14,6 +15,7 @@ import {IERC7540VaultSettlementFacet} from "../src/interfaces/IERC7540VaultSettl
 import {IPausable} from "../src/interfaces/IPausable.sol";
 import {ERC7540VaultRedeemFacet} from "../src/vault/facets/ERC7540VaultRedeemFacet.sol";
 import {ERC4626VaultFacetFixture} from "./helpers/ERC4626VaultFacetTestHarness.sol";
+import {MockVaultStrategyForcedRevert, RevertingMockVaultStrategy} from "./helpers/ERC4626VaultStrategyTestHarness.sol";
 
 contract ERC7540VaultRedeemCoreTest is ERC4626VaultFacetFixture {
     function _initializeDiamondFullAsyncVault() internal {
@@ -113,6 +115,34 @@ contract ERC7540VaultRedeemCoreTest is ERC4626VaultFacetFixture {
         assertTrue(IERC4626(address(diamond)).balanceOf(address(diamond)) == 15, "escrow share balance mismatch");
         assertTrue(IERC4626(address(diamond)).totalSupply() == 55, "share supply mismatch");
         assertTrue(asset.balanceOf(eve) == eveAssetsBefore + 25, "receiver asset balance mismatch");
+    }
+
+    function testAsyncRedeemMaxReadsInheritStrategyPricingRevert() public {
+        _initializeDiamondFullAsyncVault();
+        _seedClaimedShares(bob, 80);
+
+        RevertingMockVaultStrategy revertingStrategy = new RevertingMockVaultStrategy(address(diamond), address(asset));
+
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(address(revertingStrategy));
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).deployToStrategy(40);
+
+        VM.prank(bob);
+        IERC7540Redeem(address(diamond)).requestRedeem(40, bob, bob);
+        _settleRedeem(bob, 25);
+
+        revertingStrategy.setRevertModes(true, false, false, false);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(MockVaultStrategyForcedRevert.selector, revertingStrategy.totalAssets.selector)
+        );
+        IERC4626(address(diamond)).maxWithdraw(bob);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(MockVaultStrategyForcedRevert.selector, revertingStrategy.totalAssets.selector)
+        );
+        IERC4626(address(diamond)).maxRedeem(bob);
     }
 
     function testOnlyManagerCanSettleAsyncRedeemRequests() public {

--- a/test/helpers/ERC4626VaultStrategyAccountingTestHarness.sol
+++ b/test/helpers/ERC4626VaultStrategyAccountingTestHarness.sol
@@ -5,7 +5,6 @@ import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
 import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
 import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
 import {IERC4626VaultFacet} from "../../src/interfaces/IERC4626VaultFacet.sol";
-import {IERC4626VaultIntegrationFacet} from "../../src/interfaces/IERC4626VaultIntegrationFacet.sol";
 import {IERC4626VaultStrategy} from "../../src/interfaces/IERC4626VaultStrategy.sol";
 import {ERC7535VaultFacet} from "../../src/vault/facets/ERC7535VaultFacet.sol";
 import {LibVaultAsset} from "../../src/vault/libraries/LibVaultAsset.sol";
@@ -21,7 +20,9 @@ import {
     LossShortfallMockVaultStrategy,
     NativeLossShortfallMockVaultStrategy,
     NativeProfitMockVaultStrategy,
-    ProfitMockVaultStrategy
+    NativeRevertingMockVaultStrategy,
+    ProfitMockVaultStrategy,
+    RevertingMockVaultStrategy
 } from "./ERC4626VaultStrategyTestHarness.sol";
 
 contract ERC4626VaultStrategyAccountingInitMock {
@@ -52,9 +53,12 @@ abstract contract ERC4626VaultStrategyAccountingFixture is TestBase {
     ERC4626VaultStrategyAccountingInitMock internal accountingInit;
     ProfitMockVaultStrategy internal directProfitStrategy;
     LossShortfallMockVaultStrategy internal directLossStrategy;
+    RevertingMockVaultStrategy internal directRevertingStrategy;
     ProfitMockVaultStrategy internal diamondProfitStrategy;
+    RevertingMockVaultStrategy internal diamondRevertingStrategy;
     NativeProfitMockVaultStrategy internal diamondNativeProfitStrategy;
     NativeLossShortfallMockVaultStrategy internal diamondNativeLossStrategy;
+    NativeRevertingMockVaultStrategy internal diamondNativeRevertingStrategy;
 
     function setUp() public virtual {
         asset = new ReentrantMockVaultAsset();
@@ -68,9 +72,12 @@ abstract contract ERC4626VaultStrategyAccountingFixture is TestBase {
         accountingInit = new ERC4626VaultStrategyAccountingInitMock();
         directProfitStrategy = new ProfitMockVaultStrategy(address(facet), address(asset));
         directLossStrategy = new LossShortfallMockVaultStrategy(address(facet), address(asset));
+        directRevertingStrategy = new RevertingMockVaultStrategy(address(facet), address(asset));
         diamondProfitStrategy = new ProfitMockVaultStrategy(address(diamond), address(asset));
+        diamondRevertingStrategy = new RevertingMockVaultStrategy(address(diamond), address(asset));
         diamondNativeProfitStrategy = new NativeProfitMockVaultStrategy(address(diamond));
         diamondNativeLossStrategy = new NativeLossShortfallMockVaultStrategy(address(diamond));
+        diamondNativeRevertingStrategy = new NativeRevertingMockVaultStrategy(address(diamond));
 
         asset.mint(bob, INITIAL_ASSETS);
         asset.mint(eve, INITIAL_ASSETS);


### PR DESCRIPTION
## Summary
- Document the trusted strategy totalAssets pricing boundary for hosted vaults
- Add truthfulness comments at the live pricing and strategy quote surfaces
- Add regression coverage for reverting strategy quotes across sync, hosted, native, and ERC-7540 async surfaces

## Verification
- forge test --offline --match-path test/ERC4626VaultStrategyAccountingCore.t.sol
- forge test --offline --match-path test/ERC7540VaultDepositCore.t.sol
- forge test --offline --match-path test/ERC7540VaultRedeemCore.t.sol
- forge test --offline --match-path test/ERC4626VaultIntegrationFacetCore.t.sol
- forge test --offline --match-path test/DiamondVaultHostHardening.t.sol
- forge test --offline --match-path test/DiamondNativeVaultHostHardening.t.sol
- forge fmt --check
- forge build --skip test