### PR TITLE
docs: complete production NatSpec cleanup

### DIFF
--- a/src/amm/AMMFactory.sol
+++ b/src/amm/AMMFactory.sol
@@ -7,30 +7,45 @@ import {IAMMFactory} from "../interfaces/IAMMFactory.sol";
 /// @title AMMFactory
 /// @notice Deterministic CREATE2 registry for standalone V2-style AMM pairs.
 contract AMMFactory is IAMMFactory {
+    /// @notice Reverts when a caller is not the fee-setting authority.
     error AMMFactoryForbidden();
+    /// @notice Reverts when a required address is zero.
     error AMMFactoryZeroAddress();
+    /// @notice Reverts when the fee-setting authority would be set to zero.
     error AMMFactoryZeroFeeToSetter();
+    /// @notice Reverts when pair creation receives the same token twice.
     error AMMFactoryIdenticalTokens();
+    /// @notice Reverts when a pair already exists for the sorted token pair.
+    /// @param token0 Lower-address token in the pair.
+    /// @param token1 Higher-address token in the pair.
     error AMMFactoryPairExists(address token0, address token1);
 
+    /// @notice Account that receives protocol liquidity fees, or zero when protocol fees are disabled.
     address public override feeTo;
+    /// @notice Account authorized to update fee recipient configuration.
     address public override feeToSetter;
+    /// @notice Returns the pair address for an ordered or unordered token pair.
     mapping(address tokenA => mapping(address tokenB => address pair)) public override getPair;
+    /// @notice Array of all pairs created by this factory.
     address[] public override allPairs;
 
+    /// @notice Initializes the factory with `msg.sender` as fee-setting authority.
     constructor() {
         feeToSetter = msg.sender;
     }
 
+    /// @inheritdoc IAMMFactory
     function pairCodeHash() public pure override returns (bytes32) {
         // forge-lint: disable-next-line(asm-keccak256) -- CREATE2 code hash is exposed in canonical high-level form.
         return keccak256(type(AMMPair).creationCode);
     }
 
+    /// @inheritdoc IAMMFactory
     function allPairsLength() external view override returns (uint256) {
         return allPairs.length;
     }
 
+    /// @inheritdoc IAMMFactory
     function createPair(address tokenA, address tokenB) external override returns (address pair) {
         (address token0, address token1) = _sortTokens(tokenA, tokenB);
         if (getPair[token0][token1] != address(0)) {
@@ -48,11 +63,15 @@ contract AMMFactory is IAMMFactory {
         AMMPair(pair).initialize(token0, token1);
     }
 
+    /// @inheritdoc IAMMFactory
+    /// @dev Restricted to the current `feeToSetter` account.
     function setFeeTo(address feeTo_) external override {
         _requireFeeToSetter();
         feeTo = feeTo_;
     }
 
+    /// @inheritdoc IAMMFactory
+    /// @dev Restricted to the current `feeToSetter` account and rejects the zero address.
     function setFeeToSetter(address feeToSetter_) external override {
         _requireFeeToSetter();
         if (feeToSetter_ == address(0)) {

--- a/src/amm/AMMLpToken.sol
+++ b/src/amm/AMMLpToken.sol
@@ -23,47 +23,83 @@ abstract contract AMMLpToken is IAMMLpToken {
     uint256 internal _cachedChainId;
     bytes32 internal _cachedDomainSeparator;
 
+    /// @notice Returns the LP token name.
+    /// @return LP token name.
     function name() public pure virtual returns (string memory) {
         return "Auralis V2 LP";
     }
 
+    /// @notice Returns the LP token symbol.
+    /// @return LP token symbol.
     function symbol() public pure virtual returns (string memory) {
         return "AUR-V2-LP";
     }
 
+    /// @notice Returns the LP token decimal precision.
+    /// @return Decimal precision used by LP token balances.
     function decimals() public pure virtual returns (uint8) {
         return 18;
     }
 
+    /// @notice Returns total minted LP token supply.
+    /// @return Current LP token supply.
     function totalSupply() public view virtual returns (uint256) {
         return _ammLpTotalSupply;
     }
 
+    /// @notice Returns an account's LP token balance.
+    /// @param account Account to inspect.
+    /// @return Current LP token balance.
     function balanceOf(address account) public view virtual returns (uint256) {
         return _ammLpBalances[account];
     }
 
+    /// @notice Returns the LP token allowance from `owner` to `spender`.
+    /// @param owner Allowance owner.
+    /// @param spender Allowance spender.
+    /// @return Current allowance amount.
     function allowance(address owner, address spender) public view virtual returns (uint256) {
         return _ammLpAllowances[owner][spender];
     }
 
+    /// @notice Approves `spender` to spend LP tokens from the caller.
+    /// @param spender Account receiving allowance.
+    /// @param value Allowance amount.
+    /// @return True when approval succeeds.
     function approve(address spender, uint256 value) external virtual returns (bool) {
         _requireInitialized();
         _approveLp(msg.sender, spender, value);
         return true;
     }
 
+    /// @notice Transfers LP tokens from the caller.
+    /// @param to Recipient account.
+    /// @param value LP token amount.
+    /// @return True when transfer succeeds.
     function transfer(address to, uint256 value) external virtual returns (bool) {
         _transferLp(msg.sender, to, value);
         return true;
     }
 
+    /// @notice Transfers LP tokens using the caller's allowance.
+    /// @param from Account whose LP tokens are moved.
+    /// @param to Recipient account.
+    /// @param value LP token amount.
+    /// @return True when transfer succeeds.
     function transferFrom(address from, address to, uint256 value) external virtual returns (bool) {
         _spendAllowance(from, msg.sender, value);
         _transferLp(from, to, value);
         return true;
     }
 
+    /// @notice Approves LP token allowance using an EIP-2612 permit signature.
+    /// @param owner Token owner that signed the permit.
+    /// @param spender Account receiving allowance.
+    /// @param value Allowance amount.
+    /// @param deadline Latest timestamp at which the permit is valid.
+    /// @param v Signature recovery id.
+    /// @param r Signature r value.
+    /// @param s Signature s value.
     function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s)
         external
         virtual
@@ -88,10 +124,15 @@ abstract contract AMMLpToken is IAMMLpToken {
         _approveLp(owner, spender, value);
     }
 
+    /// @notice Returns the current permit nonce for an owner.
+    /// @param owner Account whose nonce is read.
+    /// @return Current permit nonce.
     function nonces(address owner) external view virtual returns (uint256) {
         return _permitNonces[owner];
     }
 
+    /// @notice Returns the EIP-712 domain separator for LP token permits.
+    /// @return Current domain separator.
     // forge-lint: disable-next-line(mixed-case-function)
     function DOMAIN_SEPARATOR() public view virtual returns (bytes32) {
         bytes32 hashedName = _hashedName == bytes32(0) ? NAME_HASH : _hashedName;

--- a/src/amm/AMMPair.sol
+++ b/src/amm/AMMPair.sol
@@ -15,29 +15,54 @@ contract AMMPair is AMMLpToken, IAMMPair {
     uint256 internal constant FEE_UNITS = 3;
     address internal constant MINIMUM_LIQUIDITY_SINK = 0x000000000000000000000000000000000000dEaD;
 
+    /// @notice Reverts when a caller is not the factory.
     error AMMPairForbidden();
+    /// @notice Reverts when pair initialization is attempted more than once.
     error AMMPairAlreadyInitialized();
+    /// @notice Reverts when one of the pair tokens is the zero address.
     error AMMPairZeroTokenAddress();
+    /// @notice Reverts when both pair token addresses are identical.
     error AMMPairIdenticalTokens();
+    /// @notice Reverts when a reentrant pair operation is attempted.
     error AMMPairLocked();
+    /// @notice Reverts when a swap recipient is invalid.
+    /// @param to Invalid recipient.
     error AMMPairInvalidRecipient(address to);
+    /// @notice Reverts when minting would produce zero or insufficient liquidity.
     error AMMPairInsufficientLiquidityMinted();
+    /// @notice Reverts when burning would return zero liquidity on either side.
     error AMMPairInsufficientLiquidityBurned();
+    /// @notice Reverts when reserves cannot cover the requested output.
     error AMMPairInsufficientLiquidity();
+    /// @notice Reverts when a swap observes no input amount.
     error AMMPairInsufficientInputAmount();
+    /// @notice Reverts when a swap requests no output amount.
     error AMMPairInsufficientOutputAmount();
+    /// @notice Reverts when balances exceed uint112 reserve storage.
     error AMMPairReserveOverflow();
+    /// @notice Reverts when swap callback data is supplied; callbacks are unsupported.
     error AMMPairUnsupportedSwapData();
+    /// @notice Reverts when a token transfer from the pair fails.
+    /// @param token Token being transferred.
+    /// @param to Transfer recipient.
+    /// @param value Transfer amount.
     error AMMPairTransferFailed(address token, address to, uint256 value);
+    /// @notice Reverts when a swap would violate the constant-product invariant.
     error AMMPairKInvariant();
 
+    /// @notice Factory that deployed this pair.
     // forge-lint: disable-next-line(screaming-snake-case-immutable) -- public immutable preserves the IAMMPair getter name.
     address public immutable override factory;
 
+    /// @notice Lower-address token in the pair after initialization.
     address public override token0;
+    /// @notice Higher-address token in the pair after initialization.
     address public override token1;
+    /// @notice Last cumulative price of token0 in UQ112x112 time-weighted units.
     uint256 public override price0CumulativeLast;
+    /// @notice Last cumulative price of token1 in UQ112x112 time-weighted units.
     uint256 public override price1CumulativeLast;
+    /// @notice Last reserve product used for protocol-fee minting.
     uint256 public override kLast;
 
     uint112 internal _reserve0;
@@ -45,10 +70,13 @@ contract AMMPair is AMMLpToken, IAMMPair {
     uint32 internal _blockTimestampLast;
     uint256 internal _unlocked = 1;
 
+    /// @notice Initializes the pair with the deploying factory as immutable owner.
     constructor() {
         factory = msg.sender;
     }
 
+    /// @notice Prevents reentrant pair state transitions.
+    /// @dev Applied to liquidity, swap, skim, and sync entrypoints.
     modifier lock() {
         _lockBefore();
         _;
@@ -67,11 +95,13 @@ contract AMMPair is AMMLpToken, IAMMPair {
         _unlocked = 1;
     }
 
+    /// @inheritdoc IAMMPair
     // forge-lint: disable-next-line(mixed-case-function)
     function MINIMUM_LIQUIDITY() public pure override returns (uint256) {
         return 1000;
     }
 
+    /// @inheritdoc IAMMPair
     function getReserves()
         external
         view
@@ -81,6 +111,7 @@ contract AMMPair is AMMLpToken, IAMMPair {
         return (_reserve0, _reserve1, _blockTimestampLast);
     }
 
+    /// @inheritdoc IAMMPair
     function initialize(address token0_, address token1_) external override {
         if (msg.sender != factory) {
             revert AMMPairForbidden();
@@ -100,6 +131,8 @@ contract AMMPair is AMMLpToken, IAMMPair {
         token1 = token1_;
     }
 
+    /// @inheritdoc IAMMPair
+    /// @dev Guarded by the `lock` reentrancy modifier.
     function mint(address to) external override lock returns (uint256 liquidity) {
         uint112 reserve0_ = _reserve0;
         uint112 reserve1_ = _reserve1;
@@ -139,6 +172,8 @@ contract AMMPair is AMMLpToken, IAMMPair {
         emit Mint(msg.sender, amount0, amount1);
     }
 
+    /// @inheritdoc IAMMPair
+    /// @dev Guarded by the `lock` reentrancy modifier.
     function burn(address to) external override lock returns (uint256 amount0, uint256 amount1) {
         uint112 reserve0_ = _reserve0;
         uint112 reserve1_ = _reserve1;
@@ -171,6 +206,8 @@ contract AMMPair is AMMLpToken, IAMMPair {
         emit Burn(msg.sender, amount0, amount1, to);
     }
 
+    /// @inheritdoc IAMMPair
+    /// @dev Guarded by the `lock` reentrancy modifier; swap callback data is intentionally unsupported.
     function swap(uint256 amount0Out, uint256 amount1Out, address to, bytes calldata data) external override lock {
         if (amount0Out == 0 && amount1Out == 0) {
             revert AMMPairInsufficientOutputAmount();
@@ -220,20 +257,32 @@ contract AMMPair is AMMLpToken, IAMMPair {
         emit Swap(msg.sender, amount0In, amount1In, amount0Out, amount1Out, to);
     }
 
+    /// @inheritdoc IAMMPair
+    /// @dev Guarded by the `lock` reentrancy modifier.
     function skim(address to) external override lock {
         _safeTransfer(token0, to, IERC20(token0).balanceOf(address(this)) - _reserve0);
         _safeTransfer(token1, to, IERC20(token1).balanceOf(address(this)) - _reserve1);
     }
 
+    /// @inheritdoc IAMMPair
+    /// @dev Guarded by the `lock` reentrancy modifier.
     function sync() external override lock {
         (uint256 balance0, uint256 balance1) = _currentBalances();
         _update(balance0, balance1, _reserve0, _reserve1);
     }
 
+    /// @notice Reads current token balances held by the pair.
+    /// @return balance0 Current token0 balance.
+    /// @return balance1 Current token1 balance.
     function _currentBalances() internal view returns (uint256 balance0, uint256 balance1) {
         return (IERC20(token0).balanceOf(address(this)), IERC20(token1).balanceOf(address(this)));
     }
 
+    /// @notice Mints protocol liquidity fees when fee collection is enabled.
+    /// @dev Uses the V2-style one-sixth share of root-K growth since `kLast`.
+    /// @param reserve0_ Previous token0 reserve.
+    /// @param reserve1_ Previous token1 reserve.
+    /// @return feeOn True when protocol fee collection is enabled.
     function _mintFee(uint112 reserve0_, uint112 reserve1_) internal returns (bool feeOn) {
         address feeTo = IAMMFactory(factory).feeTo();
         feeOn = feeTo != address(0);
@@ -258,6 +307,11 @@ contract AMMPair is AMMLpToken, IAMMPair {
         }
     }
 
+    /// @notice Updates reserves and cumulative prices from observed balances.
+    /// @param balance0 Observed token0 balance.
+    /// @param balance1 Observed token1 balance.
+    /// @param reserve0_ Previous token0 reserve.
+    /// @param reserve1_ Previous token1 reserve.
     function _update(uint256 balance0, uint256 balance1, uint112 reserve0_, uint112 reserve1_) internal {
         if (balance0 > type(uint112).max || balance1 > type(uint112).max) {
             revert AMMPairReserveOverflow();
@@ -285,6 +339,10 @@ contract AMMPair is AMMLpToken, IAMMPair {
         emit Sync(_reserve0, _reserve1);
     }
 
+    /// @notice Transfers tokens and accepts either no return data or a true boolean return.
+    /// @param token Token to transfer.
+    /// @param to Transfer recipient.
+    /// @param value Transfer amount.
     function _safeTransfer(address token, address to, uint256 value) internal {
         if (value == 0) {
             return;

--- a/src/amm/AMMRouter.sol
+++ b/src/amm/AMMRouter.sol
@@ -13,25 +13,70 @@ contract AMMRouter is IAMMRouter {
     uint256 internal constant FEE_DENOMINATOR = 1000;
     uint256 internal constant FEE_NUMERATOR = 997;
 
+    /// @notice Reverts when a required address is zero.
     error AMMRouterZeroAddress();
+    /// @notice Reverts when a deadline has expired.
+    /// @param deadline Supplied deadline.
+    /// @param currentTimestamp Current block timestamp.
     error AMMRouterExpired(uint256 deadline, uint256 currentTimestamp);
+    /// @notice Reverts when a swap path has fewer than two tokens.
     error AMMRouterInvalidPath();
+    /// @notice Reverts when a native route does not begin or end with the wrapped native token as required.
     error AMMRouterInvalidWrappedNativePath();
+    /// @notice Reverts when a native liquidity route uses the wrapped native token as the explicit token leg.
+    /// @param token Invalid explicit token.
     error AMMRouterInvalidWrappedNativeToken(address token);
+    /// @notice Reverts when both token inputs are identical.
     error AMMRouterIdenticalTokens();
+    /// @notice Reverts when a token input is the zero address.
     error AMMRouterZeroTokenAddress();
+    /// @notice Reverts when native value is sent by an account other than the wrapped native token.
+    /// @param sender Native sender.
     error AMMRouterInvalidNativeSender(address sender);
+    /// @notice Reverts when a required pair is unavailable.
+    /// @param tokenA First token in the pair.
+    /// @param tokenB Second token in the pair.
     error AMMRouterPairUnavailable(address tokenA, address tokenB);
+    /// @notice Reverts when a quoted amount is zero.
     error AMMRouterInsufficientAmount();
+    /// @notice Reverts when pair reserves cannot satisfy the quote.
     error AMMRouterInsufficientLiquidity();
+    /// @notice Reverts when the tokenA leg of an add-liquidity quote is below the caller minimum.
+    /// @param amountA Quoted tokenA amount.
+    /// @param minimumAmountA Minimum tokenA amount required.
     error AMMRouterInsufficientAAmount(uint256 amountA, uint256 minimumAmountA);
+    /// @notice Reverts when the tokenB leg of an add-liquidity quote is below the caller minimum.
+    /// @param amountB Quoted tokenB amount.
+    /// @param minimumAmountB Minimum tokenB amount required.
     error AMMRouterInsufficientBAmount(uint256 amountB, uint256 minimumAmountB);
+    /// @notice Reverts when final swap output is below the caller minimum.
+    /// @param amountOut Quoted output amount.
+    /// @param minimumAmountOut Minimum output required.
     error AMMRouterInsufficientOutputAmount(uint256 amountOut, uint256 minimumAmountOut);
+    /// @notice Reverts when required input exceeds the caller maximum.
+    /// @param amountIn Required input amount.
+    /// @param maximumAmountIn Maximum input allowed.
     error AMMRouterExcessiveInputAmount(uint256 amountIn, uint256 maximumAmountIn);
+    /// @notice Reverts when an ERC-20 transfer fails.
+    /// @param token Token being transferred.
+    /// @param to Transfer recipient.
+    /// @param value Transfer amount.
     error AMMRouterTransferFailed(address token, address to, uint256 value);
+    /// @notice Reverts when an ERC-20 transferFrom fails.
+    /// @param token Token being transferred.
+    /// @param from Transfer source.
+    /// @param to Transfer recipient.
+    /// @param value Transfer amount.
     error AMMRouterTransferFromFailed(address token, address from, address to, uint256 value);
+    /// @notice Reverts when wrapping native value fails.
+    /// @param value Native value that failed to wrap.
     error AMMRouterWrapFailed(uint256 value);
+    /// @notice Reverts when unwrapping wrapped native value fails.
+    /// @param value Wrapped native value that failed to unwrap.
     error AMMRouterUnwrapFailed(uint256 value);
+    /// @notice Reverts when sending native value fails.
+    /// @param to Native recipient.
+    /// @param value Native value.
     error AMMRouterNativeTransferFailed(address to, uint256 value);
 
     // forge-lint: disable-next-line(screaming-snake-case-immutable) -- public immutable preserves the IAMMRouter getter name.
@@ -39,6 +84,8 @@ contract AMMRouter is IAMMRouter {
     // forge-lint: disable-next-line(screaming-snake-case-immutable) -- public immutable preserves the IAMMRouter getter name.
     address public immutable override wrappedNative;
 
+    /// @notice Reverts after the caller-supplied deadline has expired.
+    /// @param deadline Latest acceptable block timestamp for the operation.
     modifier ensure(uint256 deadline) {
         _ensure(deadline);
         _;
@@ -50,6 +97,9 @@ contract AMMRouter is IAMMRouter {
         }
     }
 
+    /// @notice Initializes router dependencies.
+    /// @param factory_ AMM factory address.
+    /// @param wrappedNative_ Wrapped native token address.
     constructor(address factory_, address wrappedNative_) {
         if (factory_ == address(0) || wrappedNative_ == address(0)) {
             revert AMMRouterZeroAddress();
@@ -59,12 +109,14 @@ contract AMMRouter is IAMMRouter {
         wrappedNative = wrappedNative_;
     }
 
+    /// @notice Accepts native assets only from the configured wrapped native token during unwraps.
     receive() external payable {
         if (msg.sender != wrappedNative) {
             revert AMMRouterInvalidNativeSender(msg.sender);
         }
     }
 
+    /// @inheritdoc IAMMRouter
     function quote(uint256 amountA, uint256 reserveA, uint256 reserveB) public pure override returns (uint256 amountB) {
         if (amountA == 0) {
             revert AMMRouterInsufficientAmount();
@@ -76,6 +128,7 @@ contract AMMRouter is IAMMRouter {
         amountB = (amountA * reserveB) / reserveA;
     }
 
+    /// @inheritdoc IAMMRouter
     function getAmountOut(uint256 amountIn, uint256 reserveIn, uint256 reserveOut)
         public
         pure
@@ -93,6 +146,7 @@ contract AMMRouter is IAMMRouter {
         amountOut = (amountInWithFee * reserveOut) / ((reserveIn * FEE_DENOMINATOR) + amountInWithFee);
     }
 
+    /// @inheritdoc IAMMRouter
     function getAmountIn(uint256 amountOut, uint256 reserveIn, uint256 reserveOut)
         public
         pure
@@ -111,6 +165,7 @@ contract AMMRouter is IAMMRouter {
         amountIn = (numerator / denominator) + 1;
     }
 
+    /// @inheritdoc IAMMRouter
     function getAmountsOut(uint256 amountIn, address[] calldata path)
         public
         view
@@ -128,6 +183,7 @@ contract AMMRouter is IAMMRouter {
         }
     }
 
+    /// @inheritdoc IAMMRouter
     function getAmountsIn(uint256 amountOut, address[] calldata path)
         public
         view
@@ -145,6 +201,7 @@ contract AMMRouter is IAMMRouter {
         }
     }
 
+    /// @inheritdoc IAMMRouter
     function addLiquidity(
         address tokenA,
         address tokenB,
@@ -165,6 +222,8 @@ contract AMMRouter is IAMMRouter {
         return (addAmountA, addAmountB, liquidity);
     }
 
+    /// @inheritdoc IAMMRouter
+    /// @dev The ERC-20 leg cannot be the configured wrapped native token; use the non-native liquidity path instead.
     function addLiquidityNative(
         address token,
         uint256 amountTokenDesired,
@@ -200,6 +259,7 @@ contract AMMRouter is IAMMRouter {
         return (addAmountToken, addAmountNative, liquidity);
     }
 
+    /// @inheritdoc IAMMRouter
     function removeLiquidity(
         address tokenA,
         address tokenB,
@@ -212,6 +272,8 @@ contract AMMRouter is IAMMRouter {
         return _removeLiquidity(tokenA, tokenB, liquidity, amountAMin, amountBMin, to);
     }
 
+    /// @inheritdoc IAMMRouter
+    /// @dev The ERC-20 leg cannot be the configured wrapped native token; use the non-native liquidity path instead.
     function removeLiquidityNative(
         address token,
         uint256 liquidity,
@@ -232,6 +294,7 @@ contract AMMRouter is IAMMRouter {
         _safeTransferNative(to, amountNative);
     }
 
+    /// @inheritdoc IAMMRouter
     function removeLiquidityWithPermit(
         address tokenA,
         address tokenB,
@@ -249,6 +312,7 @@ contract AMMRouter is IAMMRouter {
         return removeLiquidity(tokenA, tokenB, liquidity, amountAMin, amountBMin, to, deadline);
     }
 
+    /// @inheritdoc IAMMRouter
     function removeLiquidityNativeWithPermit(
         address token,
         uint256 liquidity,
@@ -265,6 +329,7 @@ contract AMMRouter is IAMMRouter {
         return removeLiquidityNative(token, liquidity, amountTokenMin, amountNativeMin, to, deadline);
     }
 
+    /// @inheritdoc IAMMRouter
     function swapExactTokensForTokens(
         uint256 amountIn,
         uint256 amountOutMin,
@@ -282,6 +347,7 @@ contract AMMRouter is IAMMRouter {
         _swap(amounts, path, to);
     }
 
+    /// @inheritdoc IAMMRouter
     function swapTokensForExactTokens(
         uint256 amountOut,
         uint256 amountInMax,
@@ -299,6 +365,7 @@ contract AMMRouter is IAMMRouter {
         _swap(amounts, path, to);
     }
 
+    /// @inheritdoc IAMMRouter
     function swapExactNativeForTokens(uint256 amountOutMin, address[] calldata path, address to, uint256 deadline)
         external
         payable
@@ -319,6 +386,7 @@ contract AMMRouter is IAMMRouter {
         _swap(amounts, path, to);
     }
 
+    /// @inheritdoc IAMMRouter
     function swapTokensForExactNative(
         uint256 amountOut,
         uint256 amountInMax,
@@ -341,6 +409,7 @@ contract AMMRouter is IAMMRouter {
         _safeTransferNative(to, amounts[amounts.length - 1]);
     }
 
+    /// @inheritdoc IAMMRouter
     function swapExactTokensForNative(
         uint256 amountIn,
         uint256 amountOutMin,
@@ -363,6 +432,7 @@ contract AMMRouter is IAMMRouter {
         _safeTransferNative(to, finalAmountOut);
     }
 
+    /// @inheritdoc IAMMRouter
     function swapNativeForExactTokens(uint256 amountOut, address[] calldata path, address to, uint256 deadline)
         external
         payable

--- a/src/amm/libraries/AMMFixedPoint.sol
+++ b/src/amm/libraries/AMMFixedPoint.sol
@@ -6,15 +6,24 @@ pragma solidity ^0.8.30;
 library AMMFixedPoint {
     uint224 internal constant Q112 = uint224(1) << 112;
 
+    /// @notice Encodes a UQ112x112 fixed-point value.
+    /// @param value Raw fixed-point numerator scaled by `2**112`.
     // forge-lint: disable-next-line(pascal-case-struct) -- UQ112x112 is the canonical fixed-point type name.
     struct UQ112x112 {
         uint224 value;
     }
 
+    /// @notice Encodes an integer as a UQ112x112 fixed-point value.
+    /// @param value Integer value to encode.
+    /// @return Encoded fixed-point value.
     function encode(uint112 value) internal pure returns (UQ112x112 memory) {
         return UQ112x112({value: uint224(value) * Q112});
     }
 
+    /// @notice Divides a UQ112x112 value by an integer denominator.
+    /// @param self Encoded fixed-point value.
+    /// @param value Integer denominator.
+    /// @return Encoded quotient.
     function uqdiv(UQ112x112 memory self, uint112 value) internal pure returns (UQ112x112 memory) {
         return UQ112x112({value: self.value / uint224(value)});
     }

--- a/src/amm/libraries/AMMMath.sol
+++ b/src/amm/libraries/AMMMath.sol
@@ -4,10 +4,17 @@ pragma solidity ^0.8.30;
 /// @title AMMMath
 /// @notice Shared math helpers for the standalone AMM subsystem.
 library AMMMath {
+    /// @notice Returns the smaller of two unsigned integers.
+    /// @param x First value.
+    /// @param y Second value.
+    /// @return The minimum of `x` and `y`.
     function min(uint256 x, uint256 y) internal pure returns (uint256) {
         return x < y ? x : y;
     }
 
+    /// @notice Returns the integer square root of `y` using the Babylonian method.
+    /// @param y Value to square-root.
+    /// @return z Floor of the square root.
     function sqrt(uint256 y) internal pure returns (uint256 z) {
         if (y == 0) {
             return 0;

--- a/src/diamond/libraries/LibDiamond.sol
+++ b/src/diamond/libraries/LibDiamond.sol
@@ -9,33 +9,47 @@ import {LibDiamondStorage} from "../storage/LibDiamondStorage.sol";
 /// @notice Shared diamond bookkeeping helpers for ownership, interfaces, and selector routing.
 library LibDiamond {
     /// @notice Emitted when ownership changes.
+    /// @param previousOwner Previous diamond owner.
+    /// @param newOwner New diamond owner.
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
 
     /// @notice Thrown when a zero owner is provided.
     error DiamondOwnerZeroAddress();
     /// @notice Thrown when `account` is not the current owner.
+    /// @param account Unauthorized caller.
+    /// @param owner Current owner required for the call.
     error DiamondUnauthorized(address account, address owner);
     /// @notice Thrown when a zero facet address is provided.
     error DiamondFacetAddressZero();
     /// @notice Thrown when an invalid ERC-165 interface id is registered.
+    /// @param interfaceId Invalid interface id.
     error DiamondInvalidInterfaceId(bytes4 interfaceId);
     /// @notice Thrown when a selector already exists on another facet.
+    /// @param selector Selector that is already installed.
+    /// @param existingFacet Current owning facet.
     error DiamondSelectorAlreadyExists(bytes4 selector, address existingFacet);
     /// @notice Thrown when a selector is not currently installed.
+    /// @param selector Selector that was not found.
     error DiamondSelectorNotFound(bytes4 selector);
     /// @notice Thrown when replacing a selector with the same facet.
+    /// @param selector Selector being replaced.
+    /// @param facetAddress Existing facet address.
     error DiamondReplaceWithSameFacet(bytes4 selector, address facetAddress);
     /// @notice Thrown when a facet cut contains no selectors.
     error DiamondCutEmptySelectors();
     /// @notice Thrown when removing selectors with a nonzero facet address.
+    /// @param facetAddress Nonzero facet address supplied for a remove cut.
     error DiamondCutRemoveFacetAddressNotZero(address facetAddress);
     /// @notice Thrown when a facet or init target has no code.
+    /// @param target Address that must contain runtime code.
     error DiamondTargetHasNoCode(address target);
     /// @notice Thrown when init calldata is provided without an init target.
     error DiamondCutInitTargetRequired();
     /// @notice Thrown when an init target is provided without calldata.
     error DiamondCutInitCalldataRequired();
     /// @notice Thrown when the init delegatecall fails.
+    /// @param init Init target that reverted.
+    /// @param reason Raw revert data returned by the init target.
     error DiamondCutInitFailed(address init, bytes reason);
 
     /// @notice Returns the current contract owner.

--- a/src/interfaces/IAMMFactory.sol
+++ b/src/interfaces/IAMMFactory.sol
@@ -4,16 +4,51 @@ pragma solidity ^0.8.30;
 /// @title IAMMFactory
 /// @notice Factory and registry surface for deterministic AMM pair deployment.
 interface IAMMFactory {
+    /// @notice Emitted when a deterministic pair is deployed for two sorted tokens.
+    /// @param token0 Lower-address token in the pair.
+    /// @param token1 Higher-address token in the pair.
+    /// @param pair Deployed pair address.
+    /// @param pairIndex One-based pair count after deployment.
     event PairCreated(address indexed token0, address indexed token1, address pair, uint256 pairIndex);
 
+    /// @notice Returns the protocol fee recipient.
+    /// @return Fee recipient address, or zero address when protocol fees are disabled.
     function feeTo() external view returns (address);
+
+    /// @notice Returns the account authorized to update fee settings.
+    /// @return Address with factory fee-configuration authority.
     function feeToSetter() external view returns (address);
+
+    /// @notice Returns the AMM pair creation-code hash used in CREATE2 address derivation.
+    /// @return Hash of the AMMPair creation bytecode.
     function pairCodeHash() external pure returns (bytes32);
+
+    /// @notice Returns the deployed pair for two tokens.
+    /// @param tokenA First token address.
+    /// @param tokenB Second token address.
+    /// @return Pair address, or zero address when no pair exists.
     function getPair(address tokenA, address tokenB) external view returns (address);
+
+    /// @notice Returns a pair by registry index.
+    /// @param index Zero-based index into the pair registry.
+    /// @return Pair address at the requested index.
     function allPairs(uint256 index) external view returns (address);
+
+    /// @notice Returns the number of pairs deployed by the factory.
+    /// @return Total pair count.
     function allPairsLength() external view returns (uint256);
 
+    /// @notice Deploys the deterministic pair for two tokens if it does not already exist.
+    /// @param tokenA First token address.
+    /// @param tokenB Second token address.
+    /// @return pair Deployed pair address.
     function createPair(address tokenA, address tokenB) external returns (address pair);
+
+    /// @notice Updates the protocol fee recipient.
+    /// @param feeTo_ New fee recipient, or zero address to disable protocol fees.
     function setFeeTo(address feeTo_) external;
+
+    /// @notice Updates the account authorized to change factory fee settings.
+    /// @param feeToSetter_ New fee-setting authority.
     function setFeeToSetter(address feeToSetter_) external;
 }

--- a/src/interfaces/IAMMLpToken.sol
+++ b/src/interfaces/IAMMLpToken.sol
@@ -7,11 +7,29 @@ import {IERC20Permit} from "./IERC20Permit.sol";
 /// @title IAMMLpToken
 /// @notice ERC-20 + permit surface for the standalone AMM LP token.
 interface IAMMLpToken is IERC20Metadata, IERC20Permit {
+    /// @notice Reverts when LP token initialization is attempted more than once.
     error AMMLpAlreadyInitialized();
+    /// @notice Reverts when LP token state is used before pair initialization.
     error AMMLpNotInitialized();
+    /// @notice Reverts when a zero address is used where an account is required.
     error AMMLpZeroAddress();
+    /// @notice Reverts when an account cannot cover an LP token transfer or burn.
+    /// @param account Account whose balance was checked.
+    /// @param available Current LP token balance.
+    /// @param required Required LP token amount.
     error AMMLpInsufficientBalance(address account, uint256 available, uint256 required);
+    /// @notice Reverts when a spender cannot cover an LP token transferFrom allowance.
+    /// @param owner Allowance owner.
+    /// @param spender Allowance spender.
+    /// @param available Current allowance.
+    /// @param required Required allowance.
     error AMMLpInsufficientAllowance(address owner, address spender, uint256 available, uint256 required);
+    /// @notice Reverts when a permit deadline has passed.
+    /// @param deadline Permit deadline supplied by the signer.
+    /// @param currentTimestamp Current block timestamp.
     error AMMLpPermitExpired(uint256 deadline, uint256 currentTimestamp);
+    /// @notice Reverts when permit signature recovery does not match the owner.
+    /// @param signer Recovered signer.
+    /// @param owner Expected owner.
     error AMMLpPermitInvalidSigner(address signer, address owner);
 }

--- a/src/interfaces/IAMMPair.sol
+++ b/src/interfaces/IAMMPair.sol
@@ -6,8 +6,24 @@ import {IAMMLpToken} from "./IAMMLpToken.sol";
 /// @title IAMMPair
 /// @notice Constant-product AMM pair surface, including LP token behavior.
 interface IAMMPair is IAMMLpToken {
+    /// @notice Emitted when liquidity is minted from deposited token balances.
+    /// @param sender Account that triggered the mint.
+    /// @param amount0 Token0 amount added to reserves.
+    /// @param amount1 Token1 amount added to reserves.
     event Mint(address indexed sender, uint256 amount0, uint256 amount1);
+    /// @notice Emitted when liquidity is burned for underlying reserves.
+    /// @param sender Account that triggered the burn.
+    /// @param amount0 Token0 amount withdrawn.
+    /// @param amount1 Token1 amount withdrawn.
+    /// @param to Recipient of the withdrawn tokens.
     event Burn(address indexed sender, uint256 amount0, uint256 amount1, address indexed to);
+    /// @notice Emitted after a swap updates pair reserves.
+    /// @param sender Account that triggered the swap.
+    /// @param amount0In Token0 amount paid in.
+    /// @param amount1In Token1 amount paid in.
+    /// @param amount0Out Token0 amount paid out.
+    /// @param amount1Out Token1 amount paid out.
+    /// @param to Recipient of output tokens.
     event Swap(
         address indexed sender,
         uint256 amount0In,
@@ -16,22 +32,73 @@ interface IAMMPair is IAMMLpToken {
         uint256 amount1Out,
         address indexed to
     );
+    /// @notice Emitted when stored reserves are updated.
+    /// @param reserve0 New token0 reserve.
+    /// @param reserve1 New token1 reserve.
     event Sync(uint112 reserve0, uint112 reserve1);
 
+    /// @notice Returns the factory that deployed and initialized this pair.
+    /// @return Factory address.
     function factory() external view returns (address);
+
+    /// @notice Returns the lower-address token in the pair.
+    /// @return Token0 address.
     function token0() external view returns (address);
+
+    /// @notice Returns the higher-address token in the pair.
+    /// @return Token1 address.
     function token1() external view returns (address);
+
+    /// @notice Returns the permanently locked minimum LP liquidity.
+    /// @return Minimum liquidity minted to the dead address on first mint.
     // forge-lint: disable-next-line(mixed-case-function) -- canonical AMM interface getter preserves selector compatibility.
     function MINIMUM_LIQUIDITY() external pure returns (uint256);
+
+    /// @notice Returns current reserves and the timestamp of the last reserve update.
+    /// @return reserve0 Stored token0 reserve.
+    /// @return reserve1 Stored token1 reserve.
+    /// @return blockTimestampLast Timestamp truncated to uint32 at the last update.
     function getReserves() external view returns (uint112 reserve0, uint112 reserve1, uint32 blockTimestampLast);
+
+    /// @notice Returns cumulative token0 price for TWAP consumers.
+    /// @return Token0 cumulative price value.
     function price0CumulativeLast() external view returns (uint256);
+
+    /// @notice Returns cumulative token1 price for TWAP consumers.
+    /// @return Token1 cumulative price value.
     function price1CumulativeLast() external view returns (uint256);
+
+    /// @notice Returns the last reserve product used for protocol fee minting.
+    /// @return Last recorded reserve product.
     function kLast() external view returns (uint256);
 
+    /// @notice Initializes pair tokens; callable only once by the factory.
+    /// @param token0_ Lower-address token.
+    /// @param token1_ Higher-address token.
     function initialize(address token0_, address token1_) external;
+
+    /// @notice Mints LP tokens to `to` from the pair's current token balance surplus.
+    /// @param to Recipient of minted LP tokens.
+    /// @return liquidity LP tokens minted.
     function mint(address to) external returns (uint256 liquidity);
+
+    /// @notice Burns LP tokens held by the pair and sends underlying tokens to `to`.
+    /// @param to Recipient of withdrawn tokens.
+    /// @return amount0 Token0 amount withdrawn.
+    /// @return amount1 Token1 amount withdrawn.
     function burn(address to) external returns (uint256 amount0, uint256 amount1);
+
+    /// @notice Swaps output tokens to `to` after input tokens have been transferred to the pair.
+    /// @param amount0Out Token0 output amount.
+    /// @param amount1Out Token1 output amount.
+    /// @param to Output recipient.
+    /// @param data Unsupported callback data; must be empty in this implementation.
     function swap(uint256 amount0Out, uint256 amount1Out, address to, bytes calldata data) external;
+
+    /// @notice Transfers token balances above stored reserves to `to`.
+    /// @param to Recipient of excess balances.
     function skim(address to) external;
+
+    /// @notice Syncs stored reserves to current token balances.
     function sync() external;
 }

--- a/src/interfaces/IAMMRouter.sol
+++ b/src/interfaces/IAMMRouter.sol
@@ -4,15 +4,59 @@ pragma solidity ^0.8.30;
 /// @title IAMMRouter
 /// @notice User-facing router and quoting surface for the standalone AMM subsystem.
 interface IAMMRouter {
+    /// @notice Returns the AMM factory used for pair lookup and deployment.
+    /// @return Factory address.
     function factory() external view returns (address);
+
+    /// @notice Returns the wrapped native token used by native-asset routes.
+    /// @return Wrapped native token address.
     function wrappedNative() external view returns (address);
 
+    /// @notice Quotes the counter-asset amount for an equivalent-value add-liquidity leg.
+    /// @param amountA Input amount for reserve A.
+    /// @param reserveA Reserve backing amount A.
+    /// @param reserveB Reserve backing amount B.
+    /// @return amountB Quoted amount for reserve B.
     function quote(uint256 amountA, uint256 reserveA, uint256 reserveB) external pure returns (uint256 amountB);
+
+    /// @notice Quotes swap output for an exact input amount and reserves.
+    /// @param amountIn Exact input amount.
+    /// @param reserveIn Input-side reserve.
+    /// @param reserveOut Output-side reserve.
+    /// @return amountOut Output amount after AMM fee.
     function getAmountOut(uint256 amountIn, uint256 reserveIn, uint256 reserveOut) external pure returns (uint256);
+
+    /// @notice Quotes swap input required for an exact output amount and reserves.
+    /// @param amountOut Exact output amount.
+    /// @param reserveIn Input-side reserve.
+    /// @param reserveOut Output-side reserve.
+    /// @return amountIn Required input amount including AMM fee.
     function getAmountIn(uint256 amountOut, uint256 reserveIn, uint256 reserveOut) external pure returns (uint256);
+
+    /// @notice Quotes output amounts through a multi-hop path for an exact input amount.
+    /// @param amountIn Exact input amount for the first hop.
+    /// @param path Ordered token path.
+    /// @return amounts Per-hop amounts, ending with final output.
     function getAmountsOut(uint256 amountIn, address[] calldata path) external view returns (uint256[] memory amounts);
+
+    /// @notice Quotes input amounts through a multi-hop path for an exact output amount.
+    /// @param amountOut Exact output amount for the final hop.
+    /// @param path Ordered token path.
+    /// @return amounts Per-hop amounts, beginning with required input.
     function getAmountsIn(uint256 amountOut, address[] calldata path) external view returns (uint256[] memory amounts);
 
+    /// @notice Adds ERC-20/ERC-20 liquidity to a pair, deploying the pair if needed.
+    /// @param tokenA First token address.
+    /// @param tokenB Second token address.
+    /// @param amountADesired Desired tokenA amount.
+    /// @param amountBDesired Desired tokenB amount.
+    /// @param amountAMin Minimum tokenA amount accepted.
+    /// @param amountBMin Minimum tokenB amount accepted.
+    /// @param to Recipient of LP tokens.
+    /// @param deadline Latest timestamp at which the call may execute.
+    /// @return amountA TokenA amount deposited.
+    /// @return amountB TokenB amount deposited.
+    /// @return liquidity LP tokens minted.
     function addLiquidity(
         address tokenA,
         address tokenB,
@@ -24,6 +68,16 @@ interface IAMMRouter {
         uint256 deadline
     ) external returns (uint256 amountA, uint256 amountB, uint256 liquidity);
 
+    /// @notice Adds ERC-20/native liquidity, wrapping the native leg before minting LP tokens.
+    /// @param token ERC-20 token paired with wrapped native.
+    /// @param amountTokenDesired Desired ERC-20 amount.
+    /// @param amountTokenMin Minimum ERC-20 amount accepted.
+    /// @param amountNativeMin Minimum native amount accepted.
+    /// @param to Recipient of LP tokens.
+    /// @param deadline Latest timestamp at which the call may execute.
+    /// @return amountToken ERC-20 amount deposited.
+    /// @return amountNative Native amount wrapped and deposited.
+    /// @return liquidity LP tokens minted.
     function addLiquidityNative(
         address token,
         uint256 amountTokenDesired,
@@ -33,6 +87,16 @@ interface IAMMRouter {
         uint256 deadline
     ) external payable returns (uint256 amountToken, uint256 amountNative, uint256 liquidity);
 
+    /// @notice Removes ERC-20/ERC-20 liquidity from a pair.
+    /// @param tokenA First token address.
+    /// @param tokenB Second token address.
+    /// @param liquidity LP token amount to burn.
+    /// @param amountAMin Minimum tokenA amount accepted.
+    /// @param amountBMin Minimum tokenB amount accepted.
+    /// @param to Recipient of withdrawn tokens.
+    /// @param deadline Latest timestamp at which the call may execute.
+    /// @return amountA TokenA amount withdrawn.
+    /// @return amountB TokenB amount withdrawn.
     function removeLiquidity(
         address tokenA,
         address tokenB,
@@ -43,6 +107,15 @@ interface IAMMRouter {
         uint256 deadline
     ) external returns (uint256 amountA, uint256 amountB);
 
+    /// @notice Removes ERC-20/native liquidity, unwrapping the native leg before transfer.
+    /// @param token ERC-20 token paired with wrapped native.
+    /// @param liquidity LP token amount to burn.
+    /// @param amountTokenMin Minimum ERC-20 amount accepted.
+    /// @param amountNativeMin Minimum native amount accepted.
+    /// @param to Recipient of withdrawn assets.
+    /// @param deadline Latest timestamp at which the call may execute.
+    /// @return amountToken ERC-20 amount withdrawn.
+    /// @return amountNative Native amount withdrawn.
     function removeLiquidityNative(
         address token,
         uint256 liquidity,
@@ -52,6 +125,20 @@ interface IAMMRouter {
         uint256 deadline
     ) external returns (uint256 amountToken, uint256 amountNative);
 
+    /// @notice Removes ERC-20/ERC-20 liquidity after approving LP tokens by permit.
+    /// @param tokenA First token address.
+    /// @param tokenB Second token address.
+    /// @param liquidity LP token amount to burn.
+    /// @param amountAMin Minimum tokenA amount accepted.
+    /// @param amountBMin Minimum tokenB amount accepted.
+    /// @param to Recipient of withdrawn tokens.
+    /// @param deadline Latest timestamp at which the call may execute and permit must be valid.
+    /// @param approveMax Whether the permit approved uint256 max instead of `liquidity`.
+    /// @param v Permit recovery id.
+    /// @param r Permit signature r value.
+    /// @param s Permit signature s value.
+    /// @return amountA TokenA amount withdrawn.
+    /// @return amountB TokenB amount withdrawn.
     function removeLiquidityWithPermit(
         address tokenA,
         address tokenB,
@@ -66,6 +153,19 @@ interface IAMMRouter {
         bytes32 s
     ) external returns (uint256 amountA, uint256 amountB);
 
+    /// @notice Removes ERC-20/native liquidity after approving LP tokens by permit.
+    /// @param token ERC-20 token paired with wrapped native.
+    /// @param liquidity LP token amount to burn.
+    /// @param amountTokenMin Minimum ERC-20 amount accepted.
+    /// @param amountNativeMin Minimum native amount accepted.
+    /// @param to Recipient of withdrawn assets.
+    /// @param deadline Latest timestamp at which the call may execute and permit must be valid.
+    /// @param approveMax Whether the permit approved uint256 max instead of `liquidity`.
+    /// @param v Permit recovery id.
+    /// @param r Permit signature r value.
+    /// @param s Permit signature s value.
+    /// @return amountToken ERC-20 amount withdrawn.
+    /// @return amountNative Native amount withdrawn.
     function removeLiquidityNativeWithPermit(
         address token,
         uint256 liquidity,
@@ -79,6 +179,13 @@ interface IAMMRouter {
         bytes32 s
     ) external returns (uint256 amountToken, uint256 amountNative);
 
+    /// @notice Swaps an exact ERC-20 input amount for at least `amountOutMin` output through `path`.
+    /// @param amountIn Exact input token amount.
+    /// @param amountOutMin Minimum final output amount accepted.
+    /// @param path Ordered token path.
+    /// @param to Recipient of final output tokens.
+    /// @param deadline Latest timestamp at which the call may execute.
+    /// @return amounts Per-hop swap amounts.
     function swapExactTokensForTokens(
         uint256 amountIn,
         uint256 amountOutMin,
@@ -87,6 +194,13 @@ interface IAMMRouter {
         uint256 deadline
     ) external returns (uint256[] memory amounts);
 
+    /// @notice Swaps up to `amountInMax` ERC-20 input for an exact ERC-20 output amount.
+    /// @param amountOut Exact final output amount.
+    /// @param amountInMax Maximum input amount accepted.
+    /// @param path Ordered token path.
+    /// @param to Recipient of final output tokens.
+    /// @param deadline Latest timestamp at which the call may execute.
+    /// @return amounts Per-hop swap amounts.
     function swapTokensForExactTokens(
         uint256 amountOut,
         uint256 amountInMax,
@@ -95,11 +209,24 @@ interface IAMMRouter {
         uint256 deadline
     ) external returns (uint256[] memory amounts);
 
+    /// @notice Swaps exact native input for at least `amountOutMin` output through `path`.
+    /// @param amountOutMin Minimum final output amount accepted.
+    /// @param path Ordered token path beginning with wrapped native.
+    /// @param to Recipient of final output tokens.
+    /// @param deadline Latest timestamp at which the call may execute.
+    /// @return amounts Per-hop swap amounts.
     function swapExactNativeForTokens(uint256 amountOutMin, address[] calldata path, address to, uint256 deadline)
         external
         payable
         returns (uint256[] memory amounts);
 
+    /// @notice Swaps up to `amountInMax` ERC-20 input for an exact native output amount.
+    /// @param amountOut Exact native output amount.
+    /// @param amountInMax Maximum input token amount accepted.
+    /// @param path Ordered token path ending with wrapped native.
+    /// @param to Recipient of unwrapped native output.
+    /// @param deadline Latest timestamp at which the call may execute.
+    /// @return amounts Per-hop swap amounts.
     function swapTokensForExactNative(
         uint256 amountOut,
         uint256 amountInMax,
@@ -108,6 +235,13 @@ interface IAMMRouter {
         uint256 deadline
     ) external returns (uint256[] memory amounts);
 
+    /// @notice Swaps an exact ERC-20 input amount for at least `amountOutMin` native output.
+    /// @param amountIn Exact input token amount.
+    /// @param amountOutMin Minimum native output amount accepted.
+    /// @param path Ordered token path ending with wrapped native.
+    /// @param to Recipient of unwrapped native output.
+    /// @param deadline Latest timestamp at which the call may execute.
+    /// @return amounts Per-hop swap amounts.
     function swapExactTokensForNative(
         uint256 amountIn,
         uint256 amountOutMin,
@@ -116,6 +250,12 @@ interface IAMMRouter {
         uint256 deadline
     ) external returns (uint256[] memory amounts);
 
+    /// @notice Swaps native input for an exact output token amount, refunding unused native input.
+    /// @param amountOut Exact final output amount.
+    /// @param path Ordered token path beginning with wrapped native.
+    /// @param to Recipient of output tokens.
+    /// @param deadline Latest timestamp at which the call may execute.
+    /// @return amounts Per-hop swap amounts.
     function swapNativeForExactTokens(uint256 amountOut, address[] calldata path, address to, uint256 deadline)
         external
         payable

--- a/src/interfaces/IAccessControl.sol
+++ b/src/interfaces/IAccessControl.sol
@@ -7,12 +7,23 @@ import {IERC165} from "./IERC165.sol";
 /// @notice Interface for minimal role-based access control with admin hierarchy.
 interface IAccessControl is IERC165 {
     /// @notice Emitted when a role's admin is changed.
+    /// @param role Role whose admin changed.
+    /// @param previousAdminRole Previous admin role.
+    /// @param newAdminRole New admin role.
     event RoleAdminChanged(bytes32 indexed role, bytes32 indexed previousAdminRole, bytes32 indexed newAdminRole);
     /// @notice Emitted when a role is granted.
+    /// @param role Role that was granted.
+    /// @param account Account receiving the role.
+    /// @param sender Account that granted the role.
     event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender);
     /// @notice Emitted when a role is revoked.
+    /// @param role Role that was revoked.
+    /// @param account Account losing the role.
+    /// @param sender Account that revoked the role.
     event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender);
     /// @notice Thrown when an account is missing a required role.
+    /// @param account Account that failed authorization.
+    /// @param role Required role.
     error AccessControlUnauthorized(address account, bytes32 role);
     /// @notice Thrown when renouncing a role for another account.
     error AccessControlRenounceSelfOnly();

--- a/src/interfaces/IAccessControlTime.sol
+++ b/src/interfaces/IAccessControlTime.sol
@@ -7,15 +7,27 @@ import {IERC165} from "./IERC165.sol";
 /// @notice Interface for optional time-gated role behavior.
 interface IAccessControlTime is IERC165 {
     /// @notice Emitted when a role time window is set.
+    /// @param role Role whose account window changed.
+    /// @param account Account whose window changed.
+    /// @param start Activation timestamp.
+    /// @param end Expiration timestamp, or zero for no expiry.
+    /// @param sender Account that set the window.
     event RoleWindowSet(
         bytes32 indexed role, address indexed account, uint64 start, uint64 end, address indexed sender
     );
     /// @notice Emitted when a role time window is cleared.
+    /// @param role Role whose account window was cleared.
+    /// @param account Account whose window was cleared.
+    /// @param sender Account that cleared the window.
     event RoleWindowCleared(bytes32 indexed role, address indexed account, address indexed sender);
 
     /// @notice Thrown when a role time window is invalid.
+    /// @param start Activation timestamp.
+    /// @param end Expiration timestamp.
     error AccessControlInvalidRoleWindow(uint64 start, uint64 end);
     /// @notice Thrown when an account is outside its role time window.
+    /// @param account Account whose role is inactive.
+    /// @param role Role being checked.
     error AccessControlRoleNotActive(address account, bytes32 role);
 
     /// @notice Grants `role` to `account` and sets an active time window.

--- a/src/interfaces/IERC20.sol
+++ b/src/interfaces/IERC20.sol
@@ -5,9 +5,15 @@ pragma solidity ^0.8.30;
 /// @notice Minimal ERC-20 token interface.
 interface IERC20 {
     /// @notice Emitted when `value` tokens move from `from` to `to`.
+    /// @param from Source account.
+    /// @param to Recipient account.
+    /// @param value Token amount transferred.
     event Transfer(address indexed from, address indexed to, uint256 value);
 
     /// @notice Emitted when `owner` sets `value` allowance for `spender`.
+    /// @param owner Allowance owner.
+    /// @param spender Allowance spender.
+    /// @param value New allowance amount.
     event Approval(address indexed owner, address indexed spender, uint256 value);
 
     /// @notice Returns the total token supply.

--- a/src/interfaces/IERC20TokenBase.sol
+++ b/src/interfaces/IERC20TokenBase.sol
@@ -13,8 +13,15 @@ interface IERC20TokenBase is IERC20Metadata {
     /// @notice Thrown when a required account is the zero address.
     error ERC20TokenZeroAddress();
     /// @notice Thrown when an account balance is insufficient.
+    /// @param account Account whose balance was checked.
+    /// @param available Current token balance.
+    /// @param required Required token amount.
     error ERC20TokenInsufficientBalance(address account, uint256 available, uint256 required);
     /// @notice Thrown when allowance is insufficient.
+    /// @param owner Allowance owner.
+    /// @param spender Allowance spender.
+    /// @param available Current allowance.
+    /// @param required Required allowance.
     error ERC20TokenInsufficientAllowance(address owner, address spender, uint256 available, uint256 required);
 
     /// @notice Returns true when ERC-20 storage is initialized.

--- a/src/interfaces/IERC20TokenFacet.sol
+++ b/src/interfaces/IERC20TokenFacet.sol
@@ -11,8 +11,12 @@ import {IPausable} from "./IPausable.sol";
 /// @notice Hosted ERC-20 facet surface for diamond deployments.
 interface IERC20TokenFacet is IERC20Metadata, IERC20TokenBase, IERC20Permit, IAccessControl, IPausable {
     /// @notice Thrown when a Permit signature is expired.
+    /// @param deadline Permit deadline.
+    /// @param currentTimestamp Current block timestamp.
     error ERC20PermitExpired(uint256 deadline, uint256 currentTimestamp);
     /// @notice Thrown when a Permit signature does not recover the expected signer.
+    /// @param signer Recovered signer.
+    /// @param owner Expected owner.
     error ERC20PermitInvalidSigner(address signer, address owner);
 
     /// @notice Returns the shared token admin role identifier.

--- a/src/interfaces/IERC4626.sol
+++ b/src/interfaces/IERC4626.sol
@@ -7,9 +7,18 @@ import {IERC20Metadata} from "./IERC20Metadata.sol";
 /// @notice ERC-4626 tokenized vault interface.
 interface IERC4626 is IERC20Metadata {
     /// @notice Emitted after a successful deposit or mint.
+    /// @param caller Account that initiated the deposit or mint.
+    /// @param owner Share receiver.
+    /// @param assets Asset amount supplied.
+    /// @param shares Share amount minted.
     event Deposit(address indexed caller, address indexed owner, uint256 assets, uint256 shares);
 
     /// @notice Emitted after a successful withdraw or redeem.
+    /// @param caller Account that initiated the withdraw or redeem.
+    /// @param receiver Asset receiver.
+    /// @param owner Share owner.
+    /// @param assets Asset amount withdrawn.
+    /// @param shares Share amount burned.
     event Withdraw(
         address indexed caller, address indexed receiver, address indexed owner, uint256 assets, uint256 shares
     );

--- a/src/interfaces/IERC4626VaultBase.sol
+++ b/src/interfaces/IERC4626VaultBase.sol
@@ -15,10 +15,19 @@ interface IERC4626VaultBase is IERC20Metadata {
     /// @notice Thrown when a required account is zero address.
     error ERC4626VaultZeroAddress();
     /// @notice Thrown when an account balance is insufficient for requested operation.
+    /// @param account Account whose share balance was checked.
+    /// @param available Current share balance.
+    /// @param required Required share amount.
     error ERC4626VaultInsufficientBalance(address account, uint256 available, uint256 required);
     /// @notice Thrown when allowance is insufficient for requested operation.
+    /// @param owner Allowance owner.
+    /// @param spender Allowance spender.
+    /// @param available Current allowance.
+    /// @param required Required allowance.
     error ERC4626VaultInsufficientAllowance(address owner, address spender, uint256 available, uint256 required);
     /// @notice Thrown when managed asset accounting would underflow.
+    /// @param available Current managed asset amount.
+    /// @param required Required decrement.
     error ERC4626VaultManagedAssetsUnderflow(uint256 available, uint256 required);
 
     /// @notice Returns true when vault storage is initialized.

--- a/src/interfaces/IERC4626VaultControls.sol
+++ b/src/interfaces/IERC4626VaultControls.sol
@@ -7,6 +7,13 @@ import {IERC165} from "./IERC165.sol";
 /// @notice Interface for ERC-4626 fee, limit, and safety control extensions.
 interface IERC4626VaultControls is IERC165 {
     /// @notice Emitted when fee configuration is updated.
+    /// @param previousDepositFeeBps Previous deposit fee in basis points.
+    /// @param previousWithdrawFeeBps Previous withdraw fee in basis points.
+    /// @param previousFeeRecipient Previous fee recipient.
+    /// @param newDepositFeeBps New deposit fee in basis points.
+    /// @param newWithdrawFeeBps New withdraw fee in basis points.
+    /// @param newFeeRecipient New fee recipient.
+    /// @param sender Account that updated fees.
     event VaultFeeConfigUpdated(
         uint16 previousDepositFeeBps,
         uint16 previousWithdrawFeeBps,
@@ -18,6 +25,12 @@ interface IERC4626VaultControls is IERC165 {
     );
 
     /// @notice Emitted when limit configuration is updated.
+    /// @param maxTotalAssets New total managed-assets cap.
+    /// @param maxDeposit New per-call deposit cap.
+    /// @param maxMint New per-call mint cap.
+    /// @param maxWithdraw New per-call withdraw cap.
+    /// @param maxRedeem New per-call redeem cap.
+    /// @param sender Account that updated limits.
     event VaultLimitConfigUpdated(
         uint128 maxTotalAssets,
         uint128 maxDeposit,
@@ -28,18 +41,30 @@ interface IERC4626VaultControls is IERC165 {
     );
 
     /// @notice Thrown when a fee basis point value is invalid.
+    /// @param feeBps Invalid fee basis points.
     error ERC4626VaultInvalidFeeBps(uint16 feeBps);
     /// @notice Thrown when fee recipient is invalid for non-zero fee config.
     error ERC4626VaultInvalidFeeRecipient();
     /// @notice Thrown when deposit input exceeds configured limits.
+    /// @param requestedAssets Requested deposit assets.
+    /// @param maxAssets Maximum allowed deposit assets.
     error ERC4626VaultDepositLimitExceeded(uint256 requestedAssets, uint256 maxAssets);
     /// @notice Thrown when mint input exceeds configured limits.
+    /// @param requestedShares Requested mint shares.
+    /// @param maxShares Maximum allowed mint shares.
     error ERC4626VaultMintLimitExceeded(uint256 requestedShares, uint256 maxShares);
     /// @notice Thrown when withdraw input exceeds configured limits.
+    /// @param requestedAssets Requested withdraw assets.
+    /// @param maxAssets Maximum allowed withdraw assets.
     error ERC4626VaultWithdrawLimitExceeded(uint256 requestedAssets, uint256 maxAssets);
     /// @notice Thrown when redeem input exceeds configured limits.
+    /// @param requestedShares Requested redeem shares.
+    /// @param maxShares Maximum allowed redeem shares.
     error ERC4626VaultRedeemLimitExceeded(uint256 requestedShares, uint256 maxShares);
     /// @notice Thrown when operation would exceed total-assets cap.
+    /// @param currentAssets Current total assets.
+    /// @param addedAssets Assets that would be added.
+    /// @param maxTotalAssets Maximum allowed total assets.
     error ERC4626VaultTotalAssetsCapExceeded(uint256 currentAssets, uint256 addedAssets, uint256 maxTotalAssets);
 
     /// @notice Role that can manage vault fees and limits.
@@ -64,12 +89,14 @@ interface IERC4626VaultControls is IERC165 {
         returns (uint128 maxTotalAssets, uint128 maxDeposit, uint128 maxMint, uint128 maxWithdraw, uint128 maxRedeem);
 
     /// @notice Sets fee configuration.
+    /// @dev Requires `VAULT_MANAGER_ROLE`.
     /// @param depositFeeBps Deposit fee in basis points.
     /// @param withdrawFeeBps Withdraw fee in basis points.
     /// @param feeRecipient Fee recipient account.
     function setFeeConfig(uint16 depositFeeBps, uint16 withdrawFeeBps, address feeRecipient) external;
 
     /// @notice Sets limit configuration.
+    /// @dev Requires `VAULT_MANAGER_ROLE`.
     /// @param maxTotalAssets Cap for managed assets (`0` means unlimited).
     /// @param maxDeposit Per-call deposit limit (`0` means unlimited).
     /// @param maxMint Per-call mint limit (`0` means unlimited).

--- a/src/interfaces/IERC4626VaultIntegrationFacet.sol
+++ b/src/interfaces/IERC4626VaultIntegrationFacet.sol
@@ -8,28 +8,50 @@ import {IOracleAdapter} from "./IOracleAdapter.sol";
 /// @notice Hosted integration/config surface for vault oracle wiring and active strategy lifecycle management.
 interface IERC4626VaultIntegrationFacet is IERC165 {
     /// @notice Emitted when the configured oracle adapter is updated.
+    /// @param previousAdapter Previous adapter address.
+    /// @param newAdapter New adapter address.
+    /// @param sender Account that updated the adapter.
     event VaultOracleAdapterUpdated(
         address indexed previousAdapter, address indexed newAdapter, address indexed sender
     );
 
     /// @notice Emitted when the configured strategy address is updated.
+    /// @param previousStrategy Previous strategy address.
+    /// @param newStrategy New strategy address.
+    /// @param sender Account that updated the strategy.
     event VaultStrategyUpdated(address indexed previousStrategy, address indexed newStrategy, address indexed sender);
 
     /// @notice Emitted when assets are deployed from the vault into the configured strategy.
+    /// @param assets Asset amount deployed.
+    /// @param newStrategyDebt Strategy debt after deployment.
+    /// @param sender Account that deployed assets.
     event VaultStrategyDeployed(uint256 assets, uint256 newStrategyDebt, address indexed sender);
 
     /// @notice Emitted when assets are withdrawn from the configured strategy back to the vault.
+    /// @param requestedAssets Requested withdrawal amount.
+    /// @param returnedAssets Actual assets returned by the strategy.
+    /// @param newStrategyDebt Strategy debt after withdrawal accounting.
+    /// @param sender Account that withdrew assets.
     event VaultStrategyWithdrawn(
         uint256 requestedAssets, uint256 returnedAssets, uint256 newStrategyDebt, address indexed sender
     );
 
     /// @notice Emitted when live strategy assets are synced into vault book accounting.
+    /// @param previousDebt Strategy debt before sync.
+    /// @param liveAssets Live strategy assets reported during sync.
+    /// @param sender Account that synced strategy accounting.
     event VaultStrategySynced(uint256 previousDebt, uint256 liveAssets, address indexed sender);
 
     /// @notice Emitted when emergency exit is triggered and the strategy is unwound as far as possible.
+    /// @param returnedAssets Assets returned by the unwind attempt.
+    /// @param newStrategyDebt Strategy debt after emergency accounting.
+    /// @param sender Account that triggered emergency exit.
     event VaultStrategyEmergencyExitTriggered(uint256 returnedAssets, uint256 newStrategyDebt, address indexed sender);
 
     /// @notice Emitted when emergency exit is activated but the unwind attempt reverts.
+    /// @param strategy Strategy that reverted during unwind.
+    /// @param sender Account that triggered emergency exit.
+    /// @param revertData Raw strategy revert data.
     event VaultStrategyEmergencyExitFailed(address indexed strategy, address indexed sender, bytes revertData);
 
     /// @notice Thrown when `oracleQuote()` is called without a configured adapter.
@@ -91,26 +113,32 @@ interface IERC4626VaultIntegrationFacet is IERC165 {
     function oracleQuote() external view returns (IOracleAdapter.OracleQuote memory quotePayload);
 
     /// @notice Sets the external oracle adapter reference.
+    /// @dev Requires `VAULT_MANAGER_ROLE`.
     /// @param newAdapter The new adapter address, or zero to clear.
     function setOracleAdapter(address newAdapter) external;
 
     /// @notice Sets the configured strategy reference.
+    /// @dev Requires `VAULT_MANAGER_ROLE`; strategies are trusted accounting modules once debt is active.
     /// @param newStrategy The new strategy address, or zero to clear.
     function setStrategy(address newStrategy) external;
 
     /// @notice Deploys idle vault assets into the configured strategy.
+    /// @dev Requires `VAULT_MANAGER_ROLE`.
     /// @param assets The asset amount to deploy.
     function deployToStrategy(uint256 assets) external;
 
     /// @notice Withdraws assets from the configured strategy back to the vault.
+    /// @dev Requires `VAULT_MANAGER_ROLE`.
     /// @param assets The requested asset amount to withdraw.
     /// @return assetsReturned The actual returned asset amount.
     function withdrawFromStrategy(uint256 assets) external returns (uint256 assetsReturned);
 
     /// @notice Syncs live strategy assets into vault book accounting.
+    /// @dev Requires `VAULT_MANAGER_ROLE`.
     function syncStrategyAssets() external;
 
     /// @notice Activates emergency-exit mode and attempts to unwind the configured strategy.
+    /// @dev Requires `VAULT_MANAGER_ROLE`.
     /// @return assetsReturned The actual returned asset amount from the unwind attempt.
     function emergencyExitStrategy() external returns (uint256 assetsReturned);
 }

--- a/src/interfaces/IERC721.sol
+++ b/src/interfaces/IERC721.sol
@@ -7,12 +7,21 @@ import {IERC165} from "./IERC165.sol";
 /// @notice ERC-721 non-fungible token standard interface.
 interface IERC721 is IERC165 {
     /// @notice Emitted when `tokenId` transfers from `from` to `to`.
+    /// @param from Previous token owner.
+    /// @param to New token owner.
+    /// @param tokenId Token identifier.
     event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
 
     /// @notice Emitted when `owner` approves `approved` for `tokenId`.
+    /// @param owner Token owner.
+    /// @param approved Approved account.
+    /// @param tokenId Token identifier.
     event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId);
 
     /// @notice Emitted when `owner` enables or disables `operator`.
+    /// @param owner Token owner.
+    /// @param operator Operator account.
+    /// @param approved True when approved, false when revoked.
     event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
 
     /// @notice Returns the token count owned by `owner`.

--- a/src/interfaces/IERC721TokenBase.sol
+++ b/src/interfaces/IERC721TokenBase.sol
@@ -13,16 +13,25 @@ interface IERC721TokenBase is IERC721Metadata {
     /// @notice Thrown when a required account is the zero address.
     error ERC721TokenZeroAddress();
     /// @notice Thrown when `owner` is invalid for the requested operation.
+    /// @param owner Invalid owner.
     error ERC721TokenInvalidOwner(address owner);
     /// @notice Thrown when a token does not exist.
+    /// @param tokenId Missing token identifier.
     error ERC721TokenNonexistentToken(uint256 tokenId);
     /// @notice Thrown when a mint targets an existing token.
+    /// @param tokenId Existing token identifier.
     error ERC721TokenAlreadyMinted(uint256 tokenId);
     /// @notice Thrown when `from` is not the current owner of `tokenId`.
+    /// @param from Supplied owner.
+    /// @param tokenId Token identifier.
+    /// @param actualOwner Current token owner.
     error ERC721TokenIncorrectOwner(address from, uint256 tokenId, address actualOwner);
     /// @notice Thrown when a receiver does not implement `IERC721Receiver`.
+    /// @param receiver Unsafe receiver address.
     error ERC721TokenUnsafeReceiver(address receiver);
     /// @notice Thrown when `owner` tries to set themselves as operator.
+    /// @param owner Token owner.
+    /// @param operator Invalid operator.
     error ERC721TokenInvalidOperator(address owner, address operator);
 
     /// @notice Returns true when ERC-721 storage is initialized.

--- a/src/interfaces/IERC721TokenFacet.sol
+++ b/src/interfaces/IERC721TokenFacet.sol
@@ -10,6 +10,8 @@ import {IPausable} from "./IPausable.sol";
 /// @notice Hosted ERC-721 facet surface for diamond deployments.
 interface IERC721TokenFacet is IERC721Metadata, IERC721TokenBase, IAccessControl, IPausable {
     /// @notice Thrown when `operator` is not authorized to manage `tokenId`.
+    /// @param operator Unauthorized operator.
+    /// @param tokenId Token identifier.
     error ERC721TokenUnauthorizedOperator(address operator, uint256 tokenId);
 
     /// @notice Returns the shared token admin role identifier.

--- a/src/interfaces/IERC7540VaultFacet.sol
+++ b/src/interfaces/IERC7540VaultFacet.sol
@@ -9,15 +9,28 @@ import {IERC7540Redeem} from "./IERC7540Redeem.sol";
 /// @notice Hosted async-vault extension surface for ERC-7540-style request flows.
 interface IERC7540VaultFacet is IERC7540Operators, IERC7540Deposit, IERC7540Redeem {
     /// @notice Emitted when a deposit request is submitted.
+    /// @param controller Controller that will own the async claim.
+    /// @param owner Asset owner funding the request.
+    /// @param requestId Request identifier.
+    /// @param sender Account that submitted the request.
+    /// @param assets Requested deposit assets.
     event DepositRequest(
         address indexed controller, address indexed owner, uint256 indexed requestId, address sender, uint256 assets
     );
 
     /// @notice Emitted when a redeem request is submitted.
+    /// @param controller Controller that will own the async claim.
+    /// @param owner Share owner funding the request.
+    /// @param requestId Request identifier.
+    /// @param sender Account that submitted the request.
+    /// @param shares Requested redeem shares.
     event RedeemRequest(
         address indexed controller, address indexed owner, uint256 indexed requestId, address sender, uint256 shares
     );
 
     /// @notice Emitted when `controller` updates `operator` approval.
+    /// @param controller Account granting or revoking operator authority.
+    /// @param operator Operator account.
+    /// @param approved True when approved, false when revoked.
     event OperatorSet(address indexed controller, address indexed operator, bool approved);
 }

--- a/src/interfaces/IERC7540VaultSettlementFacet.sol
+++ b/src/interfaces/IERC7540VaultSettlementFacet.sol
@@ -7,9 +7,15 @@ import {IERC165} from "./IERC165.sol";
 /// @notice Manager-facing settlement surface for hosted ERC-7540 async vault requests.
 interface IERC7540VaultSettlementFacet is IERC165 {
     /// @notice Emitted when pending deposit assets are moved into claimable state.
+    /// @param controller Controller whose pending deposit was settled.
+    /// @param assets Asset amount moved into claimable state.
+    /// @param sender Account that settled the request.
     event VaultDepositRequestSettled(address indexed controller, uint256 assets, address indexed sender);
 
     /// @notice Emitted when pending redeem shares are moved into claimable state.
+    /// @param controller Controller whose pending redeem was settled.
+    /// @param shares Share amount moved into claimable state.
+    /// @param sender Account that settled the request.
     event VaultRedeemRequestSettled(address indexed controller, uint256 shares, address indexed sender);
 
     /// @notice Returns the pause scope that gates manager settlement entrypoints.
@@ -17,11 +23,13 @@ interface IERC7540VaultSettlementFacet is IERC165 {
     function ASYNC_SETTLEMENT_SCOPE() external view returns (bytes32);
 
     /// @notice Moves pending deposit assets into claimable state for `controller`.
+    /// @dev Requires `VAULT_MANAGER_ROLE` and an unpaused `ASYNC_SETTLEMENT_SCOPE`.
     /// @param controller Request controller account.
     /// @param assets Asset amount to settle.
     function settleDepositRequest(address controller, uint256 assets) external;
 
     /// @notice Moves pending redeem shares into claimable state for `controller`.
+    /// @dev Requires `VAULT_MANAGER_ROLE` and an unpaused `ASYNC_SETTLEMENT_SCOPE`.
     /// @param controller Request controller account.
     /// @param shares Share amount to settle.
     function settleRedeemRequest(address controller, uint256 shares) external;

--- a/src/interfaces/IMultiSendCallOnly.sol
+++ b/src/interfaces/IMultiSendCallOnly.sol
@@ -4,8 +4,13 @@ pragma solidity ^0.8.30;
 /// @title IMultiSendCallOnly
 /// @notice Delegatecall helper for atomic call-only batch execution from a wallet context.
 interface IMultiSendCallOnly {
+    /// @notice Reverts when the encoded batch has no transactions.
     error MultiSendCallOnlyEmptyBatch();
+    /// @notice Reverts when transaction bytes cannot be decoded at `offset`.
+    /// @param offset Byte offset where decoding failed.
     error MultiSendCallOnlyInvalidEncoding(uint256 offset);
+    /// @notice Reverts when a batch item targets the zero address.
+    /// @param transactionIndex Zero-based index of the invalid transaction.
     error MultiSendCallOnlyZeroTarget(uint256 transactionIndex);
 
     /// @notice Executes concatenated call-only transactions.
@@ -14,5 +19,6 @@ interface IMultiSendCallOnly {
     ///      - 32 bytes value
     ///      - 32 bytes calldata length
     ///      - N bytes calldata
+    /// @param transactions Concatenated encoded call-only transactions.
     function multiSend(bytes calldata transactions) external;
 }

--- a/src/interfaces/IMultisigWallet.sol
+++ b/src/interfaces/IMultisigWallet.sol
@@ -4,47 +4,158 @@ pragma solidity ^0.8.30;
 /// @title IMultisigWallet
 /// @notice Foundation interface for the standalone multisig wallet.
 interface IMultisigWallet {
+    /// @notice Reverts when wallet initialization is attempted more than once.
     error MultisigWalletAlreadyInitialized();
+    /// @notice Reverts when execution is attempted before the wallet has a nonzero threshold.
     error MultisigWalletNotOperational();
+    /// @notice Reverts when owner-management functions are called outside wallet self-execution.
     error MultisigWalletCallerNotSelf();
+    /// @notice Reverts when a threshold is zero or exceeds owner count.
+    /// @param threshold Supplied threshold.
+    /// @param ownerCount Current or supplied owner count.
     error MultisigWalletInvalidThreshold(uint256 threshold, uint256 ownerCount);
+    /// @notice Reverts when an owner address is zero.
     error MultisigWalletZeroOwner();
+    /// @notice Reverts when an owner is duplicated.
+    /// @param owner Duplicate owner.
     error MultisigWalletDuplicateOwner(address owner);
+    /// @notice Reverts when an owner is not in the owner set.
+    /// @param owner Missing owner.
     error MultisigWalletOwnerNotFound(address owner);
+    /// @notice Reverts when replacing an owner with itself.
+    /// @param owner Owner supplied for both old and new owner.
     error MultisigWalletReplaceOwnerNoop(address owner);
+    /// @notice Reverts when attempting to remove the only owner.
     error MultisigWalletCannotRemoveLastOwner();
+    /// @notice Reverts when owner removal would leave threshold above owner count.
+    /// @param threshold Current threshold.
+    /// @param newOwnerCount Owner count after removal.
     error MultisigWalletRemovalInvalidatesThreshold(uint256 threshold, uint256 newOwnerCount);
+    /// @notice Reverts when the batch execution helper is zero.
     error MultisigWalletZeroMultiSend();
+    /// @notice Reverts when the signature payload length does not match threshold.
+    /// @param providedLength Provided signature byte length.
+    /// @param requiredLength Required signature byte length.
     error MultisigWalletInvalidSignaturesLength(uint256 providedLength, uint256 requiredLength);
+    /// @notice Reverts when a recovered signer is not an owner.
+    /// @param signer Recovered signer.
     error MultisigWalletInvalidSigner(address signer);
+    /// @notice Reverts when signatures are not sorted in strict ascending signer order.
+    /// @param previousSigner Previous recovered signer.
+    /// @param currentSigner Current recovered signer.
     error MultisigWalletSignersNotStrictlyOrdered(address previousSigner, address currentSigner);
+    /// @notice Reverts when single-call execution targets the zero address.
     error MultisigWalletZeroTarget();
 
+    /// @notice Emitted when a wallet clone is initialized.
+    /// @param owners Initial owner set.
+    /// @param threshold Initial signature threshold.
+    /// @param multiSendCallOnly Batch execution helper address.
     event WalletInitialized(address[] owners, uint256 threshold, address multiSendCallOnly);
+    /// @notice Emitted after a successful single-call transaction.
+    /// @param digest EIP-712 transaction digest.
+    /// @param nonce Nonce consumed by the transaction.
+    /// @param target Call target.
+    /// @param value Native value sent with the call.
     event TransactionExecuted(bytes32 indexed digest, uint256 indexed nonce, address indexed target, uint256 value);
+    /// @notice Emitted after a successful batch transaction.
+    /// @param digest EIP-712 batch digest.
+    /// @param nonce Nonce consumed by the batch.
     event BatchExecuted(bytes32 indexed digest, uint256 indexed nonce);
+    /// @notice Emitted when an owner is added by wallet self-execution.
+    /// @param owner Added owner.
     event OwnerAdded(address indexed owner);
+    /// @notice Emitted when an owner is removed by wallet self-execution.
+    /// @param owner Removed owner.
     event OwnerRemoved(address indexed owner);
+    /// @notice Emitted when an owner is replaced by wallet self-execution.
+    /// @param oldOwner Removed owner.
+    /// @param newOwner Added owner.
     event OwnerReplaced(address indexed oldOwner, address indexed newOwner);
+    /// @notice Emitted when threshold changes by wallet self-execution.
+    /// @param threshold New threshold.
     event ThresholdChanged(uint256 threshold);
 
+    /// @notice Initializes wallet owner set, threshold, and batch helper.
+    /// @param owners Initial owner set.
+    /// @param threshold_ Initial signature threshold.
+    /// @param multiSendCallOnly_ Batch execution helper address.
     function initialize(address[] calldata owners, uint256 threshold_, address multiSendCallOnly_) external;
+
+    /// @notice Returns the EIP-712 digest for a single-call transaction.
+    /// @param to Call target.
+    /// @param value Native value to send.
+    /// @param data Calldata to send.
+    /// @param nonce_ Nonce to include in the digest.
+    /// @return Transaction digest.
     function getTransactionHash(address to, uint256 value, bytes calldata data, uint256 nonce_)
         external
         view
         returns (bytes32);
+
+    /// @notice Returns the EIP-712 digest for an encoded batch transaction.
+    /// @param transactions Encoded batch transactions.
+    /// @param nonce_ Nonce to include in the digest.
+    /// @return Batch digest.
     function getBatchHash(bytes calldata transactions, uint256 nonce_) external view returns (bytes32);
+
+    /// @notice Executes a signed single-call transaction.
+    /// @param to Call target.
+    /// @param value Native value to send.
+    /// @param data Calldata to send.
+    /// @param signatures Concatenated owner signatures in strict ascending signer order.
     function executeTransaction(address to, uint256 value, bytes calldata data, bytes calldata signatures) external;
+
+    /// @notice Executes a signed call-only batch through the configured helper.
+    /// @param transactions Encoded batch transactions.
+    /// @param signatures Concatenated owner signatures in strict ascending signer order.
     function executeBatch(bytes calldata transactions, bytes calldata signatures) external;
+
+    /// @notice Adds an owner; callable only by the wallet itself.
+    /// @param owner Owner to add.
     function addOwner(address owner) external;
+
+    /// @notice Removes an owner; callable only by the wallet itself.
+    /// @param owner Owner to remove.
     function removeOwner(address owner) external;
+
+    /// @notice Replaces an owner; callable only by the wallet itself.
+    /// @param oldOwner Owner to remove.
+    /// @param newOwner Owner to add.
     function replaceOwner(address oldOwner, address newOwner) external;
+
+    /// @notice Updates the signature threshold; callable only by the wallet itself.
+    /// @param newThreshold New signature threshold.
     function changeThreshold(uint256 newThreshold) external;
+
+    /// @notice Validates an ERC-1271 signature payload against current owners and threshold.
+    /// @param digest Digest being validated.
+    /// @param signatures Concatenated owner signatures.
+    /// @return ERC-1271 magic value on success, otherwise `0xffffffff`.
     function isValidSignature(bytes32 digest, bytes calldata signatures) external view returns (bytes4);
+
+    /// @notice Returns the next nonce to be consumed by execution.
+    /// @return Current wallet nonce.
     function nonce() external view returns (uint256);
+
+    /// @notice Returns the current signature threshold.
+    /// @return Current threshold.
     function threshold() external view returns (uint256);
+
+    /// @notice Returns the number of owners.
+    /// @return Current owner count.
     function ownerCount() external view returns (uint256);
+
+    /// @notice Returns the configured batch execution helper.
+    /// @return MultiSendCallOnly helper address.
     function multiSendCallOnly() external view returns (address);
+
+    /// @notice Returns whether `account` is an owner.
+    /// @param account Account to inspect.
+    /// @return True when account is an owner.
     function isOwner(address account) external view returns (bool);
+
+    /// @notice Returns the full owner set.
+    /// @return Current owners in stored order.
     function getOwners() external view returns (address[] memory);
 }

--- a/src/interfaces/IMultisigWalletFactory.sol
+++ b/src/interfaces/IMultisigWalletFactory.sol
@@ -4,13 +4,31 @@ pragma solidity ^0.8.30;
 /// @title IMultisigWalletFactory
 /// @notice Deterministic clone deployment surface for standalone multisig wallets.
 interface IMultisigWalletFactory {
+    /// @notice Reverts when the factory is constructed with a zero implementation.
     error MultisigWalletFactoryZeroImplementation();
 
+    /// @notice Emitted when a wallet clone is deployed and initialized.
+    /// @param wallet Deployed wallet clone.
+    /// @param implementation Wallet implementation used by the clone.
+    /// @param salt CREATE2 salt used for deployment.
     event WalletDeployed(address indexed wallet, address indexed implementation, bytes32 indexed salt);
 
+    /// @notice Returns the master wallet implementation cloned by this factory.
+    /// @return Implementation address.
     function implementation() external view returns (address);
+
+    /// @notice Deploys and initializes a deterministic wallet clone.
+    /// @param salt CREATE2 salt.
+    /// @param owners Initial owner set.
+    /// @param threshold_ Initial signature threshold.
+    /// @param multiSendCallOnly_ Batch execution helper address.
+    /// @return wallet Deployed wallet address.
     function deployWallet(bytes32 salt, address[] calldata owners, uint256 threshold_, address multiSendCallOnly_)
         external
         returns (address wallet);
+
+    /// @notice Predicts the wallet clone address for `salt`.
+    /// @param salt CREATE2 salt.
+    /// @return predicted Predicted wallet address.
     function predictWalletAddress(bytes32 salt) external view returns (address predicted);
 }

--- a/src/interfaces/IOracleAdapter.sol
+++ b/src/interfaces/IOracleAdapter.sol
@@ -20,10 +20,23 @@ interface IOracleAdapter is IERC165 {
     }
 
     /// @notice Emitted when oracle source is updated.
+    /// @param previousSource Previous oracle source.
+    /// @param newSource New oracle source.
+    /// @param sender Account that updated the source.
     event OracleSourceUpdated(address indexed previousSource, address indexed newSource, address indexed sender);
     /// @notice Emitted when max staleness is updated.
+    /// @param previousMaxStaleness Previous staleness threshold.
+    /// @param newMaxStaleness New staleness threshold.
+    /// @param sender Account that updated staleness.
     event OracleMaxStalenessUpdated(uint64 previousMaxStaleness, uint64 newMaxStaleness, address indexed sender);
     /// @notice Emitted when validation bounds policy is updated.
+    /// @param previousMinAnswer Previous minimum accepted answer.
+    /// @param previousMaxAnswer Previous maximum accepted answer.
+    /// @param previousBoundsEnabled Previous bounds-enabled flag.
+    /// @param newMinAnswer New minimum accepted answer.
+    /// @param newMaxAnswer New maximum accepted answer.
+    /// @param newBoundsEnabled New bounds-enabled flag.
+    /// @param sender Account that updated bounds.
     event OracleValidationBoundsUpdated(
         int256 previousMinAnswer,
         int256 previousMaxAnswer,
@@ -34,14 +47,24 @@ interface IOracleAdapter is IERC165 {
         address indexed sender
     );
     /// @notice Emitted when circuit breaker is tripped.
+    /// @param sender Account that tripped the breaker.
     event OracleCircuitBreakerTripped(address indexed sender);
     /// @notice Emitted when circuit breaker is reset.
+    /// @param sender Account that reset the breaker.
     event OracleCircuitBreakerReset(address indexed sender);
     /// @notice Emitted when fallback mode is updated.
+    /// @param previousMode Previous fallback mode.
+    /// @param newMode New fallback mode.
+    /// @param sender Account that updated fallback mode.
     event OracleFallbackModeUpdated(FallbackMode previousMode, FallbackMode newMode, address indexed sender);
     /// @notice Emitted when fallback quote is configured.
+    /// @param value Fallback quote value.
+    /// @param updatedAt Fallback quote timestamp.
+    /// @param decimals Fallback quote decimals.
+    /// @param sender Account that updated the fallback quote.
     event OracleFallbackQuoteUpdated(int256 value, uint64 updatedAt, uint8 decimals, address indexed sender);
     /// @notice Emitted when fallback quote is cleared.
+    /// @param sender Account that cleared the fallback quote.
     event OracleFallbackQuoteCleared(address indexed sender);
 
     /// @notice Thrown when the oracle source address is zero.
@@ -49,18 +72,31 @@ interface IOracleAdapter is IERC165 {
     /// @notice Thrown when adapter initializer runs more than once.
     error OracleAdapterAlreadyInitialized();
     /// @notice Thrown when feed timestamp does not fit in uint64.
+    /// @param updatedAt Feed timestamp that exceeded uint64.
     error OracleAdapterInvalidUpdatedAt(uint256 updatedAt);
     /// @notice Thrown when feed timestamp is zero.
     error OracleAdapterZeroUpdatedAt();
     /// @notice Thrown when feed timestamp is in the future.
+    /// @param updatedAt Feed timestamp.
+    /// @param currentTimestamp Current block timestamp.
     error OracleAdapterFutureUpdatedAt(uint64 updatedAt, uint64 currentTimestamp);
     /// @notice Thrown when quote exceeds configured staleness threshold.
+    /// @param updatedAt Feed timestamp.
+    /// @param currentTimestamp Current block timestamp.
+    /// @param maxStaleness Maximum allowed age.
     error OracleAdapterStaleQuote(uint64 updatedAt, uint64 currentTimestamp, uint64 maxStaleness);
     /// @notice Thrown when feed round consistency is invalid.
+    /// @param roundId Reported round id.
+    /// @param answeredInRound Round id that produced the answer.
     error OracleAdapterInvalidRound(uint80 roundId, uint80 answeredInRound);
     /// @notice Thrown when configured bounds are invalid.
+    /// @param minAnswer Minimum answer.
+    /// @param maxAnswer Maximum answer.
     error OracleAdapterInvalidValidationBounds(int256 minAnswer, int256 maxAnswer);
     /// @notice Thrown when quote value falls outside configured bounds.
+    /// @param answer Oracle answer.
+    /// @param minAnswer Minimum accepted answer.
+    /// @param maxAnswer Maximum accepted answer.
     error OracleAdapterAnswerOutOfBounds(int256 answer, int256 minAnswer, int256 maxAnswer);
     /// @notice Thrown when breaker is already active.
     error OracleAdapterBreakerAlreadyActive();
@@ -73,6 +109,7 @@ interface IOracleAdapter is IERC165 {
     /// @notice Thrown when fallback mode is selected but no fallback quote is configured.
     error OracleAdapterFallbackUnavailable();
     /// @notice Thrown when configured fallback quote is invalid.
+    /// @param updatedAt Fallback quote timestamp.
     error OracleAdapterInvalidFallbackQuote(uint64 updatedAt);
 
     /// @notice Returns the configured oracle source address.

--- a/src/interfaces/IPausable.sol
+++ b/src/interfaces/IPausable.sol
@@ -7,12 +7,18 @@ import {IERC165} from "./IERC165.sol";
 /// @notice Interface for role-gated pause and unpause controls.
 interface IPausable is IERC165 {
     /// @notice Emitted when the contract is paused.
+    /// @param account Account that paused the contract.
     event Paused(address indexed account);
     /// @notice Emitted when the contract is unpaused.
+    /// @param account Account that unpaused the contract.
     event Unpaused(address indexed account);
     /// @notice Emitted when a pause scope is paused.
+    /// @param scope Scope that was paused.
+    /// @param account Account that paused the scope.
     event ScopePaused(bytes32 indexed scope, address indexed account);
     /// @notice Emitted when a pause scope is unpaused.
+    /// @param scope Scope that was unpaused.
+    /// @param account Account that unpaused the scope.
     event ScopeUnpaused(bytes32 indexed scope, address indexed account);
 
     /// @notice Thrown when pause is required but contract is not paused.
@@ -20,8 +26,10 @@ interface IPausable is IERC165 {
     /// @notice Thrown when unpaused state is required but contract is paused.
     error PausableEnforcedPause();
     /// @notice Thrown when a scope-specific pause is required but scope is not paused.
+    /// @param scope Scope expected to be paused.
     error PausableScopeExpectedPause(bytes32 scope);
     /// @notice Thrown when unpaused scope state is required but scope is paused.
+    /// @param scope Scope required to be unpaused.
     error PausableScopeEnforcedPause(bytes32 scope);
     /// @notice Thrown when a zero-value scope is used.
     error PausableZeroScope();
@@ -48,16 +56,20 @@ interface IPausable is IERC165 {
     function scopePaused(bytes32 scope) external view returns (bool);
 
     /// @notice Pauses the contract.
+    /// @dev Requires `PAUSER_ROLE`.
     function pause() external;
 
     /// @notice Unpauses the contract.
+    /// @dev Requires `PAUSER_ROLE`.
     function unpause() external;
 
     /// @notice Pauses a specific scope.
+    /// @dev Requires `PAUSER_ROLE`.
     /// @param scope The scope identifier.
     function pauseScope(bytes32 scope) external;
 
     /// @notice Unpauses a specific scope.
+    /// @dev Requires `PAUSER_ROLE`.
     /// @param scope The scope identifier.
     function unpauseScope(bytes32 scope) external;
 }

--- a/src/interfaces/IUpgradeGuardrails.sol
+++ b/src/interfaces/IUpgradeGuardrails.sol
@@ -7,10 +7,17 @@ import {IERC165} from "./IERC165.sol";
 /// @notice Interface for role-gated upgrade guard rails.
 interface IUpgradeGuardrails is IERC165 {
     /// @notice Emitted when an upgrade intent is queued.
+    /// @param implementation Queued implementation address.
+    /// @param executeAfter Earliest execution timestamp.
+    /// @param sender Account that queued the intent.
     event UpgradeIntentQueued(address indexed implementation, uint64 executeAfter, address indexed sender);
     /// @notice Emitted when an upgrade intent is cancelled.
+    /// @param implementation Cancelled implementation address.
+    /// @param sender Account that cancelled the intent.
     event UpgradeIntentCancelled(address indexed implementation, address indexed sender);
     /// @notice Emitted when an upgrade is executed.
+    /// @param implementation Executed implementation address.
+    /// @param sender Account that executed the upgrade.
     event UpgradeExecuted(address indexed implementation, address indexed sender);
 
     /// @notice Thrown when implementation is zero address.
@@ -18,8 +25,12 @@ interface IUpgradeGuardrails is IERC165 {
     /// @notice Thrown when attempting to execute/cancel without a queued intent.
     error UpgradeGuardrailsNoUpgradeIntent();
     /// @notice Thrown when requested implementation does not match queued implementation.
+    /// @param queuedImplementation Currently queued implementation.
+    /// @param requestedImplementation Requested implementation.
     error UpgradeGuardrailsImplementationNotQueued(address queuedImplementation, address requestedImplementation);
     /// @notice Thrown when upgrade timelock is still active.
+    /// @param executeAfter Earliest execution timestamp.
+    /// @param currentTime Current block timestamp.
     error UpgradeGuardrailsUpgradeNotReady(uint64 executeAfter, uint64 currentTime);
     /// @notice Thrown when upgrade guardrails module is initialized more than once.
     error UpgradeGuardrailsAlreadyInitialized();
@@ -49,4 +60,3 @@ interface IUpgradeGuardrails is IERC165 {
     /// @param implementation The queued implementation address.
     function executeUpgrade(address implementation) external;
 }
-

--- a/src/interfaces/IWrappedNative.sol
+++ b/src/interfaces/IWrappedNative.sol
@@ -6,6 +6,10 @@ import {IERC20} from "./IERC20.sol";
 /// @title IWrappedNative
 /// @notice Minimal wrapped-native token surface for AMM router integration.
 interface IWrappedNative is IERC20 {
+    /// @notice Wraps native currency into ERC-20 wrapped-native tokens.
     function deposit() external payable;
+
+    /// @notice Burns wrapped-native tokens and releases native currency.
+    /// @param value Wrapped-native amount to unwrap.
     function withdraw(uint256 value) external;
 }

--- a/src/libraries/LibClone.sol
+++ b/src/libraries/LibClone.sol
@@ -4,8 +4,13 @@ pragma solidity ^0.8.30;
 /// @title LibClone
 /// @notice Minimal proxy deployment helpers for deterministic wallet clones.
 library LibClone {
+    /// @notice Reverts when CREATE2 clone deployment returns the zero address.
     error CloneCreate2Failed();
 
+    /// @notice Deploys an ERC-1167 minimal proxy clone with CREATE2.
+    /// @param implementation Logic contract address copied into the minimal proxy init code.
+    /// @param salt CREATE2 salt.
+    /// @return instance Deployed clone address.
     function cloneDeterministic(address implementation, bytes32 salt) internal returns (address instance) {
         bytes memory initCode = _minimalProxyInitCode(implementation);
         assembly {
@@ -17,6 +22,11 @@ library LibClone {
         }
     }
 
+    /// @notice Predicts the CREATE2 address for a deterministic minimal proxy clone.
+    /// @param implementation Logic contract address copied into the minimal proxy init code.
+    /// @param salt CREATE2 salt.
+    /// @param deployer Address that will deploy the clone.
+    /// @return predicted Predicted clone address.
     function predictDeterministicAddress(address implementation, bytes32 salt, address deployer)
         internal
         pure

--- a/src/vault/ERC4626Vault.sol
+++ b/src/vault/ERC4626Vault.sol
@@ -27,6 +27,8 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
     /// @notice Thrown when a native-only entrypoint is used on an ERC-20 vault.
     error ERC4626VaultNativeAssetDisabled();
     /// @notice Thrown when `msg.value` does not match the required native asset amount.
+    /// @param supplied Native value supplied by caller.
+    /// @param required Native value required by the operation.
     error ERC4626VaultInvalidNativeAssetValue(uint256 supplied, uint256 required);
 
     /// @notice Returns vault underlying asset token address.
@@ -200,6 +202,7 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
     /// @dev Decreases managed assets for a user exit while ignoring untracked native surplus.
     /// @dev Forced ETH can increase `address(this).balance` without increasing managed assets. When a native
     ///      withdrawal is satisfied from that surplus, book accounting must only burn the tracked portion.
+    /// @param assets Gross assets exiting the vault.
     function _decreaseManagedAssetsForAssetExit(uint256 assets) internal {
         LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
         if (LibVaultAsset.isNativeAsset(layout.asset) && layout.strategyDebt != 0) {
@@ -218,6 +221,7 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
     }
 
     /// @dev Returns the vault's immediately idle asset balance.
+    /// @return Immediately held asset balance.
     function _idleAssetBalance() internal view returns (uint256) {
         return LibVaultAsset.balanceOfSelf(asset());
     }
@@ -225,6 +229,7 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
     /// @dev Returns the tracked idle assets available to support exits when a strategy is active.
     /// @dev Raw idle balances can exceed tracked idle because of pending async deposits or direct transfers.
     ///      Exit paths that must preserve strategy-debt accounting use the smaller tracked value instead.
+    /// @return Tracked idle assets available for exits.
     function _trackedIdleAssetBalance() internal view returns (uint256) {
         LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
         uint256 actualIdleAssets = _idleAssetBalance();
@@ -233,6 +238,7 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
     }
 
     /// @dev Returns the configured strategy's immediately withdrawable assets.
+    /// @return Strategy assets that can be withdrawn immediately.
     function _strategyWithdrawableAssets() internal view returns (uint256) {
         LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
         if (layout.strategyDebt == 0) {
@@ -246,6 +252,9 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
     }
 
     /// @dev Pulls assets from the configured strategy back to the vault.
+    /// @param assets Requested withdrawal amount.
+    /// @return returnedAssets Assets returned by the strategy call.
+    /// @return postCallLiveAssets Strategy live assets reported after the call.
     function _withdrawStrategyAssets(uint256 assets)
         internal
         returns (uint256 returnedAssets, uint256 postCallLiveAssets)
@@ -257,6 +266,8 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
     }
 
     /// @dev Fully unwinds assets from the configured strategy back to the vault.
+    /// @return returnedAssets Assets returned by the strategy call.
+    /// @return postCallLiveAssets Strategy live assets reported after the call.
     function _withdrawAllStrategyAssets() internal returns (uint256 returnedAssets, uint256 postCallLiveAssets) {
         LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
         IERC4626VaultStrategy configuredStrategy = IERC4626VaultStrategy(layout.strategy);
@@ -265,6 +276,8 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
     }
 
     /// @dev Realizes strategy mark-to-market changes into book accounting without moving idle vault assets.
+    /// @param liveAssets Strategy live assets to sync into stored debt.
+    /// @return previousDebt Strategy debt before syncing.
     function _syncStrategyDebtToLiveAssets(uint256 liveAssets) internal returns (uint256 previousDebt) {
         LibERC4626VaultStorage.Layout storage layout = LibERC4626VaultStorage.layout();
         previousDebt = layout.strategyDebt;
@@ -280,6 +293,9 @@ abstract contract ERC4626Vault is ERC4626VaultBase, IERC4626 {
     }
 
     /// @dev Reconciles book accounting after a strategy withdrawal-like call that returned assets to the vault.
+    /// @param returnedAssets Assets returned to the vault by the strategy call.
+    /// @param postCallLiveAssets Strategy live assets reported after the call.
+    /// @return previousDebt Strategy debt before reconciliation.
     function _reconcileStrategyWithdrawalAccounting(uint256 returnedAssets, uint256 postCallLiveAssets)
         internal
         returns (uint256 previousDebt)

--- a/src/vault/ERC4626VaultControlLogic.sol
+++ b/src/vault/ERC4626VaultControlLogic.sol
@@ -16,11 +16,21 @@ library LibERC4626VaultControlLogic {
         Up
     }
 
+    /// @notice Reads the current vault fee configuration from storage.
+    /// @return depositFeeBps Deposit fee in basis points.
+    /// @return withdrawFeeBps Withdraw fee in basis points.
+    /// @return recipient Fee recipient account.
     function feeConfig() internal view returns (uint16 depositFeeBps, uint16 withdrawFeeBps, address recipient) {
         LibERC4626VaultStorage.FeeConfig storage fees = LibERC4626VaultStorage.layout().fees;
         return (fees.depositFeeBps, fees.withdrawFeeBps, fees.feeRecipient);
     }
 
+    /// @notice Reads the current vault limit configuration from storage.
+    /// @return maxTotalAssets Cap for managed assets, or zero when unlimited.
+    /// @return maxDeposit Per-call deposit limit, or zero when unlimited.
+    /// @return maxMint Per-call mint limit, or zero when unlimited.
+    /// @return maxWithdraw Per-call withdraw limit, or zero when unlimited.
+    /// @return maxRedeem Per-call redeem limit, or zero when unlimited.
     function limitConfig()
         internal
         view
@@ -30,22 +40,33 @@ library LibERC4626VaultControlLogic {
         return (limits.maxTotalAssets, limits.maxDeposit, limits.maxMint, limits.maxWithdraw, limits.maxRedeem);
     }
 
+    /// @notice Reads the configured vault fee recipient.
+    /// @return Fee recipient account.
     function feeRecipient() internal view returns (address) {
         return LibERC4626VaultStorage.layout().fees.feeRecipient;
     }
 
+    /// @notice Reverts unless a fee rate is below 100%.
+    /// @param feeBps Fee rate in basis points.
     function validateFeeBps(uint16 feeBps) internal pure {
         if (feeBps >= BPS_DENOMINATOR) {
             revert IERC4626VaultControls.ERC4626VaultInvalidFeeBps(feeBps);
         }
     }
 
+    /// @notice Computes net managed assets credited after a deposit fee.
+    /// @param assets Gross assets paid by the depositor.
+    /// @return netAssets Assets credited to vault managed accounting.
+    /// @return feeAssets Assets paid to the configured fee recipient.
     function netAfterDepositFee(uint256 assets) internal view returns (uint256 netAssets, uint256 feeAssets) {
         uint16 depositFeeBps = LibERC4626VaultStorage.layout().fees.depositFeeBps;
         feeAssets = feeOnRaw(assets, depositFeeBps, FeeRounding.Down);
         netAssets = assets - feeAssets;
     }
 
+    /// @notice Computes the smallest gross deposit that credits at least `netAssets`.
+    /// @param netAssets Desired net managed assets after deposit fee.
+    /// @return grossAssets Gross assets required from the depositor.
     function grossUpForDepositFee(uint256 netAssets) internal view returns (uint256 grossAssets) {
         uint16 depositFeeBps = LibERC4626VaultStorage.layout().fees.depositFeeBps;
         if (depositFeeBps == 0 || netAssets == 0) {
@@ -61,6 +82,10 @@ library LibERC4626VaultControlLogic {
         }
     }
 
+    /// @notice Computes gross accounting assets needed to withdraw an exact net amount.
+    /// @param assets Net assets requested by the receiver.
+    /// @return grossAssets Gross assets removed from vault accounting.
+    /// @return feeAssets Withdraw fee paid to the configured recipient.
     function withdrawGrossFromNet(uint256 assets) internal view returns (uint256 grossAssets, uint256 feeAssets) {
         uint256 withdrawFeeBps = LibERC4626VaultStorage.layout().fees.withdrawFeeBps;
 
@@ -76,12 +101,21 @@ library LibERC4626VaultControlLogic {
         grossAssets = assets + feeAssets;
     }
 
+    /// @notice Computes net receiver assets and fees from a gross redeem amount.
+    /// @param grossAssets Gross assets removed from vault accounting.
+    /// @return netAssets Assets paid to the receiver.
+    /// @return feeAssets Withdraw fee paid to the configured recipient.
     function withdrawNetFromGross(uint256 grossAssets) internal view returns (uint256 netAssets, uint256 feeAssets) {
         uint16 withdrawFeeBps = LibERC4626VaultStorage.layout().fees.withdrawFeeBps;
         feeAssets = feeOnRaw(grossAssets, withdrawFeeBps, FeeRounding.Down);
         netAssets = grossAssets - feeAssets;
     }
 
+    /// @notice Computes a raw basis-point fee with the requested rounding direction.
+    /// @param assets Asset amount used as fee basis.
+    /// @param feeBps Fee rate in basis points.
+    /// @param rounding Rounding direction for non-even divisions.
+    /// @return Fee amount.
     function feeOnRaw(uint256 assets, uint16 feeBps, FeeRounding rounding) internal pure returns (uint256) {
         if (feeBps == 0 || assets == 0) {
             return 0;
@@ -90,6 +124,12 @@ library LibERC4626VaultControlLogic {
         return mulDiv(assets, feeBps, BPS_DENOMINATOR, rounding);
     }
 
+    /// @notice Multiplies and divides with optional upward rounding.
+    /// @param x Multiplicand.
+    /// @param y Multiplier.
+    /// @param denominator Division denominator.
+    /// @param rounding Rounding direction for non-even divisions.
+    /// @return result Computed `x * y / denominator`.
     function mulDiv(uint256 x, uint256 y, uint256 denominator, FeeRounding rounding)
         internal
         pure
@@ -107,30 +147,37 @@ library LibERC4626VaultControlLogic {
 /// @title ERC4626VaultControlledCore
 /// @notice Shared fee-aware and limit-aware ERC-4626 core behavior.
 abstract contract ERC4626VaultControlledCore is ERC4626Vault {
-    /// @dev Non-core facets inherit this type for shared helpers but do not own every ERC-4626 selector.
-    ///      Leaf facets override the selectors they expose through the diamond.
+    /// @notice Unconditionally reverts because this facet does not own this ERC-4626 selector.
+    /// @dev Exists only to satisfy concrete inheritance; intended calls are routed by the diamond proxy to the owning facet.
+    /// @return Never returns.
     function deposit(uint256, address) public virtual override returns (uint256) {
         revert();
     }
 
-    /// @dev Non-core facets inherit this type for shared helpers but do not own every ERC-4626 selector.
-    ///      Leaf facets override the selectors they expose through the diamond.
+    /// @notice Unconditionally reverts because this facet does not own this ERC-4626 selector.
+    /// @dev Exists only to satisfy concrete inheritance; intended calls are routed by the diamond proxy to the owning facet.
+    /// @return Never returns.
     function mint(uint256, address) public virtual override returns (uint256) {
         revert();
     }
 
-    /// @dev Non-core facets inherit this type for shared helpers but do not own every ERC-4626 selector.
-    ///      Leaf facets override the selectors they expose through the diamond.
+    /// @notice Unconditionally reverts because this facet does not own this ERC-4626 selector.
+    /// @dev Exists only to satisfy concrete inheritance; intended calls are routed by the diamond proxy to the owning facet.
+    /// @return Never returns.
     function withdraw(uint256, address, address) public virtual override returns (uint256) {
         revert();
     }
 
-    /// @dev Non-core facets inherit this type for shared helpers but do not own every ERC-4626 selector.
-    ///      Leaf facets override the selectors they expose through the diamond.
+    /// @notice Unconditionally reverts because this facet does not own this ERC-4626 selector.
+    /// @dev Exists only to satisfy concrete inheritance; intended calls are routed by the diamond proxy to the owning facet.
+    /// @return Never returns.
     function redeem(uint256, address, address) public virtual override returns (uint256) {
         revert();
     }
 
+    /// @inheritdoc ERC4626Vault
+    /// @dev Returns zero while vault operations are paused, and otherwise applies per-call deposit and total-assets caps.
+    ///      The total-assets cap is fee-aware because deposit limits are enforced on net managed assets.
     function maxDeposit(address receiver) public view virtual override returns (uint256) {
         if (receiver == address(0) || _vaultOperationsPaused()) {
             return 0;
@@ -165,6 +212,8 @@ abstract contract ERC4626VaultControlledCore is ERC4626Vault {
         return maxAssets;
     }
 
+    /// @inheritdoc ERC4626Vault
+    /// @dev Returns zero while vault operations are paused, and otherwise applies per-call mint and total-assets caps.
     function maxMint(address receiver) public view virtual override returns (uint256) {
         if (receiver == address(0) || _vaultOperationsPaused()) {
             return 0;
@@ -193,6 +242,9 @@ abstract contract ERC4626VaultControlledCore is ERC4626Vault {
         return maxShares;
     }
 
+    /// @inheritdoc ERC4626Vault
+    /// @dev Returns zero while paused or empty, caps by immediate withdrawable liquidity, then reports net assets after fees
+    ///      and any configured per-call withdraw limit.
     function maxWithdraw(address owner) public view virtual override returns (uint256) {
         if (owner == address(0) || _vaultOperationsPaused() || totalAssets() == 0) {
             return 0;
@@ -215,6 +267,9 @@ abstract contract ERC4626VaultControlledCore is ERC4626Vault {
         return netAssets;
     }
 
+    /// @inheritdoc ERC4626Vault
+    /// @dev Returns zero while paused or empty, caps shares by immediate withdrawable liquidity, then applies any configured
+    ///      per-call redeem limit.
     function maxRedeem(address owner) public view virtual override returns (uint256) {
         if (owner == address(0) || _vaultOperationsPaused() || totalAssets() == 0) {
             return 0;
@@ -237,21 +292,29 @@ abstract contract ERC4626VaultControlledCore is ERC4626Vault {
         return redeemableShares;
     }
 
+    /// @inheritdoc ERC4626Vault
+    /// @dev Deposit preview converts the post-fee net assets that would be credited to managed accounting.
     function previewDeposit(uint256 assets) public view virtual override returns (uint256) {
         (uint256 netAssets,) = LibERC4626VaultControlLogic.netAfterDepositFee(assets);
         return _convertToShares(netAssets, Rounding.Down);
     }
 
+    /// @inheritdoc ERC4626Vault
+    /// @dev Mint preview returns the gross assets required to credit the fee-adjusted net assets for `shares`.
     function previewMint(uint256 shares) public view virtual override returns (uint256) {
         uint256 netAssets = _convertToAssets(shares, Rounding.Up);
         return LibERC4626VaultControlLogic.grossUpForDepositFee(netAssets);
     }
 
+    /// @inheritdoc ERC4626Vault
+    /// @dev Withdraw preview returns shares needed to cover the gross accounting assets backing the requested net assets.
     function previewWithdraw(uint256 assets) public view virtual override returns (uint256) {
         (uint256 grossAssets,) = LibERC4626VaultControlLogic.withdrawGrossFromNet(assets);
         return _convertToShares(grossAssets, Rounding.Up);
     }
 
+    /// @inheritdoc ERC4626Vault
+    /// @dev Redeem preview converts shares to gross accounting assets first, then subtracts any withdraw fee.
     function previewRedeem(uint256 shares) public view virtual override returns (uint256) {
         uint256 grossAssets = _convertToAssets(shares, Rounding.Down);
         // Redeem previews follow the same boundary: shares map to gross accounting assets first, then
@@ -260,6 +323,10 @@ abstract contract ERC4626VaultControlledCore is ERC4626Vault {
         return netAssets;
     }
 
+    /// @notice Executes a fee-aware and limit-aware ERC-4626 deposit.
+    /// @param assets Gross assets paid by the caller.
+    /// @param receiver Account receiving minted shares.
+    /// @return shares Shares minted to `receiver`.
     function _depositWithControls(uint256 assets, address receiver) internal returns (uint256 shares) {
         _requireInitialized();
         _requireNonZeroAddress(receiver);
@@ -288,6 +355,10 @@ abstract contract ERC4626VaultControlledCore is ERC4626Vault {
         emit Deposit(msg.sender, receiver, assets, shares);
     }
 
+    /// @notice Executes a fee-aware and limit-aware ERC-4626 mint.
+    /// @param shares Exact shares to mint.
+    /// @param receiver Account receiving minted shares.
+    /// @return assets Gross assets paid by the caller.
     function _mintWithControls(uint256 shares, address receiver) internal returns (uint256 assets) {
         _requireInitialized();
         _requireNonZeroAddress(receiver);
@@ -317,6 +388,9 @@ abstract contract ERC4626VaultControlledCore is ERC4626Vault {
         emit Deposit(msg.sender, receiver, assets, shares);
     }
 
+    /// @notice Executes a fee-aware and limit-aware native-asset deposit using `msg.value`.
+    /// @param receiver Account receiving minted shares.
+    /// @return shares Shares minted to `receiver`.
     function _depositNativeWithControls(address receiver) internal returns (uint256 shares) {
         _requireInitialized();
         _requireNonZeroAddress(receiver);
@@ -346,6 +420,10 @@ abstract contract ERC4626VaultControlledCore is ERC4626Vault {
         emit Deposit(msg.sender, receiver, assets, shares);
     }
 
+    /// @notice Executes a fee-aware and limit-aware native-asset mint using exact `msg.value`.
+    /// @param shares Exact shares to mint.
+    /// @param receiver Account receiving minted shares.
+    /// @return assets Required native asset value.
     function _mintNativeWithControls(uint256 shares, address receiver) internal returns (uint256 assets) {
         _requireInitialized();
         _requireNonZeroAddress(receiver);
@@ -378,6 +456,11 @@ abstract contract ERC4626VaultControlledCore is ERC4626Vault {
         emit Deposit(msg.sender, receiver, assets, shares);
     }
 
+    /// @notice Executes a fee-aware and limit-aware exact-assets withdrawal.
+    /// @param assets Net assets paid to `receiver`.
+    /// @param receiver Account receiving withdrawn assets.
+    /// @param owner Account whose shares are burned.
+    /// @return shares Shares burned from `owner`.
     function _withdrawWithControls(uint256 assets, address receiver, address owner) internal returns (uint256 shares) {
         _requireInitialized();
         _requireNonZeroAddress(receiver);
@@ -409,6 +492,11 @@ abstract contract ERC4626VaultControlledCore is ERC4626Vault {
         emit Withdraw(msg.sender, receiver, owner, assets, shares);
     }
 
+    /// @notice Executes a fee-aware and limit-aware exact-shares redeem.
+    /// @param shares Shares burned from `owner`.
+    /// @param receiver Account receiving withdrawn assets.
+    /// @param owner Account whose shares are burned.
+    /// @return assets Net assets paid to `receiver`.
     function _redeemWithControls(uint256 shares, address receiver, address owner) internal returns (uint256 assets) {
         _requireInitialized();
         _requireNonZeroAddress(receiver);
@@ -441,6 +529,8 @@ abstract contract ERC4626VaultControlledCore is ERC4626Vault {
         emit Withdraw(msg.sender, receiver, owner, assets, shares);
     }
 
+    /// @notice Reverts if adding managed assets would exceed the configured total-assets cap.
+    /// @param additionalAssets Net managed assets about to be added.
     function _enforceTotalAssetsCap(uint256 additionalAssets) internal view {
         (uint128 maxTotalAssets_,,,,) = LibERC4626VaultControlLogic.limitConfig();
         if (maxTotalAssets_ == 0) {
@@ -456,6 +546,8 @@ abstract contract ERC4626VaultControlledCore is ERC4626Vault {
         }
     }
 
+    /// @notice Transfers collected fees to the configured fee recipient.
+    /// @param feeAssets Fee amount to pay.
     function _payoutFee(uint256 feeAssets) internal {
         if (feeAssets == 0) {
             return;
@@ -464,16 +556,21 @@ abstract contract ERC4626VaultControlledCore is ERC4626Vault {
         _safeTransferAsset(LibERC4626VaultControlLogic.feeRecipient(), feeAssets);
     }
 
+    /// @notice Returns the immediate gross assets available for withdraw/redeem views.
+    /// @return Gross asset liquidity cap, or max uint256 when uncapped.
     function _withdrawLiquidityCapAssets() internal view virtual returns (uint256) {
         return type(uint256).max;
     }
 
+    /// @notice Returns whether vault operations are currently paused for this facet context.
+    /// @return True when vault operations should be treated as paused.
     function _vaultOperationsPaused() internal view virtual returns (bool);
 }
 
 /// @title ERC4626VaultControlSurface
 /// @notice Shared hosted and standalone control-plane surface for vault config and governance.
 abstract contract ERC4626VaultControlSurface is VaultFacetControl, IERC4626VaultControls {
+    /// @inheritdoc IERC4626VaultControls
     // forge-lint: disable-next-line(mixed-case-function) -- interface role getter name is selector-stable.
     function VAULT_MANAGER_ROLE()
         public
@@ -485,6 +582,7 @@ abstract contract ERC4626VaultControlSurface is VaultFacetControl, IERC4626Vault
         return VaultFacetControl.VAULT_MANAGER_ROLE();
     }
 
+    /// @inheritdoc IERC4626VaultControls
     function feeConfig()
         public
         view
@@ -495,6 +593,7 @@ abstract contract ERC4626VaultControlSurface is VaultFacetControl, IERC4626Vault
         return LibERC4626VaultControlLogic.feeConfig();
     }
 
+    /// @inheritdoc IERC4626VaultControls
     function limitConfig()
         public
         view
@@ -505,6 +604,9 @@ abstract contract ERC4626VaultControlSurface is VaultFacetControl, IERC4626Vault
         return LibERC4626VaultControlLogic.limitConfig();
     }
 
+    /// @inheritdoc IERC4626VaultControls
+    /// @dev Requires `VAULT_MANAGER_ROLE`, rejects fee rates at or above 100%, and requires a nonzero recipient
+    ///      whenever either fee is nonzero.
     function setFeeConfig(uint16 depositFeeBps, uint16 withdrawFeeBps, address feeRecipient)
         public
         virtual
@@ -537,6 +639,7 @@ abstract contract ERC4626VaultControlSurface is VaultFacetControl, IERC4626Vault
         );
     }
 
+    /// @inheritdoc IERC4626VaultControls
     function setLimitConfig(
         uint128 maxTotalAssets,
         uint128 maxDeposit,

--- a/src/vault/VaultFacetControl.sol
+++ b/src/vault/VaultFacetControl.sol
@@ -62,10 +62,12 @@ abstract contract VaultFacetControl is IAccessControl, IAccessControlTime, IPaus
         _;
     }
 
+    /// @inheritdoc IAccessControl
     function hasRole(bytes32 role, address account) public view returns (bool) {
         return LibAccessControlStorage.layout().roles[role].members[account];
     }
 
+    /// @inheritdoc IAccessControl
     function getRoleAdmin(bytes32 role) public view returns (bytes32) {
         return LibAccessControlStorage.layout().roles[role].adminRole;
     }
@@ -77,10 +79,12 @@ abstract contract VaultFacetControl is IAccessControl, IAccessControlTime, IPaus
         return VAULT_MANAGER_ROLE_VALUE;
     }
 
+    /// @inheritdoc IAccessControl
     function grantRole(bytes32 role, address account) public onlyRole(getRoleAdmin(role)) {
         _grantRole(role, account);
     }
 
+    /// @inheritdoc IAccessControlTime
     function grantRoleWithWindow(bytes32 role, address account, uint64 start, uint64 end)
         public
         onlyRole(getRoleAdmin(role))
@@ -89,10 +93,12 @@ abstract contract VaultFacetControl is IAccessControl, IAccessControlTime, IPaus
         _setRoleWindow(role, account, start, end, msg.sender);
     }
 
+    /// @inheritdoc IAccessControl
     function revokeRole(bytes32 role, address account) public onlyRole(getRoleAdmin(role)) {
         _revokeRole(role, account);
     }
 
+    /// @inheritdoc IAccessControl
     function renounceRole(bytes32 role, address account) public {
         if (account != msg.sender) {
             revert AccessControlRenounceSelfOnly();
@@ -100,14 +106,17 @@ abstract contract VaultFacetControl is IAccessControl, IAccessControlTime, IPaus
         _revokeRole(role, account);
     }
 
+    /// @inheritdoc IAccessControl
     function getRoleMember(bytes32 role, uint256 index) public view returns (address) {
         return LibAccessControlStorage.layout().roles[role].memberList[index];
     }
 
+    /// @inheritdoc IAccessControl
     function getRoleMemberCount(bytes32 role) public view returns (uint256) {
         return LibAccessControlStorage.layout().roles[role].memberList.length;
     }
 
+    /// @inheritdoc IAccessControlTime
     function setRoleWindow(bytes32 role, address account, uint64 start, uint64 end)
         public
         onlyRole(getRoleAdmin(role))
@@ -115,17 +124,20 @@ abstract contract VaultFacetControl is IAccessControl, IAccessControlTime, IPaus
         _setRoleWindow(role, account, start, end, msg.sender);
     }
 
+    /// @inheritdoc IAccessControlTime
     function clearRoleWindow(bytes32 role, address account) public onlyRole(getRoleAdmin(role)) {
         _requireNonZeroAccount(account);
         _clearRoleWindow(role, account, msg.sender);
     }
 
+    /// @inheritdoc IAccessControlTime
     function getRoleWindow(bytes32 role, address account) public view returns (uint64 start, uint64 end, bool exists) {
         LibAccessControlTimeStorage.RoleWindow storage window =
             LibAccessControlTimeStorage.layout().roleWindows[role][account];
         return (window.start, window.end, window.exists);
     }
 
+    /// @inheritdoc IAccessControlTime
     function hasActiveRole(bytes32 role, address account) public view returns (bool) {
         if (!hasRole(role, account)) {
             return false;
@@ -147,28 +159,34 @@ abstract contract VaultFacetControl is IAccessControl, IAccessControlTime, IPaus
         return true;
     }
 
+    /// @inheritdoc IPausable
     function paused() public view returns (bool) {
         return LibPausableStorage.layout().paused;
     }
 
+    /// @inheritdoc IPausable
     function paused(bytes32 scope) public view returns (bool) {
         return paused() || scopePaused(scope);
     }
 
+    /// @inheritdoc IPausable
     function scopePaused(bytes32 scope) public view returns (bool) {
         return LibPausableStorage.layout().pausedScopes[scope];
     }
 
+    /// @inheritdoc IPausable
     function pause() public onlyRole(PAUSER_ROLE) whenNotPaused {
         LibPausableStorage.layout().paused = true;
         emit Paused(msg.sender);
     }
 
+    /// @inheritdoc IPausable
     function unpause() public onlyRole(PAUSER_ROLE) whenPaused {
         LibPausableStorage.layout().paused = false;
         emit Unpaused(msg.sender);
     }
 
+    /// @inheritdoc IPausable
     function pauseScope(bytes32 scope) public onlyRole(PAUSER_ROLE) {
         _requireValidScope(scope);
         if (scopePaused(scope)) {
@@ -179,6 +197,7 @@ abstract contract VaultFacetControl is IAccessControl, IAccessControlTime, IPaus
         emit ScopePaused(scope, msg.sender);
     }
 
+    /// @inheritdoc IPausable
     function unpauseScope(bytes32 scope) public onlyRole(PAUSER_ROLE) {
         _requireValidScope(scope);
         if (!scopePaused(scope)) {
@@ -189,10 +208,12 @@ abstract contract VaultFacetControl is IAccessControl, IAccessControlTime, IPaus
         emit ScopeUnpaused(scope, msg.sender);
     }
 
+    /// @inheritdoc IReentrancyGuard
     function reentrancyGuardEntered() public view returns (bool) {
         return LibReentrancyGuardStorage.layout().status == ENTERED;
     }
 
+    /// @inheritdoc IERC165
     function supportsInterface(bytes4 interfaceId) public view virtual returns (bool) {
         return interfaceId == type(IERC165).interfaceId || interfaceId == type(IAccessControl).interfaceId
             || interfaceId == type(IAccessControlTime).interfaceId || interfaceId == type(IPausable).interfaceId

--- a/src/vault/facets/ERC4626VaultIntegrationFacet.sol
+++ b/src/vault/facets/ERC4626VaultIntegrationFacet.sol
@@ -19,22 +19,30 @@ contract ERC4626VaultIntegrationFacet is
     IERC4626VaultIntegrationFacet,
     IERC7540VaultSettlementFacet
 {
-    /// @dev The integration facet inherits ERC-4626 helpers but does not own mutating ERC-4626 selectors.
+    /// @notice Unconditionally reverts because this facet does not own this ERC-4626 selector.
+    /// @dev Exists only to satisfy concrete inheritance; intended calls are routed by the diamond proxy to the owning facet.
+    /// @return Never returns.
     function deposit(uint256, address) public virtual override returns (uint256) {
         revert();
     }
 
-    /// @dev The integration facet inherits ERC-4626 helpers but does not own mutating ERC-4626 selectors.
+    /// @notice Unconditionally reverts because this facet does not own this ERC-4626 selector.
+    /// @dev Exists only to satisfy concrete inheritance; intended calls are routed by the diamond proxy to the owning facet.
+    /// @return Never returns.
     function mint(uint256, address) public virtual override returns (uint256) {
         revert();
     }
 
-    /// @dev The integration facet inherits ERC-4626 helpers but does not own mutating ERC-4626 selectors.
+    /// @notice Unconditionally reverts because this facet does not own this ERC-4626 selector.
+    /// @dev Exists only to satisfy concrete inheritance; intended calls are routed by the diamond proxy to the owning facet.
+    /// @return Never returns.
     function withdraw(uint256, address, address) public virtual override returns (uint256) {
         revert();
     }
 
-    /// @dev The integration facet inherits ERC-4626 helpers but does not own mutating ERC-4626 selectors.
+    /// @notice Unconditionally reverts because this facet does not own this ERC-4626 selector.
+    /// @dev Exists only to satisfy concrete inheritance; intended calls are routed by the diamond proxy to the owning facet.
+    /// @return Never returns.
     function redeem(uint256, address, address) public virtual override returns (uint256) {
         revert();
     }
@@ -220,6 +228,7 @@ contract ERC4626VaultIntegrationFacet is
     }
 
     /// @notice Moves pending deposit assets into claimable state for `controller`.
+    /// @dev Requires `VAULT_MANAGER_ROLE` and an unpaused `ASYNC_SETTLEMENT_SCOPE`.
     /// @param controller Request controller account.
     /// @param assets Asset amount to settle.
     function settleDepositRequest(address controller, uint256 assets) public {
@@ -232,6 +241,7 @@ contract ERC4626VaultIntegrationFacet is
     }
 
     /// @notice Moves pending redeem shares into claimable state for `controller`.
+    /// @dev Requires `VAULT_MANAGER_ROLE` and an unpaused `ASYNC_SETTLEMENT_SCOPE`.
     /// @param controller Request controller account.
     /// @param shares Share amount to settle.
     function settleRedeemRequest(address controller, uint256 shares) public {

--- a/src/vault/facets/ERC7540VaultDepositFacet.sol
+++ b/src/vault/facets/ERC7540VaultDepositFacet.sol
@@ -15,11 +15,19 @@ import {LibVaultAsset} from "../libraries/LibVaultAsset.sol";
 /// @notice Hosted async deposit and operator extension facet for ERC-7540-style request flows.
 contract ERC7540VaultDepositFacet is ERC4626VaultControlledCore, VaultFacetControl, IERC7540Deposit, IERC7540Operators {
     /// @notice Emitted when a deposit request is submitted.
+    /// @param controller Controller that will own the async claim.
+    /// @param owner Asset owner funding the request.
+    /// @param requestId Request identifier.
+    /// @param sender Account that submitted the request.
+    /// @param assets Requested deposit assets.
     event DepositRequest(
         address indexed controller, address indexed owner, uint256 indexed requestId, address sender, uint256 assets
     );
 
     /// @notice Emitted when `controller` updates `operator` approval.
+    /// @param controller Account granting or revoking operator authority.
+    /// @param operator Operator account.
+    /// @param approved True when approved, false when revoked.
     event OperatorSet(address indexed controller, address indexed operator, bool approved);
 
     /// @notice Thrown when an async deposit entrypoint is used before the async deposit extension is active.
@@ -29,11 +37,14 @@ contract ERC7540VaultDepositFacet is ERC4626VaultControlledCore, VaultFacetContr
     error ERC7540VaultAsyncDepositPreviewUnsupported();
 
     /// @notice Thrown when `sender` is not approved to manage requests for `account`.
+    /// @param account Account whose request authority was checked.
+    /// @param sender Unauthorized sender.
     error ERC7540VaultUnauthorizedOperator(address account, address sender);
 
-    /// @notice Returns max assets that can currently be claimed for `receiver`.
+    /// @notice Returns max assets that `msg.sender` can currently claim into shares for `receiver`.
+    /// @dev `receiver` is only validated as the destination; the claimable deposit balance is keyed by `msg.sender`.
     /// @param receiver Receiver of minted shares.
-    /// @return assets Max gross claimable asset amount.
+    /// @return assets Max gross claimable asset amount for `msg.sender`.
     function maxDeposit(address receiver)
         public
         view
@@ -50,9 +61,10 @@ contract ERC7540VaultDepositFacet is ERC4626VaultControlledCore, VaultFacetContr
         );
     }
 
-    /// @notice Returns max shares that can currently be claimed for `receiver`.
+    /// @notice Returns max shares that `msg.sender` can currently claim for `receiver`.
+    /// @dev `receiver` is only validated as the destination; the claimable deposit balance is keyed by `msg.sender`.
     /// @param receiver Receiver of minted shares.
-    /// @return shares Max claimable share amount at the current exchange rate.
+    /// @return shares Max claimable share amount for `msg.sender` at the current exchange rate.
     function maxMint(address receiver)
         public
         view

--- a/src/vault/facets/ERC7540VaultRedeemFacet.sol
+++ b/src/vault/facets/ERC7540VaultRedeemFacet.sol
@@ -15,6 +15,11 @@ import {LibERC4626VaultStorage} from "../storage/LibERC4626VaultStorage.sol";
 /// @notice Hosted async redeem extension facet for ERC-7540-style request flows.
 contract ERC7540VaultRedeemFacet is ERC4626VaultControlledCore, VaultFacetControl, IERC7540Redeem {
     /// @notice Emitted when a redeem request is submitted.
+    /// @param controller Controller that will own the async claim.
+    /// @param owner Share owner funding the request.
+    /// @param requestId Request identifier.
+    /// @param sender Account that submitted the request.
+    /// @param shares Requested redeem shares.
     event RedeemRequest(
         address indexed controller, address indexed owner, uint256 indexed requestId, address sender, uint256 shares
     );
@@ -26,6 +31,8 @@ contract ERC7540VaultRedeemFacet is ERC4626VaultControlledCore, VaultFacetContro
     error ERC7540VaultAsyncRedeemPreviewUnsupported();
 
     /// @notice Thrown when `sender` is not approved to manage requests for `account`.
+    /// @param account Account whose request authority was checked.
+    /// @param sender Unauthorized sender.
     error ERC7540VaultUnauthorizedOperator(address account, address sender);
 
     /// @notice Returns max assets that can currently be claimed for `controller`.

--- a/src/wallet/MultiSendCallOnly.sol
+++ b/src/wallet/MultiSendCallOnly.sol
@@ -6,6 +6,7 @@ import {IMultiSendCallOnly} from "../interfaces/IMultiSendCallOnly.sol";
 /// @title MultiSendCallOnly
 /// @notice Executes atomic call-only batches when delegatecalled from a wallet.
 contract MultiSendCallOnly is IMultiSendCallOnly {
+    /// @inheritdoc IMultiSendCallOnly
     function multiSend(bytes calldata transactions) external {
         uint256 totalLength = transactions.length;
         if (totalLength == 0) {

--- a/src/wallet/MultisigWallet.sol
+++ b/src/wallet/MultisigWallet.sol
@@ -9,15 +9,23 @@ import {IMultisigWallet} from "../interfaces/IMultisigWallet.sol";
 /// @title MultisigWallet
 /// @notice Standalone multisig wallet foundation with initializer-based owner/threshold state.
 contract MultisigWallet is IERC165, IERC1271, IMultisigWallet {
+    /// @notice ERC-1271 success value returned for valid signatures.
     bytes4 internal constant ERC1271_MAGIC_VALUE = 0x1626ba7e;
+    /// @notice ERC-1271 invalid signature value.
     bytes4 internal constant ERC1271_INVALID_SIGNATURE = 0xffffffff;
+    /// @notice EIP-712 domain type hash used in wallet digest construction.
     bytes32 internal constant EIP712_DOMAIN_TYPEHASH =
         keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    /// @notice EIP-712 type hash for single-call wallet transactions.
     bytes32 internal constant TRANSACTION_TYPEHASH =
         keccak256("WalletTransaction(address to,uint256 value,bytes32 dataHash,uint256 nonce)");
+    /// @notice EIP-712 type hash for batched wallet transactions.
     bytes32 internal constant BATCH_TYPEHASH = keccak256("WalletBatch(bytes32 transactionsHash,uint256 nonce)");
+    /// @notice EIP-712 hashed wallet name.
     bytes32 internal constant NAME_HASH = keccak256("Auralis Multisig Wallet");
+    /// @notice EIP-712 hashed wallet version.
     bytes32 internal constant VERSION_HASH = keccak256("1");
+    /// @notice Lower-half secp256k1 scalar bound used to reject malleable signatures.
     uint256 internal constant SECP256K1N_DIV_2 = 0x7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0;
 
     bool internal _initialized;
@@ -27,11 +35,13 @@ contract MultisigWallet is IERC165, IERC1271, IMultisigWallet {
     address[] internal _owners;
     mapping(address owner => uint256 indexPlusOne) internal _ownerIndexPlusOne;
 
+    /// @notice Locks the master implementation as initialized so only clones can run `initialize`.
     constructor() {
         _nonce = 0;
         _initialized = true;
     }
 
+    /// @inheritdoc IMultisigWallet
     function initialize(address[] calldata owners, uint256 threshold_, address multiSendCallOnly_) external {
         if (_initialized) {
             revert MultisigWalletAlreadyInitialized();
@@ -50,11 +60,13 @@ contract MultisigWallet is IERC165, IERC1271, IMultisigWallet {
 
     receive() external payable {}
 
+    /// @inheritdoc IERC165
     function supportsInterface(bytes4 interfaceId) public pure override returns (bool) {
         return interfaceId == type(IERC165).interfaceId || interfaceId == type(IERC1271).interfaceId
             || interfaceId == type(IMultisigWallet).interfaceId;
     }
 
+    /// @inheritdoc IMultisigWallet
     function getTransactionHash(address to, uint256 value, bytes calldata data, uint256 nonce_)
         external
         view
@@ -63,10 +75,13 @@ contract MultisigWallet is IERC165, IERC1271, IMultisigWallet {
         return _getTransactionHash(to, value, data, nonce_);
     }
 
+    /// @inheritdoc IMultisigWallet
     function getBatchHash(bytes calldata transactions, uint256 nonce_) external view returns (bytes32) {
         return _getBatchHash(transactions, nonce_);
     }
 
+    /// @inheritdoc IMultisigWallet
+    /// @dev Reverts while the wallet is non-operational (`threshold == 0`), including on the master implementation.
     // slither-disable-next-line reentrancy-events
     function executeTransaction(address to, uint256 value, bytes calldata data, bytes calldata signatures) external {
         _requireOperational();
@@ -91,6 +106,8 @@ contract MultisigWallet is IERC165, IERC1271, IMultisigWallet {
         emit TransactionExecuted(digest, currentNonce, to, value);
     }
 
+    /// @inheritdoc IMultisigWallet
+    /// @dev Reverts while the wallet is non-operational (`threshold == 0`), including on the master implementation.
     // slither-disable-next-line reentrancy-events
     function executeBatch(bytes calldata transactions, bytes calldata signatures) external {
         _requireOperational();
@@ -112,21 +129,25 @@ contract MultisigWallet is IERC165, IERC1271, IMultisigWallet {
         emit BatchExecuted(digest, currentNonce);
     }
 
+    /// @inheritdoc IMultisigWallet
     function addOwner(address owner) external {
         _requireSelfCall();
         _addOwner(owner);
     }
 
+    /// @inheritdoc IMultisigWallet
     function removeOwner(address owner) external {
         _requireSelfCall();
         _removeOwner(owner);
     }
 
+    /// @inheritdoc IMultisigWallet
     function replaceOwner(address oldOwner, address newOwner) external {
         _requireSelfCall();
         _replaceOwner(oldOwner, newOwner);
     }
 
+    /// @inheritdoc IMultisigWallet
     function changeThreshold(uint256 newThreshold) external {
         _requireSelfCall();
         _requireValidThreshold(newThreshold, _owners.length);
@@ -135,6 +156,7 @@ contract MultisigWallet is IERC165, IERC1271, IMultisigWallet {
         emit ThresholdChanged(newThreshold);
     }
 
+    /// @inheritdoc IMultisigWallet
     function isValidSignature(bytes32 digest, bytes calldata signatures)
         external
         view
@@ -150,26 +172,32 @@ contract MultisigWallet is IERC165, IERC1271, IMultisigWallet {
         return ERC1271_INVALID_SIGNATURE;
     }
 
+    /// @inheritdoc IMultisigWallet
     function nonce() external view returns (uint256) {
         return _nonce;
     }
 
+    /// @inheritdoc IMultisigWallet
     function threshold() external view returns (uint256) {
         return _threshold;
     }
 
+    /// @inheritdoc IMultisigWallet
     function ownerCount() external view returns (uint256) {
         return _owners.length;
     }
 
+    /// @inheritdoc IMultisigWallet
     function multiSendCallOnly() external view returns (address) {
         return _multiSendCallOnly;
     }
 
+    /// @inheritdoc IMultisigWallet
     function isOwner(address account) external view returns (bool) {
         return _ownerIndexPlusOne[account] != 0;
     }
 
+    /// @inheritdoc IMultisigWallet
     function getOwners() external view returns (address[] memory) {
         return _owners;
     }

--- a/src/wallet/MultisigWalletFactory.sol
+++ b/src/wallet/MultisigWalletFactory.sol
@@ -11,6 +11,8 @@ contract MultisigWalletFactory is IMultisigWalletFactory {
     // forge-lint: disable-next-line(screaming-snake-case-immutable) -- public immutable preserves the factory getter selector.
     address public immutable implementation;
 
+    /// @notice Initializes the factory with the multisig implementation to clone.
+    /// @param implementation_ Master wallet implementation address.
     constructor(address implementation_) {
         if (implementation_ == address(0)) {
             revert MultisigWalletFactoryZeroImplementation();
@@ -19,6 +21,7 @@ contract MultisigWalletFactory is IMultisigWalletFactory {
         implementation = implementation_;
     }
 
+    /// @inheritdoc IMultisigWalletFactory
     function deployWallet(bytes32 salt, address[] calldata owners, uint256 threshold_, address multiSendCallOnly_)
         external
         returns (address wallet)
@@ -29,6 +32,7 @@ contract MultisigWalletFactory is IMultisigWalletFactory {
         emit WalletDeployed(wallet, implementation, salt);
     }
 
+    /// @inheritdoc IMultisigWalletFactory
     function predictWalletAddress(bytes32 salt) external view returns (address predicted) {
         return LibClone.predictDeterministicAddress(implementation, salt, address(this));
     }

--- a/test/helpers/ERC4626VaultIntegrationFacetTestHarness.sol
+++ b/test/helpers/ERC4626VaultIntegrationFacetTestHarness.sol
@@ -32,6 +32,92 @@ contract InitializedERC4626VaultIntegrationFacetHarness is ERC4626VaultIntegrati
         _initializeVaultFacetControl(admin);
         _initializeErc4626Vault(vaultAsset, vaultName, vaultSymbol);
     }
+
+    function deposit(uint256 assets, address receiver) public override returns (uint256 shares) {
+        _requireInitialized();
+        _requireNonZeroAddress(receiver);
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        shares = previewDeposit(assets);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        _safeTransferFromAsset(msg.sender, address(this), assets);
+        _increaseManagedAssets(assets);
+        _mintShares(receiver, shares);
+
+        emit Deposit(msg.sender, receiver, assets, shares);
+    }
+
+    function mint(uint256 shares, address receiver) public override returns (uint256 assets) {
+        _requireInitialized();
+        _requireNonZeroAddress(receiver);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        assets = previewMint(shares);
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        _safeTransferFromAsset(msg.sender, address(this), assets);
+        _increaseManagedAssets(assets);
+        _mintShares(receiver, shares);
+
+        emit Deposit(msg.sender, receiver, assets, shares);
+    }
+
+    function withdraw(uint256 assets, address receiver, address owner) public override returns (uint256 shares) {
+        _requireInitialized();
+        _requireNonZeroAddress(receiver);
+        _requireNonZeroAddress(owner);
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        shares = previewWithdraw(assets);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        if (msg.sender != owner) {
+            _spendAllowance(owner, msg.sender, shares);
+        }
+
+        _burnShares(owner, shares);
+        _decreaseManagedAssetsForAssetExit(assets);
+        _safeTransferAsset(receiver, assets);
+
+        emit Withdraw(msg.sender, receiver, owner, assets, shares);
+    }
+
+    function redeem(uint256 shares, address receiver, address owner) public override returns (uint256 assets) {
+        _requireInitialized();
+        _requireNonZeroAddress(receiver);
+        _requireNonZeroAddress(owner);
+        if (shares == 0) {
+            revert ERC4626VaultZeroShares();
+        }
+
+        assets = previewRedeem(shares);
+        if (assets == 0) {
+            revert ERC4626VaultZeroAssets();
+        }
+
+        if (msg.sender != owner) {
+            _spendAllowance(owner, msg.sender, shares);
+        }
+
+        _burnShares(owner, shares);
+        _decreaseManagedAssetsForAssetExit(assets);
+        _safeTransferAsset(receiver, assets);
+
+        emit Withdraw(msg.sender, receiver, owner, assets, shares);
+    }
 }
 
 abstract contract ERC4626VaultIntegrationFacetFixture is TestBase {


### PR DESCRIPTION
## Summary
- Complete production NatSpec coverage for `src/` interfaces, facets, libraries, AMM, wallet, token, diamond, and vault surfaces.
- Add targeted implementation-specific `@dev` notes for access control, reentrancy, native routing, fee/limit behavior, and operational gates.
- Restore standalone integration-facet harness ERC-4626 behavior after #215 stubs; production `src/` changes are comment-only.

## Validation
- Temporary NatSpec scanner: `src/**/*.sol` files 97, issues 0.
- `forge fmt --check`
- `git diff --check`
- `forge lint src/`
- `forge build --force --sizes --skip script`
- `forge test --offline --cache-path /tmp/auralis-forge-full-clean-cache` — 668 passed, 0 failed.

## Notes
- No production ABI, selector, storage-layout, initializer, event, error, or runtime changes.
- `ERC4626VaultFacet` runtime size remains 24,575 bytes.
- Plain local `forge test --offline` replayed a persisted invariant failure cache; clean-cache full suite and isolated native invariant suite both pass.