### PR TITLE
Fix redeem pricing after strategy liquidity sourcing

### DIFF
--- a/docs/erc4626-vault.md
+++ b/docs/erc4626-vault.md
@@ -123,7 +123,9 @@ Deposit and mint use deposit fee:
 Withdraw and redeem use withdraw fee:
 - `withdraw(assetsOut)`: requested net assets are grossed-up before share burn.
 - `redeem(shares)`: gross assets from shares are computed first, then net
-  receiver assets are derived by subtracting fee.
+  receiver assets are derived by subtracting fee. Hosted redeems recompute the
+  gross asset value after any strategy liquidity sourcing, so exact-share exits
+  settle at the post-sourcing price.
 
 Fee rounding:
 - Deposit fee on raw assets rounds down.
@@ -174,6 +176,9 @@ vault entrypoints. This is the primary emergency stop for vault write paths.
   `totalAssets()`, conversions, previews, `maxMint()`, `maxWithdraw()`, and
   `maxRedeem()` are expected to revert rather than silently fall back to book
   value.
+- `previewRedeem()` is a read-only pre-call quote; actual `redeem()` can return
+  a different asset amount when call-time strategy liquidity sourcing realizes
+  profit or loss before final settlement.
 - the expected mark-to-market behavior is covered by
   `testDirectStrategyProfitMakesPricingMarkToMarketAndExtendsLiquidity()` and
   `testDirectStrategyLossMovesPricingDownwardAndCapsLiquidityByWithdrawableAssets()`

--- a/docs/erc7540-vault.md
+++ b/docs/erc7540-vault.md
@@ -120,7 +120,9 @@ Fully async hosts extend the model to redeem requests:
    - `redeem(shares, receiver, controller)`
 5. Claiming consumes claimable shares, burns the escrowed shares, reduces
    managed assets by the gross asset exit amount, transfers the net assets to
-   the receiver, and pays any configured withdraw fee.
+   the receiver, and pays any configured withdraw fee. Exact-share redeem
+   claims recompute the gross asset value after strategy liquidity sourcing, so
+   claim settlement uses the post-sourcing share price.
 
 Reviewer-visible implications:
 
@@ -216,6 +218,9 @@ reviewer needs to track.
 
 - async redeem claims may pull immediately withdrawable assets from the active
   strategy before paying the receiver
+- exact-share `redeem(shares, receiver, controller)` claims settle at the
+  post-sourcing asset value if strategy withdrawal reconciles gain or loss
+  during the claim transaction
 - `maxWithdraw` and `maxRedeem` do not promise access to full mark-to-market
   value when strategy liquidity is constrained
 - async host reads that depend on live pricing inherit the same strategy trust

--- a/docs/vault-facets.md
+++ b/docs/vault-facets.md
@@ -462,10 +462,13 @@ are strategy-aware.
 ### `redeem(shares)`
 
 - exact-shares semantics are preserved
-- the vault burns the requested shares and returns the current post-loss asset
-  value of those shares
 - if strategy liquidity must be sourced first, the vault pulls it before final
   asset calculation and transfer
+- the vault burns the requested shares and returns the post-sourcing asset value
+  of those shares after any strategy gain/loss reconciliation performed during
+  the call
+- `previewRedeem()` remains a pre-call quote; actual `redeem()` output can
+  differ if liquidity sourcing changes strategy accounting in the transaction
 
 ### `max*` Helpers
 

--- a/src/vault/facets/ERC4626VaultFacet.sol
+++ b/src/vault/facets/ERC4626VaultFacet.sol
@@ -165,6 +165,9 @@ contract ERC4626VaultFacet is ERC4626VaultStrategyPricing, VaultFacetControl, IE
 
         uint256 grossAssets = _convertToAssets(shares, Rounding.Down);
         _sourceStrategyLiquidity(grossAssets);
+        // Exact-share redeems settle at the post-sourcing price if strategy withdrawal reconciles
+        // live gains or losses into managed accounting during this call.
+        grossAssets = _convertToAssets(shares, Rounding.Down);
 
         uint256 availableIdleAssets =
             LibERC4626VaultStorage.layout().strategyDebt == 0 ? _idleAssetBalance() : _trackedIdleAssetBalance();

--- a/src/vault/facets/ERC7540VaultRedeemFacet.sol
+++ b/src/vault/facets/ERC7540VaultRedeemFacet.sol
@@ -193,6 +193,9 @@ contract ERC7540VaultRedeemFacet is ERC4626VaultControlledCore, VaultFacetContro
 
         uint256 grossAssets = _convertToAssets(shares, Rounding.Down);
         _sourceStrategyLiquidity(grossAssets);
+        // Exact-share redeem claims settle at the post-sourcing price if strategy withdrawal
+        // reconciles live gains or losses into managed accounting during this call.
+        grossAssets = _convertToAssets(shares, Rounding.Down);
 
         uint256 availableIdleAssets =
             LibERC4626VaultStorage.layout().strategyDebt == 0 ? _idleAssetBalance() : _trackedIdleAssetBalance();

--- a/test/ERC4626VaultStrategyAccountingCore.t.sol
+++ b/test/ERC4626VaultStrategyAccountingCore.t.sol
@@ -106,9 +106,13 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
         _setDirectStrategy(directProfitStrategy, STRATEGY_DEBT);
         directProfitStrategy.injectProfit(20);
 
+        uint256 expectedAssets = facet.previewRedeem(50);
+
         VM.prank(bob);
         uint256 returnedAssets = facet.redeem(50, bob, bob);
 
+        assertTrue(expectedAssets == 60, "profit fixture should expose non-1:1 redeem pricing");
+        assertTrue(returnedAssets == expectedAssets, "redeem should match no-loss pre-call quote");
         assertTrue(returnedAssets == 60, "redeem should return current share value");
         assertTrue(facet.balanceOf(bob) == 50, "remaining shares mismatch after redeem");
         assertTrue(facet.totalManagedAssets() == 60, "book value mismatch after redeem");
@@ -116,6 +120,67 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
         assertTrue(asset.balanceOf(address(facet)) == 0, "vault idle balance should be exhausted after redeem");
         assertTrue(directProfitStrategy.totalAssets() == 60, "remaining strategy assets mismatch");
         assertTrue(asset.balanceOf(bob) == INITIAL_ASSETS - 40, "underlying balance mismatch after redeem");
+    }
+
+    function testDirectRedeemRepricesAfterWithdrawalTimeLoss() public {
+        _initializeDirectVault();
+        _approveAsset(bob, address(facet), DEPOSIT_ASSETS);
+
+        VM.prank(bob);
+        facet.deposit(DEPOSIT_ASSETS, bob);
+
+        _setDirectStrategy(directLossOnWithdrawStrategy, STRATEGY_DEBT);
+        directLossOnWithdrawStrategy.setLossOnNextWithdraw(20);
+
+        VM.prank(bob);
+        uint256 returnedAssets = facet.redeem(50, bob, bob);
+
+        assertTrue(returnedAssets == 40, "redeem should settle at post-loss share value");
+        assertTrue(facet.balanceOf(bob) == 50, "remaining shares mismatch");
+        assertTrue(facet.totalManagedAssets() == 40, "managed assets should reflect loss and exit");
+        assertTrue(facet.totalAssets() == 40, "total assets mismatch after post-loss redeem");
+        assertTrue(asset.balanceOf(bob) == INITIAL_ASSETS - 60, "receiver assets mismatch");
+    }
+
+    function testDirectWithdrawBurnsPostSourcingSharesAfterWithdrawalTimeLoss() public {
+        _initializeDirectVault();
+        _approveAsset(bob, address(facet), DEPOSIT_ASSETS);
+
+        VM.prank(bob);
+        facet.deposit(DEPOSIT_ASSETS, bob);
+
+        _setDirectStrategy(directLossOnWithdrawStrategy, STRATEGY_DEBT);
+        directLossOnWithdrawStrategy.setLossOnNextWithdraw(20);
+
+        VM.prank(bob);
+        uint256 burnedShares = facet.withdraw(50, bob, bob);
+
+        assertTrue(burnedShares == 63, "withdraw should burn post-loss priced shares");
+        assertTrue(burnedShares > 50, "withdraw should burn more than stale pre-loss pricing");
+        assertTrue(facet.balanceOf(bob) == 37, "remaining shares mismatch");
+        assertTrue(facet.totalManagedAssets() == 30, "managed assets should reflect loss and exit");
+        assertTrue(facet.totalAssets() == 30, "total assets mismatch after post-loss withdraw");
+        assertTrue(asset.balanceOf(bob) == INITIAL_ASSETS - 50, "receiver assets mismatch");
+    }
+
+    function testDirectRedeemSucceedsWhenWithdrawalTimeLossMakesInitialGrossAssetsStale() public {
+        _initializeDirectVault();
+        _approveAsset(bob, address(facet), DEPOSIT_ASSETS);
+
+        VM.prank(bob);
+        facet.deposit(DEPOSIT_ASSETS, bob);
+
+        _setDirectStrategy(directLossOnWithdrawStrategy, STRATEGY_DEBT);
+        directLossOnWithdrawStrategy.setLossOnNextWithdraw(55);
+
+        VM.prank(bob);
+        uint256 returnedAssets = facet.redeem(50, bob, bob);
+
+        assertTrue(returnedAssets == 22, "redeem should recompute below stale gross assets");
+        assertTrue(facet.balanceOf(bob) == 50, "remaining shares mismatch");
+        assertTrue(facet.totalManagedAssets() == 23, "managed assets should preserve remaining post-loss value");
+        assertTrue(facet.totalAssets() == 23, "total assets mismatch after partial-liquidity redeem");
+        assertTrue(asset.balanceOf(address(facet)) == 23, "idle assets mismatch");
     }
 
     function testDirectWithdrawRevertsWhenStrategyLiquidityCannotCoverExactAssets() public {
@@ -225,6 +290,30 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
         );
         assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 40, "managed assets mismatch");
         assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 40, "post-withdraw totalAssets mismatch");
+    }
+
+    function testDiamondRedeemRepricesAfterWithdrawalTimeLoss() public {
+        _installHostedVaultFacetsToDiamond();
+        _initializeDiamondVault();
+        _approveAsset(bob, address(diamond), DEPOSIT_ASSETS);
+
+        VM.prank(bob);
+        IERC4626VaultFacet(address(diamond)).deposit(DEPOSIT_ASSETS, bob);
+
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(address(diamondLossOnWithdrawStrategy));
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).deployToStrategy(STRATEGY_DEBT);
+        diamondLossOnWithdrawStrategy.setLossOnNextWithdraw(20);
+
+        VM.prank(bob);
+        uint256 returnedAssets = IERC4626VaultFacet(address(diamond)).redeem(50, bob, bob);
+
+        assertTrue(returnedAssets == 40, "diamond redeem should settle at post-loss share value");
+        assertTrue(IERC4626VaultFacet(address(diamond)).balanceOf(bob) == 50, "remaining shares mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 40, "managed assets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 40, "total assets mismatch");
+        assertTrue(asset.balanceOf(bob) == INITIAL_ASSETS - 60, "receiver assets mismatch");
     }
 
     function testDiamondHostedRevertingStrategyMakesLiveSyncPricingReadsRevert() public {
@@ -613,6 +702,31 @@ contract ERC4626VaultStrategyAccountingCoreTest is ERC4626VaultStrategyAccountin
         assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 60, "total assets mismatch");
         assertTrue(address(diamond).balance == 0, "vault idle balance should be exhausted after redeem");
         assertTrue(diamondNativeProfitStrategy.totalAssets() == 60, "remaining strategy assets mismatch");
+    }
+
+    function testDiamondNativeRedeemRepricesAfterWithdrawalTimeLoss() public {
+        _installHostedVaultNativeFacetsToDiamond();
+        _initializeDiamondNativeVault();
+        VM.deal(bob, INITIAL_ASSETS);
+
+        VM.prank(bob);
+        IERC7535VaultFacet(address(diamond)).depositNative{value: DEPOSIT_ASSETS}(bob);
+
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(address(diamondNativeLossOnWithdrawStrategy));
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).deployToStrategy(STRATEGY_DEBT);
+        diamondNativeLossOnWithdrawStrategy.setLossOnNextWithdraw(20);
+
+        uint256 bobBalanceBefore = bob.balance;
+        VM.prank(bob);
+        uint256 returnedAssets = IERC4626VaultFacet(address(diamond)).redeem(50, bob, bob);
+
+        assertTrue(returnedAssets == 40, "native redeem should settle at post-loss share value");
+        assertTrue(bob.balance == bobBalanceBefore + 40, "native receiver balance mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).balanceOf(bob) == 50, "remaining shares mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 40, "managed assets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 40, "total assets mismatch");
     }
 
     function testDiamondNativeWithdrawRevertsWhenStrategyLiquidityCannotCoverExactAssets() public {

--- a/test/ERC7540VaultRedeemCore.t.sol
+++ b/test/ERC7540VaultRedeemCore.t.sol
@@ -15,7 +15,11 @@ import {IERC7540VaultSettlementFacet} from "../src/interfaces/IERC7540VaultSettl
 import {IPausable} from "../src/interfaces/IPausable.sol";
 import {ERC7540VaultRedeemFacet} from "../src/vault/facets/ERC7540VaultRedeemFacet.sol";
 import {ERC4626VaultFacetFixture} from "./helpers/ERC4626VaultFacetTestHarness.sol";
-import {MockVaultStrategyForcedRevert, RevertingMockVaultStrategy} from "./helpers/ERC4626VaultStrategyTestHarness.sol";
+import {
+    LossOnWithdrawMockVaultStrategy,
+    MockVaultStrategyForcedRevert,
+    RevertingMockVaultStrategy
+} from "./helpers/ERC4626VaultStrategyTestHarness.sol";
 
 contract ERC7540VaultRedeemCoreTest is ERC4626VaultFacetFixture {
     function _initializeDiamondFullAsyncVault() internal {
@@ -115,6 +119,65 @@ contract ERC7540VaultRedeemCoreTest is ERC4626VaultFacetFixture {
         assertTrue(IERC4626(address(diamond)).balanceOf(address(diamond)) == 15, "escrow share balance mismatch");
         assertTrue(IERC4626(address(diamond)).totalSupply() == 55, "share supply mismatch");
         assertTrue(asset.balanceOf(eve) == eveAssetsBefore + 25, "receiver asset balance mismatch");
+    }
+
+    function testAsyncRedeemRepricesAfterWithdrawalTimeLoss() public {
+        _initializeDiamondFullAsyncVault();
+        _seedClaimedShares(bob, 100);
+
+        LossOnWithdrawMockVaultStrategy lossStrategy =
+            new LossOnWithdrawMockVaultStrategy(address(diamond), address(asset));
+
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(address(lossStrategy));
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).deployToStrategy(60);
+        lossStrategy.setLossOnNextWithdraw(20);
+
+        VM.prank(bob);
+        IERC7540Redeem(address(diamond)).requestRedeem(50, bob, bob);
+        _settleRedeem(bob, 50);
+
+        uint256 eveAssetsBefore = asset.balanceOf(eve);
+
+        VM.prank(bob);
+        uint256 assets = IERC4626(address(diamond)).redeem(50, eve, bob);
+
+        assertTrue(assets == 40, "async redeem should settle at post-loss share value");
+        assertTrue(IERC7540Redeem(address(diamond)).claimableRedeemRequest(0, bob) == 0, "claimable should clear");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 40, "managed assets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 40, "total assets mismatch");
+        assertTrue(asset.balanceOf(eve) == eveAssetsBefore + 40, "receiver asset balance mismatch");
+    }
+
+    function testAsyncWithdrawBurnsPostSourcingSharesAfterWithdrawalTimeLoss() public {
+        _initializeDiamondFullAsyncVault();
+        _seedClaimedShares(bob, 100);
+
+        LossOnWithdrawMockVaultStrategy lossStrategy =
+            new LossOnWithdrawMockVaultStrategy(address(diamond), address(asset));
+
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).setStrategy(address(lossStrategy));
+        VM.prank(admin);
+        IERC4626VaultIntegrationFacet(address(diamond)).deployToStrategy(60);
+        lossStrategy.setLossOnNextWithdraw(20);
+
+        VM.prank(bob);
+        IERC7540Redeem(address(diamond)).requestRedeem(100, bob, bob);
+        _settleRedeem(bob, 100);
+
+        uint256 eveAssetsBefore = asset.balanceOf(eve);
+
+        VM.prank(bob);
+        uint256 shares = IERC4626(address(diamond)).withdraw(50, eve, bob);
+
+        assertTrue(shares == 63, "async withdraw should burn post-loss priced shares");
+        assertTrue(shares > 50, "async withdraw should burn more than stale pre-loss pricing");
+        assertTrue(IERC7540Redeem(address(diamond)).claimableRedeemRequest(0, bob) == 37, "claimable mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalManagedAssets() == 30, "managed assets mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).totalAssets() == 30, "total assets mismatch");
+        assertTrue(asset.balanceOf(eve) == eveAssetsBefore + 50, "receiver asset balance mismatch");
     }
 
     function testAsyncRedeemMaxReadsInheritStrategyPricingRevert() public {

--- a/test/helpers/ERC4626VaultStrategyAccountingTestHarness.sol
+++ b/test/helpers/ERC4626VaultStrategyAccountingTestHarness.sol
@@ -18,7 +18,9 @@ import {ReentrantMockVaultAsset} from "./ERC4626VaultControlsTestHarness.sol";
 import {ERC4626VaultIntegrationFacetHarness} from "./ERC4626VaultIntegrationFacetTestHarness.sol";
 import {
     LossShortfallMockVaultStrategy,
+    LossOnWithdrawMockVaultStrategy,
     NativeLossShortfallMockVaultStrategy,
+    NativeLossOnWithdrawMockVaultStrategy,
     NativeProfitMockVaultStrategy,
     NativeRevertingMockVaultStrategy,
     ProfitMockVaultStrategy,
@@ -53,11 +55,14 @@ abstract contract ERC4626VaultStrategyAccountingFixture is TestBase {
     ERC4626VaultStrategyAccountingInitMock internal accountingInit;
     ProfitMockVaultStrategy internal directProfitStrategy;
     LossShortfallMockVaultStrategy internal directLossStrategy;
+    LossOnWithdrawMockVaultStrategy internal directLossOnWithdrawStrategy;
     RevertingMockVaultStrategy internal directRevertingStrategy;
     ProfitMockVaultStrategy internal diamondProfitStrategy;
+    LossOnWithdrawMockVaultStrategy internal diamondLossOnWithdrawStrategy;
     RevertingMockVaultStrategy internal diamondRevertingStrategy;
     NativeProfitMockVaultStrategy internal diamondNativeProfitStrategy;
     NativeLossShortfallMockVaultStrategy internal diamondNativeLossStrategy;
+    NativeLossOnWithdrawMockVaultStrategy internal diamondNativeLossOnWithdrawStrategy;
     NativeRevertingMockVaultStrategy internal diamondNativeRevertingStrategy;
 
     function setUp() public virtual {
@@ -72,11 +77,14 @@ abstract contract ERC4626VaultStrategyAccountingFixture is TestBase {
         accountingInit = new ERC4626VaultStrategyAccountingInitMock();
         directProfitStrategy = new ProfitMockVaultStrategy(address(facet), address(asset));
         directLossStrategy = new LossShortfallMockVaultStrategy(address(facet), address(asset));
+        directLossOnWithdrawStrategy = new LossOnWithdrawMockVaultStrategy(address(facet), address(asset));
         directRevertingStrategy = new RevertingMockVaultStrategy(address(facet), address(asset));
         diamondProfitStrategy = new ProfitMockVaultStrategy(address(diamond), address(asset));
+        diamondLossOnWithdrawStrategy = new LossOnWithdrawMockVaultStrategy(address(diamond), address(asset));
         diamondRevertingStrategy = new RevertingMockVaultStrategy(address(diamond), address(asset));
         diamondNativeProfitStrategy = new NativeProfitMockVaultStrategy(address(diamond));
         diamondNativeLossStrategy = new NativeLossShortfallMockVaultStrategy(address(diamond));
+        diamondNativeLossOnWithdrawStrategy = new NativeLossOnWithdrawMockVaultStrategy(address(diamond));
         diamondNativeRevertingStrategy = new NativeRevertingMockVaultStrategy(address(diamond));
 
         asset.mint(bob, INITIAL_ASSETS);

--- a/test/helpers/ERC4626VaultStrategyTestHarness.sol
+++ b/test/helpers/ERC4626VaultStrategyTestHarness.sol
@@ -122,6 +122,35 @@ contract LossShortfallMockVaultStrategy is MockVaultStrategyBase {
     }
 }
 
+contract LossOnWithdrawMockVaultStrategy is MockVaultStrategyBase {
+    uint256 internal _lossOnNextWithdraw;
+
+    constructor(address vault_, address asset_) MockVaultStrategyBase(vault_, asset_) {}
+
+    /// @dev Realizes this loss on the next withdrawToVault(...) call only.
+    function setLossOnNextWithdraw(uint256 lossAssets) external {
+        _lossOnNextWithdraw = lossAssets;
+    }
+
+    function withdrawToVault(uint256 assets) external override onlyVault returns (uint256 assetsReturned) {
+        uint256 realizedLoss = _min(_lossOnNextWithdraw, _trackedAssets);
+        _lossOnNextWithdraw = 0;
+
+        if (realizedLoss != 0) {
+            MockVaultAsset(_asset).transfer(LOSS_SINK, realizedLoss);
+            _trackedAssets -= realizedLoss;
+            _withdrawableAssets = _min(_withdrawableAssets, _trackedAssets);
+        }
+
+        assetsReturned = _min(assets, maxWithdrawableAssets());
+        _trackedAssets -= assetsReturned;
+        _withdrawableAssets -= assetsReturned;
+        if (assetsReturned != 0) {
+            MockVaultAsset(_asset).transfer(_vault, assetsReturned);
+        }
+    }
+}
+
 contract RevertingMockVaultStrategy is MockVaultStrategyBase {
     bool internal _revertTotalAssets;
     bool internal _revertDeployFunds;
@@ -344,6 +373,35 @@ contract NativeLossShortfallMockVaultStrategy is MockNativeVaultStrategyBase {
             _trackedAssets -= realizedLoss;
         }
         _withdrawableAssets = _min(withdrawableAssets_, _trackedAssets);
+    }
+}
+
+contract NativeLossOnWithdrawMockVaultStrategy is MockNativeVaultStrategyBase {
+    uint256 internal _lossOnNextWithdraw;
+
+    constructor(address vault_) MockNativeVaultStrategyBase(vault_) {}
+
+    /// @dev Realizes this loss on the next withdrawToVault(...) call only.
+    function setLossOnNextWithdraw(uint256 lossAssets) external {
+        _lossOnNextWithdraw = lossAssets;
+    }
+
+    function withdrawToVault(uint256 assets) external override onlyVault returns (uint256 assetsReturned) {
+        uint256 realizedLoss = _min(_lossOnNextWithdraw, _trackedAssets);
+        _lossOnNextWithdraw = 0;
+
+        if (realizedLoss != 0) {
+            _transferNative(LOSS_SINK, realizedLoss);
+            _trackedAssets -= realizedLoss;
+            _withdrawableAssets = _min(_withdrawableAssets, _trackedAssets);
+        }
+
+        assetsReturned = _min(assets, maxWithdrawableAssets());
+        _trackedAssets -= assetsReturned;
+        _withdrawableAssets -= assetsReturned;
+        if (assetsReturned != 0) {
+            _transferNative(_vault, assetsReturned);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- recompute exact-share redeem asset value after strategy liquidity sourcing for ERC-4626 and ERC-7540 redeem paths
- add withdrawal-time-loss strategy mocks and regressions for direct, diamond ERC20, native, and async redeem/withdraw paths
- document post-sourcing redeem settlement and previewRedeem as a pre-call quote

## Verification
- forge test --offline --match-path test/ERC4626VaultStrategyAccountingCore.t.sol
- forge test --offline --match-path test/ERC7540VaultRedeemCore.t.sol
- forge test --offline --match-path test/DiamondVaultHostHardening.t.sol
- forge test --offline --match-path test/DiamondNativeVaultHostHardening.t.sol
- forge test --offline --match-path test/DiamondVaultHostInvariant.t.sol
- forge test --offline --match-path test/DiamondNativeVaultHostInvariant.t.sol
- forge fmt --check
- forge build --sizes --skip script
- git diff --check