### PR TITLE
Align native vault pricing with live strategy assets

### DIFF
--- a/docs/adr/0004-native-sentinel-and-facet.md
+++ b/docs/adr/0004-native-sentinel-and-facet.md
@@ -26,6 +26,8 @@ entrypoints such as `depositNative` and `mintNative` live on the native facet.
 - Native mode remains explicit in routing, selector ownership, and review.
 - Native-specific semantics such as exact `msg.value` handling do not leak into
   the standard selector surface.
+- Native selector ownership is separate, but native deposit/mint share pricing
+  stays aligned with the hosted core facet's live strategy pricing.
 - Hosted native deployments must install and validate one additional facet.
 
 ## Related Docs/Tests

--- a/docs/erc4626-vault.md
+++ b/docs/erc4626-vault.md
@@ -194,6 +194,8 @@ Implications:
   `NATIVE_ASSET_SENTINEL`; there is no separate native-only initializer.
 - native funding, exact `msg.value` validation, and raw native payouts are
   documented in `docs/vault-facets.md`.
+- native `depositNative` and `mintNative` share the hosted core facet's live
+  strategy pricing boundary while strategy debt is active.
 - async request flows, settlement, and controller/operator semantics are
   documented in `docs/erc7540-vault.md`.
 - forced native transfers are a hosted-vault accounting concern, not a

--- a/docs/vault-facets.md
+++ b/docs/vault-facets.md
@@ -406,12 +406,17 @@ Native hosted vaults use the ERC-7535-style entry surface for asset-in flows.
 - caller sends raw native asset as `msg.value`
 - shares are minted from the same fee/limit/pause logic used by hosted
   `deposit`
+- share pricing uses the same live strategy-aware accounting as the hosted
+  ERC-4626 core facet, so active strategy debt prices native deposits from
+  tracked idle assets plus the strategy's `totalAssets()`
 - the vault asset remains the sentinel address, not wrapped native token state
 
 #### `mintNative(shares, receiver)`
 
 - caller requests exact `shares`
 - the vault computes the gross native assets required under current fee logic
+- the gross native asset requirement uses the same live strategy-aware pricing
+  as hosted ERC-4626 `mint`
 - `msg.value` must equal that required gross amount exactly
 - underpayment reverts
 - overpayment also reverts

--- a/src/vault/ERC4626VaultStrategyPricing.sol
+++ b/src/vault/ERC4626VaultStrategyPricing.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC4626VaultStrategy} from "../interfaces/IERC4626VaultStrategy.sol";
+import {ERC4626VaultControlledCore} from "./ERC4626VaultControlLogic.sol";
+import {LibERC4626VaultStorage} from "./storage/LibERC4626VaultStorage.sol";
+
+/// @title ERC4626VaultStrategyPricing
+/// @notice Shared hosted-vault live strategy pricing hooks.
+abstract contract ERC4626VaultStrategyPricing is ERC4626VaultControlledCore {
+    function _managedAssetsForPricing() internal view virtual override returns (uint256) {
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        if (layout.strategyDebt == 0) {
+            return layout.totalManagedAssets;
+        }
+
+        // Native asset-in selectors live on ERC7535VaultFacet, so hosted pricing stays shared here
+        // to keep native and ERC-20 deposits aligned when strategy debt is active. Hosted pricing also
+        // intentionally trusts the bound strategy's live assets and does not fall back to stored debt
+        // when the strategy quote reverts.
+        uint256 idleBookAssets = layout.totalManagedAssets - layout.strategyDebt;
+        uint256 liveStrategyAssets = IERC4626VaultStrategy(layout.strategy).totalAssets();
+        return idleBookAssets + liveStrategyAssets;
+    }
+
+    function _withdrawLiquidityCapAssets() internal view virtual override returns (uint256) {
+        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
+        if (layout.strategyDebt == 0) {
+            return type(uint256).max;
+        }
+
+        return _trackedIdleAssetBalance() + _strategyWithdrawableAssets();
+    }
+}

--- a/src/vault/facets/ERC4626VaultFacet.sol
+++ b/src/vault/facets/ERC4626VaultFacet.sol
@@ -4,17 +4,17 @@ pragma solidity ^0.8.30;
 import {IERC4626} from "../../interfaces/IERC4626.sol";
 import {IERC4626VaultControls} from "../../interfaces/IERC4626VaultControls.sol";
 import {IERC4626VaultFacet} from "../../interfaces/IERC4626VaultFacet.sol";
-import {IERC4626VaultStrategy} from "../../interfaces/IERC4626VaultStrategy.sol";
 import {ERC4626Vault} from "../ERC4626Vault.sol";
 import {ERC4626VaultBase} from "../ERC4626VaultBase.sol";
-import {ERC4626VaultControlledCore, LibERC4626VaultControlLogic} from "../ERC4626VaultControlLogic.sol";
+import {LibERC4626VaultControlLogic} from "../ERC4626VaultControlLogic.sol";
+import {ERC4626VaultStrategyPricing} from "../ERC4626VaultStrategyPricing.sol";
 import {VaultFacetControl} from "../VaultFacetControl.sol";
 import {LibVaultAsset} from "../libraries/LibVaultAsset.sol";
 import {LibERC4626VaultStorage} from "../storage/LibERC4626VaultStorage.sol";
 
 /// @title ERC4626VaultFacet
 /// @notice Hosted ERC-4626 core facet with constructor-free initialization.
-contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IERC4626VaultFacet {
+contract ERC4626VaultFacet is ERC4626VaultStrategyPricing, VaultFacetControl, IERC4626VaultFacet {
     /// @notice Returns true when vault storage is initialized.
     /// @return True if initialized.
     function isVaultInitialized() public view virtual override(IERC4626VaultFacet, ERC4626VaultBase) returns (bool) {
@@ -188,28 +188,6 @@ contract ERC4626VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IER
         _payoutFee(feeAssets);
 
         emit Withdraw(msg.sender, receiver, owner, assets, shares);
-    }
-
-    function _managedAssetsForPricing() internal view virtual override returns (uint256) {
-        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
-        if (layout.strategyDebt == 0) {
-            return layout.totalManagedAssets;
-        }
-
-        // The base vault path is pure book pricing. Once strategy debt is active, hosted pricing
-        // intentionally trusts the bound strategy's live assets and does not fall back to stored debt.
-        uint256 idleBookAssets = layout.totalManagedAssets - layout.strategyDebt;
-        uint256 liveStrategyAssets = IERC4626VaultStrategy(layout.strategy).totalAssets();
-        return idleBookAssets + liveStrategyAssets;
-    }
-
-    function _withdrawLiquidityCapAssets() internal view virtual override returns (uint256) {
-        LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
-        if (layout.strategyDebt == 0) {
-            return type(uint256).max;
-        }
-
-        return _trackedIdleAssetBalance() + _strategyWithdrawableAssets();
     }
 
     function _vaultOperationsPaused() internal view virtual override returns (bool) {

--- a/src/vault/facets/ERC7535VaultFacet.sol
+++ b/src/vault/facets/ERC7535VaultFacet.sol
@@ -3,13 +3,13 @@ pragma solidity ^0.8.30;
 
 import {IERC7535VaultFacet} from "../../interfaces/IERC7535VaultFacet.sol";
 import {ERC4626Vault} from "../ERC4626Vault.sol";
-import {ERC4626VaultControlledCore} from "../ERC4626VaultControlLogic.sol";
+import {ERC4626VaultStrategyPricing} from "../ERC4626VaultStrategyPricing.sol";
 import {VaultFacetControl} from "../VaultFacetControl.sol";
 import {LibVaultAsset} from "../libraries/LibVaultAsset.sol";
 
 /// @title ERC7535VaultFacet
 /// @notice Hosted native-asset extension facet for ERC-7535-style vault entrypoints.
-contract ERC7535VaultFacet is ERC4626VaultControlledCore, VaultFacetControl, IERC7535VaultFacet {
+contract ERC7535VaultFacet is ERC4626VaultStrategyPricing, VaultFacetControl, IERC7535VaultFacet {
     /// @notice Deposits native asset and mints shares to `receiver`.
     /// @param receiver Receiver of minted shares.
     /// @return shares Minted shares.

--- a/test/ERC4626VaultStrategyAccountingCore.t.sol
+++ b/test/ERC4626VaultStrategyAccountingCore.t.sol
@@ -6,6 +6,7 @@ import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControl
 import {IERC4626VaultFacet} from "../src/interfaces/IERC4626VaultFacet.sol";
 import {IERC4626VaultIntegrationFacet} from "../src/interfaces/IERC4626VaultIntegrationFacet.sol";
 import {IERC7535VaultFacet} from "../src/interfaces/IERC7535VaultFacet.sol";
+import {ERC4626Vault} from "../src/vault/ERC4626Vault.sol";
 import {MockVaultStrategyForcedRevert} from "./helpers/ERC4626VaultStrategyTestHarness.sol";
 import {ERC4626VaultStrategyAccountingFixture} from "./helpers/ERC4626VaultStrategyAccountingTestHarness.sol";
 
@@ -359,6 +360,167 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
         assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 40, "managed assets mismatch");
         assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 40, "post-withdraw totalAssets mismatch");
         assertTrue(address(diamond).balance == 0, "vault idle balance should be exhausted");
+    }
+
+    function testDiamondNativeDepositUsesLiveStrategyPricingAfterProfit() public {
+        _installHostedVaultNativeFacetsToDiamond();
+        _initializeDiamondNativeVault();
+        VM.deal(bob, INITIAL_ASSETS);
+        VM.deal(eve, INITIAL_ASSETS);
+        VM.deal(address(this), 20);
+
+        VM.prank(bob);
+        IERC7535VaultFacet(address(diamond)).depositNative{value: DEPOSIT_ASSETS}(bob);
+
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(address(diamondNativeProfitStrategy));
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).deployToStrategy(60);
+        diamondNativeProfitStrategy.injectProfit{value: 20}();
+
+        uint256 depositAssets = 12;
+        uint256 expectedShares = IERC4626VaultFacet(address(diamond)).previewDeposit(depositAssets);
+
+        VM.prank(eve);
+        uint256 mintedShares = IERC7535VaultFacet(address(diamond)).depositNative{value: depositAssets}(eve);
+
+        assertTrue(expectedShares == 10, "fixture should expose non-1:1 live pricing");
+        assertTrue(mintedShares == expectedShares, "native deposit should match live-priced previewDeposit");
+    }
+
+    function testDiamondNativeMintUsesLiveStrategyPricingAfterProfit() public {
+        _installHostedVaultNativeFacetsToDiamond();
+        _initializeDiamondNativeVault();
+        VM.deal(bob, INITIAL_ASSETS);
+        VM.deal(eve, INITIAL_ASSETS);
+        VM.deal(address(this), 20);
+
+        VM.prank(bob);
+        IERC7535VaultFacet(address(diamond)).depositNative{value: DEPOSIT_ASSETS}(bob);
+
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(address(diamondNativeProfitStrategy));
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).deployToStrategy(60);
+        diamondNativeProfitStrategy.injectProfit{value: 20}();
+
+        uint256 mintShares = 10;
+        uint256 expectedAssets = IERC4626VaultFacet(address(diamond)).previewMint(mintShares);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                ERC4626Vault.ERC4626VaultInvalidNativeAssetValue.selector, expectedAssets - 1, expectedAssets
+            )
+        );
+        VM.prank(eve);
+        IERC7535VaultFacet(address(diamond)).mintNative{value: expectedAssets - 1}(mintShares, eve);
+
+        VM.prank(eve);
+        uint256 consumedAssets = IERC7535VaultFacet(address(diamond)).mintNative{value: expectedAssets}(mintShares, eve);
+
+        assertTrue(expectedAssets == 12, "fixture should expose non-1:1 live pricing");
+        assertTrue(consumedAssets == expectedAssets, "native mint should match live-priced previewMint");
+    }
+
+    function testDiamondNativeDepositAndMintUseLiveStrategyPricingAfterLoss() public {
+        _installHostedVaultNativeFacetsToDiamond();
+        _initializeDiamondNativeVault();
+        VM.deal(bob, INITIAL_ASSETS);
+        VM.deal(eve, INITIAL_ASSETS);
+
+        VM.prank(bob);
+        IERC7535VaultFacet(address(diamond)).depositNative{value: DEPOSIT_ASSETS}(bob);
+
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(address(diamondNativeLossStrategy));
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).deployToStrategy(60);
+        diamondNativeLossStrategy.applyLoss(30, 10);
+
+        uint256 depositAssets = 14;
+        uint256 bookOnlyShares = depositAssets;
+        uint256 expectedShares = IERC4626VaultFacet(address(diamond)).previewDeposit(depositAssets);
+
+        VM.prank(eve);
+        uint256 mintedShares = IERC7535VaultFacet(address(diamond)).depositNative{value: depositAssets}(eve);
+
+        assertTrue(expectedShares > bookOnlyShares, "loss should increase shares per deposited asset");
+        assertTrue(mintedShares == expectedShares, "native deposit should match loss-adjusted previewDeposit");
+
+        uint256 mintShares = 10;
+        uint256 bookOnlyAssets = mintShares;
+        uint256 expectedAssets = IERC4626VaultFacet(address(diamond)).previewMint(mintShares);
+
+        VM.prank(eve);
+        uint256 consumedAssets = IERC7535VaultFacet(address(diamond)).mintNative{value: expectedAssets}(mintShares, eve);
+
+        assertTrue(expectedAssets < bookOnlyAssets, "loss should reduce required assets per minted share");
+        assertTrue(consumedAssets == expectedAssets, "native mint should match loss-adjusted previewMint");
+    }
+
+    function testDiamondNativeDepositAndMintRevertWhenLiveStrategyQuoteReverts() public {
+        _installHostedVaultNativeFacetsToDiamond();
+        _initializeDiamondNativeVault();
+        VM.deal(bob, INITIAL_ASSETS);
+        VM.deal(eve, INITIAL_ASSETS);
+
+        VM.prank(bob);
+        IERC7535VaultFacet(address(diamond)).depositNative{value: DEPOSIT_ASSETS}(bob);
+
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(address(diamondNativeRevertingStrategy));
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).deployToStrategy(STRATEGY_DEBT);
+        diamondNativeRevertingStrategy.setRevertModes(true, false, false, false);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                MockVaultStrategyForcedRevert.selector, diamondNativeRevertingStrategy.totalAssets.selector
+            )
+        );
+        VM.prank(eve);
+        IERC7535VaultFacet(address(diamond)).depositNative{value: 10}(eve);
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                MockVaultStrategyForcedRevert.selector, diamondNativeRevertingStrategy.totalAssets.selector
+            )
+        );
+        VM.prank(eve);
+        IERC7535VaultFacet(address(diamond)).mintNative{value: 10}(10, eve);
+    }
+
+    function testDiamondNativeDepositInternalCapUsesLiveStrategyPricing() public {
+        _installHostedVaultNativeFacetsToDiamond();
+        _initializeDiamondNativeVault();
+        VM.deal(bob, INITIAL_ASSETS);
+        VM.deal(eve, INITIAL_ASSETS);
+        VM.deal(address(this), 20);
+
+        VM.prank(bob);
+        IERC7535VaultFacet(address(diamond)).depositNative{value: DEPOSIT_ASSETS}(bob);
+
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(address(diamondNativeProfitStrategy));
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).deployToStrategy(60);
+        diamondNativeProfitStrategy.injectProfit{value: 20}();
+
+        VM.prank(admin);
+        IERC4626VaultControlsFacet(address(diamond)).setLimitConfig(125, 0, 0, 0, 0);
+
+        uint256 livePricedCap = IERC4626VaultFacet(address(diamond)).maxDeposit(eve);
+        uint256 amountAboveCap = livePricedCap + 1;
+
+        assertTrue(livePricedCap == 5, "external maxDeposit should use live strategy pricing");
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IERC4626VaultControls.ERC4626VaultDepositLimitExceeded.selector, amountAboveCap, livePricedCap
+            )
+        );
+        VM.prank(eve);
+        IERC7535VaultFacet(address(diamond)).depositNative{value: amountAboveCap}(eve);
     }
 
     function testDiamondNativeHostedRevertingStrategyMakesLiveSyncPricingReadsRevert() public {


### PR DESCRIPTION
## Summary
- Move hosted live strategy pricing hooks into a shared internal abstract
- Make ERC7535 native deposit/mint paths use the same live pricing as the hosted ERC-4626 core facet
- Add native profit, loss, reverting quote, and internal cap parity regressions
- Update native vault docs and ADR to state pricing alignment

## Verification
- forge test --offline --match-path test/ERC4626VaultStrategyAccountingCore.t.sol
- forge test --offline --match-path test/ERC4626VaultFacetCore.t.sol
- forge test --offline --match-path test/ERC4626VaultControlsFacetCore.t.sol
- forge test --offline --match-path test/DiamondNativeVaultHostHardening.t.sol
- forge test --offline --match-path test/DiamondNativeVaultHostInvariant.t.sol
- forge fmt --check
- forge build --sizes --skip script