### PR TITLE
Add high-value async vault and wallet coverage

### DIFF
--- a/docs/erc7540-vault.md
+++ b/docs/erc7540-vault.md
@@ -281,6 +281,16 @@ Use these suites to review the async request surface locally:
   claim, operator, limit, and settlement-pause behavior
 - `test/ERC7540VaultRedeemCore.t.sol`: async redeem request, settlement,
   claim, allowance/operator behavior, limit, and settlement-pause behavior
+- `test/ERC7540VaultRequestAccountingInvariant.t.sol`: library-level
+  invariant coverage for aggregate pending/claimable request accounting and
+  operator pair isolation
+- `test/ERC7540VaultDepositFuzz.t.sol`: diamond-routed fuzz coverage for async
+  deposit request, settlement, claim, max-helper, and operator behavior
+- `test/ERC7540VaultRedeemFuzz.t.sol`: diamond-routed fuzz coverage for async
+  redeem request, settlement, claim, escrow, allowance/operator, and max-helper
+  behavior
+- `test/ERC7540VaultRequestTime.t.sol`: time-neutrality coverage proving time
+  alone does not settle requests and settlement pause persists across warps
 - `testAsyncDepositClaimHelpersStayClaimableBasedWhileHostTotalAssetsStillReverts()`
   in `test/ERC7540VaultDepositCore.t.sol`: async deposit claim-path boundary
 - `testAsyncRedeemMaxReadsInheritStrategyPricingRevert()` in
@@ -290,4 +300,5 @@ Use these suites to review the async request surface locally:
 - `test/DiamondVaultHostHardening.t.sol`: persistence across replace/remove
   flows with async selectors installed
 - `test/DiamondVaultHostInvariant.t.sol`: diamond-routed invariant coverage for
-  the hosted async vault path
+  the hosted async vault path, including broader cross-facet strategy, pause,
+  fee, limit, and request lifecycle interactions

--- a/docs/multisig-wallet.md
+++ b/docs/multisig-wallet.md
@@ -125,6 +125,11 @@ The current wallet track does not include:
 
 - `test/MultisigWalletFoundationCore.t.sol`
 - `test/MultisigWalletCoreExecution.t.sol`
+- `test/MultisigWalletFuzz.t.sol`
 - `test/MultisigWalletIntegration.t.sol`
 - `test/MultisigWalletManagement.t.sol`
 - `test/MultisigWalletInvariant.t.sol`
+
+`test/MultisigWalletFuzz.t.sol` is the signature/threshold/nonce fuzz evidence:
+it exercises sorted threshold signatures, malformed lengths, invalid signers,
+wrong nonces, replay rejection, target reverts, and batch execution.

--- a/docs/security-checks.md
+++ b/docs/security-checks.md
@@ -90,6 +90,10 @@ forge test --offline --match-path test/DiamondVaultDeploymentIntegration.t.sol
 forge test --offline --match-path test/ERC7540VaultFoundationCore.t.sol
 forge test --offline --match-path test/ERC7540VaultDepositCore.t.sol
 forge test --offline --match-path test/ERC7540VaultRedeemCore.t.sol
+forge test --offline --match-path test/ERC7540VaultRequestAccountingInvariant.t.sol
+forge test --offline --match-path test/ERC7540VaultDepositFuzz.t.sol
+forge test --offline --match-path test/ERC7540VaultRedeemFuzz.t.sol
+forge test --offline --match-path test/ERC7540VaultRequestTime.t.sol
 forge test --offline --match-path test/ERC4626VaultIntegrationFacetCore.t.sol
 forge test --offline --match-path test/ERC4626VaultStrategyAccountingCore.t.sol
 forge test --offline --match-path test/VaultStrategyFoundationCore.t.sol
@@ -112,6 +116,10 @@ vault strategy suites:
 forge test --offline --match-path test/ERC7540VaultFoundationCore.t.sol
 forge test --offline --match-path test/ERC7540VaultDepositCore.t.sol
 forge test --offline --match-path test/ERC7540VaultRedeemCore.t.sol
+forge test --offline --match-path test/ERC7540VaultRequestAccountingInvariant.t.sol
+forge test --offline --match-path test/ERC7540VaultDepositFuzz.t.sol
+forge test --offline --match-path test/ERC7540VaultRedeemFuzz.t.sol
+forge test --offline --match-path test/ERC7540VaultRequestTime.t.sol
 forge test --offline --match-path test/DiamondVaultDeploymentIntegration.t.sol
 forge test --offline --match-path test/DiamondVaultHostHardening.t.sol
 forge test --offline --match-path test/DiamondVaultHostInvariant.t.sol
@@ -153,13 +161,15 @@ forge test --offline --match-path test/MultisigWalletFoundationCore.t.sol
 forge test --offline --match-path test/MultisigWalletCoreExecution.t.sol
 forge test --offline --match-path test/MultisigWalletIntegration.t.sol
 forge test --offline --match-path test/MultisigWalletManagement.t.sol
+forge test --offline --match-path test/MultisigWalletFuzz.t.sol
 forge test --offline --match-path test/MultisigWalletInvariant.t.sol
 ```
 
 Use these to reproduce initializer behavior, EIP-712 signing, ERC-1271
 verification, deterministic clone deployment, call-only batch execution,
 self-managed owner/threshold changes, and the wallet invariants around owner
-uniqueness, threshold bounds, and nonce progression.
+uniqueness, threshold bounds, signature validity, signer ordering, and nonce
+progression.
 
 ### Slither
 

--- a/docs/testing-conventions.md
+++ b/docs/testing-conventions.md
@@ -57,9 +57,14 @@ Use a split test layout so modules stay readable as complexity grows.
 - Fuzz example: `test/PausableFuzz.t.sol`
 - Fuzz example: `test/UpgradeGuardrailsFuzz.t.sol`
 - Fuzz example: `test/ERC4626VaultAccountingFuzz.t.sol`
+- Fuzz example: `test/ERC7540VaultDepositFuzz.t.sol`
+- Fuzz example: `test/ERC7540VaultRedeemFuzz.t.sol`
+- Fuzz example: `test/MultisigWalletFuzz.t.sol`
 - Invariant example: `test/ERC4626VaultAccountingInvariant.t.sol`
+- Invariant example: `test/ERC7540VaultRequestAccountingInvariant.t.sol`
 - Time example: `test/AccessControlTime.t.sol`
 - Time example: `test/UpgradeGuardrailsTime.t.sol`
+- Time example: `test/ERC7540VaultRequestTime.t.sol`
 - Helper example: `test/helpers/AccessControlTestHarness.sol`
 - Helper example: `test/helpers/PausableTestHarness.sol`
 - Helper example: `test/helpers/OracleAdapterTestHarness.sol`

--- a/test/ERC7540VaultDepositFuzz.t.sol
+++ b/test/ERC7540VaultDepositFuzz.t.sol
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC4626} from "../src/interfaces/IERC4626.sol";
+import {IERC7540Deposit} from "../src/interfaces/IERC7540Deposit.sol";
+import {IERC7540Operators} from "../src/interfaces/IERC7540Operators.sol";
+import {IERC7540VaultSettlementFacet} from "../src/interfaces/IERC7540VaultSettlementFacet.sol";
+import {ERC7540VaultDepositFacet} from "../src/vault/facets/ERC7540VaultDepositFacet.sol";
+import {ERC4626VaultFacetFixture} from "./helpers/ERC4626VaultFacetTestHarness.sol";
+
+contract ERC7540VaultDepositFuzzTest is ERC4626VaultFacetFixture {
+    function setUp() public override {
+        super.setUp();
+        _installHostedVaultAsyncDepositFacetsToDiamond();
+
+        VM.prank(admin);
+        _initializeHostedVault(address(diamond));
+    }
+
+    function testFuzzRequestDepositTracksOnlyControllerBucket(uint8 controllerSeed, uint96 assetsRaw) public {
+        address controller = _controller(controllerSeed);
+        address unrelated = _otherController(controller);
+        uint256 assets = _boundedAmount(assetsRaw, 10_000);
+
+        _approveAsset(controller, address(diamond), assets);
+
+        VM.prank(controller);
+        uint256 requestId = IERC7540Deposit(address(diamond)).requestDeposit(assets, controller, controller);
+
+        assertTrue(requestId == 0, "request id mismatch");
+        assertTrue(IERC7540Deposit(address(diamond)).pendingDepositRequest(0, controller) == assets, "pending mismatch");
+        assertTrue(IERC7540Deposit(address(diamond)).claimableDepositRequest(0, controller) == 0, "claimable mismatch");
+        assertTrue(IERC7540Deposit(address(diamond)).pendingDepositRequest(0, unrelated) == 0, "unrelated pending");
+        assertTrue(IERC7540Deposit(address(diamond)).claimableDepositRequest(0, unrelated) == 0, "unrelated claimable");
+        assertTrue(asset.balanceOf(address(diamond)) == assets, "raw vault balance mismatch");
+        assertTrue(IERC4626(address(diamond)).totalAssets() == 0, "managed assets should not change on request");
+    }
+
+    function testFuzzSettleAndClaimDepositConsumeClaimableOnly(
+        uint8 controllerSeed,
+        uint8 receiverSeed,
+        uint96 requestRaw,
+        uint96 settleRaw,
+        uint96 claimRaw
+    ) public {
+        address controller = _controller(controllerSeed);
+        address receiver = _controller(receiverSeed);
+        address unrelated = _otherController(controller);
+        uint256 requestAssets = _boundedAmount(requestRaw, 10_000);
+        uint256 settleAssets = _boundedAmount(settleRaw, requestAssets);
+        uint256 claimAssets = _boundedAmount(claimRaw, settleAssets);
+
+        _approveAsset(controller, address(diamond), requestAssets);
+
+        VM.prank(controller);
+        IERC7540Deposit(address(diamond)).requestDeposit(requestAssets, controller, controller);
+
+        VM.prank(admin);
+        IERC7540VaultSettlementFacet(address(diamond)).settleDepositRequest(controller, settleAssets);
+
+        VM.prank(controller);
+        uint256 shares = IERC4626(address(diamond)).deposit(claimAssets, receiver);
+
+        assertTrue(shares == claimAssets, "claim shares mismatch");
+        assertTrue(
+            IERC7540Deposit(address(diamond)).pendingDepositRequest(0, controller) == requestAssets - settleAssets,
+            "pending mismatch"
+        );
+        assertTrue(
+            IERC7540Deposit(address(diamond)).claimableDepositRequest(0, controller) == settleAssets - claimAssets,
+            "claimable mismatch"
+        );
+        assertTrue(IERC7540Deposit(address(diamond)).pendingDepositRequest(0, unrelated) == 0, "unrelated pending");
+        assertTrue(IERC7540Deposit(address(diamond)).claimableDepositRequest(0, unrelated) == 0, "unrelated claimable");
+        assertTrue(IERC4626(address(diamond)).balanceOf(receiver) == shares, "receiver shares mismatch");
+        assertTrue(IERC4626(address(diamond)).totalAssets() == claimAssets, "managed assets mismatch");
+    }
+
+    function testFuzzDepositMaxHelpersTrackClaimableBalance(uint8 controllerSeed, uint96 requestRaw, uint96 settleRaw)
+        public
+    {
+        address controller = _controller(controllerSeed);
+        uint256 requestAssets = _boundedAmount(requestRaw, 10_000);
+        uint256 settleAssets = _boundedAmount(settleRaw, requestAssets);
+
+        _approveAsset(controller, address(diamond), requestAssets);
+
+        VM.prank(controller);
+        IERC7540Deposit(address(diamond)).requestDeposit(requestAssets, controller, controller);
+
+        VM.prank(admin);
+        IERC7540VaultSettlementFacet(address(diamond)).settleDepositRequest(controller, settleAssets);
+
+        VM.prank(controller);
+        uint256 maxDeposit = IERC4626(address(diamond)).maxDeposit(controller);
+        VM.prank(controller);
+        uint256 maxMint = IERC4626(address(diamond)).maxMint(controller);
+
+        assertTrue(maxDeposit == settleAssets, "maxDeposit should match claimable assets");
+        assertTrue(maxMint == settleAssets, "maxMint should match claimable assets at book price");
+    }
+
+    function testFuzzApprovedOperatorCanRequestAndClaimDeposit(
+        uint8 controllerSeed,
+        uint8 receiverSeed,
+        uint96 requestRaw,
+        uint96 settleRaw,
+        uint96 claimRaw
+    ) public {
+        address controller = _controller(controllerSeed);
+        address operator = _otherController(controller);
+        address receiver = _controller(receiverSeed);
+        uint256 requestAssets = _boundedAmount(requestRaw, 10_000);
+        uint256 settleAssets = _boundedAmount(settleRaw, requestAssets);
+        uint256 claimAssets = _boundedAmount(claimRaw, settleAssets);
+
+        _approveAsset(controller, address(diamond), requestAssets);
+
+        VM.prank(controller);
+        IERC7540Operators(address(diamond)).setOperator(operator, true);
+
+        VM.prank(operator);
+        IERC7540Deposit(address(diamond)).requestDeposit(requestAssets, controller, controller);
+
+        VM.prank(admin);
+        IERC7540VaultSettlementFacet(address(diamond)).settleDepositRequest(controller, settleAssets);
+
+        VM.prank(operator);
+        uint256 shares = IERC7540Deposit(address(diamond)).deposit(claimAssets, receiver, controller);
+
+        assertTrue(shares == claimAssets, "operator claim shares mismatch");
+        assertTrue(
+            IERC7540Deposit(address(diamond)).claimableDepositRequest(0, controller) == settleAssets - claimAssets,
+            "remaining claimable mismatch"
+        );
+        assertTrue(IERC4626(address(diamond)).balanceOf(receiver) == shares, "receiver shares mismatch");
+    }
+
+    function testFuzzUnauthorizedOperatorCannotRequestOrClaimDeposit(uint8 controllerSeed, uint96 assetsRaw) public {
+        address controller = _controller(controllerSeed);
+        address unauthorized = _otherController(controller);
+        uint256 assets = _boundedAmount(assetsRaw, 10_000);
+
+        _approveAsset(controller, address(diamond), assets);
+
+        VM.prank(unauthorized);
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                ERC7540VaultDepositFacet.ERC7540VaultUnauthorizedOperator.selector, controller, unauthorized
+            )
+        );
+        IERC7540Deposit(address(diamond)).requestDeposit(assets, controller, controller);
+
+        VM.prank(controller);
+        IERC7540Deposit(address(diamond)).requestDeposit(assets, controller, controller);
+
+        VM.prank(admin);
+        IERC7540VaultSettlementFacet(address(diamond)).settleDepositRequest(controller, assets);
+
+        VM.prank(unauthorized);
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                ERC7540VaultDepositFacet.ERC7540VaultUnauthorizedOperator.selector, controller, unauthorized
+            )
+        );
+        IERC7540Deposit(address(diamond)).deposit(assets, unauthorized, controller);
+    }
+
+    function _controller(uint8 seed) internal view returns (address) {
+        return seed % 2 == 0 ? bob : eve;
+    }
+
+    function _otherController(address controller) internal view returns (address) {
+        return controller == bob ? eve : bob;
+    }
+
+    function _boundedAmount(uint256 raw, uint256 max) internal pure returns (uint256) {
+        return (raw % max) + 1;
+    }
+}

--- a/test/ERC7540VaultRedeemFuzz.t.sol
+++ b/test/ERC7540VaultRedeemFuzz.t.sol
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC4626} from "../src/interfaces/IERC4626.sol";
+import {IERC4626VaultBase} from "../src/interfaces/IERC4626VaultBase.sol";
+import {IERC7540Deposit} from "../src/interfaces/IERC7540Deposit.sol";
+import {IERC7540Operators} from "../src/interfaces/IERC7540Operators.sol";
+import {IERC7540Redeem} from "../src/interfaces/IERC7540Redeem.sol";
+import {IERC7540VaultSettlementFacet} from "../src/interfaces/IERC7540VaultSettlementFacet.sol";
+import {ERC7540VaultRedeemFacet} from "../src/vault/facets/ERC7540VaultRedeemFacet.sol";
+import {ERC4626VaultFacetFixture} from "./helpers/ERC4626VaultFacetTestHarness.sol";
+
+contract ERC7540VaultRedeemFuzzTest is ERC4626VaultFacetFixture {
+    function setUp() public override {
+        super.setUp();
+        _installHostedVaultFullyAsyncFacetsToDiamond();
+
+        VM.prank(admin);
+        _initializeHostedVault(address(diamond));
+    }
+
+    function testFuzzRequestRedeemEscrowsSharesForControllerOnly(
+        uint8 controllerSeed,
+        uint96 seedRaw,
+        uint96 sharesRaw
+    ) public {
+        address controller = _controller(controllerSeed);
+        address unrelated = _otherController(controller);
+        uint256 seedAssets = _boundedAmount(seedRaw, 10_000);
+        uint256 shares = _boundedAmount(sharesRaw, seedAssets);
+
+        _seedClaimedShares(controller, seedAssets);
+
+        VM.prank(controller);
+        uint256 requestId = IERC7540Redeem(address(diamond)).requestRedeem(shares, controller, controller);
+
+        assertTrue(requestId == 0, "request id mismatch");
+        assertTrue(IERC7540Redeem(address(diamond)).pendingRedeemRequest(0, controller) == shares, "pending mismatch");
+        assertTrue(IERC7540Redeem(address(diamond)).claimableRedeemRequest(0, controller) == 0, "claimable mismatch");
+        assertTrue(IERC7540Redeem(address(diamond)).pendingRedeemRequest(0, unrelated) == 0, "unrelated pending");
+        assertTrue(IERC7540Redeem(address(diamond)).claimableRedeemRequest(0, unrelated) == 0, "unrelated claimable");
+        assertTrue(
+            IERC4626(address(diamond)).balanceOf(controller) == seedAssets - shares, "controller shares mismatch"
+        );
+        assertTrue(IERC4626(address(diamond)).balanceOf(address(diamond)) == shares, "escrow shares mismatch");
+        assertTrue(IERC4626(address(diamond)).totalSupply() == seedAssets, "supply should not change on request");
+    }
+
+    function testFuzzSettleAndClaimRedeemConsumeClaimableOnly(
+        uint8 controllerSeed,
+        uint8 receiverSeed,
+        uint96 seedRaw,
+        uint96 requestRaw,
+        uint96 settleRaw,
+        uint96 claimRaw
+    ) public {
+        address controller = _controller(controllerSeed);
+        address receiver = _controller(receiverSeed);
+        address unrelated = _otherController(controller);
+        uint256 seedAssets = _boundedAmount(seedRaw, 10_000);
+        uint256 requestShares = _boundedAmount(requestRaw, seedAssets);
+        uint256 settleShares = _boundedAmount(settleRaw, requestShares);
+        uint256 claimShares = _boundedAmount(claimRaw, settleShares);
+
+        _seedClaimedShares(controller, seedAssets);
+
+        VM.prank(controller);
+        IERC7540Redeem(address(diamond)).requestRedeem(requestShares, controller, controller);
+
+        VM.prank(admin);
+        IERC7540VaultSettlementFacet(address(diamond)).settleRedeemRequest(controller, settleShares);
+
+        uint256 receiverAssetsBefore = asset.balanceOf(receiver);
+
+        VM.prank(controller);
+        uint256 assets = IERC4626(address(diamond)).redeem(claimShares, receiver, controller);
+
+        assertTrue(assets == claimShares, "redeem claim assets mismatch");
+        assertTrue(
+            IERC7540Redeem(address(diamond)).pendingRedeemRequest(0, controller) == requestShares - settleShares,
+            "pending mismatch"
+        );
+        assertTrue(
+            IERC7540Redeem(address(diamond)).claimableRedeemRequest(0, controller) == settleShares - claimShares,
+            "claimable mismatch"
+        );
+        assertTrue(IERC7540Redeem(address(diamond)).pendingRedeemRequest(0, unrelated) == 0, "unrelated pending");
+        assertTrue(IERC7540Redeem(address(diamond)).claimableRedeemRequest(0, unrelated) == 0, "unrelated claimable");
+        assertTrue(IERC4626(address(diamond)).balanceOf(address(diamond)) == requestShares - claimShares, "escrow");
+        assertTrue(asset.balanceOf(receiver) == receiverAssetsBefore + assets, "receiver assets mismatch");
+    }
+
+    function testFuzzRedeemMaxHelpersTrackClaimableShares(
+        uint8 controllerSeed,
+        uint96 seedRaw,
+        uint96 requestRaw,
+        uint96 settleRaw
+    ) public {
+        address controller = _controller(controllerSeed);
+        uint256 seedAssets = _boundedAmount(seedRaw, 10_000);
+        uint256 requestShares = _boundedAmount(requestRaw, seedAssets);
+        uint256 settleShares = _boundedAmount(settleRaw, requestShares);
+
+        _seedClaimedShares(controller, seedAssets);
+
+        VM.prank(controller);
+        IERC7540Redeem(address(diamond)).requestRedeem(requestShares, controller, controller);
+
+        VM.prank(admin);
+        IERC7540VaultSettlementFacet(address(diamond)).settleRedeemRequest(controller, settleShares);
+
+        assertTrue(IERC4626(address(diamond)).maxRedeem(controller) == settleShares, "maxRedeem mismatch");
+        assertTrue(IERC4626(address(diamond)).maxWithdraw(controller) == settleShares, "maxWithdraw mismatch");
+    }
+
+    function testFuzzAllowanceHolderCanRequestRedeemAndOperatorCanClaim(
+        uint8 controllerSeed,
+        uint8 receiverSeed,
+        uint96 seedRaw,
+        uint96 requestRaw,
+        uint96 settleRaw,
+        uint96 claimRaw
+    ) public {
+        address controller = _controller(controllerSeed);
+        address operator = _otherController(controller);
+        address receiver = _controller(receiverSeed);
+        uint256 seedAssets = _boundedAmount(seedRaw, 10_000);
+        uint256 requestShares = _boundedAmount(requestRaw, seedAssets);
+        uint256 settleShares = _boundedAmount(settleRaw, requestShares);
+        uint256 claimShares = _boundedAmount(claimRaw, settleShares);
+
+        _seedClaimedShares(controller, seedAssets);
+
+        VM.prank(controller);
+        IERC4626(address(diamond)).approve(operator, requestShares);
+
+        VM.prank(operator);
+        IERC7540Redeem(address(diamond)).requestRedeem(requestShares, controller, controller);
+
+        VM.prank(admin);
+        IERC7540VaultSettlementFacet(address(diamond)).settleRedeemRequest(controller, settleShares);
+
+        VM.prank(controller);
+        IERC7540Operators(address(diamond)).setOperator(operator, true);
+
+        uint256 receiverAssetsBefore = asset.balanceOf(receiver);
+
+        VM.prank(operator);
+        uint256 assets = IERC4626(address(diamond)).redeem(claimShares, receiver, controller);
+
+        assertTrue(assets == claimShares, "operator claim assets mismatch");
+        assertTrue(asset.balanceOf(receiver) == receiverAssetsBefore + assets, "receiver assets mismatch");
+        assertTrue(
+            IERC7540Redeem(address(diamond)).claimableRedeemRequest(0, controller) == settleShares - claimShares,
+            "remaining claimable mismatch"
+        );
+    }
+
+    function testFuzzUnauthorizedRedeemRequestAndClaimRevert(uint8 controllerSeed, uint96 seedRaw, uint96 sharesRaw)
+        public
+    {
+        address controller = _controller(controllerSeed);
+        address unauthorized = _otherController(controller);
+        uint256 seedAssets = _boundedAmount(seedRaw, 10_000);
+        uint256 shares = _boundedAmount(sharesRaw, seedAssets);
+
+        _seedClaimedShares(controller, seedAssets);
+
+        VM.prank(unauthorized);
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IERC4626VaultBase.ERC4626VaultInsufficientAllowance.selector, controller, unauthorized, 0, shares
+            )
+        );
+        IERC7540Redeem(address(diamond)).requestRedeem(shares, controller, controller);
+
+        VM.prank(controller);
+        IERC7540Redeem(address(diamond)).requestRedeem(shares, controller, controller);
+
+        VM.prank(admin);
+        IERC7540VaultSettlementFacet(address(diamond)).settleRedeemRequest(controller, shares);
+
+        VM.prank(unauthorized);
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                ERC7540VaultRedeemFacet.ERC7540VaultUnauthorizedOperator.selector, controller, unauthorized
+            )
+        );
+        IERC4626(address(diamond)).redeem(shares, unauthorized, controller);
+    }
+
+    function _seedClaimedShares(address controller, uint256 assets) internal {
+        _approveAsset(controller, address(diamond), assets);
+
+        VM.prank(controller);
+        IERC7540Deposit(address(diamond)).requestDeposit(assets, controller, controller);
+
+        VM.prank(admin);
+        IERC7540VaultSettlementFacet(address(diamond)).settleDepositRequest(controller, assets);
+
+        VM.prank(controller);
+        IERC4626(address(diamond)).deposit(assets, controller);
+    }
+
+    function _controller(uint8 seed) internal view returns (address) {
+        return seed % 2 == 0 ? bob : eve;
+    }
+
+    function _otherController(address controller) internal view returns (address) {
+        return controller == bob ? eve : bob;
+    }
+
+    function _boundedAmount(uint256 raw, uint256 max) internal pure returns (uint256) {
+        return (raw % max) + 1;
+    }
+}

--- a/test/ERC7540VaultRequestAccountingInvariant.t.sol
+++ b/test/ERC7540VaultRequestAccountingInvariant.t.sol
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {ERC7540VaultFoundationFixture} from "./helpers/ERC7540VaultFoundationTestHarness.sol";
+
+contract ERC7540VaultRequestAccountingInvariantTest is ERC7540VaultFoundationFixture {
+    address[] internal controllers;
+    address[] internal operators;
+
+    mapping(address controller => uint256 assets) internal expectedPendingDeposit;
+    mapping(address controller => uint256 assets) internal expectedClaimableDeposit;
+    mapping(address controller => uint256 shares) internal expectedPendingRedeem;
+    mapping(address controller => uint256 shares) internal expectedClaimableRedeem;
+    mapping(address controller => mapping(address operator => bool approved)) internal expectedOperators;
+
+    function setUp() public override {
+        super.setUp();
+
+        controllers = new address[](3);
+        controllers[0] = bob;
+        controllers[1] = carol;
+        controllers[2] = eve;
+
+        operators = new address[](3);
+        operators[0] = address(0xA11CE);
+        operators[1] = address(0xD00D);
+        operators[2] = address(0xF00D);
+    }
+
+    function targetContracts() external view returns (address[] memory contracts) {
+        contracts = new address[](1);
+        contracts[0] = address(this);
+    }
+
+    function actionIncreasePendingDeposit(uint8 controllerSeed, uint96 assetsRaw) external {
+        address controller = _controller(controllerSeed);
+        uint256 assets = _boundedAmount(assetsRaw);
+
+        harness.increasePendingDeposit(controller, assets);
+        expectedPendingDeposit[controller] += assets;
+    }
+
+    function actionMovePendingDepositToClaimable(uint8 controllerSeed, uint96 assetsRaw) external {
+        address controller = _controller(controllerSeed);
+        uint256 assets = _boundedExistingAmount(assetsRaw, expectedPendingDeposit[controller]);
+        if (assets == 0) {
+            return;
+        }
+
+        harness.movePendingDepositToClaimable(controller, assets);
+        expectedPendingDeposit[controller] -= assets;
+        expectedClaimableDeposit[controller] += assets;
+    }
+
+    function actionConsumeClaimableDeposit(uint8 controllerSeed, uint96 assetsRaw) external {
+        address controller = _controller(controllerSeed);
+        uint256 assets = _boundedExistingAmount(assetsRaw, expectedClaimableDeposit[controller]);
+        if (assets == 0) {
+            return;
+        }
+
+        harness.consumeClaimableDeposit(controller, assets);
+        expectedClaimableDeposit[controller] -= assets;
+    }
+
+    function actionIncreasePendingRedeem(uint8 controllerSeed, uint96 sharesRaw) external {
+        address controller = _controller(controllerSeed);
+        uint256 shares = _boundedAmount(sharesRaw);
+
+        harness.increasePendingRedeem(controller, shares);
+        expectedPendingRedeem[controller] += shares;
+    }
+
+    function actionMovePendingRedeemToClaimable(uint8 controllerSeed, uint96 sharesRaw) external {
+        address controller = _controller(controllerSeed);
+        uint256 shares = _boundedExistingAmount(sharesRaw, expectedPendingRedeem[controller]);
+        if (shares == 0) {
+            return;
+        }
+
+        harness.movePendingRedeemToClaimable(controller, shares);
+        expectedPendingRedeem[controller] -= shares;
+        expectedClaimableRedeem[controller] += shares;
+    }
+
+    function actionConsumeClaimableRedeem(uint8 controllerSeed, uint96 sharesRaw) external {
+        address controller = _controller(controllerSeed);
+        uint256 shares = _boundedExistingAmount(sharesRaw, expectedClaimableRedeem[controller]);
+        if (shares == 0) {
+            return;
+        }
+
+        harness.consumeClaimableRedeem(controller, shares);
+        expectedClaimableRedeem[controller] -= shares;
+    }
+
+    function actionSetOperator(uint8 controllerSeed, uint8 operatorSeed, bool approved) external {
+        address controller = _controller(controllerSeed);
+        address operator = _operator(operatorSeed);
+
+        VM.prank(controller);
+        harness.setOperator(operator, approved);
+        expectedOperators[controller][operator] = approved;
+    }
+
+    function invariantAggregateDepositTotalsMatchTrackedControllers() public view {
+        uint256 pendingTotal;
+        uint256 claimableTotal;
+        for (uint256 i = 0; i < controllers.length; i++) {
+            address controller = controllers[i];
+            pendingTotal += expectedPendingDeposit[controller];
+            claimableTotal += expectedClaimableDeposit[controller];
+
+            assertTrue(
+                harness.pendingDepositRequest(0, controller) == expectedPendingDeposit[controller],
+                "pending deposit controller bucket mismatch"
+            );
+            assertTrue(
+                harness.claimableDepositRequest(0, controller) == expectedClaimableDeposit[controller],
+                "claimable deposit controller bucket mismatch"
+            );
+        }
+
+        assertTrue(harness.totalPendingDepositRequestAssets() == pendingTotal, "pending deposit total mismatch");
+        assertTrue(harness.totalClaimableDepositRequestAssets() == claimableTotal, "claimable deposit total mismatch");
+    }
+
+    function invariantAggregateRedeemTotalsMatchTrackedControllers() public view {
+        uint256 pendingTotal;
+        uint256 claimableTotal;
+        for (uint256 i = 0; i < controllers.length; i++) {
+            address controller = controllers[i];
+            pendingTotal += expectedPendingRedeem[controller];
+            claimableTotal += expectedClaimableRedeem[controller];
+
+            assertTrue(
+                harness.pendingRedeemRequest(0, controller) == expectedPendingRedeem[controller],
+                "pending redeem controller bucket mismatch"
+            );
+            assertTrue(
+                harness.claimableRedeemRequest(0, controller) == expectedClaimableRedeem[controller],
+                "claimable redeem controller bucket mismatch"
+            );
+        }
+
+        assertTrue(harness.totalPendingRedeemRequestShares() == pendingTotal, "pending redeem total mismatch");
+        assertTrue(harness.totalClaimableRedeemRequestShares() == claimableTotal, "claimable redeem total mismatch");
+    }
+
+    function invariantUnsupportedRequestIdsAlwaysReadZero() public view {
+        for (uint256 i = 0; i < controllers.length; i++) {
+            address controller = controllers[i];
+            assertTrue(harness.pendingDepositRequest(1, controller) == 0, "nonzero pending deposit id should be zero");
+            assertTrue(
+                harness.claimableDepositRequest(2, controller) == 0, "nonzero claimable deposit id should be zero"
+            );
+            assertTrue(harness.pendingRedeemRequest(3, controller) == 0, "nonzero pending redeem id should be zero");
+            assertTrue(harness.claimableRedeemRequest(4, controller) == 0, "nonzero claimable redeem id should be zero");
+        }
+    }
+
+    function invariantDepositAndRedeemBucketsStayIsolated() public view {
+        address untouched = address(0xDEAD);
+        assertTrue(harness.pendingDepositRequest(0, untouched) == 0, "untouched pending deposit should stay zero");
+        assertTrue(harness.claimableDepositRequest(0, untouched) == 0, "untouched claimable deposit should stay zero");
+        assertTrue(harness.pendingRedeemRequest(0, untouched) == 0, "untouched pending redeem should stay zero");
+        assertTrue(harness.claimableRedeemRequest(0, untouched) == 0, "untouched claimable redeem should stay zero");
+    }
+
+    function invariantOperatorApprovalsArePairScoped() public view {
+        for (uint256 i = 0; i < controllers.length; i++) {
+            for (uint256 j = 0; j < operators.length; j++) {
+                address controller = controllers[i];
+                address operator = operators[j];
+                assertTrue(
+                    harness.isOperator(controller, operator) == expectedOperators[controller][operator],
+                    "operator approval mismatch"
+                );
+            }
+        }
+    }
+
+    function _controller(uint8 seed) internal view returns (address) {
+        return controllers[uint256(seed) % controllers.length];
+    }
+
+    function _operator(uint8 seed) internal view returns (address) {
+        return operators[uint256(seed) % operators.length];
+    }
+
+    function _boundedAmount(uint256 raw) internal pure returns (uint256) {
+        return (raw % 1_000) + 1;
+    }
+
+    function _boundedExistingAmount(uint256 raw, uint256 available) internal pure returns (uint256) {
+        if (available == 0) {
+            return 0;
+        }
+        return (raw % available) + 1;
+    }
+}

--- a/test/ERC7540VaultRequestTime.t.sol
+++ b/test/ERC7540VaultRequestTime.t.sol
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IERC4626} from "../src/interfaces/IERC4626.sol";
+import {IERC7540Deposit} from "../src/interfaces/IERC7540Deposit.sol";
+import {IERC7540Redeem} from "../src/interfaces/IERC7540Redeem.sol";
+import {IERC7540VaultSettlementFacet} from "../src/interfaces/IERC7540VaultSettlementFacet.sol";
+import {IPausable} from "../src/interfaces/IPausable.sol";
+import {IERC4626VaultControlsFacet} from "../src/interfaces/IERC4626VaultControlsFacet.sol";
+import {ERC4626VaultFacetFixture} from "./helpers/ERC4626VaultFacetTestHarness.sol";
+
+contract ERC7540VaultRequestTimeTest is ERC4626VaultFacetFixture {
+    function setUp() public override {
+        super.setUp();
+        _installHostedVaultFullyAsyncFacetsToDiamond();
+
+        VM.prank(admin);
+        _initializeHostedVault(address(diamond));
+    }
+
+    function testElapsedTimeAloneDoesNotSettleDepositRequests() public {
+        _approveAsset(bob, address(diamond), 100);
+
+        VM.prank(bob);
+        IERC7540Deposit(address(diamond)).requestDeposit(60, bob, bob);
+
+        VM.warp(block.timestamp + 30 days);
+
+        assertTrue(IERC7540Deposit(address(diamond)).pendingDepositRequest(0, bob) == 60, "pending should remain");
+        assertTrue(IERC7540Deposit(address(diamond)).claimableDepositRequest(0, bob) == 0, "claimable should stay zero");
+        assertTrue(IERC7540Deposit(address(diamond)).pendingDepositRequest(1, bob) == 0, "nonzero id should be zero");
+        assertTrue(IERC7540Deposit(address(diamond)).claimableDepositRequest(1, bob) == 0, "nonzero id should be zero");
+    }
+
+    function testElapsedTimeAloneDoesNotSettleRedeemRequests() public {
+        _seedClaimedShares(bob, 80);
+
+        VM.prank(bob);
+        IERC7540Redeem(address(diamond)).requestRedeem(50, bob, bob);
+
+        VM.warp(block.timestamp + 30 days);
+
+        assertTrue(IERC7540Redeem(address(diamond)).pendingRedeemRequest(0, bob) == 50, "pending should remain");
+        assertTrue(IERC7540Redeem(address(diamond)).claimableRedeemRequest(0, bob) == 0, "claimable should stay zero");
+        assertTrue(IERC7540Redeem(address(diamond)).pendingRedeemRequest(1, bob) == 0, "nonzero id should be zero");
+        assertTrue(IERC7540Redeem(address(diamond)).claimableRedeemRequest(1, bob) == 0, "nonzero id should be zero");
+    }
+
+    function testOnlyManagerSettlementMovesDepositPendingToClaimableAcrossWarps() public {
+        _approveAsset(bob, address(diamond), 100);
+
+        VM.prank(bob);
+        IERC7540Deposit(address(diamond)).requestDeposit(60, bob, bob);
+
+        VM.warp(block.timestamp + 7 days);
+
+        VM.prank(admin);
+        IERC7540VaultSettlementFacet(address(diamond)).settleDepositRequest(bob, 25);
+
+        assertTrue(IERC7540Deposit(address(diamond)).pendingDepositRequest(0, bob) == 35, "pending mismatch");
+        assertTrue(IERC7540Deposit(address(diamond)).claimableDepositRequest(0, bob) == 25, "claimable mismatch");
+    }
+
+    function testOnlyManagerSettlementMovesRedeemPendingToClaimableAcrossWarps() public {
+        _seedClaimedShares(bob, 80);
+
+        VM.prank(bob);
+        IERC7540Redeem(address(diamond)).requestRedeem(50, bob, bob);
+
+        VM.warp(block.timestamp + 7 days);
+
+        VM.prank(admin);
+        IERC7540VaultSettlementFacet(address(diamond)).settleRedeemRequest(bob, 25);
+
+        assertTrue(IERC7540Redeem(address(diamond)).pendingRedeemRequest(0, bob) == 25, "pending mismatch");
+        assertTrue(IERC7540Redeem(address(diamond)).claimableRedeemRequest(0, bob) == 25, "claimable mismatch");
+    }
+
+    function testSettlementPauseBlocksSettlementAcrossWarpsButExistingClaimsRemainClaimable() public {
+        _approveAsset(bob, address(diamond), 100);
+
+        VM.prank(bob);
+        IERC7540Deposit(address(diamond)).requestDeposit(60, bob, bob);
+
+        VM.prank(admin);
+        IERC7540VaultSettlementFacet(address(diamond)).settleDepositRequest(bob, 20);
+
+        bytes32 settlementScope = IERC7540VaultSettlementFacet(address(diamond)).ASYNC_SETTLEMENT_SCOPE();
+
+        VM.prank(admin);
+        IERC4626VaultControlsFacet(address(diamond)).pauseScope(settlementScope);
+
+        VM.warp(block.timestamp + 14 days);
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, settlementScope));
+        IERC7540VaultSettlementFacet(address(diamond)).settleDepositRequest(bob, 10);
+
+        assertTrue(IERC7540Deposit(address(diamond)).claimableDepositRequest(0, bob) == 20, "claimable should remain");
+
+        VM.prank(bob);
+        uint256 shares = IERC4626(address(diamond)).deposit(20, bob);
+
+        assertTrue(shares == 20, "claim should still succeed");
+        assertTrue(IERC7540Deposit(address(diamond)).claimableDepositRequest(0, bob) == 0, "claimable should clear");
+        assertTrue(IERC7540Deposit(address(diamond)).pendingDepositRequest(0, bob) == 40, "pending should remain");
+    }
+
+    function testSettlementPauseBlocksRedeemSettlementAcrossWarpsButExistingClaimsRemainClaimable() public {
+        _seedClaimedShares(bob, 80);
+
+        VM.prank(bob);
+        IERC7540Redeem(address(diamond)).requestRedeem(50, bob, bob);
+
+        VM.prank(admin);
+        IERC7540VaultSettlementFacet(address(diamond)).settleRedeemRequest(bob, 20);
+
+        bytes32 settlementScope = IERC7540VaultSettlementFacet(address(diamond)).ASYNC_SETTLEMENT_SCOPE();
+
+        VM.prank(admin);
+        IERC4626VaultControlsFacet(address(diamond)).pauseScope(settlementScope);
+
+        VM.warp(block.timestamp + 14 days);
+
+        VM.prank(admin);
+        VM.expectRevert(abi.encodeWithSelector(IPausable.PausableScopeEnforcedPause.selector, settlementScope));
+        IERC7540VaultSettlementFacet(address(diamond)).settleRedeemRequest(bob, 10);
+
+        assertTrue(IERC7540Redeem(address(diamond)).claimableRedeemRequest(0, bob) == 20, "claimable should remain");
+
+        uint256 bobAssetsBefore = asset.balanceOf(bob);
+
+        VM.prank(bob);
+        uint256 assets = IERC4626(address(diamond)).redeem(20, bob, bob);
+
+        assertTrue(assets == 20, "claim should still succeed");
+        assertTrue(asset.balanceOf(bob) == bobAssetsBefore + 20, "receiver assets mismatch");
+        assertTrue(IERC7540Redeem(address(diamond)).claimableRedeemRequest(0, bob) == 0, "claimable should clear");
+        assertTrue(IERC7540Redeem(address(diamond)).pendingRedeemRequest(0, bob) == 30, "pending should remain");
+    }
+
+    function _seedClaimedShares(address controller, uint256 assets) internal {
+        _approveAsset(controller, address(diamond), assets);
+
+        VM.prank(controller);
+        IERC7540Deposit(address(diamond)).requestDeposit(assets, controller, controller);
+
+        VM.prank(admin);
+        IERC7540VaultSettlementFacet(address(diamond)).settleDepositRequest(controller, assets);
+
+        VM.prank(controller);
+        IERC4626(address(diamond)).deposit(assets, controller);
+    }
+}

--- a/test/MultisigWalletFuzz.t.sol
+++ b/test/MultisigWalletFuzz.t.sol
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IMultisigWallet} from "../src/interfaces/IMultisigWallet.sol";
+import {MultisigWalletFixture} from "./helpers/MultisigWalletTestHarness.sol";
+
+contract FuzzWalletExecutionTarget {
+    uint256 public storedNumber;
+    address public lastCaller;
+    uint256 public lastValue;
+
+    receive() external payable {
+        lastCaller = msg.sender;
+        lastValue = msg.value;
+    }
+
+    function setNumber(uint256 newNumber) external payable {
+        storedNumber = newNumber;
+        lastCaller = msg.sender;
+        lastValue = msg.value;
+    }
+
+    function revertWithReason() external pure {
+        revert("wallet-call-failed");
+    }
+}
+
+contract MultisigWalletFuzzTest is MultisigWalletFixture {
+    FuzzWalletExecutionTarget internal firstTarget;
+    FuzzWalletExecutionTarget internal secondTarget;
+
+    function setUp() public override {
+        super.setUp();
+        firstTarget = new FuzzWalletExecutionTarget();
+        secondTarget = new FuzzWalletExecutionTarget();
+    }
+
+    function testFuzzExecuteTransactionWithThresholdSignatures(uint96 numberRaw, uint96 valueRaw) public {
+        uint256 value = uint256(valueRaw) % 1 ether;
+        bytes memory data = abi.encodeCall(FuzzWalletExecutionTarget.setNumber, (uint256(numberRaw)));
+        bytes memory signatures = _packedSignaturesForTransaction(address(firstTarget), value, data, wallet.nonce(), 2);
+
+        VM.deal(address(wallet), value);
+
+        uint256 nonceBefore = wallet.nonce();
+        wallet.executeTransaction(address(firstTarget), value, data, signatures);
+
+        assertTrue(firstTarget.storedNumber() == uint256(numberRaw), "target number mismatch");
+        assertTrue(firstTarget.lastCaller() == address(wallet), "wallet should be caller");
+        assertTrue(firstTarget.lastValue() == value, "target value mismatch");
+        assertTrue(wallet.nonce() == nonceBefore + 1, "nonce should increment once");
+    }
+
+    function testFuzzExecuteBatchWithThresholdSignatures(uint96 firstRaw, uint96 secondRaw, uint96 valueRaw) public {
+        uint256 value = uint256(valueRaw) % 1 ether;
+        bytes memory transactions = bytes.concat(
+            _encodeBatchEntry(
+                address(firstTarget), 0, abi.encodeCall(FuzzWalletExecutionTarget.setNumber, (uint256(firstRaw)))
+            ),
+            _encodeBatchEntry(
+                address(secondTarget), value, abi.encodeCall(FuzzWalletExecutionTarget.setNumber, (uint256(secondRaw)))
+            )
+        );
+        bytes memory signatures = _packedSignaturesForBatch(transactions, wallet.nonce(), 2);
+
+        VM.deal(address(wallet), value);
+
+        uint256 nonceBefore = wallet.nonce();
+        wallet.executeBatch(transactions, signatures);
+
+        assertTrue(firstTarget.storedNumber() == uint256(firstRaw), "first target mismatch");
+        assertTrue(secondTarget.storedNumber() == uint256(secondRaw), "second target mismatch");
+        assertTrue(firstTarget.lastCaller() == address(wallet), "wallet should call first target");
+        assertTrue(secondTarget.lastCaller() == address(wallet), "wallet should call second target");
+        assertTrue(secondTarget.lastValue() == value, "second target value mismatch");
+        assertTrue(wallet.nonce() == nonceBefore + 1, "nonce should increment once");
+    }
+
+    function testFuzzMalformedSignatureLengthPreservesNonce(uint16 lengthRaw) public {
+        uint256 length = uint256(lengthRaw) % 260;
+        if (length == 130) {
+            length = 129;
+        }
+        bytes memory data = abi.encodeCall(FuzzWalletExecutionTarget.setNumber, (1));
+        bytes memory signatures = new bytes(length);
+
+        uint256 nonceBefore = wallet.nonce();
+
+        VM.expectRevert(
+            abi.encodeWithSelector(IMultisigWallet.MultisigWalletInvalidSignaturesLength.selector, length, 130)
+        );
+        wallet.executeTransaction(address(firstTarget), 0, data, signatures);
+
+        assertTrue(wallet.nonce() == nonceBefore, "nonce should not change");
+    }
+
+    function testFuzzWrongNonceSignaturePreservesNonce(uint8 nonceOffsetRaw, uint96 numberRaw) public {
+        uint256 wrongNonce = wallet.nonce() + (uint256(nonceOffsetRaw) % 64) + 1;
+        bytes memory data = abi.encodeCall(FuzzWalletExecutionTarget.setNumber, (uint256(numberRaw)));
+        bytes memory signatures = _packedSignaturesForTransaction(address(firstTarget), 0, data, wrongNonce, 2);
+
+        uint256 nonceBefore = wallet.nonce();
+
+        VM.expectRevert();
+        wallet.executeTransaction(address(firstTarget), 0, data, signatures);
+
+        assertTrue(wallet.nonce() == nonceBefore, "nonce should not change");
+    }
+
+    function testFuzzDuplicateSignersPreserveNonce(uint96 numberRaw) public {
+        bytes memory data = abi.encodeCall(FuzzWalletExecutionTarget.setNumber, (uint256(numberRaw)));
+        bytes32 digest = wallet.getTransactionHash(address(firstTarget), 0, data, wallet.nonce());
+        bytes memory signatures = bytes.concat(_signatureForOwnerIndex(digest, 0), _signatureForOwnerIndex(digest, 0));
+
+        uint256 nonceBefore = wallet.nonce();
+
+        VM.expectRevert();
+        wallet.executeTransaction(address(firstTarget), 0, data, signatures);
+
+        assertTrue(wallet.nonce() == nonceBefore, "nonce should not change");
+    }
+
+    function testFuzzUnsortedSignersPreserveNonce(uint96 numberRaw) public {
+        bytes memory data = abi.encodeCall(FuzzWalletExecutionTarget.setNumber, (uint256(numberRaw)));
+        bytes32 digest = wallet.getTransactionHash(address(firstTarget), 0, data, wallet.nonce());
+        uint256[] memory sortedIndexes = _sortedOwnerIndexes(2);
+        bytes memory signatures = bytes.concat(
+            _signatureForOwnerIndex(digest, sortedIndexes[1]), _signatureForOwnerIndex(digest, sortedIndexes[0])
+        );
+
+        uint256 nonceBefore = wallet.nonce();
+
+        VM.expectRevert();
+        wallet.executeTransaction(address(firstTarget), 0, data, signatures);
+
+        assertTrue(wallet.nonce() == nonceBefore, "nonce should not change");
+    }
+
+    function testFuzzInvalidNonOwnerSignerPreservesNonce(uint96 numberRaw) public {
+        bytes memory data = abi.encodeCall(FuzzWalletExecutionTarget.setNumber, (uint256(numberRaw)));
+        uint256[] memory signerIndexes = new uint256[](2);
+        signerIndexes[0] = 0;
+        signerIndexes[1] = 3;
+        bytes memory signatures =
+            _packedSignaturesForTransactionByIndexes(address(firstTarget), 0, data, wallet.nonce(), signerIndexes);
+
+        uint256 nonceBefore = wallet.nonce();
+
+        VM.expectRevert();
+        wallet.executeTransaction(address(firstTarget), 0, data, signatures);
+
+        assertTrue(wallet.nonce() == nonceBefore, "nonce should not change");
+    }
+
+    function testFuzzReplayPreservesNonceAfterSuccessfulExecution(uint96 numberRaw) public {
+        bytes memory data = abi.encodeCall(FuzzWalletExecutionTarget.setNumber, (uint256(numberRaw)));
+        bytes memory signatures = _packedSignaturesForTransaction(address(firstTarget), 0, data, wallet.nonce(), 2);
+
+        wallet.executeTransaction(address(firstTarget), 0, data, signatures);
+        uint256 nonceAfterSuccess = wallet.nonce();
+
+        VM.expectRevert();
+        wallet.executeTransaction(address(firstTarget), 0, data, signatures);
+
+        assertTrue(wallet.nonce() == nonceAfterSuccess, "nonce should not change on replay");
+    }
+
+    function testFuzzTargetRevertPreservesNonce(bool useBatch) public {
+        uint256 nonceBefore = wallet.nonce();
+
+        if (useBatch) {
+            bytes memory transactions = _encodeBatchEntry(
+                address(firstTarget), 0, abi.encodeCall(FuzzWalletExecutionTarget.revertWithReason, ())
+            );
+            bytes memory signatures = _packedSignaturesForBatch(transactions, wallet.nonce(), 2);
+
+            VM.expectRevert(bytes("wallet-call-failed"));
+            wallet.executeBatch(transactions, signatures);
+        } else {
+            bytes memory data = abi.encodeCall(FuzzWalletExecutionTarget.revertWithReason, ());
+            bytes memory signatures = _packedSignaturesForTransaction(address(firstTarget), 0, data, wallet.nonce(), 2);
+
+            VM.expectRevert(bytes("wallet-call-failed"));
+            wallet.executeTransaction(address(firstTarget), 0, data, signatures);
+        }
+
+        assertTrue(wallet.nonce() == nonceBefore, "nonce should not change");
+    }
+
+    function testFuzzFreshWalletThresholdRequiresExactSignatureCount(uint8 ownerCountRaw, uint8 thresholdRaw) public {
+        uint256 ownerCount = (uint256(ownerCountRaw) % actorAddresses.length) + 1;
+        uint256 threshold_ = (uint256(thresholdRaw) % ownerCount) + 1;
+        address[] memory owners = _ownerPrefix(ownerCount);
+        bytes32 salt = keccak256(abi.encode("threshold-fuzz", ownerCount, threshold_, ownerCountRaw, thresholdRaw));
+        IMultisigWallet localWallet = _deployInitializedWallet(salt, owners, threshold_, defaultMultiSend);
+
+        bytes memory data = abi.encodeCall(FuzzWalletExecutionTarget.setNumber, (ownerCount + threshold_));
+        bytes memory validSignatures =
+            _packedSignaturesForTransactionAtWallet(address(localWallet), address(firstTarget), 0, data, 0, threshold_);
+
+        localWallet.executeTransaction(address(firstTarget), 0, data, validSignatures);
+        assertTrue(localWallet.nonce() == 1, "valid threshold nonce mismatch");
+        assertTrue(firstTarget.storedNumber() == ownerCount + threshold_, "valid threshold execution mismatch");
+
+        bytes memory shortSignatures = _packedSignaturesForTransactionAtWallet(
+            address(localWallet), address(firstTarget), 0, data, localWallet.nonce(), threshold_ - 1
+        );
+
+        VM.expectRevert(
+            abi.encodeWithSelector(
+                IMultisigWallet.MultisigWalletInvalidSignaturesLength.selector, shortSignatures.length, threshold_ * 65
+            )
+        );
+        localWallet.executeTransaction(address(firstTarget), 0, data, shortSignatures);
+
+        assertTrue(localWallet.nonce() == 1, "short signature nonce should not change");
+    }
+
+    function _ownerPrefix(uint256 ownerCount) internal view returns (address[] memory owners) {
+        owners = new address[](ownerCount);
+        for (uint256 i = 0; i < ownerCount; i++) {
+            owners[i] = actorAddresses[i];
+        }
+    }
+
+    function _signatureForOwnerIndex(bytes32 digest, uint256 ownerIndex) internal returns (bytes memory signature) {
+        (uint8 v, bytes32 r, bytes32 s) = VM.sign(actorKeys[ownerIndex], digest);
+        signature = new bytes(65);
+
+        assembly {
+            mstore(add(signature, 0x20), r)
+            mstore(add(signature, 0x40), s)
+            mstore8(add(signature, 0x60), v)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Resolves #219 by adding reviewer-facing coverage for the ERC-7540 async vault request surface and multisig wallet signature/threshold/nonce behavior.

## Changes

- Added library-level ERC-7540 request-accounting invariants for aggregate totals, bucket isolation, unsupported request IDs, and operator pair isolation.
- Added diamond-routed ERC-7540 deposit and redeem fuzz suites covering request, settlement, claim, max helpers, escrow, allowance, and operator authorization behavior.
- Added ERC-7540 time coverage proving elapsed time alone does not settle requests and settlement pause persists across warps while existing claims remain claimable.
- Added multisig fuzz coverage for successful threshold execution, batch execution, malformed signatures, wrong nonces, duplicate/unsorted/invalid signers, replay, target reverts, and fresh wallet threshold bounds.
- Updated reviewer evidence docs to include the new suites without changing CI scope.

## Scope

- No production Solidity changes.
- No ABI, selector, storage-layout, initializer, or runtime behavior changes.
- Changes are limited to new tests and docs.

## Validation

- `forge fmt --check`
- `forge build --sizes --skip script`
- `forge test --offline --match-path test/ERC7540VaultFoundationCore.t.sol`
- `forge test --offline --match-path test/ERC7540VaultDepositCore.t.sol`
- `forge test --offline --match-path test/ERC7540VaultRedeemCore.t.sol`
- `forge test --offline --match-path test/ERC7540VaultRequestAccountingInvariant.t.sol`
- `forge test --offline --match-path test/ERC7540VaultDepositFuzz.t.sol`
- `forge test --offline --match-path test/ERC7540VaultRedeemFuzz.t.sol`
- `forge test --offline --match-path test/ERC7540VaultRequestTime.t.sol`
- `forge test --offline --match-path test/DiamondVaultHostInvariant.t.sol`
- `forge test --offline --match-path test/MultisigWalletCoreExecution.t.sol`
- `forge test --offline --match-path test/MultisigWalletManagement.t.sol`
- `forge test --offline --match-path test/MultisigWalletInvariant.t.sol`
- `forge test --offline --match-path test/MultisigWalletFuzz.t.sol`
- `forge test --offline` (`699 passed, 0 failed`)