### PR TITLE
Fix reviewer path protocol docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,22 +79,47 @@ reviewable engineering system.
   init, async selector ownership, settlement surface, and oracle wiring.
 - `test/DiamondVaultHostHardening.t.sol`: replace/remove/re-add hardening
   across the hosted vault diamond path.
+- `test/DiamondVaultHostInvariant.t.sol`: diamond-routed hosted vault
+  invariants across deposits, withdrawals, strategy lifecycle, roles, and
+  pause state.
+- `test/DiamondNativeVaultHostHardening.t.sol`: native hosted vault
+  force-sent ETH, strategy, selector replacement, and persistence hardening.
+- `test/DiamondNativeVaultHostInvariant.t.sol`: native hosted vault invariants
+  for managed accounting, immediate liquidity, limits, strategy debt, and
+  force-sent surplus.
 - `test/ERC7540VaultFoundationCore.t.sol`: aggregate request model, selector
   split, and operator bookkeeping coverage.
 - `test/ERC7540VaultDepositCore.t.sol`: async deposit request, settlement, and
   claim coverage.
 - `test/ERC7540VaultRedeemCore.t.sol`: async redeem request, settlement, and
   claim coverage.
+- `test/ERC7540VaultDepositFuzz.t.sol` and
+  `test/ERC7540VaultRedeemFuzz.t.sol`: async request property coverage for
+  deposit and redeem flows.
+- `test/ERC7540VaultRequestAccountingInvariant.t.sol`: async request
+  accounting invariants across pending, claimable, escrowed, and managed
+  buckets.
+- `test/ERC7540VaultRequestTime.t.sol`: async controller/operator and
+  settlement-scope time-window coverage.
 - `test/DiamondTokenDeploymentIntegration.t.sol`: ERC20 and ERC721 host
   deployment and selector ownership.
+- `test/DiamondTokenHostHardening.t.sol`: token-host replace/remove/re-add,
+  role, pause, Permit, and metadata persistence coverage.
+- `test/DiamondErc20HostInvariant.t.sol` and
+  `test/DiamondErc721HostInvariant.t.sol`: diamond-routed token-host
+  invariants for ERC20 and ERC721 behavior.
 - `test/AMMFactoryRegistry.t.sol`: AMM factory registry behavior, sorted pair
   lookups, and deterministic pair address coverage.
 - `test/AMMPairCore.t.sol`: pair mint/burn/swap accounting, fee switch, and
   reserve update behavior.
 - `test/AMMRouterCore.t.sol`: router quoting, liquidity, wrapped-native, and
   single-hop/multi-hop swap coverage.
-- `test/AMMHardening.t.sol`: malformed token, transfer-failure, protocol-fee,
-  and router balance hardening coverage.
+- `test/AMMRouterTime.t.sol`: cumulative price and reserve timestamp coverage.
+- `test/AMMPairFuzz.t.sol` and `test/AMMRouterFuzz.t.sol`: pair and router
+  property coverage.
+- `test/AMMInvariant.t.sol`: AMM reserve, balance, LP, and factory invariants.
+- `test/AMMHardening.t.sol`: malformed token, false/silent transfer,
+  reentrancy, protocol-fee, and router balance hardening coverage.
 - `test/SystemOracleFailureScenarios.t.sol`: stale-data, breaker, fallback, and
   recovery behavior.
 - `test/SystemVaultStressInvariant.t.sol`: higher-signal system stress coverage
@@ -107,6 +132,8 @@ reviewable engineering system.
   factory deployment coverage.
 - `test/MultisigWalletManagement.t.sol`: self-managed owner and threshold
   mutation coverage.
+- `test/MultisigWalletFuzz.t.sol`: signature, signer-ordering, batch, and
+  management fuzz coverage.
 - `test/MultisigWalletInvariant.t.sol`: owner uniqueness, threshold bounds, and
   nonce progression invariants.
 
@@ -123,20 +150,41 @@ Foundry uses the Solidity compiler pinned in `foundry.toml` (currently
 `0.8.34`); Foundry `1.4.3` will fetch that compiler version on first build if
 it is not already installed locally.
 
-Run a bounded reviewer-facing path with:
+Run a bounded reviewer-facing path with the curated groups below. The fuller
+local command inventory lives in `docs/security-checks.md`.
 
 ```shell
 forge fmt --check
 forge build --sizes --skip script
+```
+
+For hosted diamond and vault behavior:
+
+```shell
 forge test --offline --match-path test/DiamondSelectorIntegrityCore.t.sol
 forge test --offline --match-path test/DiamondVaultDeploymentIntegration.t.sol
 forge test --offline --match-path test/DiamondVaultHostHardening.t.sol
+forge test --offline --match-path test/DiamondVaultHostInvariant.t.sol
+forge test --offline --match-path test/DiamondNativeVaultHostHardening.t.sol
+forge test --offline --match-path test/DiamondNativeVaultHostInvariant.t.sol
 forge test --offline --match-path test/ERC7540VaultFoundationCore.t.sol
 forge test --offline --match-path test/ERC7540VaultDepositCore.t.sol
 forge test --offline --match-path test/ERC7540VaultRedeemCore.t.sol
-forge test --offline --match-path test/DiamondTokenDeploymentIntegration.t.sol
+forge test --offline --match-path test/ERC7540VaultDepositFuzz.t.sol
+forge test --offline --match-path test/ERC7540VaultRedeemFuzz.t.sol
+forge test --offline --match-path test/ERC7540VaultRequestAccountingInvariant.t.sol
+forge test --offline --match-path test/ERC7540VaultRequestTime.t.sol
 forge test --offline --match-path test/SystemOracleFailureScenarios.t.sol
 forge test --offline --match-path test/SystemVaultStressInvariant.t.sol
+```
+
+For the token-host track:
+
+```shell
+forge test --offline --match-path test/DiamondTokenDeploymentIntegration.t.sol
+forge test --offline --match-path test/DiamondTokenHostHardening.t.sol
+forge test --offline --match-path test/DiamondErc20HostInvariant.t.sol
+forge test --offline --match-path test/DiamondErc721HostInvariant.t.sol
 ```
 
 For the wallet track:
@@ -146,6 +194,7 @@ forge test --offline --match-path test/MultisigWalletFoundationCore.t.sol
 forge test --offline --match-path test/MultisigWalletCoreExecution.t.sol
 forge test --offline --match-path test/MultisigWalletIntegration.t.sol
 forge test --offline --match-path test/MultisigWalletManagement.t.sol
+forge test --offline --match-path test/MultisigWalletFuzz.t.sol
 forge test --offline --match-path test/MultisigWalletInvariant.t.sol
 ```
 
@@ -157,6 +206,10 @@ forge test --offline --match-path test/AMMFactoryRegistry.t.sol
 forge test --offline --match-path test/AMMPairCore.t.sol
 forge test --offline --match-path test/AMMRouterCore.t.sol
 forge test --offline --match-path test/AMMRouterTime.t.sol
+forge test --offline --match-path test/AMMPairFuzz.t.sol
+forge test --offline --match-path test/AMMRouterFuzz.t.sol
+FOUNDRY_INVARIANT_RUNS=64 FOUNDRY_INVARIANT_DEPTH=32 forge test --offline --match-path test/AMMInvariant.t.sol
+forge test --offline --match-path test/AMMHardening.t.sol
 ```
 
 For the local Auralis workflow:

--- a/docs/amm.md
+++ b/docs/amm.md
@@ -134,6 +134,23 @@ Protocol-fee behavior is optional and factory-controlled:
 - `kLast` refreshes on fee-on liquidity events
 - disabling `feeTo` clears `kLast` on the next liquidity event
 
+## Token Assumptions
+
+The AMM pricing and invariant model assumes standard ERC-20 balance deltas:
+the amount sent by a caller is the amount received by the pair or router, and
+token supply does not mutate unexpectedly during AMM calls.
+
+Out-of-scope token economics:
+
+- fee-on-transfer or transfer-tax tokens
+- rebasing tokens
+- reflection tokens
+- hook-style token behavior that mutates balances or supply during AMM calls
+
+Malformed tokens, silent tokens, false-returning tokens, and reentrant tokens
+are part of the current hardening surface. Transfer-tax and rebasing economics
+are not part of the current invariant or pricing model.
+
 ## Security Notes
 
 The AMM track is opinionated about what it supports and what it rejects.

--- a/docs/testing-conventions.md
+++ b/docs/testing-conventions.md
@@ -8,6 +8,7 @@ Use a split test layout so modules stay readable as complexity grows.
 - `test/<Module>Time.t.sol` (only when time-window behavior exists)
 - `test/<Module>Fuzz.t.sol` (for property/fuzz coverage)
 - `test/<Module>Invariant.t.sol` (for stateful invariant coverage)
+- `test/<Module>Hardening.t.sol` (for adversarial and regression coverage)
 - `test/<Module>Integration.t.sol` (optional, cross-module workflows)
 - `test/helpers/<Module>TestHarness.sol`
 
@@ -18,12 +19,15 @@ Use a split test layout so modules stay readable as complexity grows.
 - `Integration`: interactions between modules and end-to-end flows.
 - `Fuzz`: property-style checks across random inputs and edge value ranges.
 - `Invariant`: stateful safety properties across randomized action sequences.
+- `Hardening`: adversarial and regression suites that combine realistic edge
+  cases, hostile integrations, selector replacement, and remove/re-add flows.
 - `helpers`: shared fixture setup, actors, harness wrappers, and utility assertions.
 
 ## Naming
 
 - Test contract names: `<Module>CoreTest`, `<Module>TimeTest`, `<Module>IntegrationTest`.
-- Test contract names: `<Module>FuzzTest`, `<Module>InvariantTest`.
+- Test contract names: `<Module>FuzzTest`, `<Module>InvariantTest`,
+  `<Module>HardeningTest`.
 - Test function names should describe one behavior each, for example:
   - `testNonAdminCannotSetRoleWindow`
   - `testRoleWindowBoundariesAndOnlyActiveRole`
@@ -62,6 +66,10 @@ Use a split test layout so modules stay readable as complexity grows.
 - Fuzz example: `test/MultisigWalletFuzz.t.sol`
 - Invariant example: `test/ERC4626VaultAccountingInvariant.t.sol`
 - Invariant example: `test/ERC7540VaultRequestAccountingInvariant.t.sol`
+- Hardening example: `test/AMMHardening.t.sol`
+- Hardening example: `test/DiamondTokenHostHardening.t.sol`
+- Hardening example: `test/DiamondVaultHostHardening.t.sol`
+- Hardening example: `test/DiamondNativeVaultHostHardening.t.sol`
 - Time example: `test/AccessControlTime.t.sol`
 - Time example: `test/UpgradeGuardrailsTime.t.sol`
 - Time example: `test/ERC7540VaultRequestTime.t.sol`

--- a/docs/token-facets.md
+++ b/docs/token-facets.md
@@ -85,6 +85,8 @@ Initialization seeds:
 - Permit domain state
 - shared control state when the host is first initialized
 - role assignments for the provided `admin`
+- `DEFAULT_ADMIN_ROLE`, `TOKEN_ADMIN_ROLE`, `PAUSER_ROLE`,
+  `ERC20_MINTER_ROLE`, and `ERC20_BURNER_ROLE` are granted to `admin`
 
 Initialization expectations:
 
@@ -105,6 +107,9 @@ Initialization seeds:
 - token metadata and base URI
 - shared control state when the host is first initialized
 - role assignments for the provided `admin`
+- `DEFAULT_ADMIN_ROLE`, `TOKEN_ADMIN_ROLE`, `PAUSER_ROLE`,
+  `ERC721_MINTER_ROLE`, `ERC721_BURNER_ROLE`, and `ERC721_METADATA_ROLE` are
+  granted to `admin`
 
 Initialization expectations:
 

--- a/docs/vault-facets.md
+++ b/docs/vault-facets.md
@@ -173,6 +173,14 @@ Initialization behavior:
 - `ERC4626VaultIntegrationFacet` has no independent initializer.
 - a second call to `initializeVault(...)` reverts.
 
+Post-initialization configuration is role-gated through the initialized control
+plane. `setOracleAdapter(...)`, `setStrategy(...)`, strategy lifecycle calls,
+and async settlement require `VAULT_MANAGER_ROLE`; installing the integration
+selectors, or retaining diamond ownership by itself, is not enough to call
+those operations after initialization. The initialized `admin` receives that
+manager role by default and can delegate or revoke it through the shared access
+control surface.
+
 The local reference deployment in `script/DeployDiamondVaultHost.s.sol` wires a
 vault-bound, asset-bound strategy by default. It leaves the vault in a ready
 state with:
@@ -432,12 +440,15 @@ Native hosted vaults use the ERC-7535-style entry surface for asset-in flows.
 ## Native-Asset Accounting And Safety Assumptions
 
 Hosted native vaults still use tracked managed assets rather than raw
-`address(this).balance`.
+`address(this).balance`. Force-sent ETH is untracked surplus, not managed vault
+capital.
 
 Implications:
-- force-sent ETH does not increase `totalManagedAssets()`
-- force-sent ETH does not increase share price through `totalAssets()` pricing
-- force-sent ETH does not increase hosted `maxWithdraw()` or `maxRedeem()`
+- force-sent ETH does not change `totalManagedAssets()`
+- force-sent ETH does not change `totalAssets()` pricing, conversions,
+  previews, or share issuance
+- force-sent ETH does not increase hosted `maxDeposit()`, `maxMint()`,
+  `maxWithdraw()`, or `maxRedeem()`
 - if a native exit is satisfied partly or fully from untracked force-sent ETH,
   book accounting only burns the tracked portion of assets
 
@@ -447,6 +458,10 @@ This is an explicit safety choice:
   to represent managed assets
 - the vault does not attempt to reconcile unsolicited ETH into strategy debt or
   book value automatically
+
+This follows ADR 0005 (`docs/adr/0005-exclude-force-sent-eth.md`) and is
+covered by `test/DiamondNativeVaultHostHardening.t.sol` and
+`test/DiamondNativeVaultHostInvariant.t.sol`.
 
 `withdraw(assets)` and `redeem(shares)` remain core-facet entrypoints, but they
 are strategy-aware.


### PR DESCRIPTION
## Summary

Closes #220.

This docs-only PR aligns the reviewer-facing documentation with the current suite inventory and protocol assumptions:

- refreshes the README evidence and validation path for async vault fuzz/invariant/time suites, token-host hardening/invariants, native vault hardening/invariants, multisig fuzz, and AMM fuzz/invariant/hardening/time coverage
- updates testing conventions to document the hardening test family and current hardening examples
- clarifies native hosted vault force-sent ETH semantics and post-init vault manager role requirements
- documents token initializer role bootstrap details for ERC20 and ERC721 hosts
- states AMM token assumptions and out-of-scope transfer-tax/rebasing economics

## Validation

- `forge fmt --check`
- `forge build --sizes --skip script`
- `forge test --offline --match-path test/ERC7540VaultDepositFuzz.t.sol`
- `forge test --offline --match-path test/ERC7540VaultRedeemFuzz.t.sol`
- `forge test --offline --match-path test/ERC7540VaultRequestAccountingInvariant.t.sol`
- `forge test --offline --match-path test/ERC7540VaultRequestTime.t.sol`
- `forge test --offline --match-path test/MultisigWalletFuzz.t.sol`
- `forge test --offline --match-path test/DiamondTokenHostHardening.t.sol`
- `forge test --offline --match-path test/DiamondNativeVaultHostHardening.t.sol`
- `forge test --offline --match-path test/AMMRouterTime.t.sol`
- `forge test --offline --match-path test/AMMHardening.t.sol`
- `forge test --offline --match-path test/AMMInvariant.t.sol`
- `forge test --offline`