### PR TITLE
Fix withdraw redeem fee basis

### DIFF
--- a/docs/erc4626-vault.md
+++ b/docs/erc4626-vault.md
@@ -121,7 +121,8 @@ Deposit and mint use deposit fee:
   computed with fee gross-up.
 
 Withdraw and redeem use withdraw fee:
-- `withdraw(assetsOut)`: requested net assets are grossed-up before share burn.
+- `withdraw(assetsOut)`: requested net assets are grossed-up on the same
+  gross-asset fee basis used by redeem, then converted to burned shares.
 - `redeem(shares)`: gross assets from shares are computed first, then net
   receiver assets are derived by subtracting fee. Hosted redeems recompute the
   gross asset value after any strategy liquidity sourcing, so exact-share exits
@@ -129,8 +130,11 @@ Withdraw and redeem use withdraw fee:
 
 Fee rounding:
 - Deposit fee on raw assets rounds down.
-- Withdraw fee on requested net assets rounds up.
-- Withdraw fee on gross redeem amount rounds down.
+- Withdraw fee on gross exit assets rounds down.
+- Exact-withdraw gross-up rounds down to remain inverse with redeem's
+  net-from-gross calculation. For small exits with non-round withdraw fee bps,
+  this can pay less fee than a net-basis gross-up; that is intentional to avoid
+  withdraw/redeem route-choice differences.
 
 ## Limits and Cap Behavior (`ERC4626VaultControls`)
 

--- a/docs/vault-facets.md
+++ b/docs/vault-facets.md
@@ -454,6 +454,8 @@ are strategy-aware.
 ### `withdraw(assets)`
 
 - exact-assets semantics are preserved
+- withdraw fees use the same gross-asset fee basis as `redeem(shares)`, so the
+  exact-assets gross-up is inverse with redeem's net-from-gross calculation
 - if idle vault assets are insufficient, the core facet automatically pulls
   immediately withdrawable strategy liquidity
 - if the requested assets still cannot be sourced after realizing any loss, the
@@ -467,6 +469,8 @@ are strategy-aware.
 - the vault burns the requested shares and returns the post-sourcing asset value
   of those shares after any strategy gain/loss reconciliation performed during
   the call
+- withdraw fees are deducted from the gross asset value, matching the
+  exact-withdraw fee basis
 - `previewRedeem()` remains a pre-call quote; actual `redeem()` output can
   differ if liquidity sourcing changes strategy accounting in the transaction
 

--- a/src/vault/ERC4626VaultControlLogic.sol
+++ b/src/vault/ERC4626VaultControlLogic.sol
@@ -62,8 +62,17 @@ library LibERC4626VaultControlLogic {
     }
 
     function withdrawGrossFromNet(uint256 assets) internal view returns (uint256 grossAssets, uint256 feeAssets) {
-        uint16 withdrawFeeBps = LibERC4626VaultStorage.layout().fees.withdrawFeeBps;
-        feeAssets = feeOnRaw(assets, withdrawFeeBps, FeeRounding.Up);
+        uint256 withdrawFeeBps = LibERC4626VaultStorage.layout().fees.withdrawFeeBps;
+
+        // Withdraw gross-up intentionally rounds down so it is inverse with the
+        // gross-asset fee basis used by withdrawNetFromGross().
+        uint256 denominator;
+        // Fee setters validate bps below the denominator, so this subtraction
+        // cannot underflow for supported vault state.
+        unchecked {
+            denominator = BPS_DENOMINATOR - withdrawFeeBps;
+        }
+        feeAssets = mulDiv(assets, withdrawFeeBps, denominator, FeeRounding.Down);
         grossAssets = assets + feeAssets;
     }
 

--- a/test/ERC4626VaultControlsCore.t.sol
+++ b/test/ERC4626VaultControlsCore.t.sol
@@ -160,6 +160,74 @@ contract ERC4626VaultControlsCoreTest is ERC4626VaultControlsFixture {
         assertTrue(asset.balanceOf(eve) == INITIAL_ASSETS + 2, "fee recipient balance mismatch");
     }
 
+    function testWithdrawAndRedeemUseSameGrossFeeBasisForNonRoundFees() public {
+        _seedPosition(bob, 100);
+
+        VM.prank(admin);
+        vault.setFeeConfig(0, 3_333, eve);
+
+        assertTrue(vault.previewWithdraw(2) == 2, "previewWithdraw should use gross-basis inverse");
+
+        VM.prank(bob);
+        uint256 sharesBurned = vault.withdraw(2, bob, bob);
+
+        assertTrue(sharesBurned == 2, "withdraw burned shares mismatch");
+        assertTrue(vault.totalAssets() == 98, "total assets mismatch after withdraw");
+        assertTrue(vault.balanceOf(bob) == 98, "share balance mismatch after withdraw");
+        assertTrue(asset.balanceOf(bob) == INITIAL_ASSETS + 2, "withdraw receiver balance mismatch");
+        assertTrue(asset.balanceOf(eve) == INITIAL_ASSETS, "fee recipient should not receive rounded-up fee");
+
+        VM.prank(bob);
+        uint256 assetsOut = vault.redeem(2, bob, bob);
+
+        assertTrue(assetsOut == 2, "redeem should match same gross-basis fee outcome");
+        assertTrue(vault.totalAssets() == 96, "total assets mismatch after redeem");
+        assertTrue(vault.balanceOf(bob) == 96, "share balance mismatch after redeem");
+        assertTrue(asset.balanceOf(bob) == INITIAL_ASSETS + 4, "redeem receiver balance mismatch");
+        assertTrue(asset.balanceOf(eve) == INITIAL_ASSETS, "fee recipient balance should stay unchanged");
+    }
+
+    function testWithdrawAndRedeemRemainEquivalentWhenGrossFeeRoundsUpToOneAsset() public {
+        _seedPosition(bob, 100);
+
+        VM.prank(admin);
+        vault.setFeeConfig(0, 5_000, eve);
+
+        assertTrue(vault.previewWithdraw(1) == 2, "previewWithdraw mismatch");
+
+        VM.prank(bob);
+        uint256 sharesBurned = vault.withdraw(1, bob, bob);
+
+        assertTrue(sharesBurned == 2, "withdraw burned shares mismatch");
+        assertTrue(asset.balanceOf(eve) == INITIAL_ASSETS + 1, "withdraw fee recipient balance mismatch");
+
+        VM.prank(bob);
+        uint256 assetsOut = vault.redeem(2, bob, bob);
+
+        assertTrue(assetsOut == 1, "redeem assets mismatch");
+        assertTrue(asset.balanceOf(eve) == INITIAL_ASSETS + 2, "redeem fee recipient balance mismatch");
+    }
+
+    function testMaxAndPreviewWithdrawRedeemRemainInverseForNonRoundFees() public {
+        _seedPosition(bob, 100);
+
+        VM.prank(admin);
+        vault.setFeeConfig(0, 3_333, eve);
+
+        assertTrue(vault.maxWithdraw(bob) == 67, "maxWithdraw mismatch");
+        assertTrue(vault.maxRedeem(bob) == 100, "maxRedeem mismatch");
+        assertTrue(vault.previewWithdraw(67) == 100, "previewWithdraw max mismatch");
+        assertTrue(vault.previewRedeem(100) == 67, "previewRedeem max mismatch");
+
+        VM.prank(bob);
+        uint256 sharesBurned = vault.withdraw(67, bob, bob);
+
+        assertTrue(sharesBurned == 100, "withdraw should burn all shares");
+        assertTrue(vault.totalAssets() == 0, "total assets should be exhausted");
+        assertTrue(vault.balanceOf(bob) == 0, "share balance should be exhausted");
+        assertTrue(asset.balanceOf(eve) == INITIAL_ASSETS + 33, "fee recipient balance mismatch");
+    }
+
     function testDepositLimitEnforced() public {
         VM.prank(admin);
         vault.setLimitConfig(0, 50, 0, 0, 0);

--- a/test/ERC4626VaultControlsFacetCore.t.sol
+++ b/test/ERC4626VaultControlsFacetCore.t.sol
@@ -232,6 +232,39 @@ contract ERC4626VaultControlsFacetCoreTest is ERC4626VaultControlsFacetFixture {
         IERC4626VaultFacet(address(diamond)).redeem(21, bob, bob);
     }
 
+    function testDiamondWithdrawAndRedeemUseSameGrossFeeBasisForNonRoundFees() public {
+        _installHostedVaultFacetsToDiamond();
+        _initializeDiamondVault();
+        address carol = address(0xCA20);
+        asset.mint(carol, 100);
+        _approveAsset(bob, address(diamond), 100);
+        _approveAsset(carol, address(diamond), 100);
+
+        VM.prank(admin);
+        IERC4626VaultControlsFacet(address(diamond)).setFeeConfig(0, 3_333, eve);
+
+        VM.prank(bob);
+        IERC4626VaultFacet(address(diamond)).deposit(100, bob);
+        VM.prank(carol);
+        IERC4626VaultFacet(address(diamond)).deposit(100, carol);
+
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxWithdraw(bob) == 67, "maxWithdraw mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxRedeem(bob) == 100, "maxRedeem mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewWithdraw(67) == 100, "previewWithdraw mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewRedeem(100) == 67, "previewRedeem mismatch");
+
+        VM.prank(bob);
+        uint256 sharesBurned = IERC4626VaultFacet(address(diamond)).withdraw(67, bob, bob);
+        VM.prank(carol);
+        uint256 assetsOut = IERC4626VaultFacet(address(diamond)).redeem(100, carol, carol);
+
+        assertTrue(sharesBurned == 100, "withdraw should burn all owner shares");
+        assertTrue(assetsOut == 67, "redeem should return same net assets");
+        assertTrue(IERC4626VaultFacet(address(diamond)).balanceOf(bob) == 0, "bob shares should be exhausted");
+        assertTrue(IERC4626VaultFacet(address(diamond)).balanceOf(carol) == 0, "carol shares should be exhausted");
+        assertTrue(asset.balanceOf(eve) == INITIAL_ASSETS + 66, "fee recipient balance mismatch");
+    }
+
     function testDiamondGlobalPauseBlocksVaultEntrypointsButNotShareTokenFlows() public {
         _installHostedVaultFacetsToDiamond();
         _initializeDiamondVault();
@@ -362,6 +395,35 @@ contract ERC4626VaultControlsFacetCoreTest is ERC4626VaultControlsFacetFixture {
         VM.prank(bob);
         VM.expectRevert(abi.encodeWithSelector(IERC4626VaultControls.ERC4626VaultRedeemLimitExceeded.selector, 21, 20));
         IERC4626VaultFacet(address(diamond)).redeem(21, bob, bob);
+    }
+
+    function testDiamondNativeWithdrawUsesGrossFeeBasisForNonRoundFees() public {
+        _installHostedVaultNativeFacetsToDiamond();
+
+        VM.prank(admin);
+        IERC4626VaultFacet(address(diamond))
+            .initializeVault(LibVaultAsset.NATIVE_ASSET_SENTINEL, "Vault Share", "vSHARE", admin);
+
+        VM.prank(admin);
+        IERC4626VaultControlsFacet(address(diamond)).setFeeConfig(0, 3_333, eve);
+
+        VM.deal(bob, 100);
+        VM.prank(bob);
+        IERC7535VaultFacet(address(diamond)).depositNative{value: 100}(bob);
+
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxWithdraw(bob) == 67, "native maxWithdraw mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).maxRedeem(bob) == 100, "native maxRedeem mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewWithdraw(67) == 100, "native previewWithdraw mismatch");
+        assertTrue(IERC4626VaultFacet(address(diamond)).previewRedeem(100) == 67, "native previewRedeem mismatch");
+
+        uint256 bobBalanceBefore = bob.balance;
+        VM.prank(bob);
+        uint256 sharesBurned = IERC4626VaultFacet(address(diamond)).withdraw(67, bob, bob);
+
+        assertTrue(sharesBurned == 100, "native withdraw should burn all shares");
+        assertTrue(bob.balance == bobBalanceBefore + 67, "native receiver balance mismatch");
+        assertTrue(eve.balance == 33, "native fee recipient balance mismatch");
+        assertTrue(address(diamond).balance == 0, "native vault balance should be exhausted");
     }
 
     function testDiamondNativeGlobalPauseBlocksVaultEntrypointsButNotShareTokenFlows() public {

--- a/test/ERC7540VaultRedeemCore.t.sol
+++ b/test/ERC7540VaultRedeemCore.t.sol
@@ -121,6 +121,43 @@ contract ERC7540VaultRedeemCoreTest is ERC4626VaultFacetFixture {
         assertTrue(asset.balanceOf(eve) == eveAssetsBefore + 25, "receiver asset balance mismatch");
     }
 
+    function testAsyncWithdrawAndRedeemUseSameGrossFeeBasisForNonRoundFees() public {
+        _initializeDiamondFullAsyncVault();
+
+        VM.prank(admin);
+        IERC4626VaultControlsFacet(address(diamond)).setFeeConfig(0, 3_333, admin);
+
+        _seedClaimedShares(bob, 100);
+        _seedClaimedShares(eve, 100);
+
+        VM.prank(bob);
+        IERC7540Redeem(address(diamond)).requestRedeem(100, bob, bob);
+        _settleRedeem(bob, 100);
+
+        VM.prank(eve);
+        IERC7540Redeem(address(diamond)).requestRedeem(100, eve, eve);
+        _settleRedeem(eve, 100);
+
+        assertTrue(IERC4626(address(diamond)).maxWithdraw(bob) == 67, "async maxWithdraw mismatch");
+        assertTrue(IERC4626(address(diamond)).maxRedeem(bob) == 100, "async maxRedeem mismatch");
+
+        uint256 bobAssetsBefore = asset.balanceOf(bob);
+        uint256 eveAssetsBefore = asset.balanceOf(eve);
+
+        VM.prank(bob);
+        uint256 withdrawnShares = IERC4626(address(diamond)).withdraw(67, bob, bob);
+        VM.prank(eve);
+        uint256 redeemedAssets = IERC4626(address(diamond)).redeem(100, eve, eve);
+
+        assertTrue(withdrawnShares == 100, "async withdraw should burn all claimable shares");
+        assertTrue(redeemedAssets == 67, "async redeem should return same net assets");
+        assertTrue(asset.balanceOf(bob) == bobAssetsBefore + 67, "async withdraw receiver balance mismatch");
+        assertTrue(asset.balanceOf(eve) == eveAssetsBefore + 67, "async redeem receiver balance mismatch");
+        assertTrue(asset.balanceOf(admin) == 66, "async fee recipient balance mismatch");
+        assertTrue(IERC7540Redeem(address(diamond)).claimableRedeemRequest(0, bob) == 0, "bob claimable mismatch");
+        assertTrue(IERC7540Redeem(address(diamond)).claimableRedeemRequest(0, eve) == 0, "eve claimable mismatch");
+    }
+
     function testAsyncRedeemRepricesAfterWithdrawalTimeLoss() public {
         _initializeDiamondFullAsyncVault();
         _seedClaimedShares(bob, 100);


### PR DESCRIPTION
## Summary

- Correct exact-asset withdraw gross-up to use the same gross-asset fee basis as redeem.
- Add direct, hosted diamond, native, and ERC-7540 async regressions for non-round withdraw fees.
- Document the intentional rounding behavior and fee-recipient impact for small non-round-fee exits.

## Validation

- `forge test --offline --match-path test/ERC4626VaultControlsCore.t.sol`
- `forge test --offline --match-path test/ERC4626VaultControlsFacetCore.t.sol`
- `forge test --offline --match-path test/ERC7540VaultRedeemCore.t.sol`
- `forge test --offline --match-path test/DiamondVaultHostHardening.t.sol`
- `forge test --offline --match-path test/DiamondNativeVaultHostHardening.t.sol`
- `forge test --offline --match-path test/DiamondVaultHostInvariant.t.sol`
- `forge test --offline --match-path test/DiamondNativeVaultHostInvariant.t.sol`
- `forge fmt --check`
- `git diff --check`
- `forge build --sizes --skip script`

Note: `ERC4626VaultFacet` is 24,575 bytes, one byte under the EIP-170 runtime limit.