### PR TITLE
Add npm package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@amshirif/auralis",
+  "version": "1.0.1",
+  "description": "Security-first Solidity protocol engineering portfolio contracts and validation artifacts.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/amshirif/Auralis.git"
+  },
+  "homepage": "https://github.com/amshirif/Auralis#readme",
+  "bugs": {
+    "url": "https://github.com/amshirif/Auralis/issues"
+  },
+  "keywords": [
+    "solidity",
+    "ethereum",
+    "foundry",
+    "defi",
+    "erc4626",
+    "erc7540",
+    "diamond-standard",
+    "smart-contracts"
+  ],
+  "files": [
+    "src",
+    "docs",
+    "!docs/assets",
+    "foundry.toml",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}


### PR DESCRIPTION
## Summary
- add package metadata for publishing Auralis as @amshirif/auralis
- package Solidity sources, docs, foundry.toml, README, and LICENSE
- exclude docs/assets from npm package contents to keep the tarball small

## Validation
- npm_config_cache=/tmp/auralis-npm-cache npm pack --dry-run
- npm_config_cache=/tmp/auralis-npm-cache npm pack --dry-run --json
- npm_config_cache=/tmp/auralis-npm-cache npm view @amshirif/auralis version returned 404, so the package name appears available
- git diff --check

## Notes
Publishing will require npm auth locally. Scoped packages need public access on first publish; package.json sets publishConfig.access to public.