### PR TITLE
docs: reframe upgrade guardrails as opt-in

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -80,8 +80,8 @@ visual model materially improves comprehension.
 - `docs/access-control.md`: RBAC hierarchy and time-window access model.
 - `docs/pausable.md`: global and scoped pause behavior.
 - `docs/reentrancy-guard.md`: reentrancy protection model.
-- `docs/upgrade-guardrails.md`: queued upgrade intent model and execution
-  constraints.
+- `docs/upgrade-guardrails.md`: standalone, opt-in queued upgrade intent model
+  and execution constraints.
 
 ## ADRs
 

--- a/docs/diamond-core.md
+++ b/docs/diamond-core.md
@@ -34,7 +34,7 @@ rest of the initial selector set before regular operations begin.
 `DiamondCutFacet.diamondCut(...)` enforces owner-only access, then calls
 `LibDiamond.diamondCut(...)`.
 
-Guardrails enforced in `LibDiamond`:
+Validation checks enforced in `LibDiamond`:
 
 - empty selector arrays revert (`DiamondCutEmptySelectors`).
 - add/replace targets must contain code (`DiamondTargetHasNoCode`).
@@ -91,6 +91,9 @@ To stay diamond-safe:
 
 - Diamond owner authority is highly privileged; use multisig/governance in production.
 - This core does not include built-in timelock/governance policy for cuts.
+- Current diamond cuts are not queued or timelocked through
+  `UpgradeGuardrails`; that module is standalone unless a future deployment
+  explicitly wires a guardrail controller.
 - Bootstrap/install strategy is deployment-specific and must be reviewed.
 - Safety depends on off-chain cut payload review and post-cut validation.
 

--- a/docs/ops/local-diamond-upgrade-rehearsal.md
+++ b/docs/ops/local-diamond-upgrade-rehearsal.md
@@ -15,7 +15,8 @@ cut behavior before production-style operator changes.
 
 The rehearsal validates cut mechanics and state persistence on the current
 storage-layout baseline. It does not validate storage migration across renamed
-slot namespaces from older pre-public deployments.
+slot namespaces from older pre-public deployments, and it does not exercise
+`UpgradeGuardrails` queue/timelock checks.
 
 ## Run
 

--- a/docs/ops/runbook-diamond-cut.md
+++ b/docs/ops/runbook-diamond-cut.md
@@ -1,6 +1,9 @@
 # Runbook: Diamond Cut Execution
 
 Use this runbook for production-facing selector upgrades on the diamond core.
+This is the current repository flow: the owner submits `diamondCut(...)`
+directly to the diamond. `UpgradeGuardrails` is not part of this path unless a
+future deployment explicitly wires a guardrail controller.
 
 ## Preconditions
 

--- a/docs/ops/runbook-system-hardening.md
+++ b/docs/ops/runbook-system-hardening.md
@@ -58,6 +58,8 @@ bash script/run-local-system-hardening.sh
   state-transition regressions after deployment.
 - Upgrade rehearsal failures point to selector-collision handling, failed-cut
   atomicity, init rollback, owner drift, or selector ownership drift.
+- Upgrade rehearsal does not exercise `UpgradeGuardrails`; it validates the
+  current owner-gated diamond cut path.
 - Targeted system suite failures point to vault accounting/pause/reentrancy
   regressions or oracle incident-handling regressions.
 - If the full hardening runner fails, inspect the first failing sub-step before

--- a/docs/ops/runbook-upgrade-execution.md
+++ b/docs/ops/runbook-upgrade-execution.md
@@ -1,6 +1,8 @@
 # Runbook: Upgrade Execution
 
-Use this runbook for guarded upgrade operations.
+Use this runbook for deployments that explicitly opt into
+`UpgradeGuardrails`. It does not describe the current diamond selector-upgrade
+path; for current diamond cuts, use `docs/ops/runbook-diamond-cut.md`.
 
 ## Relevant Controls
 
@@ -18,6 +20,8 @@ Use this runbook for guarded upgrade operations.
 - Confirm implementation address is final and deployed.
 - Confirm compatibility and migration assumptions.
 - Confirm rollback or cancel path is clear.
+- Confirm the target deployment actually inherits `UpgradeGuardrails` and
+  implements `_applyUpgrade(address)` for this upgrade primitive.
 - If the change touches the diamond upgrade path or system-level validation
   surface, rehearse locally first:
   - `bash script/run-local-diamond-upgrade-rehearsal.sh`

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -30,7 +30,10 @@ For the accepted architecture decisions that shape these assumptions, see
 - Oracle reads fail closed by default and only degrade under explicit fallback policy.
 - Emergency pause controls can contain incidents.
 - Reentrant state-changing entrypoints are blocked.
-- Upgrade execution follows explicit authorization and guardrail checks.
+- Upgrade execution follows explicit authorization. Current diamond upgrades use
+  owner-gated `diamondCut` plus `LibDiamond` validation checks; optional
+  `UpgradeGuardrails` deployments add queue/timelock checks only when explicitly
+  integrated.
 - Vault share/accounting behavior remains explicit under rounding and low-liquidity edge conditions.
 - AMM liquidity, reserve updates, and fee-switch behavior remain explicit under
   direct-transfer, malformed-token, and adversarial routing conditions.
@@ -47,7 +50,8 @@ For the accepted architecture decisions that shape these assumptions, see
   withdraw, and ERC-20 transfer semantics.
 - Wallet owners review and approve transaction payloads securely off-chain.
 - The configured `MultiSendCallOnly` helper is the intended fixed batch helper for deployed wallets.
-- Deployed contracts integrate `_applyUpgrade` correctly for their proxy/diamond mechanism.
+- Deployments that opt into `UpgradeGuardrails` integrate `_applyUpgrade`
+  correctly for their own upgrade primitive.
 - Time-based checks rely on `block.timestamp` and accept normal timestamp variance.
 
 ## Key Threats and Mitigations
@@ -71,7 +75,11 @@ For the accepted architecture decisions that shape these assumptions, see
 - Mitigation: separate `ORACLE_ADMIN_ROLE` (config/reset) and `ORACLE_GUARDIAN_ROLE` (trip-only) with explicit admin hierarchy.
 
 7. Unsafe or rushed upgrades
-- Mitigation: upgrader role, queued intent model, optional timelock delay, strict implementation matching, cancel flow.
+- Mitigation: current diamond cuts require the diamond owner and pass
+  `LibDiamond` selector/init validation, with off-chain review, local rehearsal,
+  and post-cut loupe/smoke checks. Deployments that explicitly opt into
+  `UpgradeGuardrails` add `UPGRADER_ROLE`, queued intent, implementation match,
+  cancel flow, and optional timelock delay.
 
 8. Donation-style vault share-price manipulation
 - Mitigation: vault conversions use managed accounting (`totalManagedAssets`) instead of raw token balance.
@@ -123,8 +131,12 @@ For the accepted architecture decisions that shape these assumptions, see
 - Compromised privileged keys can still perform privileged actions.
 - Economic attacks and protocol-specific business logic exploits are out of scope for this base kit.
 - Oracle market manipulation resistance is feed/provider-specific and must be handled at integration and policy layers.
-- Diamond `diamondCut` flows include core guardrails, but governance policy (timelocks/multisig approvals) remains an integration responsibility.
-- The current upgrade guardrails check nonzero implementation; deeper bytecode/interface validation is protocol-specific and should be added where needed.
+- Diamond `diamondCut` flows include core diamond validation checks, but
+  governance policy (timelocks/multisig approvals) remains an integration
+  responsibility.
+- `UpgradeGuardrails` is standalone and checks only the queued implementation
+  address; deeper bytecode/interface validation is protocol-specific and should
+  be added by deployments that opt into the module.
 - Direct token donations to vault addresses can create untracked surplus unless explicitly reconciled by integration policy.
 - AMM cumulative prices are not, by themselves, a manipulation-resistant
   oracle design.
@@ -138,6 +150,7 @@ For the accepted architecture decisions that shape these assumptions, see
 ## Operational Guidance
 
 - Use multisig-controlled privileged roles in production.
-- Set nonzero upgrade delays in production.
+- Set nonzero upgrade delays in production deployments that opt into
+  `UpgradeGuardrails`.
 - Restrict and monitor role admin changes.
 - Keep pause and upgrade procedures documented and rehearsed.

--- a/docs/upgrade-guardrails.md
+++ b/docs/upgrade-guardrails.md
@@ -1,7 +1,13 @@
 # Upgrade Guardrails
 
-This module adds role-gated controls for upgrade operations with queue/execute
-guardrails and an optional timelock.
+This module adds standalone, opt-in role-gated controls for implementation-style
+upgrade operations with queue/execute guardrails and an optional timelock.
+
+`UpgradeGuardrails` is not wired into the repository's current diamond hosts.
+Current diamond selector upgrades are executed through
+`DiamondCutFacet.diamondCut(...)` and `LibDiamond.diamondCut(...)`; they do not
+call this module unless a future deployment explicitly adds a guardrail
+controller.
 
 ## Usage
 
@@ -21,16 +27,23 @@ guardrails and an optional timelock.
 - When `minUpgradeDelay == 0`, queue and execute can happen immediately.
 - Intent is cleared on cancel and after successful execution.
 
-## Diamond-Ready Usage
+## Opt-In Usage
 
-When used behind a diamond proxy, call the internal initializer from a facet or
-init contract:
+When a deployment chooses to use this module, inherit from `UpgradeGuardrails`,
+call the internal initializer from a constructor, facet, or init contract, and
+implement `_applyUpgrade(address)` for that deployment's own upgrade primitive:
 
 ```solidity
 function initUpgradeGuardrails(address initialUpgrader, uint64 minDelaySeconds) external {
     _initializeUpgradeGuardrails(initialUpgrader, minDelaySeconds);
 }
 ```
+
+No concrete diamond-cut subclass exists in this repository today. The current
+diamond cut payload shape includes `FacetCut[]`, an init target, and init
+calldata, while this module queues only an implementation address. A future
+diamond integration should define explicit queued cut-payload or cut-hash
+semantics before wiring this module into `diamondCut`.
 
 ## Example
 
@@ -39,8 +52,7 @@ contract MyUpgradeController is UpgradeGuardrails {
     constructor(address admin, uint64 delay) UpgradeGuardrails(admin, delay) {}
 
     function _applyUpgrade(address implementation) internal override {
-        // call proxy/diamond upgrade primitive here
+        // call this deployment's upgrade primitive here
     }
 }
 ```
-

--- a/src/interfaces/IUpgradeGuardrails.sol
+++ b/src/interfaces/IUpgradeGuardrails.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.30;
 import {IERC165} from "./IERC165.sol";
 
 /// @title IUpgradeGuardrails
-/// @notice Interface for role-gated upgrade guard rails.
+/// @notice Interface for opt-in role-gated upgrade guard rails.
 interface IUpgradeGuardrails is IERC165 {
     /// @notice Emitted when an upgrade intent is queued.
     /// @param implementation Queued implementation address.

--- a/src/upgrade/UpgradeGuardrails.sol
+++ b/src/upgrade/UpgradeGuardrails.sol
@@ -7,8 +7,8 @@ import {IUpgradeGuardrails} from "../interfaces/IUpgradeGuardrails.sol";
 import {LibUpgradeGuardrailsStorage} from "./storage/LibUpgradeGuardrailsStorage.sol";
 
 /// @title UpgradeGuardrails
-/// @notice Role-gated queue/execute upgrade guard rails with optional timelock.
-/// @dev Uses `UPGRADER_ROLE` and diamond-ready storage.
+/// @notice Opt-in role-gated queue/execute upgrade guard rails with optional timelock.
+/// @dev Uses `UPGRADER_ROLE` and namespaced storage; deployments must implement their own `_applyUpgrade` hook.
 abstract contract UpgradeGuardrails is AccessControl, IUpgradeGuardrails {
     /// @notice Role required to queue, cancel, and execute upgrades.
     bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
@@ -93,7 +93,7 @@ abstract contract UpgradeGuardrails is AccessControl, IUpgradeGuardrails {
             || super.supportsInterface(interfaceId);
     }
 
-    /// @dev Initializes upgrade guardrails storage (diamond-ready).
+    /// @dev Initializes upgrade guardrails storage for an opt-in deployment.
     /// @param initialUpgrader The account to receive `UPGRADER_ROLE`.
     /// @param minDelaySeconds The minimum delay between queue and execute.
     function _initializeUpgradeGuardrails(address initialUpgrader, uint64 minDelaySeconds) internal {

--- a/src/upgrade/storage/LibUpgradeGuardrailsStorage.sol
+++ b/src/upgrade/storage/LibUpgradeGuardrailsStorage.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.30;
 
 /// @title LibUpgradeGuardrailsStorage
-/// @notice Storage layout for upgrade guardrails modules (diamond-ready).
+/// @notice Namespaced storage layout for opt-in upgrade guardrails modules.
 library LibUpgradeGuardrailsStorage {
     /// @dev Storage slot for upgrade guardrails layout.
     bytes32 internal constant STORAGE_SLOT = keccak256("auralis.upgrade-guardrails.storage");
@@ -30,4 +30,3 @@ library LibUpgradeGuardrailsStorage {
         }
     }
 }
-


### PR DESCRIPTION
## Summary
- Reframe `UpgradeGuardrails` as a standalone, opt-in queue/timelock module rather than a live control in the current diamond cut path.
- Clarify current diamond upgrades route through owner-gated `DiamondCutFacet.diamondCut(...)` and `LibDiamond.diamondCut(...)`, not `UpgradeGuardrails`.
- Update threat model and ops runbooks so diamond-cut safety and optional guardrail safety are separated.
- Narrow `IUpgradeGuardrails`, `UpgradeGuardrails`, and guardrail storage NatSpec to opt-in/namespaced wording.

## Root Cause
Docs previously implied live upgrade protection in places where the code does not enforce it. `UpgradeGuardrails` queues only an implementation address through `_applyUpgrade(address)`, while diamond cuts require `FacetCut[]`, an init target, and init calldata. Wiring it into diamond upgrades would require a new queued cut-payload or cut-hash design, so this PR fixes the truthfulness boundary instead.

## Validation
- `rg -n "Diamond-Ready Usage|queued intent model|optional timelock|UpgradeGuardrails|guardrail|guardrails|diamondCut" docs src/interfaces src/upgrade`
- `forge fmt --check`
- `git diff --check`
- `forge build --sizes --skip script`
- `forge lint src/`
- `forge test --offline --match-path test/UpgradeGuardrailsCore.t.sol`
- `forge test --offline --match-path test/UpgradeGuardrailsFuzz.t.sol`
- `forge test --offline --match-path test/UpgradeGuardrailsTime.t.sol`
- `forge test --offline --match-path test/DiamondCutCore.t.sol`
- `forge test --offline --match-path test/DiamondSelectorIntegrityCore.t.sol`
- `forge test --offline` — 668 passed, 0 failed, 0 skipped

## Scope Notes
- No production runtime code changes.
- No ABI, selector, storage-layout, initializer, deployment-script, event, or error changes.

Closes #217