### PR TITLE
Fix npm package scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@amshirif/auralis",
-  "version": "1.0.1",
+  "name": "@amirshirif/auralis",
+  "version": "1.0.2",
   "description": "Security-first Solidity protocol engineering portfolio contracts and validation artifacts.",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- rename npm package from @amshirif/auralis to @amirshirif/auralis to match the authenticated npm user scope
- bump package metadata version from 1.0.1 to 1.0.2 after the failed first publish attempt

## Validation
- npm view @amirshirif/auralis version returned 404, so the corrected package name appears available
- npm_config_cache=/tmp/auralis-npm-cache npm pack --dry-run
- git diff --check