### PR TITLE
Harden production build hygiene

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ reviewable engineering system.
 
 ## Validation Path
 
+Foundry uses the Solidity compiler pinned in `foundry.toml` (currently
+`0.8.34`); Foundry `1.4.3` will fetch that compiler version on first build if
+it is not already installed locally.
+
 Run a bounded reviewer-facing path with:
 
 ```shell

--- a/foundry.toml
+++ b/foundry.toml
@@ -2,6 +2,7 @@
 src = "src"
 out = "out"
 libs = ["lib"]
+solc = "0.8.34"
 fs_permissions = [{ access = "read-write", path = "./deployments" }]
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options

--- a/src/amm/AMMFactory.sol
+++ b/src/amm/AMMFactory.sol
@@ -23,6 +23,7 @@ contract AMMFactory is IAMMFactory {
     }
 
     function pairCodeHash() public pure override returns (bytes32) {
+        // forge-lint: disable-next-line(asm-keccak256) -- CREATE2 code hash is exposed in canonical high-level form.
         return keccak256(type(AMMPair).creationCode);
     }
 
@@ -36,6 +37,7 @@ contract AMMFactory is IAMMFactory {
             revert AMMFactoryPairExists(token0, token1);
         }
 
+        // forge-lint: disable-next-line(asm-keccak256) -- pair salt mirrors the CREATE2 address formula.
         bytes32 salt = keccak256(abi.encodePacked(token0, token1));
         pair = address(new AMMPair{salt: salt}());
 

--- a/src/amm/AMMPair.sol
+++ b/src/amm/AMMPair.sol
@@ -31,6 +31,7 @@ contract AMMPair is AMMLpToken, IAMMPair {
     error AMMPairTransferFailed(address token, address to, uint256 value);
     error AMMPairKInvariant();
 
+    // forge-lint: disable-next-line(screaming-snake-case-immutable) -- public immutable preserves the IAMMPair getter name.
     address public immutable override factory;
 
     address public override token0;
@@ -49,12 +50,20 @@ contract AMMPair is AMMLpToken, IAMMPair {
     }
 
     modifier lock() {
+        _lockBefore();
+        _;
+        _lockAfter();
+    }
+
+    function _lockBefore() internal {
         if (_unlocked != 1) {
             revert AMMPairLocked();
         }
 
         _unlocked = 0;
-        _;
+    }
+
+    function _lockAfter() internal {
         _unlocked = 1;
     }
 

--- a/src/amm/AMMRouter.sol
+++ b/src/amm/AMMRouter.sol
@@ -34,14 +34,20 @@ contract AMMRouter is IAMMRouter {
     error AMMRouterUnwrapFailed(uint256 value);
     error AMMRouterNativeTransferFailed(address to, uint256 value);
 
+    // forge-lint: disable-next-line(screaming-snake-case-immutable) -- public immutable preserves the IAMMRouter getter name.
     address public immutable override factory;
+    // forge-lint: disable-next-line(screaming-snake-case-immutable) -- public immutable preserves the IAMMRouter getter name.
     address public immutable override wrappedNative;
 
     modifier ensure(uint256 deadline) {
+        _ensure(deadline);
+        _;
+    }
+
+    function _ensure(uint256 deadline) internal view {
         if (block.timestamp > deadline) {
             revert AMMRouterExpired(deadline, block.timestamp);
         }
-        _;
     }
 
     constructor(address factory_, address wrappedNative_) {

--- a/src/amm/libraries/AMMFixedPoint.sol
+++ b/src/amm/libraries/AMMFixedPoint.sol
@@ -6,15 +6,16 @@ pragma solidity ^0.8.30;
 library AMMFixedPoint {
     uint224 internal constant Q112 = uint224(1) << 112;
 
+    // forge-lint: disable-next-line(pascal-case-struct) -- UQ112x112 is the canonical fixed-point type name.
     struct UQ112x112 {
         uint224 value;
     }
 
     function encode(uint112 value) internal pure returns (UQ112x112 memory) {
-        return UQ112x112(uint224(value) * Q112);
+        return UQ112x112({value: uint224(value) * Q112});
     }
 
     function uqdiv(UQ112x112 memory self, uint112 value) internal pure returns (UQ112x112 memory) {
-        return UQ112x112(self.value / uint224(value));
+        return UQ112x112({value: self.value / uint224(value)});
     }
 }

--- a/src/diamond/libraries/LibDiamond.sol
+++ b/src/diamond/libraries/LibDiamond.sol
@@ -150,7 +150,8 @@ library LibDiamond {
 
         uint256 selectorPosition = diamondStorage.facetData[facetAddress_].selectors.length;
         diamondStorage.selectorData[selector] =
-            LibDiamondStorage.SelectorData({facetAddress: facetAddress_, selectorPosition: uint96(selectorPosition)});
+        // forge-lint: disable-next-line(unsafe-typecast) -- selector arrays cannot approach uint96 length in deployable bytecode.
+        LibDiamondStorage.SelectorData({facetAddress: facetAddress_, selectorPosition: uint96(selectorPosition)});
         diamondStorage.facetData[facetAddress_].selectors.push(selector);
     }
 
@@ -193,6 +194,7 @@ library LibDiamond {
             // position must be rewritten to keep future replace/remove operations sound.
             bytes4 lastSelector = selectors[lastSelectorPosition];
             selectors[selectorPosition] = lastSelector;
+            // forge-lint: disable-next-line(unsafe-typecast) -- selectorPosition was read from a uint96-backed stored position.
             diamondStorage.selectorData[lastSelector].selectorPosition = uint96(selectorPosition);
         }
 

--- a/src/interfaces/IAMMPair.sol
+++ b/src/interfaces/IAMMPair.sol
@@ -21,6 +21,7 @@ interface IAMMPair is IAMMLpToken {
     function factory() external view returns (address);
     function token0() external view returns (address);
     function token1() external view returns (address);
+    // forge-lint: disable-next-line(mixed-case-function) -- canonical AMM interface getter preserves selector compatibility.
     function MINIMUM_LIQUIDITY() external pure returns (uint256);
     function getReserves() external view returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast);
     function price0CumulativeLast() external view returns (uint256);

--- a/src/libraries/LibClone.sol
+++ b/src/libraries/LibClone.sol
@@ -22,6 +22,7 @@ library LibClone {
         pure
         returns (address predicted)
     {
+        // forge-lint: disable-next-line(asm-keccak256) -- CREATE2 address derivation is kept in canonical high-level form.
         bytes32 bytecodeHash = keccak256(_minimalProxyInitCode(implementation));
         predicted = address(uint160(uint256(keccak256(abi.encodePacked(bytes1(0xff), deployer, salt, bytecodeHash)))));
     }

--- a/src/token/ERC721TokenBase.sol
+++ b/src/token/ERC721TokenBase.sol
@@ -227,7 +227,7 @@ abstract contract ERC721TokenBase is IERC721TokenBase {
 
     /// @dev Sets the base URI used for tokens without explicit URI.
     /// @param baseUri The new base URI.
-    function _setBaseURI(string memory baseUri) internal {
+    function _setBaseUri(string memory baseUri) internal {
         _requireInitialized();
         LibERC721TokenStorage.layout().baseURI = baseUri;
     }
@@ -235,7 +235,7 @@ abstract contract ERC721TokenBase is IERC721TokenBase {
     /// @dev Sets explicit metadata URI for `tokenId`.
     /// @param tokenId The token identifier.
     /// @param uri The explicit metadata URI.
-    function _setTokenURI(uint256 tokenId, string memory uri) internal {
+    function _setTokenUri(uint256 tokenId, string memory uri) internal {
         _requireInitialized();
         _requireOwned(tokenId);
         LibERC721TokenStorage.layout().tokenURIs[tokenId] = uri;
@@ -318,6 +318,7 @@ abstract contract ERC721TokenBase is IERC721TokenBase {
         bytes memory buffer = new bytes(digits);
         while (value != 0) {
             digits -= 1;
+            // forge-lint: disable-next-line(unsafe-typecast) -- value % 10 is a single decimal digit.
             buffer[digits] = bytes1(uint8(48 + uint256(value % 10)));
             value /= 10;
         }

--- a/src/token/facets/ERC20TokenFacet.sol
+++ b/src/token/facets/ERC20TokenFacet.sol
@@ -133,7 +133,9 @@ contract ERC20TokenFacet is ERC20TokenBase, TokenFacetControl, IERC20TokenFacet 
 
         LibERC20TokenStorage.Layout storage layout = LibERC20TokenStorage.layout();
         uint256 nonce = layout.nonces[owner];
+        // forge-lint: disable-next-line(asm-keccak256) -- EIP-712 struct hashing stays high-level for auditability.
         bytes32 structHash = keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, value, nonce, deadline));
+        // forge-lint: disable-next-line(asm-keccak256) -- standard EIP-712 digest construction is intentionally explicit.
         bytes32 digest = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR(), structHash));
         address signer = _recoverSigner(digest, v, r, s);
         if (signer != owner) {
@@ -153,6 +155,7 @@ contract ERC20TokenFacet is ERC20TokenBase, TokenFacetControl, IERC20TokenFacet 
 
     /// @notice Returns the EIP-712 domain separator for Permit signatures.
     /// @return The domain separator.
+    // forge-lint: disable-next-line(mixed-case-function) -- ERC-2612 requires this canonical getter name.
     function DOMAIN_SEPARATOR() public view returns (bytes32) {
         LibERC20TokenStorage.Layout storage layout = LibERC20TokenStorage.layout();
         if (layout.cachedChainId == block.chainid) {
@@ -177,6 +180,7 @@ contract ERC20TokenFacet is ERC20TokenBase, TokenFacetControl, IERC20TokenFacet 
     }
 
     function _buildDomainSeparator(bytes32 hashedName, uint256 chainId) internal view returns (bytes32) {
+        // forge-lint: disable-next-line(asm-keccak256) -- EIP-712 domain hashing is clearer in canonical Solidity form.
         return keccak256(abi.encode(EIP712_DOMAIN_TYPEHASH, hashedName, VERSION_HASH, chainId, address(this)));
     }
 

--- a/src/token/facets/ERC721TokenFacet.sol
+++ b/src/token/facets/ERC721TokenFacet.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
-import {IAccessControl} from "../../interfaces/IAccessControl.sol";
 import {IERC165} from "../../interfaces/IERC165.sol";
 import {IERC721TokenFacet} from "../../interfaces/IERC721TokenFacet.sol";
 import {ERC721TokenBase} from "../ERC721TokenBase.sol";
@@ -148,14 +147,14 @@ contract ERC721TokenFacet is ERC721TokenBase, TokenFacetControl, IERC721TokenFac
     /// @notice Updates the collection base URI.
     /// @param baseURI New base URI.
     function setBaseURI(string calldata baseURI) external onlyRole(ERC721_METADATA_ROLE) {
-        _setBaseURI(baseURI);
+        _setBaseUri(baseURI);
     }
 
     /// @notice Sets an explicit metadata URI for `tokenId`.
     /// @param tokenId Token identifier.
     /// @param uri Explicit metadata URI.
     function setTokenURI(uint256 tokenId, string calldata uri) external onlyRole(ERC721_METADATA_ROLE) {
-        _setTokenURI(tokenId, uri);
+        _setTokenUri(tokenId, uri);
     }
 
     /// @notice Returns the current live token count.

--- a/src/token/storage/LibERC721TokenStorage.sol
+++ b/src/token/storage/LibERC721TokenStorage.sol
@@ -18,6 +18,7 @@ library LibERC721TokenStorage {
         mapping(address => uint256) balances;
         mapping(uint256 => address) tokenApprovals;
         mapping(address => mapping(address => bool)) operatorApprovals;
+        // forge-lint: disable-next-line(mixed-case-variable) -- storage field name is frozen for layout compatibility.
         mapping(uint256 => string) tokenURIs;
     }
 

--- a/src/vault/ERC4626Vault.sol
+++ b/src/vault/ERC4626Vault.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
-import {IERC20} from "../interfaces/IERC20.sol";
 import {IERC4626} from "../interfaces/IERC4626.sol";
 import {IERC4626VaultStrategy} from "../interfaces/IERC4626VaultStrategy.sol";
 import {LibVaultAsset} from "./libraries/LibVaultAsset.sol";
@@ -76,24 +75,7 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
     /// @param assets Asset amount.
     /// @param receiver Receiver of minted shares.
     /// @return shares Minted shares.
-    function deposit(uint256 assets, address receiver) public virtual returns (uint256 shares) {
-        _requireInitialized();
-        _requireNonZeroAddress(receiver);
-        if (assets == 0) {
-            revert ERC4626VaultZeroAssets();
-        }
-
-        shares = previewDeposit(assets);
-        if (shares == 0) {
-            revert ERC4626VaultZeroShares();
-        }
-
-        _safeTransferFromAsset(msg.sender, address(this), assets);
-        _increaseManagedAssets(assets);
-        _mintShares(receiver, shares);
-
-        emit Deposit(msg.sender, receiver, assets, shares);
-    }
+    function deposit(uint256 assets, address receiver) public virtual returns (uint256 shares);
 
     /// @notice Returns max shares `receiver` can mint.
     /// @param receiver Target receiver.
@@ -113,24 +95,7 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
     /// @param shares Share amount.
     /// @param receiver Receiver of minted shares.
     /// @return assets Deposited assets.
-    function mint(uint256 shares, address receiver) public virtual returns (uint256 assets) {
-        _requireInitialized();
-        _requireNonZeroAddress(receiver);
-        if (shares == 0) {
-            revert ERC4626VaultZeroShares();
-        }
-
-        assets = previewMint(shares);
-        if (assets == 0) {
-            revert ERC4626VaultZeroAssets();
-        }
-
-        _safeTransferFromAsset(msg.sender, address(this), assets);
-        _increaseManagedAssets(assets);
-        _mintShares(receiver, shares);
-
-        emit Deposit(msg.sender, receiver, assets, shares);
-    }
+    function mint(uint256 shares, address receiver) public virtual returns (uint256 assets);
 
     /// @notice Returns max assets `owner` can withdraw.
     /// @param owner Share owner.
@@ -154,29 +119,7 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
     /// @param receiver Asset receiver.
     /// @param owner Share owner.
     /// @return shares Burned shares.
-    function withdraw(uint256 assets, address receiver, address owner) public virtual returns (uint256 shares) {
-        _requireInitialized();
-        _requireNonZeroAddress(receiver);
-        _requireNonZeroAddress(owner);
-        if (assets == 0) {
-            revert ERC4626VaultZeroAssets();
-        }
-
-        shares = previewWithdraw(assets);
-        if (shares == 0) {
-            revert ERC4626VaultZeroShares();
-        }
-
-        if (msg.sender != owner) {
-            _spendAllowance(owner, msg.sender, shares);
-        }
-
-        _burnShares(owner, shares);
-        _decreaseManagedAssetsForAssetExit(assets);
-        _safeTransferAsset(receiver, assets);
-
-        emit Withdraw(msg.sender, receiver, owner, assets, shares);
-    }
+    function withdraw(uint256 assets, address receiver, address owner) public virtual returns (uint256 shares);
 
     /// @notice Returns max shares `owner` can redeem.
     /// @param owner Share owner.
@@ -200,29 +143,7 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
     /// @param receiver Asset receiver.
     /// @param owner Share owner.
     /// @return assets Returned assets.
-    function redeem(uint256 shares, address receiver, address owner) public virtual returns (uint256 assets) {
-        _requireInitialized();
-        _requireNonZeroAddress(receiver);
-        _requireNonZeroAddress(owner);
-        if (shares == 0) {
-            revert ERC4626VaultZeroShares();
-        }
-
-        assets = previewRedeem(shares);
-        if (assets == 0) {
-            revert ERC4626VaultZeroAssets();
-        }
-
-        if (msg.sender != owner) {
-            _spendAllowance(owner, msg.sender, shares);
-        }
-
-        _burnShares(owner, shares);
-        _decreaseManagedAssetsForAssetExit(assets);
-        _safeTransferAsset(receiver, assets);
-
-        emit Withdraw(msg.sender, receiver, owner, assets, shares);
-    }
+    function redeem(uint256 shares, address receiver, address owner) public virtual returns (uint256 assets);
 
     /// @notice Transfers shares from caller to `to`.
     /// @param to Recipient account.

--- a/src/vault/ERC4626VaultControlLogic.sol
+++ b/src/vault/ERC4626VaultControlLogic.sol
@@ -107,6 +107,30 @@ library LibERC4626VaultControlLogic {
 /// @title ERC4626VaultControlledCore
 /// @notice Shared fee-aware and limit-aware ERC-4626 core behavior.
 abstract contract ERC4626VaultControlledCore is ERC4626Vault {
+    /// @dev Non-core facets inherit this type for shared helpers but do not own every ERC-4626 selector.
+    ///      Leaf facets override the selectors they expose through the diamond.
+    function deposit(uint256, address) public virtual override returns (uint256) {
+        revert();
+    }
+
+    /// @dev Non-core facets inherit this type for shared helpers but do not own every ERC-4626 selector.
+    ///      Leaf facets override the selectors they expose through the diamond.
+    function mint(uint256, address) public virtual override returns (uint256) {
+        revert();
+    }
+
+    /// @dev Non-core facets inherit this type for shared helpers but do not own every ERC-4626 selector.
+    ///      Leaf facets override the selectors they expose through the diamond.
+    function withdraw(uint256, address, address) public virtual override returns (uint256) {
+        revert();
+    }
+
+    /// @dev Non-core facets inherit this type for shared helpers but do not own every ERC-4626 selector.
+    ///      Leaf facets override the selectors they expose through the diamond.
+    function redeem(uint256, address, address) public virtual override returns (uint256) {
+        revert();
+    }
+
     function maxDeposit(address receiver) public view virtual override returns (uint256) {
         if (receiver == address(0) || _vaultOperationsPaused()) {
             return 0;
@@ -450,6 +474,7 @@ abstract contract ERC4626VaultControlledCore is ERC4626Vault {
 /// @title ERC4626VaultControlSurface
 /// @notice Shared hosted and standalone control-plane surface for vault config and governance.
 abstract contract ERC4626VaultControlSurface is VaultFacetControl, IERC4626VaultControls {
+    // forge-lint: disable-next-line(mixed-case-function) -- interface role getter name is selector-stable.
     function VAULT_MANAGER_ROLE()
         public
         pure

--- a/src/vault/ERC4626VaultControls.sol
+++ b/src/vault/ERC4626VaultControls.sol
@@ -2,9 +2,7 @@
 pragma solidity ^0.8.30;
 
 import {IERC165} from "../interfaces/IERC165.sol";
-import {IERC4626} from "../interfaces/IERC4626.sol";
 import {IERC4626VaultControls} from "../interfaces/IERC4626VaultControls.sol";
-import {ERC4626Vault} from "./ERC4626Vault.sol";
 import {ERC4626VaultControlledCore, ERC4626VaultControlSurface} from "./ERC4626VaultControlLogic.sol";
 import {VaultFacetControl} from "./VaultFacetControl.sol";
 
@@ -41,7 +39,7 @@ abstract contract ERC4626VaultControls is ERC4626VaultControlSurface, ERC4626Vau
     function deposit(uint256 assets, address receiver)
         public
         virtual
-        override(ERC4626Vault)
+        override(ERC4626VaultControlledCore)
         whenNotPaused
         nonReentrant
         returns (uint256 shares)
@@ -56,7 +54,7 @@ abstract contract ERC4626VaultControls is ERC4626VaultControlSurface, ERC4626Vau
     function mint(uint256 shares, address receiver)
         public
         virtual
-        override(ERC4626Vault)
+        override(ERC4626VaultControlledCore)
         whenNotPaused
         nonReentrant
         returns (uint256 assets)
@@ -72,7 +70,7 @@ abstract contract ERC4626VaultControls is ERC4626VaultControlSurface, ERC4626Vau
     function withdraw(uint256 assets, address receiver, address owner)
         public
         virtual
-        override(ERC4626Vault)
+        override(ERC4626VaultControlledCore)
         whenNotPaused
         nonReentrant
         returns (uint256 shares)
@@ -88,7 +86,7 @@ abstract contract ERC4626VaultControls is ERC4626VaultControlSurface, ERC4626Vau
     function redeem(uint256 shares, address receiver, address owner)
         public
         virtual
-        override(ERC4626Vault)
+        override(ERC4626VaultControlledCore)
         whenNotPaused
         nonReentrant
         returns (uint256 assets)

--- a/src/vault/VaultFacetControl.sol
+++ b/src/vault/VaultFacetControl.sol
@@ -72,6 +72,7 @@ abstract contract VaultFacetControl is IAccessControl, IAccessControlTime, IPaus
 
     /// @notice Role that can manage vault fees and limits.
     /// @return The vault manager role identifier.
+    // forge-lint: disable-next-line(mixed-case-function) -- public role getter name is selector-stable.
     function VAULT_MANAGER_ROLE() public pure virtual returns (bytes32) {
         return VAULT_MANAGER_ROLE_VALUE;
     }

--- a/src/vault/facets/ERC4626VaultFacet.sol
+++ b/src/vault/facets/ERC4626VaultFacet.sol
@@ -6,7 +6,7 @@ import {IERC4626VaultControls} from "../../interfaces/IERC4626VaultControls.sol"
 import {IERC4626VaultFacet} from "../../interfaces/IERC4626VaultFacet.sol";
 import {ERC4626Vault} from "../ERC4626Vault.sol";
 import {ERC4626VaultBase} from "../ERC4626VaultBase.sol";
-import {LibERC4626VaultControlLogic} from "../ERC4626VaultControlLogic.sol";
+import {ERC4626VaultControlledCore, LibERC4626VaultControlLogic} from "../ERC4626VaultControlLogic.sol";
 import {ERC4626VaultStrategyPricing} from "../ERC4626VaultStrategyPricing.sol";
 import {VaultFacetControl} from "../VaultFacetControl.sol";
 import {LibVaultAsset} from "../libraries/LibVaultAsset.sol";
@@ -56,7 +56,7 @@ contract ERC4626VaultFacet is ERC4626VaultStrategyPricing, VaultFacetControl, IE
     function deposit(uint256 assets, address receiver)
         public
         virtual
-        override(ERC4626Vault, IERC4626)
+        override(ERC4626VaultControlledCore, IERC4626)
         whenNotPaused
         nonReentrant
         returns (uint256 shares)
@@ -75,7 +75,7 @@ contract ERC4626VaultFacet is ERC4626VaultStrategyPricing, VaultFacetControl, IE
     function mint(uint256 shares, address receiver)
         public
         virtual
-        override(ERC4626Vault, IERC4626)
+        override(ERC4626VaultControlledCore, IERC4626)
         whenNotPaused
         nonReentrant
         returns (uint256 assets)
@@ -95,7 +95,7 @@ contract ERC4626VaultFacet is ERC4626VaultStrategyPricing, VaultFacetControl, IE
     function withdraw(uint256 assets, address receiver, address owner)
         public
         virtual
-        override(ERC4626Vault, IERC4626)
+        override(ERC4626VaultControlledCore, IERC4626)
         whenNotPaused
         nonReentrant
         returns (uint256 shares)
@@ -146,7 +146,7 @@ contract ERC4626VaultFacet is ERC4626VaultStrategyPricing, VaultFacetControl, IE
     function redeem(uint256 shares, address receiver, address owner)
         public
         virtual
-        override(ERC4626Vault, IERC4626)
+        override(ERC4626VaultControlledCore, IERC4626)
         whenNotPaused
         nonReentrant
         returns (uint256 assets)

--- a/src/vault/facets/ERC4626VaultIntegrationFacet.sol
+++ b/src/vault/facets/ERC4626VaultIntegrationFacet.sol
@@ -19,8 +19,29 @@ contract ERC4626VaultIntegrationFacet is
     IERC4626VaultIntegrationFacet,
     IERC7540VaultSettlementFacet
 {
+    /// @dev The integration facet inherits ERC-4626 helpers but does not own mutating ERC-4626 selectors.
+    function deposit(uint256, address) public virtual override returns (uint256) {
+        revert();
+    }
+
+    /// @dev The integration facet inherits ERC-4626 helpers but does not own mutating ERC-4626 selectors.
+    function mint(uint256, address) public virtual override returns (uint256) {
+        revert();
+    }
+
+    /// @dev The integration facet inherits ERC-4626 helpers but does not own mutating ERC-4626 selectors.
+    function withdraw(uint256, address, address) public virtual override returns (uint256) {
+        revert();
+    }
+
+    /// @dev The integration facet inherits ERC-4626 helpers but does not own mutating ERC-4626 selectors.
+    function redeem(uint256, address, address) public virtual override returns (uint256) {
+        revert();
+    }
+
     /// @notice Returns the pause scope that gates manager settlement entrypoints.
     /// @return The settlement pause scope identifier.
+    // forge-lint: disable-next-line(mixed-case-function) -- public scope getter name is selector-stable.
     function ASYNC_SETTLEMENT_SCOPE() public pure returns (bytes32) {
         return LibVaultFacetConstants.ASYNC_SETTLEMENT_SCOPE;
     }

--- a/src/vault/facets/ERC7540VaultDepositFacet.sol
+++ b/src/vault/facets/ERC7540VaultDepositFacet.sol
@@ -94,7 +94,7 @@ contract ERC7540VaultDepositFacet is ERC4626VaultControlledCore, VaultFacetContr
     function deposit(uint256 assets, address receiver)
         public
         virtual
-        override(ERC4626Vault)
+        override(ERC4626VaultControlledCore)
         whenNotPaused
         nonReentrant
         returns (uint256 shares)
@@ -109,7 +109,7 @@ contract ERC7540VaultDepositFacet is ERC4626VaultControlledCore, VaultFacetContr
     function mint(uint256 shares, address receiver)
         public
         virtual
-        override(ERC4626Vault)
+        override(ERC4626VaultControlledCore)
         whenNotPaused
         nonReentrant
         returns (uint256 assets)

--- a/src/vault/facets/ERC7540VaultRedeemFacet.sol
+++ b/src/vault/facets/ERC7540VaultRedeemFacet.sol
@@ -120,7 +120,7 @@ contract ERC7540VaultRedeemFacet is ERC4626VaultControlledCore, VaultFacetContro
     function withdraw(uint256 assets, address receiver, address controller)
         public
         virtual
-        override(ERC4626Vault)
+        override(ERC4626VaultControlledCore)
         whenNotPaused
         nonReentrant
         returns (uint256 shares)
@@ -171,7 +171,7 @@ contract ERC7540VaultRedeemFacet is ERC4626VaultControlledCore, VaultFacetContro
     function redeem(uint256 shares, address receiver, address controller)
         public
         virtual
-        override(ERC4626Vault)
+        override(ERC4626VaultControlledCore)
         whenNotPaused
         nonReentrant
         returns (uint256 assets)

--- a/src/wallet/MultisigWallet.sol
+++ b/src/wallet/MultisigWallet.sol
@@ -280,6 +280,7 @@ contract MultisigWallet is IERC165, IERC1271, IMultisigWallet {
     }
 
     function _domainSeparator() internal view returns (bytes32) {
+        // forge-lint: disable-next-line(asm-keccak256) -- EIP-712 domain hashing is clearer in canonical Solidity form.
         return keccak256(abi.encode(EIP712_DOMAIN_TYPEHASH, NAME_HASH, VERSION_HASH, block.chainid, address(this)));
     }
 
@@ -288,12 +289,16 @@ contract MultisigWallet is IERC165, IERC1271, IMultisigWallet {
         view
         returns (bytes32)
     {
+        // forge-lint: disable-next-line(asm-keccak256) -- EIP-712 struct hashing stays high-level for auditability.
         bytes32 structHash = keccak256(abi.encode(TRANSACTION_TYPEHASH, to, value, keccak256(data), nonce_));
+        // forge-lint: disable-next-line(asm-keccak256) -- standard EIP-712 digest construction is intentionally explicit.
         return keccak256(abi.encodePacked("\x19\x01", _domainSeparator(), structHash));
     }
 
     function _getBatchHash(bytes calldata transactions, uint256 nonce_) internal view returns (bytes32) {
+        // forge-lint: disable-next-line(asm-keccak256) -- EIP-712 struct hashing stays high-level for auditability.
         bytes32 structHash = keccak256(abi.encode(BATCH_TYPEHASH, keccak256(transactions), nonce_));
+        // forge-lint: disable-next-line(asm-keccak256) -- standard EIP-712 digest construction is intentionally explicit.
         return keccak256(abi.encodePacked("\x19\x01", _domainSeparator(), structHash));
     }
 

--- a/src/wallet/MultisigWalletFactory.sol
+++ b/src/wallet/MultisigWalletFactory.sol
@@ -8,6 +8,7 @@ import {LibClone} from "../libraries/LibClone.sol";
 /// @title MultisigWalletFactory
 /// @notice Deterministic clone deployment for standalone multisig wallets.
 contract MultisigWalletFactory is IMultisigWalletFactory {
+    // forge-lint: disable-next-line(screaming-snake-case-immutable) -- public immutable preserves the factory getter selector.
     address public immutable implementation;
 
     constructor(address implementation_) {

--- a/test/helpers/ERC4626CoreTestHarness.sol
+++ b/test/helpers/ERC4626CoreTestHarness.sol
@@ -114,6 +114,92 @@ contract ERC4626VaultCoreHarness is ERC4626Vault {
         _initializeErc4626Vault(vaultAsset, vaultName, vaultSymbol);
     }
 
+    function deposit(uint256 assets, address receiver) public override returns (uint256 shares) {
+        _requireInitialized();
+        _requireNonZeroAddress(receiver);
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        shares = previewDeposit(assets);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        _safeTransferFromAsset(msg.sender, address(this), assets);
+        _increaseManagedAssets(assets);
+        _mintShares(receiver, shares);
+
+        emit Deposit(msg.sender, receiver, assets, shares);
+    }
+
+    function mint(uint256 shares, address receiver) public override returns (uint256 assets) {
+        _requireInitialized();
+        _requireNonZeroAddress(receiver);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        assets = previewMint(shares);
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        _safeTransferFromAsset(msg.sender, address(this), assets);
+        _increaseManagedAssets(assets);
+        _mintShares(receiver, shares);
+
+        emit Deposit(msg.sender, receiver, assets, shares);
+    }
+
+    function withdraw(uint256 assets, address receiver, address owner) public override returns (uint256 shares) {
+        _requireInitialized();
+        _requireNonZeroAddress(receiver);
+        _requireNonZeroAddress(owner);
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        shares = previewWithdraw(assets);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        if (msg.sender != owner) {
+            _spendAllowance(owner, msg.sender, shares);
+        }
+
+        _burnShares(owner, shares);
+        _decreaseManagedAssetsForAssetExit(assets);
+        _safeTransferAsset(receiver, assets);
+
+        emit Withdraw(msg.sender, receiver, owner, assets, shares);
+    }
+
+    function redeem(uint256 shares, address receiver, address owner) public override returns (uint256 assets) {
+        _requireInitialized();
+        _requireNonZeroAddress(receiver);
+        _requireNonZeroAddress(owner);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        assets = previewRedeem(shares);
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        if (msg.sender != owner) {
+            _spendAllowance(owner, msg.sender, shares);
+        }
+
+        _burnShares(owner, shares);
+        _decreaseManagedAssetsForAssetExit(assets);
+        _safeTransferAsset(receiver, assets);
+
+        emit Withdraw(msg.sender, receiver, owner, assets, shares);
+    }
+
     function seedPosition(address owner, uint256 shares, uint256 assets) external {
         _mintShares(owner, shares);
         _increaseManagedAssets(assets);

--- a/test/helpers/ERC4626VaultControlsFacetTestHarness.sol
+++ b/test/helpers/ERC4626VaultControlsFacetTestHarness.sol
@@ -4,9 +4,8 @@ pragma solidity ^0.8.30;
 import {DiamondCutFacet} from "../../src/diamond/facets/DiamondCutFacet.sol";
 import {DiamondLoupeFacet} from "../../src/diamond/facets/DiamondLoupeFacet.sol";
 import {IDiamondCut} from "../../src/interfaces/IDiamondCut.sol";
-import {IERC4626VaultControlsFacet} from "../../src/interfaces/IERC4626VaultControlsFacet.sol";
 import {IERC4626VaultFacet} from "../../src/interfaces/IERC4626VaultFacet.sol";
-import {ERC4626Vault} from "../../src/vault/ERC4626Vault.sol";
+import {ERC4626VaultBase} from "../../src/vault/ERC4626VaultBase.sol";
 import {ERC4626VaultControlsFacet} from "../../src/vault/facets/ERC4626VaultControlsFacet.sol";
 import {ERC7535VaultFacet} from "../../src/vault/facets/ERC7535VaultFacet.sol";
 import {LibVaultFacetSelectors} from "../../src/vault/libraries/LibVaultFacetSelectors.sol";
@@ -15,7 +14,7 @@ import {ERC4626VaultFacetHarness} from "./ERC4626VaultFacetTestHarness.sol";
 import {TestBase} from "./AccessControlTestHarness.sol";
 import {ReentrantMockVaultAsset} from "./ERC4626VaultControlsTestHarness.sol";
 
-contract ERC4626VaultControlsFacetHarness is ERC4626VaultControlsFacet, ERC4626Vault {
+contract ERC4626VaultControlsFacetHarness is ERC4626VaultControlsFacet, ERC4626VaultBase {
     function initializeHostedVaultForTest(
         address vaultAsset,
         string memory vaultName,
@@ -24,6 +23,18 @@ contract ERC4626VaultControlsFacetHarness is ERC4626VaultControlsFacet, ERC4626V
     ) external {
         _initializeVaultFacetControl(admin);
         _initializeErc4626Vault(vaultAsset, vaultName, vaultSymbol);
+    }
+
+    function transfer(address, uint256) public pure override returns (bool) {
+        revert();
+    }
+
+    function approve(address, uint256) public pure override returns (bool) {
+        revert();
+    }
+
+    function transferFrom(address, address, uint256) public pure override returns (bool) {
+        revert();
     }
 }
 

--- a/test/helpers/TokenFacetFoundationTestHarness.sol
+++ b/test/helpers/TokenFacetFoundationTestHarness.sol
@@ -106,11 +106,11 @@ contract ERC721TokenBaseHarness is ERC721TokenBase {
     }
 
     function setBaseURI(string calldata baseUri) external {
-        _setBaseURI(baseUri);
+        _setBaseUri(baseUri);
     }
 
     function setTokenURI(uint256 tokenId, string calldata uri) external {
-        _setTokenURI(tokenId, uri);
+        _setTokenUri(tokenId, uri);
     }
 
     function isApprovedOrOwner(address spender, uint256 tokenId) external view returns (bool) {


### PR DESCRIPTION
## Summary

- Pin local Solidity compiler policy to solc 0.8.34 and document the Foundry fetch behavior.
- Convert unreachable ERC4626Vault mutating base bodies into abstract declarations, with the standalone core behavior preserved in the test harness.
- Clean production `forge lint src` findings through source fixes or narrow line-local rationale suppressions.

## Validation

- `forge lint src`
- `forge build --force --sizes --skip script`
- `forge fmt --check`
- `forge test --offline --match-path test/ERC4626Core.t.sol`
- `forge test --offline --match-path test/ERC4626VaultControlsCore.t.sol`
- `forge test --offline --match-path test/ERC4626VaultFacetCore.t.sol`
- `forge test --offline --match-path test/ERC4626VaultControlsFacetCore.t.sol`
- `forge test --offline --match-path test/DiamondVaultHostHardening.t.sol`
- `forge test --offline --match-path test/DiamondNativeVaultHostHardening.t.sol`

## Size

- `ERC4626VaultFacet`: `24,575` bytes before, `24,575` bytes after. No positive delta.

## Notes

- `forge build --force --sizes --skip script` still reports the pre-existing test-helper `selfdestruct` warning in `test/helpers/DiamondNativeVaultHostHardeningTestHarness.sol`; this is outside #215 production-source scope.
- Tried removing the integration-facet selector stubs during audit follow-up; Solidity requires them on that inheritance path, so they are intentionally retained.

Closes #215.