### PR TITLE
Clean public metadata posture

### DIFF
--- a/.github/ISSUE_TEMPLATE/audit_docs_task.yml
+++ b/.github/ISSUE_TEMPLATE/audit_docs_task.yml
@@ -1,0 +1,35 @@
+name: Audit or documentation task
+description: Track audit-remediation, documentation, or public-reviewer cleanup work.
+title: "[audit] "
+labels:
+  - audit
+  - documentation
+body:
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What documentation, metadata, or review surface is affected?
+    validations:
+      required: true
+  - type: textarea
+    id: expected-resolution
+    attributes:
+      label: Expected resolution
+      description: What should be true when this issue is closed?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance criteria
+      description: List concrete checks or outcomes.
+      value: |
+        - [ ] <criterion>
+    validations:
+      required: true
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation
+      description: Commands or review steps expected for the PR.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,30 @@
+name: Bug report
+description: Report a reproducible issue in contracts, tests, scripts, or documentation.
+title: "[bug] "
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is wrong?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Include commands, inputs, or reasoning needed to reproduce.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should happen instead?
+    validations:
+      required: true
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation
+      description: Any checks already run.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security policy
+    url: https://github.com/amshirif/Auralis/blob/main/SECURITY.md
+    about: Review security reporting guidance before filing security-sensitive issues.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Summary
+
+- <summary>
+
+## Linked Issue
+
+Closes #
+
+## Validation
+
+- [ ] `forge fmt --check`
+- [ ] `forge build --sizes --skip script`
+- [ ] Relevant tests:
+
+## Docs And Security Impact
+
+- [ ] Public docs updated or not needed.
+- [ ] Security assumptions, threat model, or validation docs updated or not needed.
+- [ ] No secrets, private keys, or machine-local paths added.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable public changes to this repository are tracked here.
+
+This repository also keeps a release-note drafting template at
+`docs/ops/release-notes-template.md`. Use that template when preparing a tagged
+GitHub release, then summarize the release here.
+
+## Unreleased
+
+- Public metadata posture documented with contribution, security, changelog,
+  issue-template, and pull-request-template guidance.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing
+
+`Auralis` is a personal protocol-engineering portfolio repository. External
+feedback is welcome, but this repo is not operated as an open community project
+or production support channel.
+
+## Workflow
+
+- Start implementation work from a GitHub issue.
+- Branch from the active `milestone/*` branch.
+- Open task PRs back into the active milestone branch, not directly into
+  `main`.
+- Include `Closes #<issue-number>` in the PR body.
+- Keep changes scoped to the issue being addressed.
+
+The detailed local workflow is documented in
+`docs/ops/workflow-conventions.md`.
+
+## Validation Expectations
+
+Run the checks that match the change scope before requesting review. For most
+contract or test changes, start with:
+
+```shell
+forge fmt --check
+forge build --sizes --skip script
+forge test --offline
+```
+
+Documentation-only changes should still run `forge fmt --check` and a build
+when practical so the repository remains reviewer-ready.
+
+## Public Metadata Choices
+
+This repository intentionally keeps only the public metadata that matches its
+portfolio scope:
+
+- `CONTRIBUTING.md` documents the issue and PR workflow.
+- `SECURITY.md` documents the security-reporting posture.
+- `CHANGELOG.md` documents public release history.
+- `.github` templates guide future issues and PRs.
+
+The repo does not currently include `CODE_OF_CONDUCT.md`, `SUPPORT.md`, or
+`FUNDING.yml`. Those files are intentionally omitted because this is not an
+open community project, a funded project, or a production support channel.

--- a/README.md
+++ b/README.md
@@ -239,9 +239,16 @@ Built with Foundry. CI workflows live under `.github/workflows/`.
 
 Foundry docs: [book.getfoundry.sh](https://book.getfoundry.sh/)
 
+## Public Metadata
+
+This is a personal portfolio repository. Contribution, security, changelog, and
+GitHub template guidance are provided for public review, while community
+operations files such as `CODE_OF_CONDUCT.md`, `SUPPORT.md`, and `FUNDING.yml`
+are intentionally omitted.
+
 ## AI Usage
 
-AI assistance was used for tests, documentation, scripts, planning support.
+AI assistance was used for tests, documentation, scripts, and planning support.
 
 The protocol architecture, technical decisions, and final review/integration of
 changes were directed and owned by me.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Security Policy
+
+`Auralis` is a public portfolio repository for Solidity protocol engineering.
+It is not a production deployment and does not run a bug bounty program.
+
+## Reporting Security Issues
+
+For non-sensitive findings, open a GitHub issue with:
+
+- affected contract, script, or documentation area
+- reproduction steps or reasoning
+- expected impact
+- suggested fix, if known
+
+Do not include secrets, private keys, live exploit details, or third-party
+confidential information in public issues.
+
+## Supported Scope
+
+Security review in this repository focuses on the code and documentation in the
+current public tree. The repository does not provide production incident
+response, deployment support, or guaranteed response times.
+
+For validation and local reproduction guidance, see `docs/security-checks.md`.

--- a/docs/ops/release-checklist.md
+++ b/docs/ops/release-checklist.md
@@ -13,13 +13,15 @@ Use this checklist before tagging and publishing a new release.
 
 ## 2. Changelog and Notes
 
-- Draft release notes using `docs/ops/release-notes-template.md`.
+- Update `CHANGELOG.md` with the public release summary.
+- Draft GitHub release notes using `docs/ops/release-notes-template.md`.
 - Include:
   - highlights
   - security-impacting changes
   - migration notes
   - linked PRs/issues
-- Confirm closed issues and milestone status match release notes.
+- Confirm closed issues, milestone status, `CHANGELOG.md`, and release notes
+  all match.
 
 ## 3. Validation Gates
 
@@ -55,6 +57,7 @@ Required outcomes:
 - Create and push tag.
 - Publish GitHub release with finalized notes.
 - Attach milestone and key issue links.
+- Confirm `CHANGELOG.md` points readers to the published release context.
 
 ## 6. Post-Release
 

--- a/docs/ops/release-notes-template.md
+++ b/docs/ops/release-notes-template.md
@@ -2,6 +2,10 @@
 
 Release date: `YYYY-MM-DD`
 
+Use this file as the GitHub release-note drafting template. `CHANGELOG.md` is
+the public release history surface that should be updated alongside the final
+release notes.
+
 ## Summary
 
 - 

--- a/docs/ops/workflow-conventions.md
+++ b/docs/ops/workflow-conventions.md
@@ -62,8 +62,8 @@ Task PRs should:
 When GitHub `Development` links are unreliable, the issue `Delivery` section and
 the PR `Closes #...` line are treated as the canonical linkage.
 
-Use [`scripts/open-task-pr.sh`](/Users/amirshirif/Documents/personal/auralis/scripts/open-task-pr.sh)
-to create task PRs with the expected metadata and delivery links in one step.
+Use [`scripts/open-task-pr.sh`](../../scripts/open-task-pr.sh) to create task
+PRs with the expected metadata and delivery links in one step.
 
 ## Milestone PR Rules
 
@@ -76,11 +76,11 @@ Milestone PRs should:
 - have a project card on `Portfolio`
 - use `In progress` status while open
 
-Use [`scripts/open-milestone-pr.sh`](/Users/amirshirif/Documents/personal/auralis/scripts/open-milestone-pr.sh)
-to create milestone PRs with the expected metadata in one step.
+Use [`scripts/open-milestone-pr.sh`](../../scripts/open-milestone-pr.sh) to
+create milestone PRs with the expected metadata in one step.
 
 Main-branch guardrails in
-[`main-pr-branch-guard.yml`](/Users/amirshirif/Documents/personal/auralis/.github/workflows/main-pr-branch-guard.yml)
+[`main-pr-branch-guard.yml`](../../.github/workflows/main-pr-branch-guard.yml)
 enforce the parts of this checklist that GitHub Actions can verify.
 
 ## Branch Naming


### PR DESCRIPTION
## Summary

Closes #221.

This docs/metadata-only PR makes the public repository posture explicit:

- adds core public metadata files for contribution, security, changelog, PR template, and issue templates
- documents intentional omission of community/support/funding metadata for this portfolio repo
- replaces machine-local ops doc links with repo-relative links
- clarifies changelog/release-note relationship
- lightly tightens the README AI disclosure without changing its meaning

## Validation

- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/ISSUE_TEMPLATE/config.yml .github/ISSUE_TEMPLATE/audit_docs_task.yml .github/ISSUE_TEMPLATE/bug_report.yml`
- `git diff --cached --check`
- `rg -n "/Users/|/home/|C:\\|/var/folders" README.md docs .github` (no matches)
- `ls CONTRIBUTING.md SECURITY.md CHANGELOG.md .github/pull_request_template.md .github/ISSUE_TEMPLATE/config.yml`
- `forge fmt --check`
- `forge build --sizes --skip script`
- `forge test --offline --match-path test/DiamondSelectorIntegrityCore.t.sol`